### PR TITLE
Ensure that we include built-in 3rd party libraries headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -87,10 +87,9 @@ WX_RELEASE_NODOT = 33
 WX_VERSION = $(WX_RELEASE).0
 WX_VERSION_NODOT = $(WX_RELEASE_NODOT)0
 LIBDIRNAME = $(wx_top_builddir)/lib
-WXREGEX_CFLAGS = $(WX_CPPFLAGS) -DNDEBUG \
-	-I$(wx_top_builddir)/3rdparty/pcre/src -D__WX__ -DHAVE_CONFIG_H \
-	-DPCRE2_CODE_UNIT_WIDTH=$(wxPCRE2_CODE_UNIT_WIDTH) $(WX_CFLAGS) \
-	$(____SHARED) $(CPPFLAGS) $(CFLAGS)
+WXREGEX_CFLAGS = -I$(wx_top_builddir)/3rdparty/pcre/src -D__WX__ \
+	-DHAVE_CONFIG_H -DPCRE2_CODE_UNIT_WIDTH=$(wxPCRE2_CODE_UNIT_WIDTH) \
+	$(WX_CPPFLAGS) -DNDEBUG $(WX_CFLAGS) $(____SHARED) $(CPPFLAGS) $(CFLAGS)
 WXREGEX_OBJECTS =  \
 	wxregex_pcre2_auto_possess.o \
 	wxregex_pcre2_chkdint.o \
@@ -139,7 +138,7 @@ WXZLIB_OBJECTS =  \
 	wxzlib_trees.o \
 	wxzlib_uncompr.o \
 	wxzlib_zutil.o
-WXPNG_CFLAGS = $(WX_CPPFLAGS) -DNDEBUG $(__INC_ZLIB_p) -DPNG_INTEL_SSE \
+WXPNG_CFLAGS = $(__INC_ZLIB_p) -DPNG_INTEL_SSE $(WX_CPPFLAGS) -DNDEBUG \
 	$(WX_CFLAGS) $(____SHARED) $(CPPFLAGS) $(CFLAGS)
 WXPNG_OBJECTS =  \
 	wxpng_png.o \
@@ -337,9 +336,9 @@ WXJPEG_OBJECTS =  \
 	wxjpeg_jquant1.o \
 	wxjpeg_jquant2.o \
 	wxjpeg_jutils.o
-WXTIFF_CFLAGS = $(WX_CPPFLAGS) -DNDEBUG $(__INC_ZLIB_p) $(__INC_JPEG_p) \
-	$(__INC_TIFF_BUILD_p) $(__INC_TIFF_p) $(WX_CFLAGS) $(____SHARED) $(CPPFLAGS) \
-	$(CFLAGS)
+WXTIFF_CFLAGS = $(__INC_ZLIB_p) $(__INC_JPEG_p) $(__INC_TIFF_BUILD_p) \
+	$(__INC_TIFF_p) $(WX_CPPFLAGS) -DNDEBUG $(WX_CFLAGS) $(____SHARED) \
+	$(CPPFLAGS) $(CFLAGS)
 WXTIFF_OBJECTS =  \
 	$(__TIFF_PLATFORM_SRC_OBJECTS) \
 	wxtiff_tif_aux.o \
@@ -383,17 +382,16 @@ WXTIFF_OBJECTS =  \
 	wxtiff_tif_write.o \
 	wxtiff_tif_zip.o \
 	wxtiff_tif_zstd.o
-WXEXPAT_CFLAGS = $(WX_CPPFLAGS) -DNDEBUG -I./src/expat/expat \
-	-DHAVE_EXPAT_CONFIG_H $(WX_CFLAGS) $(____SHARED) $(wxCFLAGS_C99) $(CPPFLAGS) \
-	$(CFLAGS)
+WXEXPAT_CFLAGS = -I./src/expat/expat -DHAVE_EXPAT_CONFIG_H $(WX_CPPFLAGS) \
+	-DNDEBUG $(wxCFLAGS_C99) $(WX_CFLAGS) $(____SHARED) $(CPPFLAGS) $(CFLAGS)
 WXEXPAT_OBJECTS =  \
 	wxexpat_xmlparse.o \
 	wxexpat_xmlrole.o \
 	wxexpat_xmltok.o
-WXSCINTILLA_CXXFLAGS = $(WX_CPPFLAGS) -DNDEBUG \
+WXSCINTILLA_CXXFLAGS = $(__wx) -D__WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p) \
+	$(__DEBUG_DEFINE_p) $(WX_CPPFLAGS) -DNDEBUG \
 	-I$(top_srcdir)/src/stc/scintilla/include \
