### PR TITLE
Make MSW buttons more closely match common controls

### DIFF
--- a/src/msw/button.cpp
+++ b/src/msw/button.cpp
@@ -174,7 +174,7 @@ wxSize wxButtonBase::GetDefaultSize(wxWindow* win)
         // part of the button are not scaled correctly in higher than normal
         // DPI, so add them without scaling.
         s_sizeBtn.SetAtNewDPI(
-            wxWindow::FromDIP(wxSize(73, 21), win) + wxSize(2, 2)
+            wxWindow::FromDIP(wxSize(86, 24), win) + wxSize(2, 2)
         );
     }
 


### PR DESCRIPTION
This is apparently a never-ending story, with attempts to follow MSFT docs (which is wrong), using Vista+ API to get the size (also wrong), eventually settling on doing it ourselves and matching native controls. For reference: #18528, #24283, #24285, 48f8e95 ("Fix wxButton::GetDefaultSize() in high DPI under MSW"), c6d2f6d ("Really fix the standard button size in high DPI under MSW").

I wanted to call this PR "Hopefully finally actually fix the standard button size under MSW". I no longer hold that hope, but I do think doing this, or something similar, is the least bad thing.

In #24283, careful measurements were taken, a matching expression arrived at, and it was a joyous occasion and much optimism was expressed. The only problem was the methodology:

> **the button sizes in Explorer**

It turns out that Explorer uses *atypically small buttons* (...which also have slightly different sizes among themselves). Compare this (from wx code, matching Explorer, at 200%):

<img width="206" alt="Untitled" src="https://github.com/user-attachments/assets/33363354-e037-4ad0-9277-fb2f25f39ae4" />

to this (common file dialog at 200%):

<img width="210" alt="Screenshot 2025-04-05 at 12 49 23" src="https://github.com/user-attachments/assets/b5a3aca7-64c8-45d9-b671-0f73acacad6f" />

(This also shows why I care: win32 buttons have vertically misaligned labels and the smaller the button is, the more noticeable that is.)

So I went ahead to measure it, expecting to find the correct, non-Explorer size. That wasn't meant to be, see the following table. Note that I didn't bother to measure at >200% for reasons that will soon become apparent. This was done on current Windows 11, but I spot-checked some of the values against Windows 10 and they matched. Notice the sizes are 2px off  from #24283 measurements — I measured the visible size, i.e. including the blue border, but the actual control size is apparently indeed +2px. I measured "Explorer" column using the OK button in Properties; some other buttons there are slightly different, and some values were off compared to #24283; not sure why. I included native WinUI buttons for illustration, they appear to be simply 32pt.

Without further ado, let me present the results in pixels:

| Scale | Explorer / wx | *File dialog* | *Message box* | Run… dlg | WinUI | 24×scale (proposed) |
|----|-----------|-------------|--------------|------|-------|-----------|
| 100%          | 21          | 24           | 21   | 24    | 32        | 24.0 |
| 125%          | 26          | 31           | 27   | 33    | -         | 30.0 |
| 150%          | 33          | 37           | 35   | 42    | -         | 36.0 |
| 175%          | 40          | 44           | 41   | 51    | -         | 42.0 |
| 200%          | 42          | 50           | 46   | 54    | 64        | 48.0 |

That is to say, I found no less than four different "standard" sizes (not counting Explorer's deviations) and two different sizes within common dialogs!

I'm not gonna lie. That's when I threw in the towel and just applied this patch to Poedit to get more reasonable, but not-quite-native-sized buttons. It still doesn't match either file dialogs or message boxes,  but there's no hope of matching *both*, so picking a value that is easy to work with and is somewhere between the two seems reasonable. The difference is not going to be very noticeable at HiDPI.

I'm not sure if anything better can be done (probably) or what (no clue), but IMHO the common dialogs should be a reference point, not Explorer, because the are the ones commonly presented in the context of the same application as wxButton is.

P.S. wx-3.2 form needs to touch 2 places: https://github.com/poedit/wxWidgets/commit/6a2f29094de7c6b55e012558ec9d6353c92a1677