### PR TITLE
Fix versioned symbols version in 3.2

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -552,7 +552,6 @@ AC_DEFUN([WX_VERSIONED_SYMBOLS],
             ])
 
             if test $wx_cv_version_script = yes ; then
-                AC_DEFINE(wxHAVE_VERSION_SCRIPT)
                 LDFLAGS_VERSIONING="-Wl,--version-script,$1"
                 if test $wx_cv_undefined_version = yes ; then
                     LDFLAGS_VERSIONING="$LDFLAGS_VERSIONING -Wl,--undefined-version"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -552,6 +552,7 @@ AC_DEFUN([WX_VERSIONED_SYMBOLS],
             ])
 
             if test $wx_cv_version_script = yes ; then
+                AC_DEFINE(wxHAVE_VERSION_SCRIPT)
                 LDFLAGS_VERSIONING="-Wl,--version-script,$1"
                 if test $wx_cv_undefined_version = yes ; then
                     LDFLAGS_VERSIONING="$LDFLAGS_VERSIONING -Wl,--undefined-version"

--- a/configure
+++ b/configure
@@ -33818,6 +33818,8 @@ fi
 $as_echo "$wx_cv_version_script" >&6; }
 
             if test $wx_cv_version_script = yes ; then
+                $as_echo "#define wxHAVE_VERSION_SCRIPT 1" >>confdefs.h
+
                 LDFLAGS_VERSIONING="-Wl,--version-script,\$(wx_top_builddir)/version-script"
                 if test $wx_cv_undefined_version = yes ; then
                     LDFLAGS_VERSIONING="$LDFLAGS_VERSIONING -Wl,--undefined-version"

--- a/configure
+++ b/configure
@@ -1156,6 +1156,7 @@ enable_macosx_arch
 enable_compat28
 enable_compat30
 enable_rpath
+enable_symver
 enable_visibility
 enable_tls
 enable_repro_build
@@ -2131,6 +2132,7 @@ Optional Features:
   --enable-compat28       enable wxWidgets 2.8 compatibility
   --disable-compat30      disable wxWidgets 3.0 compatibility
   --disable-rpath         disable use of rpath for uninstalled builds
+  --disable-symver        disable use of ELF symbols versioning even if supported
   --disable-visibility    disable use of ELF symbols visibility even if supported
   --disable-tls           disable use of compiler TLS support
   --enable-repro-build    enable reproducible build mode
@@ -6401,6 +6403,35 @@ fi
 
           eval "$wx_cv_use_rpath"
 
+
+
+          enablestring=disable
+          defaultval=
+          if test -z "$defaultval"; then
+              if test x"$enablestring" = xdisable; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+          # Check whether --enable-symver was given.
+if test "${enable_symver+set}" = set; then :
+  enableval=$enable_symver;
+                          if test "$enableval" = yes; then
+                            wx_cv_use_symver='wxUSE_ELF_SYMVER=yes'
+                          else
+                            wx_cv_use_symver='wxUSE_ELF_SYMVER=no'
+                          fi
+
+else
+
+                          wx_cv_use_symver='wxUSE_ELF_SYMVER=${'DEFAULT_wxUSE_ELF_SYMVER":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_symver"
 
 
           enablestring=disable
@@ -33719,6 +33750,7 @@ fi
 
 if test "$wxUSE_SHARED" = "yes"; then
 
+        if test "$wxUSE_ELF_SYMVER" != "no"; then
 
     case "${host}" in
         *-*-cygwin* | *-*-mingw* )
@@ -33828,6 +33860,7 @@ $as_echo "$wx_cv_version_script" >&6; }
             ;;
     esac
 
+    fi
 
             if test "$wxUSE_VISIBILITY" != "no"; then
 

--- a/configure
+++ b/configure
@@ -33860,6 +33860,9 @@ $as_echo "$wx_cv_version_script" >&6; }
 
 
         if test "$wx_cv_version_script" = "yes"; then
+                                                                                    saveCppflags="$CPPFLAGS"
+            CPPFLAGS="$saveCppflags -I${srcdir}/include -DwxHAVE_ELF_SYMVER"
+
             saveLdflags="$LDFLAGS"
             LDFLAGS="$saveLdflags -Wl,--version-script,conftest.sym"
 
