### PR TITLE
Add missing \ in macOS CMake build example

### DIFF
--- a/docs/doxygen/overviews/cmake.md
+++ b/docs/doxygen/overviews/cmake.md
@@ -78,7 +78,7 @@ For example, the following will build a "universal binary 2" (i.e., ARM64 and In
 ~~~{.sh}
     cmake ~/Downloads/wxWidgets_3.1 \
       -DCMAKE_INSTALL_PREFIX=~/wx_install \
-      -DwxBUILD_SHARED=OFF
+      -DwxBUILD_SHARED=OFF \
       -D"CMAKE_OSX_ARCHITECTURES:STRING=arm64;x86_64"
     cmake --build . --target install
 ~~~


### PR DESCRIPTION
Sorry, I may have been the culprit behind this one, but fixing it now :)