-	-I$(top_srcdir)/src/stc/scintilla/src -D__WX__ $(__wx) -D__WX$(TOOLKIT)__ \
-	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(WX_CXXFLAGS) $(____SHARED) \
+	-I$(top_srcdir)/src/stc/scintilla/src -D__WX__ $(WX_CXXFLAGS) $(____SHARED) \
 	$(CPPFLAGS) $(CXXFLAGS)
 WXSCINTILLA_OBJECTS =  \
 	wxscintilla_AutoComplete.o \
@@ -426,14 +424,14 @@ WXSCINTILLA_OBJECTS =  \
 	wxscintilla_UniqueString.o \
 	wxscintilla_ViewStyle.o \
 	wxscintilla_XPM.o
-WXLEXILLA_CXXFLAGS = $(WX_CPPFLAGS) -DNDEBUG \
+WXLEXILLA_CXXFLAGS = $(__wx) -D__WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p) \
+	$(__DEBUG_DEFINE_p) $(WX_CPPFLAGS) -DNDEBUG \
 	-I$(top_srcdir)/src/stc/lexilla/access \
 	-I$(top_srcdir)/src/stc/lexilla/include \
 	-I$(top_srcdir)/src/stc/lexilla/lexlib \
 	-I$(top_srcdir)/src/stc/lexilla/include \
 	-I$(top_srcdir)/src/stc/scintilla/include \
-	-I$(top_srcdir)/src/stc/scintilla/src $(__wx) -D__WX$(TOOLKIT)__ \
-	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(WX_CXXFLAGS) $(____SHARED) \
+	-I$(top_srcdir)/src/stc/scintilla/src $(WX_CXXFLAGS) $(____SHARED) \
 	$(CPPFLAGS) $(CXXFLAGS)
 WXLEXILLA_OBJECTS =  \
 	wxlexilla_LexillaAccess.o \
@@ -2489,13 +2487,13 @@ COND_USE_GUI_1_wxUSE_LIBJPEG_builtin___wxjpeg___depname = \
 COND_USE_GUI_1_wxUSE_LIBTIFF_builtin___wxtiff___depname = \
 	$(LIBDIRNAME)/$(LIBPREFIX)wxtiff$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)$(LIBEXT)
 @COND_USE_GUI_1_wxUSE_LIBTIFF_builtin@__wxtiff___depname = $(COND_USE_GUI_1_wxUSE_LIBTIFF_builtin___wxtiff___depname)
+@COND_PLATFORM_MACOSX_1@__TIFF_PLATFORM_SRC_OBJECTS = wxtiff_tif_unix.o
+@COND_PLATFORM_UNIX_1@__TIFF_PLATFORM_SRC_OBJECTS = wxtiff_tif_unix.o
+@COND_PLATFORM_WIN32_1@__TIFF_PLATFORM_SRC_OBJECTS = wxtiff_tif_win32.o
 @COND_SHARED_0_USE_GUI_1_wxUSE_LIBTIFF_builtin@__install_wxtiff___depname \
 @COND_SHARED_0_USE_GUI_1_wxUSE_LIBTIFF_builtin@	= install_wxtiff
 @COND_SHARED_0_USE_GUI_1_wxUSE_LIBTIFF_builtin@__uninstall_wxtiff___depname \
 @COND_SHARED_0_USE_GUI_1_wxUSE_LIBTIFF_builtin@	= uninstall_wxtiff
-@COND_PLATFORM_MACOSX_1@__TIFF_PLATFORM_SRC_OBJECTS = wxtiff_tif_unix.o
-@COND_PLATFORM_UNIX_1@__TIFF_PLATFORM_SRC_OBJECTS = wxtiff_tif_unix.o
-@COND_PLATFORM_WIN32_1@__TIFF_PLATFORM_SRC_OBJECTS = wxtiff_tif_win32.o
 COND_wxUSE_EXPAT_builtin___wxexpat___depname = \
 	$(LIBDIRNAME)/$(LIBPREFIX)wxexpat$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)$(LIBEXT)
 @COND_wxUSE_EXPAT_builtin@__wxexpat___depname = $(COND_wxUSE_EXPAT_builtin___wxexpat___depname)
@@ -12379,9 +12377,9 @@ COND_USE_WEBVIEW_WEBKIT2_1___webkit2_ext___depname = \
 @COND_USE_XML_1@__clean_wxrc___depname = clean-wxrc
 @COND_USE_XML_1@__install_wxrc___depname = install-wxrc
 @COND_TOOLKIT_MSW@RCDEFS_H = msw/rcdefs.h
+@COND_MONOLITHIC_0_SHARED_1@__wx = -DWXUSINGDLL
 @COND_SHARED_0@____SHARED = 
 @COND_SHARED_1@____SHARED = $(PIC_FLAG)
