### PR TITLE
More 3.2.8 backports

### DIFF
--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -91,7 +91,7 @@ case $(uname -s) in
                             libglu1-mesa-dev"
             esac
 
-            pkg_install="$pkg_install $libtoolkit_dev gdb ${WX_EXTRA_PACKAGES}"
+            pkg_install="$pkg_install $libtoolkit_dev gawk gdb ${WX_EXTRA_PACKAGES}"
 
             extra_deps="$extra_deps libcurl4-openssl-dev libsecret-1-dev libnotify-dev"
             for pkg in $extra_deps; do
@@ -119,12 +119,12 @@ case $(uname -s) in
         fi
 
         if [ -f /etc/redhat-release ]; then
-            dnf install -y ${WX_EXTRA_PACKAGES} expat-devel findutils g++ git-core gspell-devel gstreamer1-plugins-base-devel gtk3-devel make libcurl-devel libGLU-devel libjpeg-devel libnotify-devel libpng-devel libSM-devel libsecret-devel libtiff-devel SDL-devel webkit2gtk4.1-devel zlib-devel
+            dnf install -y ${WX_EXTRA_PACKAGES} gawk expat-devel findutils g++ git-core gspell-devel gstreamer1-plugins-base-devel gtk3-devel make libcurl-devel libGLU-devel libjpeg-devel libnotify-devel libpng-devel libSM-devel libsecret-devel libtiff-devel SDL-devel webkit2gtk4.1-devel zlib-devel
         fi
         ;;
 
     FreeBSD)
-        pkg install -q -y ${WX_EXTRA_PACKAGES} gspell gstreamer1 gtk3 jpeg-turbo libnotify libsecret mesa-libs pkgconf png tiff webkit2-gtk_41
+        pkg install -q -y ${WX_EXTRA_PACKAGES} gawk gspell gstreamer1 gtk3 jpeg-turbo libnotify libsecret mesa-libs pkgconf png tiff webkit2-gtk_41
         ;;
 
     Darwin)

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -266,6 +266,7 @@ All (GUI):
 
 wxGTK:
 
