### PR TITLE
Fixes for wxGTK on macOS – 5 (utils_base.mm)

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -24,6 +24,10 @@
 #include "wx/osx/private.h"
 #include "wx/osx/private/available.h"
 
+#ifndef __WXOSX_IPHONE__
+#include <AppKit/AppKit.h>
+#endif
+
 #if wxUSE_SOCKETS
 // global pointer which lives in the base library, set from the net one (see
 // sockosx.cpp) and used from the GUI code (see utilsexc_cf.cpp) -- ugly but


### PR DESCRIPTION
@vadz This is the last fix I need on Sonoma to complete the build successfully. Here is the error which it addresses:

```
:info:build [ 21%] Building OBJCXX object libs/base/CMakeFiles/wxbase.dir/__/__/__/__/src/osx/core/uilocale.mm.o
:info:build cd /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/build/libs/base && /usr/bin/clang++ -DWXBUILDING -DWXDLLNAME=wx_baseu-3.3 -DWXMAKINGDLL_BASE -DWX_PRECOMP -D_FILE_OFFSET_BITS=64 -D_UNICODE -D__WXGTK3__ -D__WXGTK__ -DwxUSE_BASE=1 -DwxUSE_GUI=0 -Dwxbase_EXPORTS -I/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/build/lib/wx/include/gtk3-unicode-3.3 -I/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/include -x objective-c++ -pipe -Os -DNDEBUG -I/opt/local/include -I/opt/local/include -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk -std=gnu++11 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk -mmacosx-version-min=14.0 -fPIC -fvisibility-inlines-hidden -Wall -Wundef -Wunused-parameter -Wno-shorten-64-to-32 -Wno-ignored-attributes -Winvalid-pch -Xclang -include-pch -Xclang /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/build/libs/base/CMakeFiles/wxbase.dir/cmake_pch.objcxx.hxx.pch -Xclang -include -Xclang /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/build/libs/base/CMakeFiles/wxbase.dir/cmake_pch.objcxx.hxx -MD -MT libs/base/CMakeFiles/wxbase.dir/__/__/__/__/src/osx/core/uilocale.mm.o -MF CMakeFiles/wxbase.dir/__/__/__/__/src/osx/core/uilocale.mm.o.d -o CMakeFiles/wxbase.dir/__/__/__/__/src/osx/core/uilocale.mm.o -c /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/core/uilocale.mm
:info:build 7 warnings generated.
:info:build In file included from /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/cocoa/utils_base.mm:24:
:info:build In file included from /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/include/wx/osx/private.h:4:
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/include/wx/osx/core/private.h:42:22: warning: 'wxOSX_USE_IPHONE' is not defined, evaluates to 0 [-Wundef]
:info:build #if ( !wxUSE_GUI && !wxOSX_USE_IPHONE ) || wxOSX_USE_COCOA_OR_CARBON
:info:build                      ^
:info:build 3 warnings generated.
:info:build In file included from /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/cocoa/utils_base.mm:24:
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/include/wx/osx/private.h:6:5: warning: 'wxOSX_USE_IPHONE' is not defined, evaluates to 0 [-Wundef]
:info:build #if wxOSX_USE_IPHONE
:info:build     ^
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/include/wx/osx/private.h:8:7: warning: 'wxOSX_USE_COCOA' is not defined, evaluates to 0 [-Wundef]
:info:build #elif wxOSX_USE_COCOA
:info:build       ^
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/cocoa/utils_base.mm:225:5: error: unknown type name 'NSWorkspace'
:info:build     NSWorkspace *ws = [NSWorkspace sharedWorkspace];
:info:build     ^
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/cocoa/utils_base.mm:225:24: error: use of undeclared identifier 'NSWorkspace'
:info:build     NSWorkspace *ws = [NSWorkspace sharedWorkspace];
:info:build                        ^
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/cocoa/utils_base.mm:228:5: error: unknown type name 'NSRunningApplication'
:info:build     NSRunningApplication *app = nil;
:info:build     ^
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/cocoa/utils_base.mm:232:28: error: use of undeclared identifier 'NSWorkspaceLaunchAsync'
:info:build                    options:NSWorkspaceLaunchAsync
:info:build                            ^
:info:build /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-5bc736df13144800b64b034399d30a6111ee9cea/src/osx/cocoa/utils_base.mm:239:42: error: use of undeclared identifier 'NSWorkspaceLaunchAsync'
:info:build                                  options:NSWorkspaceLaunchAsync
:info:build                                          ^
:info:build 3 warnings and 5 errors generated.
:info:build make[2]: *** [libs/base/CMakeFiles/wxbase.dir/__/__/__/__/src/osx/cocoa/utils_base.mm.o] Error 1
:info:build make[2]: Leaving directory `/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/build'
:info:build make[1]: *** [libs/base/CMakeFiles/wxbase.dir/all] Error 2
:info:build make[1]: Leaving directory `/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_graphics_wxgtk-devel/wxgtk-devel/work/build'
:info:build make: *** [all] Error 2
```