### PR TITLE
Add "@USER@" macro to HTML and RichText printers

### DIFF
--- a/interface/wx/html/htmprint.h
+++ b/interface/wx/html/htmprint.h
@@ -325,7 +325,7 @@ public:
          - @@PAGESCNT@ is replaced by total number of pages
          - @@TIME@ is replaced by the current time in default format
          - @@TITLE@ is replaced with the title of the document
-         - @@USER@@: is replaced with the user's name.
+         - @@USER@: is replaced with the user's name.
 
         @param footer
             HTML text to be used as footer.

--- a/interface/wx/html/htmprint.h
+++ b/interface/wx/html/htmprint.h
@@ -320,11 +320,12 @@ public:
 
     /**
         Set page footer. The following macros can be used inside it:
-         @@DATE@ is replaced by the current date in default format
-         @@PAGENUM@ is replaced by page number
-         @@PAGESCNT@ is replaced by total number of pages
-         @@TIME@ is replaced by the current time in default format
-         @@TITLE@ is replaced with the title of the document
+         - @@DATE@ is replaced by the current date in default format
+         - @@PAGENUM@ is replaced by page number
+         - @@PAGESCNT@ is replaced by total number of pages
+         - @@TIME@ is replaced by the current time in default format
+         - @@TITLE@ is replaced with the title of the document
+         - @@USER@@: is replaced with the user's name.
 
         @param footer
             HTML text to be used as footer.
@@ -340,6 +341,7 @@ public:
         - @@PAGESCNT@ is replaced by total number of pages
         - @@TIME@ is replaced by the current time in default format
         - @@TITLE@ is replaced with the title of the document
+        - @@USER@@: is replaced with the user's name.
 
         @param header
             HTML text to be used as header.
@@ -447,6 +449,7 @@ public:
         - @@PAGESCNT@ is replaced by total number of pages
         - @@TIME@ is replaced by the current time in default format
         - @@TITLE@ is replaced with the title of the document
+        - @@USER@@: is replaced with the user's name.
 
         @param footer
             HTML text to be used as footer.
@@ -462,6 +465,7 @@ public:
         - @@PAGESCNT@ is replaced by total number of pages
         - @@TIME@ is replaced by the current time in default format
         - @@TITLE@ is replaced with the title of the document
+        - @@USER@@: is replaced with the user's name.
 
         @param header
             HTML text to be used as header.

--- a/interface/wx/html/htmprint.h
+++ b/interface/wx/html/htmprint.h
@@ -325,7 +325,7 @@ public:
          - @@PAGESCNT@ is replaced by total number of pages
          - @@TIME@ is replaced by the current time in default format
          - @@TITLE@ is replaced with the title of the document
-         - @@USER@: is replaced with the user's name.
+         - @@USER@ is replaced with the user's name.
 
         @param footer
             HTML text to be used as footer.
@@ -341,7 +341,7 @@ public:
         - @@PAGESCNT@ is replaced by total number of pages
         - @@TIME@ is replaced by the current time in default format
         - @@TITLE@ is replaced with the title of the document
-        - @@USER@@: is replaced with the user's name.
+        - @@USER@ is replaced with the user's name.
 
         @param header
             HTML text to be used as header.
@@ -449,7 +449,7 @@ public:
         - @@PAGESCNT@ is replaced by total number of pages
         - @@TIME@ is replaced by the current time in default format
         - @@TITLE@ is replaced with the title of the document
-        - @@USER@@: is replaced with the user's name.
+        - @@USER@ is replaced with the user's name.
 
         @param footer
             HTML text to be used as footer.
@@ -465,7 +465,7 @@ public:
         - @@PAGESCNT@ is replaced by total number of pages
         - @@TIME@ is replaced by the current time in default format
         - @@TITLE@ is replaced with the title of the document
-        - @@USER@@: is replaced with the user's name.
+        - @@USER@ is replaced with the user's name.
 
         @param header
             HTML text to be used as header.

--- a/interface/wx/richtext/richtextprint.h
+++ b/interface/wx/richtext/richtextprint.h
@@ -50,6 +50,7 @@ enum wxRichTextPageLocation {
     - @@TIME@@: the current time.
     - @@TITLE@@: the title of the document, as passed to the wxRichTextPrinting or
       wxRichTextLayout constructor.
+    - @@USER@@: the user's name.
 
     @library{wxrichtext}
     @category{richtext}

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -574,6 +574,8 @@ wxString wxHtmlPrintout::TranslateHeader(const wxString& instr, int page)
     r.Replace("@TIME@", wxEmptyString);
 #endif
 
+    r.Replace("@USER@", wxGetUserName());
+
     r.Replace("@TITLE@", GetTitle());
 
     return r;

--- a/src/richtext/richtextprint.cpp
+++ b/src/richtext/richtextprint.cpp
@@ -434,6 +434,8 @@ bool wxRichTextPrintout::SubstituteKeywords(wxString& str, const wxString& title
     str.Replace(wxT("@TIME@"), wxEmptyString);
 #endif
 
+    str.Replace("@USER@", wxGetUserName());
+
     str.Replace(wxT("@TITLE@"), title);
 
     return true;


### PR DESCRIPTION
Adding `@USER@` to your header or footer with `wxHtmlEasyPrinting` or `wxRichTextPrintout` will now expand to the current user name. For example, `"Printed by @USER@ on @DATE@"` could expand to something like `"Printed by bmadden on 04/11/2025"`.

Also, minor formatting fix in interface documentation.