-@COND_MONOLITHIC_0_SHARED_1@__wx = -DWXUSINGDLL
 @COND_TOOLKIT_MSW@__webview_additional_include_wrl_p_0 = \
 @COND_TOOLKIT_MSW@	--include-dir $(top_srcdir)/include/wx/msw/wrl
 @COND_TOOLKIT_MSW@__webview_additional_include_p_0 = \

--- a/build/bakefiles/common.bkl
+++ b/build/bakefiles/common.bkl
@@ -407,13 +407,7 @@
         <install-to>$(LIBDIR)</install-to>
     </template>
 
-    <template id="3rdparty_lib" template="common_settings,anylib">
-        <if cond="FORMAT=='autoconf'">
-            <libname>$(id)$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)</libname>
-        </if>
-        <if cond="FORMAT!='autoconf'">
-            <libname>$(id)$(WXDEBUGFLAG)$(HOST_SUFFIX)</libname>
-        </if>
+    <template id="3rdparty_lib_base" template="common_settings,anylib">
         <!--
         we want to install 3rd party libs system-wide only with static
         version of wxWidgets; otherwise they are embedded in shared libs:
@@ -438,6 +432,33 @@
         </if>
     </template>
 
+    <!--
+        This template is used for most third party libraries.
+
+        Note: when inheriting from this template, template_append should
+        be normally used instead of just template, to ensure that the built-in
+        third party libraries include directories appear before the ones
+        defined here (which could include the same headers).
+    -->
+    <template id="3rdparty_lib" template="3rdparty_lib_base">
+        <if cond="FORMAT=='autoconf'">
+            <libname>$(id)$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)</libname>
+        </if>
+        <if cond="FORMAT!='autoconf'">
+            <libname>$(id)$(WXDEBUGFLAG)$(HOST_SUFFIX)</libname>
+        </if>
+    </template>
+
+    <!-- This one is only used by wxregex currently and additionally includes
+         "u" suffix in the library name for compatibility. -->
+    <template id="3rdparty_lib_u" template="3rdparty_lib_base">
+        <libname cond="FORMAT=='autoconf'">
+            $(id)u$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)
+        </libname>
+        <libname cond="FORMAT!='autoconf'">
+            $(id)u$(WXDEBUGFLAG)$(HOST_SUFFIX)
+        </libname>
+    </template>
 
     <!-- deal with the need to copy setup.h here: -->
 

--- a/build/bakefiles/expat.bkl
+++ b/build/bakefiles/expat.bkl
@@ -23,7 +23,7 @@
         <if cond="wxUSE_EXPAT=='builtin'">$(TOP_SRCDIR)src/expat/expat/lib</if>
     </set>
 
-    <lib id="wxexpat" template="3rdparty_lib"
+    <lib id="wxexpat" template_append="3rdparty_lib"
          cond="wxUSE_EXPAT=='builtin' and BUILDING_LIB=='1'">
         <dirname>$(LIBDIRNAME)</dirname>
         <include cond="FORMAT!='autoconf'">$(LIBDIRNAME)</include>

--- a/build/bakefiles/jpeg.bkl
+++ b/build/bakefiles/jpeg.bkl
@@ -21,7 +21,7 @@
         <if cond="wxUSE_LIBJPEG=='builtin'">$(TOP_SRCDIR)src/jpeg</if>
     </set>
 
-    <lib id="wxjpeg" template="3rdparty_lib"
+    <lib id="wxjpeg" template_append="3rdparty_lib"
          cond="wxUSE_LIBJPEG=='builtin' and USE_GUI=='1' and BUILDING_LIB=='1'">
         <dirname>$(LIBDIRNAME)</dirname>
         <include cond="FORMAT!='autoconf'">$(SETUPHDIR)</include>

--- a/build/bakefiles/lexilla.bkl
+++ b/build/bakefiles/lexilla.bkl
@@ -29,7 +29,7 @@
         <if cond="SHARED=='1' and MONOLITHIC=='0'">WXUSINGDLL</if>
     </set>
 
-    <lib id="wxlexilla" template="3rdparty_lib,wxlexilla_cppflags,msvc_setup_h"
+    <lib id="wxlexilla" template_append="3rdparty_lib,wxlexilla_cppflags,msvc_setup_h"
          cond="USE_STC=='1' and BUILDING_LIB=='1'">
         <if cond="FORMAT!='autoconf'">
             <include>$(SETUPHDIR)</include>

--- a/build/bakefiles/png.bkl
+++ b/build/bakefiles/png.bkl
@@ -21,7 +21,7 @@
         <if cond="wxUSE_LIBPNG=='builtin'">$(TOP_SRCDIR)src/png</if>
     </set>
 