@@ -33874,8 +33877,9 @@ else
 /* end confdefs.h.  */
 
 
-                            __asm__(".symver foo,foo@lib_old");
-                            __asm__(".symver foo,foo@@lib_new");
+                            #include "wx/private/elfversion.h"
+                            wxELF_SYMVER("foo","foo@lib_old")
+                            wxELF_SYMVER("foo","foo@@lib_new")
                             void foo() {}
                             int main() { return 0; }
 
@@ -33909,7 +33913,8 @@ else
 /* end confdefs.h.  */
 
 
-                                __asm__(".symver foo,foo@@lib_new");
+                                #include "wx/private/elfversion.h"
+                                wxELF_SYMVER("foo","foo@@lib_new")
                                 void foo() {}
                                 int main() { return 0; }
 
@@ -33941,6 +33946,7 @@ $as_echo "$wx_cv_elf_symver" >&6; }
             fi
 
             LDFLAGS="$saveLdflags"
+            CPPFLAGS="$saveCppflags"
         fi
     fi
 

--- a/configure
+++ b/configure
@@ -33850,8 +33850,6 @@ fi
 $as_echo "$wx_cv_version_script" >&6; }
 
             if test $wx_cv_version_script = yes ; then
-                $as_echo "#define wxHAVE_VERSION_SCRIPT 1" >>confdefs.h
-
                 LDFLAGS_VERSIONING="-Wl,--version-script,\$(wx_top_builddir)/version-script"
                 if test $wx_cv_undefined_version = yes ; then
                     LDFLAGS_VERSIONING="$LDFLAGS_VERSIONING -Wl,--undefined-version"
@@ -33860,6 +33858,90 @@ $as_echo "$wx_cv_version_script" >&6; }
             ;;
     esac
 
+
+        if test "$wx_cv_version_script" = "yes"; then
+            saveLdflags="$LDFLAGS"
+            LDFLAGS="$saveLdflags -Wl,--version-script,conftest.sym"
+
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking if using multiple ELF symbol versions is supported" >&5
+$as_echo_n "checking if using multiple ELF symbol versions is supported... " >&6; }
+if ${wx_cv_elf_symver_multiple+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+                    echo "lib_new {}; lib_old { *; };" >conftest.sym
+                    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+                            __asm__(".symver foo,foo@lib_old");
+                            __asm__(".symver foo,foo@@lib_new");
+                            void foo() {}
+                            int main() { return 0; }
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  wx_cv_elf_symver_multiple=yes
+else
+  wx_cv_elf_symver_multiple=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+                    rm -f conftest.sym
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_elf_symver_multiple" >&5
+$as_echo "$wx_cv_elf_symver_multiple" >&6; }
+
+            if test "$wx_cv_elf_symver_multiple" = "yes"; then
+                wx_cv_elf_symver=yes
+            else
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking if using ELF symbol versions is supported" >&5
+$as_echo_n "checking if using ELF symbol versions is supported... " >&6; }
+if ${wx_cv_elf_symver+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+                        echo "lib_new {}; lib_old { *; };" >conftest.sym
+                        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+                                __asm__(".symver foo,foo@@lib_new");
+                                void foo() {}
+                                int main() { return 0; }
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  wx_cv_elf_symver=yes
+else
+  wx_cv_elf_symver=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+                        rm -f conftest.sym
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_elf_symver" >&5
+$as_echo "$wx_cv_elf_symver" >&6; }
+            fi
+
+            if test "$wx_cv_elf_symver" = "yes"; then
+                $as_echo "#define wxHAVE_ELF_SYMVER 1" >>confdefs.h
+
+            fi
+
+            if test "$wx_cv_elf_symver_multiple" = "yes"; then
+                $as_echo "#define wxHAVE_ELF_SYMVER_MULTIPLE 1" >>confdefs.h
+
+            fi
+
+            LDFLAGS="$saveLdflags"
+        fi
     fi
 
             if test "$wxUSE_VISIBILITY" != "no"; then

