### PR TITLE
Fixes for wxGTK on macOS – 7 (minor fix to Carbon headers parsing on powerpc)

### DIFF
--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -12,6 +12,12 @@
 #ifndef _WX_PRIVATE_CORE_H_
 #define _WX_PRIVATE_CORE_H_
 
+// Without this MachineExceptions.h of CarbonCore cannot be parsed
+// when C++11 or higher standard is used.
+#ifdef __APPLE_ALTIVEC__
+#undef __APPLE_ALTIVEC__
+#endif
+
 #include "wx/defs.h"
 
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
@vadz Could we tolerate an additional minor fix?

This is the error being addressed:
```
In file included from /opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:4,
                 from /opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/src/osx/cocoa/[utils_base.mm:24](http://utils_base.mm:24/):
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/core/private.h:42:22: warning: "wxOSX_USE_IPHONE" is not defined, evaluates to 0 [-Wundef]
   42 | #if ( !wxUSE_GUI && !wxOSX_USE_IPHONE ) || wxOSX_USE_COCOA_OR_CARBON
      |                      ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:6:5: warning: "wxOSX_USE_IPHONE" is not defined, evaluates to 0 [-Wundef]
    6 | #if wxOSX_USE_IPHONE
      |     ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:8:7: warning: "wxOSX_USE_COCOA" is not defined, evaluates to 0 [-Wundef]
    8 | #elif wxOSX_USE_COCOA
      |       ^~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:6:5: warning: "wxOSX_USE_IPHONE" is not defined, evaluates to 0 [-Wundef]
    6 | #if wxOSX_USE_IPHONE
      |     ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:8:7: warning: "wxOSX_USE_COCOA" is not defined, evaluates to 0 [-Wundef]
    8 | #elif wxOSX_USE_COCOA
      |       ^~~~~~~~~~~~~~~
/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/MachineExceptions.h:115:4: error: 'vector' does not name a type
  115 |    vector unsigned int         v;
      |    ^~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:6:5: warning: "wxOSX_USE_IPHONE" is not defined, evaluates to 0 [-Wundef]
    6 | #if wxOSX_USE_IPHONE
      |     ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:8:7: warning: "wxOSX_USE_COCOA" is not defined, evaluates to 0 [-Wundef]
    8 | #elif wxOSX_USE_COCOA
      |       ^~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/src/osx/cocoa/utils_base.mm:44:5: warning: "wxHAS_NSPROCESSINFO" is not defined, evaluates to 0 [-Wundef]
   44 | #if wxHAS_NSPROCESSINFO
      |     ^~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/src/osx/cocoa/utils_base.mm:76:5: warning: "wxHAS_NSPROCESSINFO" is not defined, evaluates to 0 [-Wundef]
   76 | #if wxHAS_NSPROCESSINFO
      |     ^~~~~~~~~~~~~~~~~~~
/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/MachineExceptions.h:115:4: error: 'vector' does not name a type
  115 |    vector unsigned int         v;
      |    ^~~~~~
/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/MachineExceptions.h:115:4: error: 'vector' does not name a type
  115 |    vector unsigned int         v;
      |    ^~~~~~
```
This header is included in multiple files, including ones which are required for wxGTK.

So far I was solving this issue by passing `-U__APPLE_ALTIVEC__` flag to CMake. However, I think it is worth actually fixing this in the source, since a) there is not reason to use this for the whole build, when it is needed in a single file, and b) it is non-trivial, and if anyone runs into this problem, they may have a hard time finding the solution.