-    <lib id="wxpng" template="3rdparty_lib"
+    <lib id="wxpng" template_append="3rdparty_lib"
          cond="wxUSE_LIBPNG=='builtin' and USE_GUI=='1' and BUILDING_LIB=='1'">
         <dirname>$(LIBDIRNAME)</dirname>
         <include>$(INC_ZLIB)</include>

--- a/build/bakefiles/regex.bkl
+++ b/build/bakefiles/regex.bkl
@@ -29,14 +29,8 @@
         </if>
     </set>
 
-    <lib id="wxregex" template="msvc_setup_h,3rdparty_lib"
+    <lib id="wxregex" template_append="msvc_setup_h,3rdparty_lib_u"
          cond="wxUSE_REGEX=='builtin' and BUILDING_LIB=='1'">
-        <libname cond="FORMAT=='autoconf'">
-            $(id)u$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)
-        </libname>
-        <libname cond="FORMAT!='autoconf'">
-            $(id)u$(WXDEBUGFLAG)$(HOST_SUFFIX)
-        </libname>
         <include cond="FORMAT!='autoconf'">$(TOP_SRCDIR)include</include>
         <include cond="FORMAT!='autoconf'">$(SETUPHDIR)</include>
         <include cond="FORMAT!='autoconf'">$(INC_REGEX)</include>

--- a/build/bakefiles/scintilla.bkl
+++ b/build/bakefiles/scintilla.bkl
@@ -39,7 +39,7 @@
         <if cond="SHARED=='1' and MONOLITHIC=='0'">WXUSINGDLL</if>
     </set>
 
-    <lib id="wxscintilla" template="3rdparty_lib,wxscintilla_cppflags,msvc_setup_h"
+    <lib id="wxscintilla" template_append="3rdparty_lib,wxscintilla_cppflags,msvc_setup_h"
          cond="USE_STC=='1' and BUILDING_LIB=='1'">
         <if cond="FORMAT!='autoconf'">
             <include>$(SETUPHDIR)</include>

--- a/build/bakefiles/tiff.bkl
+++ b/build/bakefiles/tiff.bkl
@@ -35,7 +35,7 @@
         <if cond="PLATFORM_WIN32=='1'">src/tiff/libtiff/tif_win32.c</if>
     </set>
 
-    <lib id="wxtiff" template="3rdparty_lib"
+    <lib id="wxtiff" template_append="3rdparty_lib"
          cond="wxUSE_LIBTIFF=='builtin' and USE_GUI=='1' and BUILDING_LIB=='1'">
         <dirname>$(LIBDIRNAME)</dirname>
         <include>$(INC_ZLIB)</include>

--- a/build/bakefiles/webp.bkl
+++ b/build/bakefiles/webp.bkl
@@ -24,18 +24,10 @@
         <if cond="wxUSE_LIBWEBP=='builtin'">$(TOP_SRCDIR)3rdparty/libwebp</if>
     </set>
 
-    <!--
-        By using this template before 3rdparty_lib template, the include will
-        be before includes inherited from 3rdparty_lib (i.e. all WX_CPPFLAGS),
-        which could contain system-specific webp paths.
-    -->
-    <template id="webp_include">
-        <include>$(INC_WEBP_BUILD)</include>
-    </template>
-
-    <lib id="wxwebp" template="webp_include,3rdparty_lib"
+    <lib id="wxwebp" template_append="3rdparty_lib"
          cond="wxUSE_LIBWEBP=='builtin' and USE_GUI=='1' and BUILDING_LIB=='1'">
         <dirname>$(LIBDIRNAME)</dirname>
+        <include>$(INC_WEBP_BUILD)</include>
         <sources>
             3rdparty/libwebp/sharpyuv/sharpyuv.c
             3rdparty/libwebp/sharpyuv/sharpyuv_cpu.c

--- a/build/bakefiles/zlib.bkl
+++ b/build/bakefiles/zlib.bkl
@@ -21,7 +21,7 @@
         <if cond="wxUSE_ZLIB=='builtin'">$(TOP_SRCDIR)src/zlib</if>
     </set>
 
-    <lib id="wxzlib" template="3rdparty_lib"
+    <lib id="wxzlib" template_append="3rdparty_lib"
          cond="wxUSE_ZLIB=='builtin' and BUILDING_LIB=='1'">
         <dirname>$(LIBDIRNAME)</dirname>
         <cflags-borland>

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -40,9 +40,9 @@ OBJS = \
 LIBDIRNAME = \
 	..\..\lib\$(COMPILER_PREFIX)$(COMPILER_VERSION)_$(LIBTYPE_SUFFIX)$(CFG)
 SETUPHDIR = $(LIBDIRNAME)\$(PORTNAME)$(WXUNIVNAME)u$(WXDEBUGFLAG)
