### PR TITLE
Fix padding of `wxMenu` in high DPI under Windows 11

### DIFF
--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -857,9 +857,11 @@ HandleMenuMessage(WXLRESULT* result,
         case WM_MENUBAR_MEASUREMENUITEM:
             if ( auto* const measureMenuItem = (MenuBarMeasureMenuItem*)lParam )
             {
-                // We only need to handle this message for a workaround when
-                // using non-standard DPI.
-                if ( !(w->GetDPIScaleFactor() > 1.0) )
+                // We only need to handle this message to work around the
+                // incorrect behavior of the native control not scaling its
+                // padding at high DPI, which is fixed in Windows 11.
+                if ( !(wxGetWinVersion() <= wxWinVersion_10 &&
+                       w->GetDPIScaleFactor() > 1.0) )
                     break;
 
                 MEASUREITEMSTRUCT& mis = measureMenuItem->mis;


### PR DESCRIPTION
Don't use the workaround introduced in f6e31dab421a4c7c44f6b8423477e2419724a231 (Improve padding of wxMenu and wxMenuItem in high DPI under MSW, 2025-01-24) any longer under Windows 11. The incorrect behavior of the native control has been fixed there.

See #25117.