### PR TITLE
Format page numbers with thousands separators when printing

### DIFF
--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -29,6 +29,7 @@
 #include "wx/wxhtml.h"
 #include "wx/wfstream.h"
 #include "wx/infobar.h"
+#include "wx/numformatter.h"
 
 
 // default font size of normal text (HTML font size 0) for printing, in points:
@@ -557,13 +558,14 @@ void wxHtmlPrintout::RenderPage(wxDC *dc, int page)
 wxString wxHtmlPrintout::TranslateHeader(const wxString& instr, int page)
 {
     wxString r = instr;
-    wxString num;
 
-    num.Printf("%i", page);
-    r.Replace("@PAGENUM@", num);
+    r.Replace("@PAGENUM@",
+        wxNumberFormatter::ToString(page, 0,
+            wxNumberFormatter::Style::Style_WithThousandsSep));
 
-    num.Printf("%zu", m_PageBreaks.size() - 1);
-    r.Replace("@PAGESCNT@", num);
+    r.Replace("@PAGESCNT@",
+        wxNumberFormatter::ToString(m_PageBreaks.empty() ? 1 : m_PageBreaks.size() - 1, 0,
+            wxNumberFormatter::Style::Style_WithThousandsSep));
 
 #if wxUSE_DATETIME
     const wxDateTime now = wxDateTime::Now();

--- a/src/richtext/richtextprint.cpp
+++ b/src/richtext/richtextprint.cpp
@@ -26,6 +26,7 @@
 #include "wx/printdlg.h"
 #include "wx/richtext/richtextprint.h"
 #include "wx/wfstream.h"
+#include "wx/numformatter.h"
 
 /*!
  * wxRichTextPrintout
@@ -416,16 +417,16 @@ void wxRichTextPrintout::CalculateScaling(wxDC* dc, wxRect& textRect, wxRect& he
 
 bool wxRichTextPrintout::SubstituteKeywords(wxString& str, const wxString& title, int pageNum, int pageCount)
 {
-    wxString num;
+    str.Replace("@PAGENUM@",
+        wxNumberFormatter::ToString(pageNum, 0,
+            wxNumberFormatter::Style::Style_WithThousandsSep));
 
-    num.Printf(wxT("%i"), pageNum);
-    str.Replace(wxT("@PAGENUM@"), num);
-
-    num.Printf(wxT("%lu"), (unsigned long) pageCount);
-    str.Replace(wxT("@PAGESCNT@"), num);
+    str.Replace("@PAGESCNT@",
+        wxNumberFormatter::ToString(pageCount, 0,
+            wxNumberFormatter::Style::Style_WithThousandsSep));
 
 #if wxUSE_DATETIME
-    wxDateTime now = wxDateTime::Now();
+    const wxDateTime now = wxDateTime::Now();
 
     str.Replace(wxT("@DATE@"), now.FormatDate());
     str.Replace(wxT("@TIME@"), now.FormatTime());


### PR DESCRIPTION
Applies to `wxHtmlPrintout` and `wxRichTextPrintout`.

Also, add `const` and pages count size check. I noticed the first time `wxHtmlPrintout::TranslateHeader` is called from the html printing sample, the page breaks are empty and the page count would be formatted to an enormous value.