--- a/configure.in
+++ b/configure.in
@@ -4007,6 +4007,60 @@ if test "$wxUSE_SHARED" = "yes"; then
     dnl use versioned symbols if available on the platform and not disabled
     if test "$wxUSE_ELF_SYMVER" != "no"; then
         WX_VERSIONED_SYMBOLS([\$(wx_top_builddir)/version-script])
+
+        if test "$wx_cv_version_script" = "yes"; then
+            saveLdflags="$LDFLAGS"
+            LDFLAGS="$saveLdflags -Wl,--version-script,conftest.sym"
+
+            AC_CACHE_CHECK([if using multiple ELF symbol versions is supported],
+                wx_cv_elf_symver_multiple,
+                [
+                    echo "lib_new {}; lib_old { *; };" >conftest.sym
+                    AC_LINK_IFELSE([
+                        AC_LANG_SOURCE([
+                            __asm__(".symver foo,foo@lib_old");
+                            __asm__(".symver foo,foo@@lib_new");
+                            void foo() {}
+                            int main() { return 0; }
+                        ])],
+                        wx_cv_elf_symver_multiple=yes,
+                        wx_cv_elf_symver_multiple=no
+                    )
+                    rm -f conftest.sym
+                ]
+            )
+
+            if test "$wx_cv_elf_symver_multiple" = "yes"; then
+                wx_cv_elf_symver=yes
+            else
+                AC_CACHE_CHECK([if using ELF symbol versions is supported],
+                    wx_cv_elf_symver,
+                    [
+                        echo "lib_new {}; lib_old { *; };" >conftest.sym
+                        AC_LINK_IFELSE([
+                            AC_LANG_SOURCE([
+                                __asm__(".symver foo,foo@@lib_new");
+                                void foo() {}
+                                int main() { return 0; }
+                            ])],
+                            wx_cv_elf_symver=yes,
+                            wx_cv_elf_symver=no
+                        )
+                        rm -f conftest.sym
+                    ]
+                )
+            fi
+
+            if test "$wx_cv_elf_symver" = "yes"; then
+                AC_DEFINE(wxHAVE_ELF_SYMVER)
+            fi
+
+            if test "$wx_cv_elf_symver_multiple" = "yes"; then
+                AC_DEFINE(wxHAVE_ELF_SYMVER_MULTIPLE)
+            fi
+
+            LDFLAGS="$saveLdflags"
+        fi
     fi
 
     dnl test for GCC's visibility support (sets CFLAGS_VISIBILITY, which is

