### PR TITLE
Install awk before building to fix Fedora CI job

### DIFF
--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -100,7 +100,7 @@ case $(uname -s) in
 
             # Install locales used by our tests to run all the tests instead of
             # skipping them.
-            pkg_install="$pkg_install $libtoolkit_dev gdb locales-all ${WX_EXTRA_PACKAGES}"
+            pkg_install="$pkg_install $libtoolkit_dev gawk gdb locales-all ${WX_EXTRA_PACKAGES}"
 
             extra_deps="$extra_deps libcurl4-openssl-dev libsecret-1-dev libnotify-dev"
             for pkg in $extra_deps; do
@@ -128,12 +128,12 @@ case $(uname -s) in
         fi
 
         if [ -f /etc/redhat-release ]; then
-            dnf install -y ${WX_EXTRA_PACKAGES} expat-devel findutils g++ git-core gspell-devel gstreamer1-plugins-base-devel gtk3-devel make libcurl-devel libjpeg-devel libnotify-devel libpng-devel libSM-devel libsecret-devel libtiff-devel SDL-devel webkit2gtk4.1-devel zlib-devel
+            dnf install -y ${WX_EXTRA_PACKAGES} gawk expat-devel findutils g++ git-core gspell-devel gstreamer1-plugins-base-devel gtk3-devel make libcurl-devel libjpeg-devel libnotify-devel libpng-devel libSM-devel libsecret-devel libtiff-devel SDL-devel webkit2gtk4.1-devel zlib-devel
         fi
         ;;
 
     FreeBSD)
-        pkg install -q -y ${WX_EXTRA_PACKAGES} gspell gstreamer1 gtk3 jpeg-turbo libnotify libsecret mesa-libs pkgconf png tiff webkit2-gtk_41
+        pkg install -q -y ${WX_EXTRA_PACKAGES} gawk gspell gstreamer1 gtk3 jpeg-turbo libnotify libsecret mesa-libs pkgconf png tiff webkit2-gtk_41
         ;;
 
     Darwin)


### PR DESCRIPTION
Apparently the latest Fedora doesn't include awk out of the box, but configure relies on it, so install it ourselves.

Do it also for the other platforms for consistency.