### PR TITLE
Fixes for wxGTK on macOS – 6 (legacy macOS-specific)

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -33,9 +33,15 @@ extern WXDLLIMPEXP_BASE wxSocketManager *wxOSXSocketManagerCF;
 wxSocketManager *wxOSXSocketManagerCF = nullptr;
 #endif // wxUSE_SOCKETS
 
+#if (defined(__APPLE__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101000) \
+    || (defined(__WXOSX_IPHONE__) && defined(__IPHONE_8_0))
+    #define wxHAS_NSPROCESSINFO 1
+#endif
+
 // our OS version is the same in non GUI and GUI cases
 wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
+#if wxHAS_NSPROCESSINFO
     NSOperatingSystemVersion osVer = [NSProcessInfo processInfo].operatingSystemVersion;
 
     if ( verMaj != nullptr )
@@ -46,18 +52,42 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 
     if ( verMicro != nullptr )
         *verMicro = osVer.patchVersion;
+#else
+    SInt32 maj, min, micro;
 
+    Gestalt(gestaltSystemVersionMajor, &maj);
+    Gestalt(gestaltSystemVersionMinor, &min);
+    Gestalt(gestaltSystemVersionBugFix, &micro);
+
+    if ( verMaj != NULL )
+        *verMaj = maj;
+
+    if ( verMin != NULL )
+        *verMin = min;
+
+    if ( verMicro != NULL )
+        *verMicro = micro;
+#endif
     return wxOS_MAC_OSX_DARWIN;
 }
 
 bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 {
+#if wxHAS_NSPROCESSINFO
     NSOperatingSystemVersion osVer;
     osVer.majorVersion = majorVsn;
     osVer.minorVersion = minorVsn;
     osVer.patchVersion = microVsn;
 
     return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:osVer] != NO;
+#else
+    int majorCur, minorCur, microCur;
+    wxGetOsVersion(&majorCur, &minorCur, &microCur);
+
+    return majorCur > majorVsn
+        || (majorCur == majorVsn && minorCur >= minorVsn)
+        || (majorCur == majorVsn && minorCur == minorVsn && microCur >= microVsn);
+#endif
 }
 
 wxString wxGetOsDescription()
@@ -77,6 +107,25 @@ wxString wxGetOsDescription()
     {
         switch (minorVer)
         {
+            case 5:
+                osName = "Leopard";
+                osBrand = "Mac OS X";
+                break;
+            case 6:
+                osName = "Snow Leopard";
+                osBrand = "Mac OS X";
+                break;
+            case 7:
+                osName = "Lion";
+                // 10.7 was the last version where the "Mac" prefix was used
+                osBrand = "Mac OS X";
+                break;
+            case 8:
+                osName = "Mountain Lion";
+                break;
+            case 9:
+                osName = "Mavericks";
+                break;
             case 10:
                 osName = "Yosemite";
                 break;

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -148,6 +148,7 @@
 
 #if defined(__DARWIN__)
     #include <sys/sysctl.h>
+    #include <AvailabilityMacros.h>
 #endif
 
 // ----------------------------------------------------------------------------
@@ -223,7 +224,8 @@ void wxSecureZeroMemory(void* v, size_t n)
     // but may be found in a non-standard header file, or in a library that is
     // not linked by default.
     explicit_bzero(v, n);
-#elif defined(__DARWIN__) || defined(__STDC_LIB_EXT1__)
+#elif (defined(__DARWIN__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1090)) || \
+    defined(__STDC_LIB_EXT1__)
     // memset_s() is available since OS X 10.9, and may be available on
     // other platforms.
     memset_s(v, n, 0, n);


### PR DESCRIPTION
@vadz Together with a switch to generic Unix uilocale and a fix for the headers – i.e. https://github.com/wxWidgets/wxWidgets/pull/25291 PR but without `stdpaths` change – this is all that is needed for the build to succeed on 10.6.
(This is on top of patches to support modern macOS, of course.)

P. S. The code in `utils_base` is largely restored from here itself, see https://github.com/wxWidgets/wxWidgets/commit/199a3f51ef2e6f4e99d0fdea410463ccda49fce2 (where it was removed). Since we do not build Cocoa here, the rest of those fallbacks are irrelevant.