### PR TITLE
macOS: Do not activate CLOSE button on Cmd-C

### DIFF
--- a/src/osx/cocoa/button.mm
+++ b/src/osx/cocoa/button.mm
@@ -147,7 +147,7 @@ void wxButtonCocoaImpl::SetAcceleratorFromLabel(const wxString& label)
         wxString accelstring(label[accelPos + 1]); // Skip '&' itself
         accelstring.MakeLower();
         // Avoid Cmd+C closing dialog on Mac.
-        if (accelstring == "c" && GetWXPeer()->GetId() == wxID_CANCEL)
+        if (accelstring == "c" && (GetWXPeer()->GetId() == wxID_CANCEL || GetWXPeer()->GetId() == wxID_CLOSE))
         {
             [GetNSButton() setKeyEquivalent:@""];
         }


### PR DESCRIPTION
PR #15678 and commit https://github.com/wxWidgets/wxWidgets/commit/7a45b7948a17bf4a258a44f6066e9ca1f91bbf31 corrected a problem on macOS where Cmd-C caused the dialog to close if it had a wxID_CANCEL button.

I encountered the same issue with the wxID_CLOSE button.  This PR simply extends the fix to include wxID_CLOSE.

This can be reproduced with the dialogs sample using the "Tip of the Day" dialog (Cmd-T).
Note: This issue exists in the 3.2 branch as well as master.