### PR TITLE
Add wxSsize() and use it in the code

### DIFF
--- a/include/wx/cmndata.h
+++ b/include/wx/cmndata.h
@@ -104,7 +104,7 @@ public:
 
     char* GetPrivData() { return m_privData.empty() ? nullptr : &m_privData[0]; }
     const char* GetPrivData() const { return m_privData.empty() ? nullptr : &m_privData[0]; }
-    int GetPrivDataLen() const { return static_cast<int>(m_privData.size()); }
+    int GetPrivDataLen() const { return wxSsize(m_privData); }
     void SetPrivData( char *privData, int len );
 
 

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -346,6 +346,13 @@ typedef short int WXTYPE;
 /* for consistency with wxStatic/DynamicCast defined in wx/object.h */
 #define wxConstCast(obj, className) const_cast<className *>(obj)
 
+/* Poor man's version of C++20 std::ssize(). */
+template <class C>
+int wxSsize(const C& c)
+{
+    return static_cast<int>(c.size());
+}
+
 #endif /* __cplusplus */
 
 /* provide replacement for C99 va_copy() if the compiler doesn't have it */

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1459,7 +1459,7 @@ public:
 
     // these are pure virtual in wxGridTableBase
     //
-    virtual int GetNumberRows() override { return static_cast<int>(m_data.size()); }
+    virtual int GetNumberRows() override { return wxSsize(m_data); }
     virtual int GetNumberCols() override { return m_numCols; }
     virtual wxString GetValue( int row, int col ) override;
     virtual void SetValue( int row, int col, const wxString& s ) override;

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1411,7 +1411,7 @@ private:
         });
 
         int i = 0;