-WXREGEX_CFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG \
-	-I..\..\include -I$(SETUPHDIR) -I..\..\3rdparty\pcre\src\wx -D__WX__ \
-	-DHAVE_CONFIG_H $(CPPFLAGS) $(CFLAGS)
+WXREGEX_CFLAGS = -I..\..\include -I$(SETUPHDIR) -I..\..\3rdparty\pcre\src\wx \
+	-D__WX__ -DHAVE_CONFIG_H $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
+	-DNDEBUG $(CPPFLAGS) $(CFLAGS)
 WXREGEX_OBJECTS =  \
 	$(OBJS)\wxregex_pcre2_auto_possess.o \
 	$(OBJS)\wxregex_pcre2_chkdint.o \
@@ -91,8 +91,8 @@ WXZLIB_OBJECTS =  \
 	$(OBJS)\wxzlib_trees.o \
 	$(OBJS)\wxzlib_uncompr.o \
 	$(OBJS)\wxzlib_zutil.o
-WXPNG_CFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG \
-	-I..\..\src\zlib -DPNG_INTEL_SSE $(CPPFLAGS) $(CFLAGS)
+WXPNG_CFLAGS = -I..\..\src\zlib -DPNG_INTEL_SSE $(__DEBUGINFO) \
+	$(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG $(CPPFLAGS) $(CFLAGS)
 WXPNG_OBJECTS =  \
 	$(OBJS)\wxpng_png.o \
 	$(OBJS)\wxpng_pngerror.o \
@@ -240,8 +240,8 @@ WXWEBP_OBJECTS =  \
 	$(OBJS)\wxwebp_rescaler_utils.o \
 	$(OBJS)\wxwebp_thread_utils.o \
 	$(OBJS)\wxwebp_utils.o
-WXJPEG_CFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG \
-	-I$(SETUPHDIR) $(CPPFLAGS) $(CFLAGS)
+WXJPEG_CFLAGS = -I$(SETUPHDIR) $(__DEBUGINFO) $(__OPTIMIZEFLAG) \
+	$(__THREADSFLAG) -DNDEBUG $(CPPFLAGS) $(CFLAGS)
 WXJPEG_OBJECTS =  \
 	$(OBJS)\wxjpeg_jaricom.o \
 	$(OBJS)\wxjpeg_jcapimin.o \
@@ -289,8 +289,8 @@ WXJPEG_OBJECTS =  \
 	$(OBJS)\wxjpeg_jquant1.o \
 	$(OBJS)\wxjpeg_jquant2.o \
 	$(OBJS)\wxjpeg_jutils.o
-WXTIFF_CFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG \
-	-I..\..\src\zlib -I..\..\src\jpeg -I..\..\src\tiff\libtiff $(CPPFLAGS) \
+WXTIFF_CFLAGS = -I..\..\src\zlib -I..\..\src\jpeg -I..\..\src\tiff\libtiff \
+	$(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG $(CPPFLAGS) \
 	$(CFLAGS)
 WXTIFF_OBJECTS =  \
 	$(OBJS)\wxtiff_tif_win32.o \
@@ -335,16 +335,16 @@ WXTIFF_OBJECTS =  \
 	$(OBJS)\wxtiff_tif_write.o \
 	$(OBJS)\wxtiff_tif_zip.o \
 	$(OBJS)\wxtiff_tif_zstd.o
-WXEXPAT_CFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG \
-	-I$(LIBDIRNAME) $(CPPFLAGS) $(CFLAGS)
+WXEXPAT_CFLAGS = -I$(LIBDIRNAME) $(__DEBUGINFO) $(__OPTIMIZEFLAG) \
+	$(__THREADSFLAG) -DNDEBUG $(CPPFLAGS) $(CFLAGS)
 WXEXPAT_OBJECTS =  \
 	$(OBJS)\wxexpat_xmlparse.o \
 	$(OBJS)\wxexpat_xmlrole.o \
 	$(OBJS)\wxexpat_xmltok.o
-WXSCINTILLA_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
-	-DNDEBUG -I..\..\src\stc\scintilla\include -I..\..\src\stc\scintilla\src \
-	-D__WX__ -I$(SETUPHDIR) -I..\..\include $(__wx) -D__WXMSW__ \
-	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__RTTIFLAG) $(__EXCEPTIONSFLAG) \
+WXSCINTILLA_CXXFLAGS = -I$(SETUPHDIR) -I..\..\include $(__wx) -D__WXMSW__ \
+	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__DEBUGINFO) $(__OPTIMIZEFLAG) \
+	$(__THREADSFLAG) -DNDEBUG -I..\..\src\stc\scintilla\include \
+	-I..\..\src\stc\scintilla\src -D__WX__ $(__RTTIFLAG) $(__EXCEPTIONSFLAG) \
 	$(CPPFLAGS) $(CXXFLAGS)
 WXSCINTILLA_OBJECTS =  \
 	$(OBJS)\wxscintilla_AutoComplete.o \
