### PR TITLE
Define ssize_t under Win32 in the same way as the platform SDK

### DIFF
--- a/include/wx/types.h
+++ b/include/wx/types.h
@@ -316,7 +316,14 @@ typedef wxULongLong_t wxUint64;
         #include <sys/types.h>
     #endif
 #else /* !HAVE_SSIZE_T */
-    #if SIZEOF_SIZE_T == 4
+    /* Under Windows use definitions compatible with SSIZE_T in windows.h */
+    #ifdef __WINDOWS__
+        #ifdef __WIN64__
+            typedef __int64 ssize_t;
+        #else
+            typedef long ssize_t;
+        #endif
+    #elif SIZEOF_SIZE_T == 4
         typedef wxInt32 ssize_t;
     #elif SIZEOF_SIZE_T == 8
         typedef wxInt64 ssize_t;


### PR DESCRIPTION
For compatibility with the other libraries, define ssize_t in the same way as SSIZE_T is defined in the platform headers: this was also true for Win64, but for Win32 we defined ssize_t as int while everybody else defined it as long, so do it too now.

Closes #25309.