### PR TITLE
Revert "osx/core/private.h: fix parsing included CarbonCore header on powerpc

### DIFF
--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -12,12 +12,6 @@
 #ifndef _WX_PRIVATE_CORE_H_
 #define _WX_PRIVATE_CORE_H_
 
-// Without this MachineExceptions.h of CarbonCore cannot be parsed
-// when C++11 or higher standard is used.
-#ifdef __APPLE_ALTIVEC__
-#undef __APPLE_ALTIVEC__
-#endif
-
 #include "wx/defs.h"
 
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
This reverts commit c3141dfe3e065c6913f9c3655a649240375f408d

While it worked to fix compilation, it did not address the cause of the issue, and was a suboptimal solution. To avoid parsing error on powerpc, disable precompiled headers usage in configure args.

See: https://github.com/wxWidgets/wxWidgets/pull/25321

I have verified the build of current master and 3.2.7.1 release with this change applied, and instead passing `-DwxBUILD_PRECOMP=OFF` to CMake.
https://github.com/macos-powerpc/powerpc-ports/commit/d05573fa72591f53484ebbb2ae31d8b955f6dfab 

It remains unclear at the moment why precompiled headers lead to that error (see the discussion in the PR), but not using precompiled headers is a valid choice and is preferable to hacking a header.