@@ -377,12 +377,12 @@ WXSCINTILLA_OBJECTS =  \
 	$(OBJS)\wxscintilla_UniqueString.o \
 	$(OBJS)\wxscintilla_ViewStyle.o \
 	$(OBJS)\wxscintilla_XPM.o
-WXLEXILLA_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -DNDEBUG \
-	-I..\..\src\stc\lexilla\access -I..\..\src\stc\lexilla\include \
-	-I..\..\src\stc\lexilla\lexlib -I..\..\src\stc\lexilla\include \
-	-I..\..\src\stc\scintilla\include -I..\..\src\stc\scintilla\src \
-	-I$(SETUPHDIR) -I..\..\include $(__wx) -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
-	$(__DEBUG_DEFINE_p) $(__RTTIFLAG) $(__EXCEPTIONSFLAG) $(CPPFLAGS) \
+WXLEXILLA_CXXFLAGS = -I$(SETUPHDIR) -I..\..\include $(__wx) -D__WXMSW__ \
+	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__DEBUGINFO) $(__OPTIMIZEFLAG) \
+	$(__THREADSFLAG) -DNDEBUG -I..\..\src\stc\lexilla\access \
+	-I..\..\src\stc\lexilla\include -I..\..\src\stc\lexilla\lexlib \
+	-I..\..\src\stc\lexilla\include -I..\..\src\stc\scintilla\include \
+	-I..\..\src\stc\scintilla\src $(__RTTIFLAG) $(__EXCEPTIONSFLAG) $(CPPFLAGS) \
 	$(CXXFLAGS)
 WXLEXILLA_OBJECTS =  \
 	$(OBJS)\wxlexilla_LexillaAccess.o \

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -40,12 +40,12 @@ LIBDIRNAME = \
 	..\..\lib\$(COMPILER_PREFIX)$(COMPILER_VERSION)$(ARCH_SUFFIX)_$(LIBTYPE_SUFFIX)$(CFG)
 SETUPHDIR = $(LIBDIRNAME)\$(PORTNAME)$(WXUNIVNAME)u$(WXDEBUGFLAG)
 WXREGEX_CFLAGS = /M$(__RUNTIME_LIBS_10)$(__DEBUGRUNTIME) /DWIN32 \
