### PR TITLE
Remove obsolete assert about menuitem ID zero on Mac

### DIFF
--- a/src/osx/menuitem_osx.cpp
+++ b/src/osx/menuitem_osx.cpp
@@ -36,8 +36,6 @@ wxMenuItem::wxMenuItem(wxMenu *pParentMenu,
                        wxMenu *pSubMenu)
            :wxMenuItemBase(pParentMenu, id, t, strHelp, kind, pSubMenu)
 {
-    wxASSERT_MSG( id != 0 || pSubMenu != nullptr , wxT("A MenuItem ID of Zero does not work under Mac") ) ;
-
     // In other languages there is no difference in naming the Exit/Quit menu item between MacOS and Windows guidelines
     // therefore these item must not be translated
     if (pParentMenu != nullptr && !pParentMenu->GetNoEventsMode())


### PR DESCRIPTION
The assert, introduced in 524c47a (osx new layout, 2008-09-02), says that menuitem ID zero does not work on Mac, yet empirically it seems to work just fine.

If it really doesn't work, then this assert should be present in all other ports too, to help writing portable code.