### PR TITLE
Explain how to make wxBusyInfo appear under GTK in more detail

### DIFF
--- a/interface/wx/busyinfo.h
+++ b/interface/wx/busyinfo.h
@@ -75,7 +75,32 @@
 
     but take care to not cause undesirable reentrancies when doing it (see
     wxApp::Yield for more details). The simplest way to do it is to use
-    wxWindowDisabler class as illustrated in the above example.
+    wxWindowDisabler class, as illustrated in the above example.
+
+    Under GTK, it is recommended to call `wxTheApp->Yield()` after a short
+    operation (or pause) following a wxBusyInfo's construction.
+    This will ensure that it is visible. For example:
+
+    @code
+        wxWindowDisabler disableAll;
+        wxBusyInfo wait("Please wait, working...");
+
+        DoACalculation();
+        wxTheApp->Yield();
+        MoreCalculations();
+    @endcode
+
+    or
+
+    @code
+        wxWindowDisabler disableAll;
+        wxBusyInfo wait("Please wait, working...");
+
+        wxMilliSleep(100);
+        wxTheApp->Yield();
+        DoACalculation();
+        MoreCalculations();
+    @endcode
 
     Note that a wxBusyInfo is always built with the @c wxSTAY_ON_TOP window style
     (see wxFrame window styles for more info).


### PR DESCRIPTION
This is a bit of hack workaround, but under GTK3 you need to either do a short process or sleep for a few milliseconds before calling `wxTheApp->Yield()` to get a `wxBusyInfo` object to appear. Otherwise, it never seems to appear. I've verified on Linux Mint and OpenSuse and it works fine if (and only if) I follow this sequence:

```
wxBusyInfo wait("Please wait, working...");

wxMilliSleep(100); // or some other quick process
wxTheApp->Yield();
```

The problem that I was running into was that I called `wxTheApp->Yield()` immediately after constructing a `wxBusyInfo`, and it never appeared (under GTK). Adding a `wxMilliSleep(100)` first fixed it. Anyway, I'm adding a quick explanation of that and code examples to the overview.

Closes #15912 by explaining workaround.
See also https://github.com/wxWidgets/Phoenix/issues/1992