--- a/configure.in
+++ b/configure.in
@@ -705,6 +705,7 @@ WX_ARG_DISABLE(compat30,     [  --disable-compat30      disable wxWidgets 3.0 co
 
 WX_ARG_DISABLE(rpath,        [  --disable-rpath         disable use of rpath for uninstalled builds], wxUSE_RPATH)
 
+WX_ARG_DISABLE(symver,       [  --disable-symver        disable use of ELF symbols versioning even if supported], wxUSE_ELF_SYMVER)
 WX_ARG_DISABLE(visibility,   [  --disable-visibility    disable use of ELF symbols visibility even if supported], wxUSE_VISIBILITY)
 WX_ARG_DISABLE(tls,          [  --disable-tls           disable use of compiler TLS support], wxUSE_COMPILER_TLS)
 
@@ -4003,8 +4004,10 @@ dnl --- the marker for quick search, leave it here: SHARED_LIB_SETUP ---
 
 if test "$wxUSE_SHARED" = "yes"; then
 
-    dnl use versioned symbols if available on the platform
-    WX_VERSIONED_SYMBOLS([\$(wx_top_builddir)/version-script])
+    dnl use versioned symbols if available on the platform and not disabled
+    if test "$wxUSE_ELF_SYMVER" != "no"; then
+        WX_VERSIONED_SYMBOLS([\$(wx_top_builddir)/version-script])
+    fi
 
     dnl test for GCC's visibility support (sets CFLAGS_VISIBILITY, which is
     dnl assigned to CFLAGS and CXXFLAGS below)

--- a/configure.in
+++ b/configure.in
@@ -4009,6 +4009,15 @@ if test "$wxUSE_SHARED" = "yes"; then
         WX_VERSIONED_SYMBOLS([\$(wx_top_builddir)/version-script])
 
         if test "$wx_cv_version_script" = "yes"; then
+            dnl We want to use either __symver__ attribute (preferably, as it
+            dnl works with LTO) or .symver, but to avoid checking for both of
+            dnl them, use the header file which can check if the attribute is
+            dnl available. Just remember to pretend that we do have support
+            dnl for this before including it, as it relies on this symbol,
+            dnl which we'll define below only if things do indeed work.
+            saveCppflags="$CPPFLAGS"
+            CPPFLAGS="$saveCppflags -I${srcdir}/include -DwxHAVE_ELF_SYMVER"
+
             saveLdflags="$LDFLAGS"
             LDFLAGS="$saveLdflags -Wl,--version-script,conftest.sym"
 
@@ -4018,8 +4027,9 @@ if test "$wxUSE_SHARED" = "yes"; then
                     echo "lib_new {}; lib_old { *; };" >conftest.sym
                     AC_LINK_IFELSE([
                         AC_LANG_SOURCE([
-                            __asm__(".symver foo,foo@lib_old");
-                            __asm__(".symver foo,foo@@lib_new");
+                            #include "wx/private/elfversion.h"
+                            wxELF_SYMVER("foo","foo@lib_old")
+                            wxELF_SYMVER("foo","foo@@lib_new")
                             void foo() {}
                             int main() { return 0; }
                         ])],
@@ -4039,7 +4049,8 @@ if test "$wxUSE_SHARED" = "yes"; then
                         echo "lib_new {}; lib_old { *; };" >conftest.sym
                         AC_LINK_IFELSE([
                             AC_LANG_SOURCE([
-                                __asm__(".symver foo,foo@@lib_new");
+                                #include "wx/private/elfversion.h"
+                                wxELF_SYMVER("foo","foo@@lib_new")
                                 void foo() {}
                                 int main() { return 0; }
                             ])],
@@ -4060,6 +4071,7 @@ if test "$wxUSE_SHARED" = "yes"; then
             fi
 
             LDFLAGS="$saveLdflags"
+            CPPFLAGS="$saveCppflags"
         fi
     fi
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -257,6 +257,7 @@ All:
 - Allow initializing wxVector<> from std::initializer_list<> (#25290).
 - Update Brazilian Portuguese translations (Felipe).
 - Ensure that all headers are installed by CMake (Maarten Bent, #25266).
+- Fix ABI breakage for versioned symbols in 3.2.7 under Unix (#25327).
 
 All (GUI):
 

--- a/include/wx/private/elfversion.h
+++ b/include/wx/private/elfversion.h
@@ -1,0 +1,58 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/elfversion.h
+// Purpose:     Helper macro for assigning ELF version to a symbol.
+// Author:      Vadim Zeitlin
+// Created:     2025-04-14
+// Copyright:   (c) 2025 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_ELFVERSION_H_
+#define _WX_PRIVATE_ELFVERSION_H_
+
+// We suppose that if version script is supported, then .symver assembler
+// directive is also supported.
+#ifdef wxHAVE_VERSION_SCRIPT
+    // Prefer to use the attribute if it is available, as it works with LTO,
+    // unlike the assembler directive.
+    #ifdef __has_attribute
+        #if __has_attribute(__symver__)
+            #define wxELF_SYMVER(sym, symver) __attribute__((__symver__(symver)))
+        #endif
+    #endif
+
+    #ifndef wxELF_SYMVER
+        #define wxELF_SYMVER(sym, symver) __asm__(".symver " sym "," symver);
+    #endif
+
+    // Our version tag depends on whether we're using Unicode or not.
+    #if wxUSE_UNICODE
+        #define wxMAKE_ELF_VERSION_TAG(ver) "WXU_" ver
+    #else
+        #define wxMAKE_ELF_VERSION_TAG(ver) "WX_" ver
+    #endif
+
+    // This macro is used to repair ABI compatibility problems with the symbols
+    // versions: unfortunately, some symbols were initially added with the
+    // wrong "3.2" version tag because their definitions in the version script
+    // were erroneous, and, even more unfortunately, they were later corrected
+    // to use a different version tag, which made the symbols with the old
+    // version unavailable in the shared library. This macro allows to define
+    // both the old, compatible version ("3.2") and the new ("3.2.N") one for
+    // the given symbol to restore ABI compatibility with the previous releases
+    // without breaking it with the release containing the corrected version.
+    //
+    // The parameters are the mangled symbol name (the simplest way to get is
+    // probably to use nm or readelf on the object file or library) and the
+    // part of the version after "WX[U]_", i.e. the version number itself.
+    //
+    // Note that this macro takes strings, not symbols, and that it includes
+    // the trailing semicolon for consistency with the empty version below.
+    #define wxELF_VERSION_COMPAT(sym, ver) \
+        wxELF_SYMVER(sym, sym "@" wxMAKE_ELF_VERSION_TAG("3.2")) \
+        wxELF_SYMVER(sym, sym "@@" wxMAKE_ELF_VERSION_TAG(ver))
+#else
+    #define wxELF_VERSION_COMPAT(sym, ver)
+#endif
+
+#endif // _WX_PRIVATE_ELFVERSION_H_

--- a/include/wx/private/elfversion.h
+++ b/include/wx/private/elfversion.h
@@ -10,9 +10,8 @@
 #ifndef _WX_PRIVATE_ELFVERSION_H_
 #define _WX_PRIVATE_ELFVERSION_H_
 
-// We suppose that if version script is supported, then .symver assembler
-// directive is also supported.
-#ifdef wxHAVE_VERSION_SCRIPT
+// This symbol is defined by configure if .symver directive is supported.
+#ifdef wxHAVE_ELF_SYMVER
     // Prefer to use the attribute if it is available, as it works with LTO,
     // unlike the assembler directive.
     #ifdef __has_attribute
@@ -23,6 +22,16 @@
 
     #ifndef wxELF_SYMVER
         #define wxELF_SYMVER(sym, symver) __asm__(".symver " sym "," symver);
+    #endif
+
+    // Using multiple versions for the same symbols may be not supported, in
+    // which case we omit it: this results in generating 2 default versions for
+    // the same symbol, which looks wrong, but doesn't seem to cause any
+    // problems.
+    #ifdef wxHAVE_ELF_SYMVER_MULTIPLE
+        #define wxELF_SYMVER_NON_DEFAULT(sym, ver) wxELF_SYMVER(sym, ver)
+    #else
+        #define wxELF_SYMVER_NON_DEFAULT(sym, ver)
     #endif
 
     // Our version tag depends on whether we're using Unicode or not.
@@ -49,7 +58,7 @@
     // Note that this macro takes strings, not symbols, and that it includes
     // the trailing semicolon for consistency with the empty version below.
     #define wxELF_VERSION_COMPAT(sym, ver) \
-        wxELF_SYMVER(sym, sym "@" wxMAKE_ELF_VERSION_TAG("3.2")) \
+        wxELF_SYMVER_NON_DEFAULT(sym, sym "@" wxMAKE_ELF_VERSION_TAG("3.2")) \
         wxELF_SYMVER(sym, sym "@@" wxMAKE_ELF_VERSION_TAG(ver))
 #else
     #define wxELF_VERSION_COMPAT(sym, ver)

--- a/setup.h.in
+++ b/setup.h.in
@@ -17,8 +17,11 @@
 /* the installation location prefix from configure */
 #undef wxINSTALL_PREFIX
 
-/* Is linker version script used? */
-#undef wxHAVE_VERSION_SCRIPT
+/* Is .symver assembler directive supported? */
+#undef wxHAVE_ELF_SYMVER
+
+/* Are multiple versions of the same symbol supported? */
+#undef wxHAVE_ELF_SYMVER_MULTIPLE
 
 /* Define if ssize_t type is available.  */
 #undef HAVE_SSIZE_T

--- a/setup.h.in
+++ b/setup.h.in
@@ -17,6 +17,9 @@
 /* the installation location prefix from configure */
 #undef wxINSTALL_PREFIX
 
+/* Is linker version script used? */
+#undef wxHAVE_VERSION_SCRIPT
+
 /* Define if ssize_t type is available.  */
 #undef HAVE_SSIZE_T
 

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -49,6 +49,8 @@
 #include "wx/private/threadinfo.h"
 #include "wx/uilocale.h"
 
+#include "wx/private/elfversion.h"
+
 #ifdef __WINDOWS__
     #include "wx/dynlib.h"
     #include "wx/scopedarray.h"
@@ -1420,11 +1422,13 @@ bool wxTranslations::AddCatalog(const wxString& domain,
 }
 #endif // !wxUSE_UNICODE
 
+wxELF_VERSION_COMPAT("_ZN14wxTranslations19AddAvailableCatalogERK8wxString", "3.2.3")
 bool wxTranslations::AddAvailableCatalog(const wxString& domain)
 {
     return AddAvailableCatalog(domain, wxLANGUAGE_ENGLISH_US);
 }
 
+wxELF_VERSION_COMPAT("_ZN14wxTranslations19AddAvailableCatalogERK8wxString10wxLanguage", "3.2.6")
 bool wxTranslations::AddAvailableCatalog(const wxString& domain, wxLanguage msgIdLanguage)
 {
     return DoAddCatalog(domain, msgIdLanguage) == Translations_Found;
@@ -1563,6 +1567,7 @@ wxString wxTranslations::GetBestTranslation(const wxString& domain,
     return lang;
 }
 
+wxELF_VERSION_COMPAT("_ZN14wxTranslations27GetBestAvailableTranslationERK8wxString", "3.2.3")
 wxString wxTranslations::GetBestAvailableTranslation(const wxString& domain)
 {
     // Determine the best language from the ones with actual translation file:

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -32,6 +32,7 @@
     #include "wx/language.h"
 #endif
 
+#include "wx/private/elfversion.h"
 #include "wx/private/uilocale.h"
 
 #define TRACE_I18N wxS("i18n")
@@ -612,6 +613,7 @@ wxString wxUILocale::GetLocalizedName(wxLocaleName name, wxLocaleForm form) cons
 }
 
 #if wxUSE_DATETIME
+wxELF_VERSION_COMPAT("_ZNK10wxUILocale12GetMonthNameEN10wxDateTime5MonthENS0_9NameFlagsE", "3.2.3")
 wxString wxUILocale::GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const
 {
     if (!m_impl)
@@ -620,6 +622,7 @@ wxString wxUILocale::GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags
     return m_impl->GetMonthName(month, flags);
 }
 
+wxELF_VERSION_COMPAT("_ZNK10wxUILocale14GetWeekDayNameEN10wxDateTime7WeekDayENS0_9NameFlagsE", "3.2.3")
 wxString wxUILocale::GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const
 {
     if (!m_impl)
@@ -677,6 +680,7 @@ wxUILocale::~wxUILocale()
 
 
 /* static */
+wxELF_VERSION_COMPAT("_ZN10wxUILocale17GetSystemLocaleIdEv", "3.2.2")
 wxLocaleIdent wxUILocale::GetSystemLocaleId()
 {
     wxUILocale defaultLocale(wxUILocaleImpl::CreateUserDefault());

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -32,6 +32,8 @@
 #include "wx/filefn.h" // ::wxGetCwd
 #include "wx/modalhook.h"
 
+#include "wx/private/elfversion.h"
+
 //-----------------------------------------------------------------------------
 // "clicked" for OK-button
 //-----------------------------------------------------------------------------
@@ -500,6 +502,7 @@ void wxFileDialog::GTKSelectionChanged(const wxString& filename)
     UpdateExtraControlUI();
 }
 
+wxELF_VERSION_COMPAT("_ZN12wxFileDialog11AddShortcutERK8wxStringi", "3.2.1")
 bool wxFileDialog::AddShortcut(const wxString& directory, int WXUNUSED(flags))
 {
     wxGtkError error;

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -28,6 +28,8 @@
 
 #include "wx/scopedptr.h"
 
+#include "wx/private/elfversion.h"
+
 #include "wx/gtk/private/wrapgdk.h"
 #include "wx/gtk/private/backend.h"
 #ifdef GDK_WINDOWING_WAYLAND
@@ -633,6 +635,7 @@ wxGLCanvasEGL::~wxGLCanvasEGL()
     gs_alreadySetSwapInterval.erase(this);
 }
 
+wxELF_VERSION_COMPAT("_ZN13wxGLCanvasEGL23CreateWaylandSubsurfaceEv", "3.2.3")
 void wxGLCanvasEGL::CreateWaylandSubsurface()
 {
 #ifdef GDK_WINDOWING_WAYLAND
@@ -671,6 +674,7 @@ void wxGLCanvasEGL::CreateWaylandSubsurface()
 #endif
 }
 
+wxELF_VERSION_COMPAT("_ZN13wxGLCanvasEGL24DestroyWaylandSubsurfaceEv", "3.2.3")
 void wxGLCanvasEGL::DestroyWaylandSubsurface()
 {
 #ifdef GDK_WINDOWING_WAYLAND

--- a/version-script.in
+++ b/version-script.in
@@ -18,9 +18,10 @@
 #   };
 #
 # If a symbols should have been added in this way, but is forgotten then it
-# cannot be added in the next release. This is because it has already been
-# released with the generic branch version due to the final wildcard below,
-# and once released its version cannot be changed.
+# cannot be added to the next release version tag, but we can workaround the
+# problem by using wxELF_VERSION_COMPAT() macro in the source code. Note that
+# this is why some version tags are defined here even if no symbols are
+# assigned to them: they are used by that macro.
 
 # When adding a new section here, don't forget to modify the version in
 # build/bakefiles/version.bkl to indicate that new APIs have been added and
@@ -36,35 +37,20 @@
 
 # public symbols added in 3.2.6 (please keep in alphabetical order):
 @WX_VERSION_TAG@.6 {
-    extern "C++" {
-        "wxTranslations::AddAvailableCatalog(wxString const&, wxLanguage)";
-    };
 };
 
 # public symbols added in 3.2.3 (please keep in alphabetical order):
 @WX_VERSION_TAG@.3 {
-    extern "C++" {
-        "wxGLCanvasEGL::CreateWaylandSubsurface()";
-        "wxGLCanvasEGL::DestroyWaylandSubsurface()";
-        "wxTranslations::AddAvailableCatalog(wxString const&)";
-        "wxTranslations::GetBestAvailableTranslation(wxString const&)";
-        "wxUILocale::GetMonthName(wxDateTime::Month, wxDateTime::NameFlags) const";
-        "wxUILocale::GetWeekDayName(wxDateTime::WeekDay, wxDateTime::NameFlags) const";
-    };
 };
 
 # public symbols added in 3.2.2 (please keep in alphabetical order):
 @WX_VERSION_TAG@.2 {
-    extern "C++" {
-        "wxUILocale::GetSystemLocaleId()";
-    };
 };
 
 # public symbols added in 3.2.1
 @WX_VERSION_TAG@.1 {
     extern "C++" {
         "wxApp::GTKAllowDiagnosticsControl()";
-        "wxFileDialogBase::AddShortcut(wxString const&, int)";
     };
 };
 

--- a/version-script.in
+++ b/version-script.in
@@ -38,8 +38,6 @@
 @WX_VERSION_TAG@.6 {
     extern "C++" {
         "wxTranslations::AddAvailableCatalog(wxString const&, wxLanguage)";
-        "wxEventTableEntry::wxEventTableEntry(wxEventTableEntry const&)";
-        "wxSystemSettingsNative::SelectLightDark(wxColour, wxColour)";
     };
 };
 
@@ -59,9 +57,6 @@
 @WX_VERSION_TAG@.2 {
     extern "C++" {
         "wxUILocale::GetSystemLocaleId()";
-        "wxWithImages::GetImageLogicalSize(wxWindow const*, int)";
-        "wxWithImages::GetImageLogicalSize(wxWindow const*, int, int&, int&)";
-        "wxWithImages::GetImageBitmapFor(wxWindow const*, int)";
     };
 };
 


### PR DESCRIPTION
This fixes an ABI breakage due to the changes of ed7defadd299a649f08af2436db193d7bd5a4180, see #25327.