-	$(__DEBUGINFO) /Fd$(LIBDIRNAME)\wxregexu$(WXDEBUGFLAG).pdb \
+	/I..\..\include /I$(SETUPHDIR) /I..\..\3rdparty\pcre\src\wx /D__WX__ \
+	/DHAVE_CONFIG_H $(__DEBUGINFO) /Fd$(LIBDIRNAME)\wxregexu$(WXDEBUGFLAG).pdb \
 	$(____DEBUGRUNTIME) $(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
-	/D_CRT_SECURE_NO_WARNINGS /I..\..\include /I$(SETUPHDIR) \
-	/I..\..\3rdparty\pcre\src\wx /D__WX__ /DHAVE_CONFIG_H $(CPPFLAGS) $(CFLAGS)
+	/D_CRT_SECURE_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
 WXREGEX_OBJECTS =  \
 	$(OBJS)\wxregex_pcre2_auto_possess.obj \
 	$(OBJS)\wxregex_pcre2_chkdint.obj \
@@ -76,12 +76,13 @@ WXREGEX_OBJECTS =  \
 	$(OBJS)\wxregex_pcre2_valid_utf.obj \
 	$(OBJS)\wxregex_pcre2_xclass.obj \
 	$(OBJS)\wxregex_pcre2_chartables.obj
-WXZLIB_CFLAGS = /M$(__RUNTIME_LIBS_25)$(__DEBUGRUNTIME) /DWIN32 $(__DEBUGINFO) \
+WXZLIB_CFLAGS = /M$(__RUNTIME_LIBS_25)$(__DEBUGRUNTIME) /DWIN32 \
+	/D_CRT_NONSTDC_NO_WARNINGS $(__DEBUGINFO) \
 	/Fd$(LIBDIRNAME)\wxzlib$(WXDEBUGFLAG).pdb $(____DEBUGRUNTIME) \
 	$(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
-	/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
+	/D_CRT_SECURE_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
 WXZLIB_OBJECTS =  \
 	$(OBJS)\wxzlib_adler32.obj \
 	$(OBJS)\wxzlib_compress.obj \
@@ -98,13 +99,13 @@ WXZLIB_OBJECTS =  \
 	$(OBJS)\wxzlib_trees.obj \
 	$(OBJS)\wxzlib_uncompr.obj \
 	$(OBJS)\wxzlib_zutil.obj
-WXPNG_CFLAGS = /M$(__RUNTIME_LIBS_40)$(__DEBUGRUNTIME) /DWIN32 $(__DEBUGINFO) \
+WXPNG_CFLAGS = /M$(__RUNTIME_LIBS_40)$(__DEBUGRUNTIME) /DWIN32 \
+	/I..\..\src\zlib /DPNG_INTEL_SSE $(__DEBUGINFO) \
 	/Fd$(LIBDIRNAME)\wxpng$(WXDEBUGFLAG).pdb $(____DEBUGRUNTIME) \
 	$(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
-	/D_CRT_SECURE_NO_WARNINGS /I..\..\src\zlib /DPNG_INTEL_SSE $(CPPFLAGS) \
-	$(CFLAGS)
+	/D_CRT_SECURE_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
 WXPNG_OBJECTS =  \
 	$(OBJS)\wxpng_png.obj \
 	$(OBJS)\wxpng_pngerror.obj \
@@ -253,12 +254,12 @@ WXWEBP_OBJECTS =  \
 	$(OBJS)\wxwebp_rescaler_utils.obj \
 	$(OBJS)\wxwebp_thread_utils.obj \
 	$(OBJS)\wxwebp_utils.obj
-WXJPEG_CFLAGS = /M$(__RUNTIME_LIBS_70)$(__DEBUGRUNTIME) /DWIN32 $(__DEBUGINFO) \
-	/Fd$(LIBDIRNAME)\wxjpeg$(WXDEBUGFLAG).pdb $(____DEBUGRUNTIME) \
-	$(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
+WXJPEG_CFLAGS = /M$(__RUNTIME_LIBS_70)$(__DEBUGRUNTIME) /DWIN32 /I$(SETUPHDIR) \
+	$(__DEBUGINFO) /Fd$(LIBDIRNAME)\wxjpeg$(WXDEBUGFLAG).pdb \
+	$(____DEBUGRUNTIME) $(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
-	/D_CRT_SECURE_NO_WARNINGS /I$(SETUPHDIR) $(CPPFLAGS) $(CFLAGS)
+	/D_CRT_SECURE_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
 WXJPEG_OBJECTS =  \
 	$(OBJS)\wxjpeg_jaricom.obj \
 	$(OBJS)\wxjpeg_jcapimin.obj \
@@ -306,13 +307,14 @@ WXJPEG_OBJECTS =  \
 	$(OBJS)\wxjpeg_jquant1.obj \
 	$(OBJS)\wxjpeg_jquant2.obj \
 	$(OBJS)\wxjpeg_jutils.obj
-WXTIFF_CFLAGS = /M$(__RUNTIME_LIBS_85)$(__DEBUGRUNTIME) /DWIN32 $(__DEBUGINFO) \
+WXTIFF_CFLAGS = /M$(__RUNTIME_LIBS_85)$(__DEBUGRUNTIME) /DWIN32 \
+	/I..\..\src\zlib /I..\..\src\jpeg /I..\..\src\tiff\libtiff \
+	/D_CRT_NONSTDC_NO_WARNINGS $(__DEBUGINFO) \
 	/Fd$(LIBDIRNAME)\wxtiff$(WXDEBUGFLAG).pdb $(____DEBUGRUNTIME) \
 	$(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
-	/D_CRT_SECURE_NO_WARNINGS /I..\..\src\zlib /I..\..\src\jpeg \
-	/I..\..\src\tiff\libtiff /D_CRT_NONSTDC_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
+	/D_CRT_SECURE_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
 WXTIFF_OBJECTS =  \
 	$(OBJS)\wxtiff_tif_win32.obj \
 	$(OBJS)\wxtiff_tif_aux.obj \
@@ -357,24 +359,25 @@ WXTIFF_OBJECTS =  \
 	$(OBJS)\wxtiff_tif_zip.obj \
 	$(OBJS)\wxtiff_tif_zstd.obj
 WXEXPAT_CFLAGS = /M$(__RUNTIME_LIBS_100)$(__DEBUGRUNTIME) /DWIN32 \
-	$(__DEBUGINFO) /Fd$(LIBDIRNAME)\wxexpat$(WXDEBUGFLAG).pdb \
+	/I$(LIBDIRNAME) $(__DEBUGINFO) /Fd$(LIBDIRNAME)\wxexpat$(WXDEBUGFLAG).pdb \
 	$(____DEBUGRUNTIME) $(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
-	/D_CRT_SECURE_NO_WARNINGS /I$(LIBDIRNAME) $(CPPFLAGS) $(CFLAGS)
+	/D_CRT_SECURE_NO_WARNINGS $(CPPFLAGS) $(CFLAGS)
 WXEXPAT_OBJECTS =  \
 	$(OBJS)\wxexpat_xmlparse.obj \
 	$(OBJS)\wxexpat_xmlrole.obj \
 	$(OBJS)\wxexpat_xmltok.obj
 WXSCINTILLA_CXXFLAGS = /M$(__RUNTIME_LIBS_115)$(__DEBUGRUNTIME) /DWIN32 \
-	$(__DEBUGINFO) /Fd$(LIBDIRNAME)\wxscintilla$(WXDEBUGFLAG).pdb \
-	$(____DEBUGRUNTIME) $(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
+	/I$(SETUPHDIR) /I..\..\include $(__wx) /D__WXMSW__ $(__WXUNIV_DEFINE_p) \
+	$(__DEBUG_DEFINE_p) $(__DEBUGINFO) \
+	/Fd$(LIBDIRNAME)\wxscintilla$(WXDEBUGFLAG).pdb $(____DEBUGRUNTIME) \
+	$(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
 	/D_CRT_SECURE_NO_WARNINGS /I..\..\src\stc\scintilla\include \
-	/I..\..\src\stc\scintilla\src /D__WX__ /I$(SETUPHDIR) /I..\..\include \
-	$(__wx) /D__WXMSW__ $(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__RTTIFLAG) \
-	$(__EXCEPTIONSFLAG) $(CPPFLAGS) $(CXXFLAGS)
+	/I..\..\src\stc\scintilla\src /D__WX__ $(__RTTIFLAG) $(__EXCEPTIONSFLAG) \
+	$(CPPFLAGS) $(CXXFLAGS)
 WXSCINTILLA_OBJECTS =  \
 	$(OBJS)\wxscintilla_AutoComplete.obj \
 	$(OBJS)\wxscintilla_CallTip.obj \
@@ -407,16 +410,17 @@ WXSCINTILLA_OBJECTS =  \
 	$(OBJS)\wxscintilla_ViewStyle.obj \
 	$(OBJS)\wxscintilla_XPM.obj
 WXLEXILLA_CXXFLAGS = /M$(__RUNTIME_LIBS_130)$(__DEBUGRUNTIME) /DWIN32 \
-	$(__DEBUGINFO) /Fd$(LIBDIRNAME)\wxlexilla$(WXDEBUGFLAG).pdb \
-	$(____DEBUGRUNTIME) $(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
+	/I$(SETUPHDIR) /I..\..\include $(__wx) /D__WXMSW__ $(__WXUNIV_DEFINE_p) \
+	$(__DEBUG_DEFINE_p) $(__DEBUGINFO) \
+	/Fd$(LIBDIRNAME)\wxlexilla$(WXDEBUGFLAG).pdb $(____DEBUGRUNTIME) \
+	$(__OPTIMIZEFLAG) /D_CRT_SECURE_NO_DEPRECATE=1 \
 	/D_CRT_NON_CONFORMING_SWPRINTFS=1 /D_SCL_SECURE_NO_WARNINGS=1 \
 	$(__NO_VC_CRTDBG_p) $(__TARGET_CPU_COMPFLAG_p) /DNDEBUG \
 	/D_CRT_SECURE_NO_WARNINGS /I..\..\src\stc\lexilla\access \
 	/I..\..\src\stc\lexilla\include /I..\..\src\stc\lexilla\lexlib \
 	/I..\..\src\stc\lexilla\include /I..\..\src\stc\scintilla\include \
-	/I..\..\src\stc\scintilla\src /I$(SETUPHDIR) /I..\..\include $(__wx) \
-	/D__WXMSW__ $(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__RTTIFLAG) \
-	$(__EXCEPTIONSFLAG) $(CPPFLAGS) $(CXXFLAGS)
+	/I..\..\src\stc\scintilla\src $(__RTTIFLAG) $(__EXCEPTIONSFLAG) $(CPPFLAGS) \
+	$(CXXFLAGS)
 WXLEXILLA_OBJECTS =  \
 	$(OBJS)\wxlexilla_LexillaAccess.obj \
 	$(OBJS)\wxlexilla_LexA68k.obj \


### PR DESCRIPTION
Move -I options for built-in 3rd party libraries forward in the compiler command line to ensure that they're getting included even when the system libraries are also available.

Closes #25350.