-        const int n = static_cast<int>(points.size());
+        const int n = wxSsize(points);
 
         while ( i < n )
         {
@@ -1432,7 +1432,7 @@ private:
         std::sort(sortedPointsX.begin(), sortedPointsX.end(), wxPointCmp{});
 
         int i = 0;
-        const int n = static_cast<int>(points.size());
+        const int n = wxSsize(points);
 
         while ( i < n )
         {

--- a/include/wx/headerctrl.h
+++ b/include/wx/headerctrl.h
@@ -369,7 +369,7 @@ private:
     // bring the column count in sync with the number of columns we store
     void UpdateColumnCount()
     {
-        SetColumnCount(static_cast<int>(m_cols.size()));
+        SetColumnCount(wxSsize(m_cols));
     }
 
 

--- a/include/wx/statusbr.h
+++ b/include/wx/statusbr.h
@@ -128,7 +128,7 @@ public:
     // set the number of fields and call SetStatusWidths(widths) if widths are
     // given
     virtual void SetFieldsCount(int number = 1, const int *widths = nullptr);
-    int GetFieldsCount() const { return static_cast<int>(m_panes.size()); }
+    int GetFieldsCount() const { return wxSsize(m_panes); }
 
     // field text
     // ----------

--- a/include/wx/withimages.h
+++ b/include/wx/withimages.h
@@ -49,7 +49,7 @@ public:
         if ( !m_images.empty() )
         {
             // Cast is safe, we don't risk having more than INT_MAX images.
-            return static_cast<int>(m_images.size());
+            return wxSsize(m_images);
         }
 
         return m_imageList ? m_imageList->GetImageCount() : 0;

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1870,6 +1870,19 @@ template <typename T> void wxDELETEA(T*& array);
 #define wxWARN_UNUSED __attribute__((warn_unused))
 
 /**
+    Return the size of the container as int.
+
+    This is similar to C++20 std::ssize() but can be used even even when not
+    using C++20 (if you do use it, please use the standard function).
+
+    @header{wx/defs.h}
+
+    @since 3.3.0
+ */
+template <class C>
+int wxSsize(const C& c);
+
+/**
     Swaps the contents of two variables.
 
     This is similar to std::swap() but can be used even on the platforms where

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -4527,7 +4527,7 @@ wxAuiNotebook::LoadLayout(const wxString& name,
     }
 
     // Check if there were any existing pages not added to any tab control.
-    if ( !useExistingPages && static_cast<int>(addedPages.size()) < pageCount )
+    if ( !useExistingPages && wxSsize(addedPages) < pageCount )
     {
         // Use a stack here to remove the pages from the end below.
         std::stack<int> toRemove;

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -1165,7 +1165,7 @@ void* wxWebViewChromium::GetNativeBackend() const
 bool wxWebViewChromium::CanGoForward() const
 {
     if ( m_historyEnabled )
-        return m_historyPosition != static_cast<int>(m_historyList.size()) - 1;
+        return m_historyPosition != wxSsize(m_historyList) - 1;
     else
         return false;
 }
@@ -1187,8 +1187,7 @@ void wxWebViewChromium::LoadHistoryItem(wxSharedPtr<wxWebViewHistoryItem> item)
         if(m_historyList[i].get() == item.get())
             pos = i;
     }
-    wxASSERT_MSG(pos != static_cast<int>(m_historyList.size()),
-                 "invalid history item");
+    wxASSERT_MSG(pos != wxSsize(m_historyList), "invalid history item");
     m_historyLoadingFromList = true;
     LoadURL(item->GetUrl());
     m_historyPosition = pos;
@@ -1211,7 +1210,7 @@ wxVector<wxSharedPtr<wxWebViewHistoryItem> > wxWebViewChromium::GetForwardHistor
     wxVector<wxSharedPtr<wxWebViewHistoryItem> > forwardhist;
     //As we don't have std::copy or an iterator constructor in the wxwidgets
     //native vector we construct it by hand
-    for ( int i = m_historyPosition + 1; i < static_cast<int>(m_historyList.size()); i++ )
+    for ( int i = m_historyPosition + 1; i < wxSsize(m_historyList); i++ )
     {
         forwardhist.push_back(m_historyList[i]);
     }
@@ -1779,7 +1778,7 @@ void ClientHandler::OnLoadEnd(CefRefPtr<CefBrowser> WXUNUSED(browser),
         {
             //If we are not at the end of the list, then erase everything
             //between us and the end before adding the new page
-            if ( m_webview.m_historyPosition != static_cast<int>(m_webview.m_historyList.size()) - 1 )
+            if ( m_webview.m_historyPosition != wxSsize(m_webview.m_historyList) - 1 )
             {
                 m_webview.m_historyList.erase(m_webview.m_historyList.begin() + m_webview.m_historyPosition + 1,
                                               m_webview.m_historyList.end());

--- a/src/generic/imaglist.cpp
+++ b/src/generic/imaglist.cpp
@@ -55,7 +55,7 @@ int wxGenericImageList::GetImageCount() const
 {
     wxASSERT_MSG( m_size != wxSize(0, 0), "Invalid image list" );
 
-    return static_cast<int>(m_images.size());
+    return wxSsize(m_images);
 }
 
 bool wxGenericImageList::Create( int width, int height, bool mask, int WXUNUSED(initialCount) )

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -668,7 +668,7 @@ HRESULT wxWebViewEdgeImpl::OnNavigationCompleted(ICoreWebView2* WXUNUSED(sender)
         {
             // If we are not at the end of the list, then erase everything
             // between us and the end before adding the new page
-            if (m_historyPosition != static_cast<int>(m_historyList.size()) - 1)
+            if (m_historyPosition != wxSsize(m_historyList) - 1)
             {
                 m_historyList.erase(m_historyList.begin() + m_historyPosition + 1,
                     m_historyList.end());
@@ -1145,7 +1145,7 @@ void wxWebViewEdge::LoadHistoryItem(wxSharedPtr<wxWebViewHistoryItem> item)
         if (m_impl->m_historyList[i].get() == item.get())
             pos = i;
     }
-    wxASSERT_MSG(pos != static_cast<int>(m_impl->m_historyList.size()), "invalid history item");
+    wxASSERT_MSG(pos != wxSsize(m_impl->m_historyList), "invalid history item");
     m_impl->m_historyLoadingFromList = true;
     LoadURL(item->GetUrl());
     m_impl->m_historyPosition = pos;
@@ -1168,7 +1168,7 @@ wxVector<wxSharedPtr<wxWebViewHistoryItem> > wxWebViewEdge::GetForwardHistory()
     wxVector<wxSharedPtr<wxWebViewHistoryItem> > forwardhist;
     //As we don't have std::copy or an iterator constructor in the wxwidgets
     //native vector we construct it by hand
-    for (int i = m_impl->m_historyPosition + 1; i < static_cast<int>(m_impl->m_historyList.size()); i++)
+    for (int i = m_impl->m_historyPosition + 1; i < wxSsize(m_impl->m_historyList); i++)
     {
         forwardhist.push_back(m_impl->m_historyList[i]);
     }
@@ -1178,7 +1178,7 @@ wxVector<wxSharedPtr<wxWebViewHistoryItem> > wxWebViewEdge::GetForwardHistory()
 bool wxWebViewEdge::CanGoForward() const
 {
     if (m_impl->m_historyEnabled)
-        return m_impl->m_historyPosition != static_cast<int>(m_impl->m_historyList.size()) - 1;
+        return m_impl->m_historyPosition != wxSsize(m_impl->m_historyList) - 1;
     else
         return false;
 }

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -576,8 +576,7 @@ bool wxWebViewIE::CanGoBack() const
 bool wxWebViewIE::CanGoForward() const
 {
     if(m_impl->m_historyEnabled)
-        return m_impl->m_historyPosition !=
-               static_cast<int>(m_impl->m_historyList.size()) - 1;
+        return m_impl->m_historyPosition != wxSsize(m_impl->m_historyList) - 1;
     else
         return false;
 }
@@ -591,8 +590,7 @@ void wxWebViewIE::LoadHistoryItem(wxSharedPtr<wxWebViewHistoryItem> item)
         if(m_impl->m_historyList[i].get() == item.get())
             pos = i;
     }
-    wxASSERT_MSG(pos != static_cast<int>(m_impl->m_historyList.size()),
-                 "invalid history item");
+    wxASSERT_MSG(pos != wxSsize(m_impl->m_historyList), "invalid history item");
     m_impl->m_historyLoadingFromList = true;
     LoadURL(item->GetUrl());
     m_impl->m_historyPosition = pos;
@@ -615,7 +613,7 @@ wxVector<wxSharedPtr<wxWebViewHistoryItem> > wxWebViewIE::GetForwardHistory()
     wxVector<wxSharedPtr<wxWebViewHistoryItem> > forwardhist;
     //As we don't have std::copy or an iterator constructor in the wxwidgets
     //native vector we construct it by hand
-    for(int i = m_impl->m_historyPosition + 1; i < static_cast<int>(m_impl->m_historyList.size()); i++)
+    for(int i = m_impl->m_historyPosition + 1; i < wxSsize(m_impl->m_historyList); i++)
     {
         forwardhist.push_back(m_impl->m_historyList[i]);
     }
@@ -1482,7 +1480,7 @@ void wxWebViewIE::onActiveXEvent(wxActiveXEvent& evt)
             {
                 //If we are not at the end of the list, then erase everything
                 //between us and the end before adding the new page
-                if(m_impl->m_historyPosition != static_cast<int>(m_impl->m_historyList.size()) - 1)
+                if(m_impl->m_historyPosition != wxSsize(m_impl->m_historyList) - 1)
                 {
                     m_impl->m_historyList.erase(m_impl->m_historyList.begin() + m_impl->m_historyPosition + 1,
                                                 m_impl->m_historyList.end());

--- a/src/propgrid/advprops.cpp
+++ b/src/propgrid/advprops.cpp
@@ -1811,7 +1811,7 @@ wxString wxCursorProperty::ValueToString(wxVariant& value, wxPGPropValFormatFlag
 wxSize wxCursorProperty::OnMeasureImage( int item ) const
 {
 #if wxPG_CAN_DRAW_CURSOR
-    if ( item != -1 && item < static_cast<int>(gs_cp_es_syscursors_values.size()) )
+    if ( item != -1 && item < wxSsize(gs_cp_es_syscursors_values) )
         return wxSize(wxPG_CURSOR_IMAGE_WIDTH,wxPG_CURSOR_IMAGE_WIDTH);
 #else
     wxUnusedVar(item);
@@ -1832,7 +1832,7 @@ void wxCursorProperty::OnCustomPaint( wxDC& dc,
     {
         dc.DrawRectangle( rect );
 
-        if ( paintdata.m_choiceItem < static_cast<int>(gs_cp_es_syscursors_values.size()) )
+        if ( paintdata.m_choiceItem < wxSsize(gs_cp_es_syscursors_values) )
         {
             wxStockCursor cursorIndex =
                 (wxStockCursor) gs_cp_es_syscursors_values[paintdata.m_choiceItem];

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -160,14 +160,14 @@ public:
         if ( parent.isValid() )
             return 0;
 
-        return static_cast<int>(m_rows.size());
+        return wxSsize(m_rows);
     }
     int columnCount(const QModelIndex& parent = QModelIndex()) const override
     {
         if ( parent.isValid() )
             return 0;
 
-        return static_cast<int>(m_headers.size());
+        return wxSsize(m_headers);
     }
 
     QVariant data(const QModelIndex &index, int role) const override
@@ -253,12 +253,12 @@ public:
         const int col = index.column();
 
         wxCHECK_MSG(
-            row >= 0 && static_cast<size_t>(row) < m_rows.size(),
+            row >= 0 && row < wxSsize(m_rows),
             false,
             "Invalid row index"
         );
         wxCHECK_MSG(
-            col >= 0 && static_cast<size_t>(col) < m_rows[row].m_columns.size(),
+            col >= 0 && col < wxSsize(m_rows[row].m_columns),
             false,
             "Invalid column index"
         );
@@ -296,7 +296,7 @@ public:
         if ( orientation == Qt::Vertical )
             return QVariant();
 
-        wxCHECK_MSG(static_cast<size_t>(section) < m_headers.size(),
+        wxCHECK_MSG(section < wxSsize(m_headers),
             QVariant(), "Invalid header index");
 
         const ColumnItem& header = m_headers[section];
@@ -367,7 +367,7 @@ public:
 
         eraseFromContainer(m_headers, column, count);
 
-        const int nRows = this->m_rows.size();
+        const int nRows = wxSsize(m_rows);
         for ( int i = 0; i < nRows; ++i )
         {
             eraseFromContainer(m_rows[i].m_columns, column, count);
@@ -379,8 +379,7 @@ public:
 
     bool GetColumn(int index, wxListItem &info) const
     {
-        wxCHECK_MSG(static_cast<size_t>(index) < m_headers.size(),
-            false, "Invalid column");
+        wxCHECK_MSG(index < wxSsize(m_headers), false, "Invalid column");
 
         const ColumnItem &column = m_headers[index];
         info.SetText(wxQtConvertString(column.m_label));
@@ -391,8 +390,7 @@ public:
 
     bool SetColumn(int index, const wxListItem& info)
     {
-        wxCHECK_MSG(static_cast<size_t>(index) < m_headers.size(),
-            false, "Invalid column");
+        wxCHECK_MSG(index < wxSsize(m_headers), false, "Invalid column");
 
         ColumnItem &column = m_headers[index];
 
@@ -414,13 +412,13 @@ public:
         const int col = info.m_col;
 
         wxCHECK_MSG(
-            row >= 0 && static_cast<size_t>(row) < m_rows.size(),
+            row >= 0 && row < wxSsize(m_rows),
             false,
             "Invalid row"
         );
 
         wxCHECK_MSG(
-            col >= 0 && static_cast<size_t>(col) < m_rows[row].m_columns.size(),
+            col >= 0 && col < wxSsize(m_rows[row].m_columns),
             false,
             "Invalid col"
         );
@@ -536,7 +534,7 @@ public:
 
     wxColour GetItemTextColour(long item)
     {
-        wxCHECK_MSG(item >= 0 && static_cast<size_t>(item) < m_rows.size(),
+        wxCHECK_MSG(item >= 0 && item < wxSsize(m_rows),
             wxNullColour, "Invalid row");
 
         wxCHECK_MSG(!m_rows[item].m_columns.empty(),
@@ -547,7 +545,7 @@ public:
 
     wxColour GetItemBackgroundColour(long item)
     {
-        wxCHECK_MSG(item >= 0 && static_cast<size_t>(item) < m_rows.size(),
+        wxCHECK_MSG(item >= 0 && item < wxSsize(m_rows),
             wxNullColour, "Invalid row");
         wxCHECK_MSG(!m_headers.empty(),
             wxNullColour, "No columns in model");
@@ -557,7 +555,7 @@ public:
 
     wxFont GetItemFont(long item)
     {
-        wxCHECK_MSG(item >= 0 && static_cast<size_t>(item) < m_rows.size(),
+        wxCHECK_MSG(item >= 0 && item < wxSsize(m_rows),
             wxNullFont, "Invalid row");
 
         wxCHECK_MSG(!m_headers.empty(),
@@ -573,8 +571,8 @@ public:
 
         const QString strUpper = str.toUpper();
 
-        const long numberOfRows = m_rows.size();
-        const long numberOfColumns = m_headers.size();
+        const long numberOfRows = wxSsize(m_rows);
+        const long numberOfColumns = wxSsize(m_headers);
 
         if ( partial )
         {
@@ -625,16 +623,16 @@ public:
         const int column = info.GetColumn();
         wxCHECK_MSG(column >= 0, -1, "Invalid column index");
 
-        if ( static_cast<size_t>(column) >= m_headers.size() )
+        if ( column >= wxSsize(m_headers) )
         {
-            beginInsertColumns(QModelIndex(), m_headers.size(), column);
+            beginInsertColumns(QModelIndex(), wxSsize(m_headers), column);
 
             const ColumnItem emptyColumn;
 
-            for ( int c = m_headers.size(); c <= column; ++c )
+            for ( int c = wxSsize(m_headers); c <= column; ++c )
             {
                 m_headers.push_back(emptyColumn);
-                for ( size_t r = 0; r < m_rows.size(); ++r )
+                for ( int r = 0; r < wxSsize(m_rows); ++r )
                 {
                     m_rows[r].m_columns.push_back(emptyColumn);
                 }
@@ -646,7 +644,7 @@ public:
         const long row = info.GetId();
         long newRowIndex;
 
-        if ( row == -1 || static_cast<size_t>(row) >= m_rows.size() )
+        if ( row == -1 || row >= wxSsize(m_rows) )
         {
             size_t colCount = m_headers.size();
             RowItem rowItem(colCount);
@@ -694,7 +692,7 @@ public:
         }
         newColumn.m_label = wxQtConvertString(info.GetText());
 
-        if ( col == -1 || static_cast<size_t>(col) >= m_headers.size() )
+        if ( col == -1 || col >= wxSsize(m_headers) )
         {
             newColumnIndex = m_headers.empty() ? 0 : m_headers.size();
         }
@@ -735,16 +733,14 @@ public:
 
     bool IsItemChecked(long item) const
     {
-        wxCHECK_MSG(item >= 0 && static_cast<size_t>(item) <= m_rows.size(),
-            false, "Invalid row");
+        wxCHECK_MSG(item >= 0 && item <= wxSsize(m_rows), false, "Invalid row");
 
         return m_rows[item].m_checked;
     }
 
     void CheckItem(long item, bool check)
     {
-        wxCHECK_RET(item >= 0 && static_cast<size_t>(item) <= m_rows.size(),
-            "Invalid row");
+        wxCHECK_RET(item >= 0 && item <= wxSsize(m_rows), "Invalid row");
 
         m_rows[item].m_checked = check;
 

--- a/tests/controls/dataviewctrltest.cpp
+++ b/tests/controls/dataviewctrltest.cpp
@@ -515,7 +515,7 @@ TEST_CASE_METHOD(MultiSelectDataViewCtrlTestCase,
     REQUIRE_NOTHROW( m_dvc->SetSelections(sel) );
 
     wxDataViewItemArray sel2;
-    CHECK( m_dvc->GetSelections(sel2) == static_cast<int>(sel.size()) );
+    CHECK( m_dvc->GetSelections(sel2) == wxSsize(sel) );
 
     CHECK( sel2 == sel );
 


### PR DESCRIPTION
This trivial function just performs the cast of size() of some container to int.

Using it makes it possible to write the code using int indices without (or with fewer) casts.

It doesn't check that the cast doesn't truncate currently, although perhaps it should -- but then it seems very unlikely that any of the containers we work with in wx can ever get close to INT_MAX size.