### PR TITLE
Document using MSBuild for building, not nmake

### DIFF
--- a/docs/doxygen/mainpages/samples.h
+++ b/docs/doxygen/mainpages/samples.h
@@ -35,16 +35,15 @@ and often it is even more useful to experiment by making a small change to a
 sample and checking how it works when running the sample.
 
 Before being able to run them, you need to be able build the sample you're
-interested in. The right way to do it depends on the way you built wxWidgets
-itself (see @ref overview_install for more details):
+interested in. The way to do it depends on the way you built wxWidgets itself
+(see @ref overview_install for more details):
 
 - Under Microsoft Windows (MSW):
-    - If you're using Microsoft Visual C++ compiler (MSVC), you need to
-    use @c makefile.vc from the directory of the sample to build it. Open
-    "Developer Command Prompt", navigate to the sample directory and run
-    <code>nmake -f makefile.vc</code> command with the additional arguments
-    corresponding to your library build, e.g. @c BUILD=debug. See @ref
-    msw_build_msvs "MSVS instructions" for more information.
+    - If you're using Microsoft Visual C++ compiler (MSVC), open the provided
+    `samples/samples_vc17.sln` project (which uses MSVS 2022, solution files
+    for MSVS 2019, 2017 and 2015 are also available in the same directory) and
+    build the sample you are interested in using the context menu in the
+    Solution Explorer.
     - If you're using MinGW, use @c makefile.gcc in the sample directory in a
     similar way. Note that if you use MSYS2 or another Unix-like environment
     for building, you should use the Unix instructions below instead.

--- a/docs/msw/binaries.md
+++ b/docs/msw/binaries.md
@@ -55,12 +55,3 @@ executables will require wxWidgets DLLs in addition to MSVC run-time DLLs, so
 you should consider adding the directory containing these DLLs to your PATH and
 either distributing them with your application or instructing your users to
 download them.
-
-Building samples with nmake
----------------------------
-
-When using `makefile.vc` files for building wxWidgets samples using `nmake`
-from command line, you need to use `SHARED=1` and also define `COMPILER_PREFIX`
-appropriately, e.g. the full command line could be
-
-    > nmake /f makefile.vc BUILD=release SHARED=1 COMPILER_PREFIX=vc14x

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -77,25 +77,32 @@ by MSVS installation.
 
 In this window, change directory to `%%WXWIN%\build\msw` and type
 
+        > msbuild /m /p:Configuration=Debug /p:Platform=x64 wx_vc17.sln
+
+to build wxWidgets in the debug configuration as a static library using MSVS
+2022 (MSVC 17) toolset. Use "Release" configuration instead of "Debug" for the
+release version build and `wx_vc14.sln`, `wx_vc15.sln` or `wx_vc16.sln` for
+MSVS 2015, 2017 or 2019 respectively.
+
+After the build completes, open `%%WXWIN%\samples\samples_vc17.sln` solution
+and try building and running the minimal sample to verify that your build is
+functional.
+
+
+### From the command line using nmake (legacy)
+
+Note that using MSBuild is strongly recommended, as it can use multiple
+processors for building, resulting in significant speedup, but it is also
+possible to use `nmake` with the provided makefiles. For example, use
+
         > nmake /f makefile.vc
 
 to build wxWidgets in the default debug configuration as a static library. You
-can also do
+can specify `BUILD=release`, `SHARED=1` and `TARGET_CPU=X86` to choose the
+release, DLL and 32-bit builds respectively.
 
-        > nmake /f makefile.vc BUILD=release
-
-to build a release version or
-
-        > nmake /f makefile.vc BUILD=release SHARED=1 TARGET_CPU=X86
-
-to build a 32 bit release DLL version from an x86 command prompt, or
-
-        > nmake /f makefile.vc BUILD=release SHARED=1 TARGET_CPU=X64
-
-to build a 64 bit release DLL version from an x64 command prompt.
-
-TARGET_CPU=ARM64 is supported while TARGET_CPU=ARM64EC is, at present, not
-supported.
+Note that `TARGET_CPU=ARM64` is supported while `TARGET_CPU=ARM64EC` is, at
+present, not supported here.
 
 See [Make Parameters](#msw_build_make_params) for more information about the
 additional parameters that can be specified on the command line.


### PR DESCRIPTION
MSBuild is strongly recommended, as it's much faster (and will also remain supported, unlike nmake).

Closes #24830.

----

I've done the strict minimum here, but it's better than nothing...