P. S. While the issue appears to be the same as in https://trac.macports.org/ticket/55251 – solution proposed there does not work in this case – compilation with `-faltivec` fails identically.
```
[ 18%] Building OBJCXX object libs/base/CMakeFiles/wxbase.dir/__/__/__/__/src/osx/cocoa/utils_base.mm.o
cd /opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/build/libs/base && /opt/local/bin/g++-mp-14 -DWXBUILDING -DWXDLLNAME=wx_baseu-3.3 -DWXMAKINGDLL_BASE -DWX_PRECOMP -D_FILE_OFFSET_BITS=64 -D_UNICODE -D__WXGTK3__ -D__WXGTK__ -DwxUSE_BASE=1 -DwxUSE_GUI=0 -Dwxbase_EXPORTS -I/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/build/lib/wx/include/gtk3-unicode-3.3 -I/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include -x objective-c++ -pipe -Os -F/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks -faltivec -DNDEBUG -isystem/opt/local/include/LegacySupport -I/opt/local/include -isystem/opt/local/include/LegacySupport -I/opt/local/include -D_GLIBCXX_USE_CXX11_ABI=0 -arch ppc -mmacosx-version-min=10.6 -fPIC -fvisibility-inlines-hidden -Wall -Wundef -Wunused-parameter -Wno-shorten-64-to-32 -Winvalid-pch -include /opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/build/libs/base/CMakeFiles/wxbase.dir/cmake_pch.objcxx.hxx -MD -MT libs/base/CMakeFiles/wxbase.dir/__/__/__/__/src/osx/cocoa/utils_base.mm.o -MF CMakeFiles/wxbase.dir/__/__/__/__/src/osx/cocoa/utils_base.mm.o.d -o CMakeFiles/wxbase.dir/__/__/__/__/src/osx/cocoa/utils_base.mm.o -c /opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/src/osx/cocoa/[utils_base.mm](http://utils_base.mm/)
In file included from /opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:4,
                 from /opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/src/osx/cocoa/[utils_base.mm:24](http://utils_base.mm:24/):
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/core/private.h:42:22: warning: "wxOSX_USE_IPHONE" is not defined, evaluates to 0 [-Wundef]
   42 | #if ( !wxUSE_GUI && !wxOSX_USE_IPHONE ) || wxOSX_USE_COCOA_OR_CARBON
      |                      ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:6:5: warning: "wxOSX_USE_IPHONE" is not defined, evaluates to 0 [-Wundef]
    6 | #if wxOSX_USE_IPHONE
      |     ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:8:7: warning: "wxOSX_USE_COCOA" is not defined, evaluates to 0 [-Wundef]
    8 | #elif wxOSX_USE_COCOA
      |       ^~~~~~~~~~~~~~~
/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/MachineExceptions.h:115:4: error: 'vector' does not name a type
  115 |    vector unsigned int         v;
      |    ^~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:6:5: warning: "wxOSX_USE_IPHONE" is not defined, evaluates to 0 [-Wundef]
    6 | #if wxOSX_USE_IPHONE
      |     ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/include/wx/osx/private.h:8:7: warning: "wxOSX_USE_COCOA" is not defined, evaluates to 0 [-Wundef]
    8 | #elif wxOSX_USE_COCOA
      |       ^~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/src/osx/cocoa/utils_base.mm:44:5: warning: "wxHAS_NSPROCESSINFO" is not defined, evaluates to 0 [-Wundef]
   44 | #if wxHAS_NSPROCESSINFO
      |     ^~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_local_ppcports_graphics_wxgtk-devel/wxgtk-devel/work/wxWidgets-99f77b47e91b1aa4860d9ff09fd959c9c91f854a/src/osx/cocoa/utils_base.mm:76:5: warning: "wxHAS_NSPROCESSINFO" is not defined, evaluates to 0 [-Wundef]
   76 | #if wxHAS_NSPROCESSINFO
      |     ^~~~~~~~~~~~~~~~~~~
cc1plus: note: unrecognized command-line option '-Wno-shorten-64-to-32' may have been intended to silence earlier diagnostics
make[2]: *** [libs/base/CMakeFiles/wxbase.dir/__/__/__/__/src/osx/core/evtloop_cf.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/MachineExceptions.h:115:4: error: 'vector' does not name a type
  115 |    vector unsigned int         v;
      |    ^~~~~~
```