+- Fix regression in numpad key event generation in 3.2.7 (#25263).
 - Fix handling exceptions in wxApp idle event handler (#25312).
 
 wxMSW:

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -267,6 +267,7 @@ All (GUI):
 wxGTK:
 
 - Fix regression in numpad key event generation in 3.2.7 (#25263).
+- Make key events for punctuation keys more consistent with wxMSW.
 - Fix handling exceptions in wxApp idle event handler (#25312).
 
 wxMSW:

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -268,6 +268,7 @@ wxGTK:
 
 - Fix regression in numpad key event generation in 3.2.7 (#25263).
 - Make key events for punctuation keys more consistent with wxMSW.
+- Fix for computing wxStaticText best size with non-default font (#24781).
 - Fix handling exceptions in wxApp idle event handler (#25312).
 
 wxMSW:

--- a/include/wx/gtk/stattext.h
+++ b/include/wx/gtk/stattext.h
@@ -33,6 +33,8 @@ public:
                 long style = 0,
                 const wxString &name = wxASCII_STR(wxStaticTextNameStr) );
 
+    virtual ~wxStaticText();
+
     void SetLabel( const wxString &label ) wxOVERRIDE;
 
     bool SetFont( const wxFont &font ) wxOVERRIDE;

--- a/src/common/btncmn.cpp
+++ b/src/common/btncmn.cpp
@@ -100,7 +100,16 @@ wxWindow *wxButtonBase::SetDefault()
 
     wxCHECK_MSG( tlw, NULL, wxT("button without top level window?") );
 
+    // Avoid spurious warning from gcc 15 when using -O2, see #25338.
+#if wxCHECK_GCC_VERSION(15, 0)
+    wxGCC_WARNING_SUPPRESS(dangling-pointer)
+#endif
+
     return tlw->SetDefaultItem(this);
+
+#if wxCHECK_GCC_VERSION(15, 0)
+    wxGCC_WARNING_RESTORE(dangling-pointer)
+#endif
 }
 
 void wxAnyButtonBase::SetBitmapPosition(wxDirection dir)

--- a/src/gtk/stattext.cpp
+++ b/src/gtk/stattext.cpp
@@ -13,7 +13,31 @@
 
 #include "wx/stattext.h"
 
+#ifndef WX_PRECOMP
+    #include "wx/dcclient.h"
+#endif
+
+#if wxUSE_MARKUP
+    #include "wx/generic/private/markuptext.h"
+#endif // wxUSE_MARKUP
+
 #include "wx/gtk/private.h"
+
+// We can't add a member variable to wxStaticText in 3.2 branch, so emulate it
+// by encoding the corresponding boolean value via the presence of "this"
+// pointer in the given hash set.
+#include "wx/hashset.h"
+
+namespace
+{
+
+// Define the equivalent of unordered_set<wxStaticText*>.
+WX_DECLARE_HASH_SET(wxStaticText*, wxPointerHash, wxPointerEqual, wxStaticTextSet);
+
+// Use it to remember for which objects we need to compute the size ourselves.
+wxStaticTextSet gs_computeOurOwnBestSize;
+
+} // anonymous namespace
 
 //-----------------------------------------------------------------------------
 // wxStaticText
@@ -133,6 +157,11 @@ bool wxStaticText::Create(wxWindow *parent,
     return true;
 }
 
+wxStaticText::~wxStaticText()
+{
+    gs_computeOurOwnBestSize.erase(this);
+}
+
 void wxStaticText::GTKDoSetLabel(GTKLabelSetter setter, const wxString& label)
 {
     wxCHECK_RET( m_widget != NULL, wxT("invalid static text") );
@@ -176,6 +205,14 @@ bool wxStaticText::SetFont( const wxFont &font )
 
     if ( !wxControl::SetFont(font) )
         return false;
+
+    if ( !IsShownOnScreen() )
+    {
+        // Setting the font of a hidden window doesn't update GTK style cache,
+        // see #16088, and the size computed by GTK will be wrong, so we will
+        // need to compute it ourselves.
+        gs_computeOurOwnBestSize.insert(this);
+    }
 
     const bool isUnderlined = GetFont().GetUnderlined();
     const bool isStrickenThrough = GetFont().GetStrikethrough();
@@ -227,32 +264,58 @@ wxSize wxStaticText::DoGetBestSize() const
     // Do not return any arbitrary default value...
     wxASSERT_MSG( m_widget, wxT("wxStaticText::DoGetBestSize called before creation") );
 
-    // GetBestSize is supposed to return unwrapped size but calling
-    // gtk_label_set_line_wrap() from here is a bad idea as it queues another
-    // size request by calling gtk_widget_queue_resize() and we end up in
-    // infinite loop sometimes (notably when the control is in a toolbar)
-    // With GTK3 however, there is no simple alternative, and the sizing loop
-    // no longer seems to occur.
-#ifdef __WXGTK3__
-    gtk_label_set_line_wrap(GTK_LABEL(m_widget), false);
-#else
-    GTK_LABEL(m_widget)->wrap = FALSE;
+    wxSize size;
+    if ( gs_computeOurOwnBestSize.count(wxConstCast(this, wxStaticText)) )
+    {
+        // GTK style cache may not be up to date, so we can't trust the results
+        // of wxControl::DoGetBestSize() and need to compute the best size
+        // ourselves here.
+        wxClientDC dc(wxConstCast(this, wxStaticText));
 
-    // Reset the ellipsize mode while computing the best size, otherwise it's
-    // going to be too small as the control knows that it can be shrunk to the
-    // bare minimum and just hide most of the text replacing it with ellipsis.
-    // This is especially important because we can enable ellipsization
-    // implicitly for GTK+ 2, see the code dealing with alignment in the ctor.
-    const PangoEllipsizeMode ellipsizeMode = gtk_label_get_ellipsize(GTK_LABEL(m_widget));
-    gtk_label_set_ellipsize(GTK_LABEL(m_widget), PANGO_ELLIPSIZE_NONE);
-#endif
-    wxSize size = wxStaticTextBase::DoGetBestSize();
+        const wxString
+            label = wxString::FromUTF8(gtk_label_get_label(GTK_LABEL(m_widget)));
+
+#if wxUSE_MARKUP
+        if ( gtk_label_get_use_markup(GTK_LABEL(m_widget)) )
+        {
+            wxMarkupText markupText(label);
+            size = markupText.Measure(dc);
+        }
+        else
+#endif // wxUSE_MARKUP
+        {
+            size = dc.GetMultiLineTextExtent(label);
+        }
+    }
+    else
+    {
+        // GetBestSize is supposed to return unwrapped size but calling
+        // gtk_label_set_line_wrap() from here is a bad idea as it queues another
+        // size request by calling gtk_widget_queue_resize() and we end up in
+        // infinite loop sometimes (notably when the control is in a toolbar)
+        // With GTK3 however, there is no simple alternative, and the sizing loop
+        // no longer seems to occur.
 #ifdef __WXGTK3__
-    gtk_label_set_line_wrap(GTK_LABEL(m_widget), true);
+        gtk_label_set_line_wrap(GTK_LABEL(m_widget), false);
 #else
-    gtk_label_set_ellipsize(GTK_LABEL(m_widget), ellipsizeMode);
-    GTK_LABEL(m_widget)->wrap = TRUE; // restore old value
+        GTK_LABEL(m_widget)->wrap = FALSE;
+
+        // Reset the ellipsize mode while computing the best size, otherwise it's
+        // going to be too small as the control knows that it can be shrunk to the
+        // bare minimum and just hide most of the text replacing it with ellipsis.
+        // This is especially important because we can enable ellipsization
+        // implicitly for GTK+ 2, see the code dealing with alignment in the ctor.
+        const PangoEllipsizeMode ellipsizeMode = gtk_label_get_ellipsize(GTK_LABEL(m_widget));
+        gtk_label_set_ellipsize(GTK_LABEL(m_widget), PANGO_ELLIPSIZE_NONE);
 #endif
+        size = wxStaticTextBase::DoGetBestSize();
+#ifdef __WXGTK3__
+        gtk_label_set_line_wrap(GTK_LABEL(m_widget), true);
+#else
+        gtk_label_set_ellipsize(GTK_LABEL(m_widget), ellipsizeMode);
+        GTK_LABEL(m_widget)->wrap = TRUE; // restore old value
+#endif
+    }
 
     // Adding 1 to width to workaround GTK sometimes wrapping the text needlessly
     size.x++;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1152,6 +1152,9 @@ wxTranslateGTKKeyEventToWx(wxKeyEvent& event,
         // key codes that can't be generated in the US layout (e.g. continuing
         // with the French example, "1" would generate "&" key code which can
         // never be entered in the standard US layout).
+        //
+        // However see also the hack inside the hack for some non-letter
+        // characters below.
         if ( (unichar >= 'A' && unichar <= 'Z') ||
                 (unichar >= 'a' && unichar <= 'z') )
         {
@@ -1171,6 +1174,32 @@ wxTranslateGTKKeyEventToWx(wxKeyEvent& event,
                 extraTraceInfo = " [XKB]";
 
                 key_code = key_code_str[0];
+
+                // Another hack for wxMSW compatibility: for the non-digit keys
+                // (not characters), we still use their value if it is ASCII,
+                // so that the key marked as "$" on a French keyboard generates
+                // this key and not "]" that it would generate in the US layout
+                // but which is located on a completely different key of the
+                // French keyboard.
+                //
+                // See also the code handling VK_OEM_xxx keys in wxMSW.
+                switch ( key_code )
+                {
+                    case ';':
+                    case '=':
+                    case ',':
+                    case '-':
+                    case '.':
+                    case '/':
+                    case '`':
+                    case '[':
+                    case '\\':
+                    case ']':
+                    case '\'':
+                        if ( unichar < 0x100 )
+                            key_code = unichar;
+                        break;
+                }
             }
             else
 #endif // wxHAS_XKB
@@ -1194,19 +1223,20 @@ wxTranslateGTKKeyEventToWx(wxKeyEvent& event,
         }
     }
 
-    wxLogTrace(TRACE_KEYS, "Key %s event: %lu -> key=%ld%s",
+    wxLogTrace(TRACE_KEYS, "Key %s event: %lu -> char='%c' key=%ld%s",
                event.GetEventType() == wxEVT_KEY_UP ? "release" : "press",
                static_cast<unsigned long>(keysym),
+               unichar,
                key_code,
                extraTraceInfo);
 
     event.m_keyCode = key_code;
 
 #if wxUSE_UNICODE
-    if ( event.m_keyCode <= WXK_DELETE )
+    if ( event.m_keyCode < 0x100 )
     {
-        // Set Unicode key code to the ASCII equivalent for compatibility. E.g.
-        // let RETURN generate the key event with both key and Unicode key
+        // Set Unicode key code to the Latin-1 equivalent for compatibility.
+        // E.g. let RETURN generate the key event with both key and Unicode key
         // codes of 13.
         event.m_uniChar = event.m_keyCode;
     }

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1128,9 +1128,15 @@ wxTranslateGTKKeyEventToWx(wxKeyEvent& event,
 
     wxString extraTraceInfo;
 
-    long key_code = 0;
+    // Check for special keys first: we need to do it even for the keys that
+    // could have an ASCII equivalent because we need to distinguish numpad
+    // keys from the ones on the main keyboard.
+    long key_code = wxTranslateKeySymToWXKey(keysym, false /* !isChar */);
 
-    const guint32 unichar = gdk_keyval_to_unicode(keysym);
+    guint32 unichar = 0;
+    if ( !key_code )
+        unichar = gdk_keyval_to_unicode(keysym);
+
     if ( unichar )
     {
         // The convention used here is rather strange, but conforms to what
@@ -1186,10 +1192,6 @@ wxTranslateGTKKeyEventToWx(wxKeyEvent& event,
         {
             key_code = toupper(key_code);
         }
-    }
-    else // This is not an alphanumeric key, check if we know it.
-    {
-        key_code = wxTranslateKeySymToWXKey(keysym, false /* !isChar */);
     }
 
     wxLogTrace(TRACE_KEYS, "Key %s event: %lu -> key=%ld%s",


### PR DESCRIPTION
I am not 100% sure if we want to include 3ddb4f98a50c39be7877e7aa4b1bf3d631e71851, but I think it's better, on balance, to do the right thing compatible with 3.3 than to leave this unchanged but broken for compatibility, considering how many other changes to these events we've already made in 3.2.

@unxed Please let me know if this fixes the regressions you've seen with 3.2.7.