### PR TITLE
Add wxNODISCARD to all Clone*() functions that return a pointer

### DIFF
--- a/include/wx/anidecod.h
+++ b/include/wx/anidecod.h
@@ -52,7 +52,7 @@ public:
 
     bool ConvertToImage(unsigned int frame, wxImage *image) const override;
 
-    wxAnimationDecoder *Clone() const override
+    wxNODISCARD wxAnimationDecoder *Clone() const override
         { return new wxANIDecoder; }
     wxAnimationType GetType() const override
         { return wxANIMATION_TYPE_ANI; }

--- a/include/wx/animdecod.h
+++ b/include/wx/animdecod.h
@@ -100,7 +100,7 @@ public:
                     CallIfCanSeek(&wxAnimationDecoder::DoCanRead, this);
     }
 
-    virtual wxAnimationDecoder *Clone() const = 0;
+    wxNODISCARD virtual wxAnimationDecoder *Clone() const = 0;
     virtual wxAnimationType GetType() const = 0;
 
     // convert given frame to wxImage

--- a/include/wx/archive.h
+++ b/include/wx/archive.h
@@ -55,7 +55,7 @@ public:
     virtual void SetName(const wxString& name,
                          wxPathFormat format = wxPATH_NATIVE) = 0;
 
-    wxArchiveEntry *Clone() const { return DoClone(); }
+    wxNODISCARD wxArchiveEntry *Clone() const { return DoClone(); }
 
     void SetNotifier(wxArchiveNotifier& notifier);
     virtual void UnsetNotifier() { m_notifier = nullptr; }

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -77,7 +77,7 @@ public:
         m_isDropdownClicked = false;
         m_toolId = -1;
     }
-    wxEvent *Clone() const override { return new wxAuiToolBarEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxAuiToolBarEvent(*this); }
 
     bool IsDropDownClicked() const  { return m_isDropdownClicked; }
     void SetDropDownClicked(bool c) { m_isDropdownClicked = c;    }
@@ -269,7 +269,7 @@ public:
     wxAuiToolBarArt() = default;
     virtual ~wxAuiToolBarArt() = default;
 
-    virtual wxAuiToolBarArt* Clone() = 0;
+    wxNODISCARD virtual wxAuiToolBarArt* Clone() = 0;
     virtual void SetFlags(unsigned int flags) = 0;
     virtual unsigned int GetFlags() = 0;
     virtual void SetFont(const wxFont& font) = 0;
@@ -367,7 +367,7 @@ public:
     wxAuiGenericToolBarArt();
     virtual ~wxAuiGenericToolBarArt();
 
-    virtual wxAuiToolBarArt* Clone() override;
+    wxNODISCARD virtual wxAuiToolBarArt* Clone() override;
     virtual void SetFlags(unsigned int flags) override;
     virtual unsigned int GetFlags() override;
     virtual void SetFont(const wxFont& font) override;

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -77,7 +77,7 @@ public:
     {
         m_dragSource = nullptr;
     }
-    wxEvent *Clone() const override { return new wxAuiNotebookEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxAuiNotebookEvent(*this); }
 
     void SetDragSource(wxAuiNotebook* s) { m_dragSource = s; }
     wxAuiNotebook* GetDragSource() const { return m_dragSource; }

--- a/include/wx/aui/barartmsw.h
+++ b/include/wx/aui/barartmsw.h
@@ -19,7 +19,7 @@ class WXDLLIMPEXP_AUI wxAuiMSWToolBarArt : public wxAuiGenericToolBarArt
 public:
     wxAuiMSWToolBarArt();
 
-    virtual wxAuiToolBarArt* Clone() override;
+    wxNODISCARD virtual wxAuiToolBarArt* Clone() override;
 
     virtual void DrawBackground(
         wxDC& dc,

--- a/include/wx/aui/dockart.h
+++ b/include/wx/aui/dockart.h
@@ -37,7 +37,7 @@ public:
     wxAuiDockArt() = default;
     virtual ~wxAuiDockArt() = default;
 
-    virtual wxAuiDockArt* Clone() = 0;
+    wxNODISCARD virtual wxAuiDockArt* Clone() = 0;
 
     // This function should be used for querying metrics in the new code, as it
     // will scale them by the DPI of the provided window if necessary. The
@@ -102,7 +102,7 @@ public:
 
     wxAuiDefaultDockArt();
 
-    wxAuiDockArt* Clone() override;
+    wxNODISCARD wxAuiDockArt* Clone() override;
     int GetMetric(int metricId) override;
     void SetMetric(int metricId, int newVal) override;
     wxColour GetColour(int id) override;

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -675,7 +675,7 @@ public:
         canveto_flag = true;
         dc = nullptr;
     }
-    wxEvent *Clone() const override { return new wxAuiManagerEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxAuiManagerEvent(*this); }
 
     void SetManager(wxAuiManager* mgr) { manager = mgr; }
     void SetPane(wxAuiPaneInfo* p) { pane = p; }

--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -48,7 +48,7 @@ public:
     wxAuiTabArt() = default;
     virtual ~wxAuiTabArt() = default;
 
-    virtual wxAuiTabArt* Clone() = 0;
+    wxNODISCARD virtual wxAuiTabArt* Clone() = 0;
     virtual void SetFlags(unsigned int flags) = 0;
 
     virtual void SetSizingInfo(const wxSize& tabCtrlSize,
@@ -298,7 +298,7 @@ public:
     wxAuiFlatTabArt(const wxAuiFlatTabArt&) = delete;
     wxAuiFlatTabArt& operator=(const wxAuiFlatTabArt&) = delete;
 
-    wxAuiTabArt* Clone() override;
+    wxNODISCARD wxAuiTabArt* Clone() override;
 
     void SetColour(const wxColour& colour) override;
     void SetActiveColour(const wxColour& colour) override;
@@ -348,7 +348,7 @@ public:
 
     wxAuiGenericTabArt();
 
-    wxAuiTabArt* Clone() override;
+    wxNODISCARD wxAuiTabArt* Clone() override;
 
     void SetColour(const wxColour& colour) override;
     void SetActiveColour(const wxColour& colour) override;
@@ -404,7 +404,7 @@ public:
 
     wxAuiSimpleTabArt();
 
-    wxAuiTabArt* Clone() override;
+    wxNODISCARD wxAuiTabArt* Clone() override;
 
     void SetColour(const wxColour& colour) override;
     void SetActiveColour(const wxColour& colour) override;

--- a/include/wx/aui/tabartgtk.h
+++ b/include/wx/aui/tabartgtk.h
@@ -30,7 +30,7 @@ class WXDLLIMPEXP_AUI wxAuiGtkTabArt : public wxAuiGenericTabArt
 public:
     wxAuiGtkTabArt();
 
-    virtual wxAuiTabArt* Clone() override;
+    wxNODISCARD virtual wxAuiTabArt* Clone() override;
     virtual void DrawBorder(wxDC& dc, wxWindow* wnd, const wxRect& rect) override;
     virtual void DrawBackground(wxDC& dc, wxWindow* wnd, const wxRect& rect) override;
     virtual void DrawTab(wxDC& dc,

--- a/include/wx/aui/tabartmsw.h
+++ b/include/wx/aui/tabartmsw.h
@@ -22,7 +22,7 @@ public:
     wxAuiMSWTabArt();
     virtual ~wxAuiMSWTabArt();
 
-    wxAuiTabArt* Clone() override;
+    wxNODISCARD wxAuiTabArt* Clone() override;
 
     void DrawBorder(
         wxDC& dc,

--- a/include/wx/bookctrl.h
+++ b/include/wx/bookctrl.h
@@ -401,7 +401,7 @@ public:
         m_nOldSel = event.m_nOldSel;
     }
 
-    virtual wxEvent *Clone() const override { return new wxBookCtrlEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxBookCtrlEvent(*this); }
 
     // accessors
         // the currently selected page (wxNOT_FOUND if none)

--- a/include/wx/calctrl.h
+++ b/include/wx/calctrl.h
@@ -166,7 +166,7 @@ public:
     void SetWeekDay(wxDateTime::WeekDay wd) { m_wday = wd; }
     wxDateTime::WeekDay GetWeekDay() const { return m_wday; }
 
-    virtual wxEvent *Clone() const override { return new wxCalendarEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxCalendarEvent(*this); }
 
 private:
     wxDateTime::WeekDay m_wday;

--- a/include/wx/clipbrd.h
+++ b/include/wx/clipbrd.h
@@ -116,7 +116,7 @@ public:
     bool SupportsFormat(const wxDataFormat& format) const;
     void AddFormat(const wxDataFormat& format);
 
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {
         return new wxClipboardEvent(*this);
     }

--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -177,7 +177,7 @@ public:
 
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxColourPickerEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxColourPickerEvent(*this); }
 
 private:
     wxColour m_colour;

--- a/include/wx/collpane.h
+++ b/include/wx/collpane.h
@@ -86,7 +86,7 @@ public:
 
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxCollapsiblePaneEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxCollapsiblePaneEvent(*this); }
 
 private:
     bool m_bCollapsed;

--- a/include/wx/colordlg.h
+++ b/include/wx/colordlg.h
@@ -56,7 +56,7 @@ public:
     wxColour GetColour() const { return m_colour; }
     void SetColour(const wxColour& colour) { m_colour = colour; }
 
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {
         return new wxColourDialogEvent(*this);
     }

--- a/include/wx/colour.h
+++ b/include/wx/colour.h
@@ -203,7 +203,7 @@ protected:
         return nullptr;
     }
 
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *WXUNUSED(data)) const override
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *WXUNUSED(data)) const override
     {
         wxFAIL_MSG( "must be overridden if used" );
 

--- a/include/wx/convauto.h
+++ b/include/wx/convauto.h
@@ -80,7 +80,7 @@ public:
 
     virtual bool IsUTF8() const override { return m_conv && m_conv->IsUTF8(); }
 
-    virtual wxMBConv *Clone() const override { return new wxConvAuto(*this); }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxConvAuto(*this); }
 
     // return the BOM type of this buffer
     static wxBOM DetectBOM(const char *src, size_t srcLen);

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -953,7 +953,7 @@ public:
     void InitData(wxDataObjectComposite* obj, wxDataFormat format);
 #endif // wxUSE_DRAG_AND_DROP
 
-    virtual wxEvent *Clone() const override { return new wxDataViewEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxDataViewEvent(*this); }
 
     // These methods shouldn't be used outside of wxWidgets and wxWidgets
     // itself doesn't use them any longer either as it constructs the events

--- a/include/wx/dateevt.h
+++ b/include/wx/dateevt.h
@@ -33,7 +33,7 @@ public:
     void SetDate(const wxDateTime &date) { m_date = date; }
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxDateEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxDateEvent(*this); }
 
 private:
     wxDateTime m_date;

--- a/include/wx/dfb/bitmap.h
+++ b/include/wx/dfb/bitmap.h
@@ -87,7 +87,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     void InitFromImage(const wxImage& image, int depth, double scale);
 

--- a/include/wx/dfb/brush.h
+++ b/include/wx/dfb/brush.h
@@ -55,7 +55,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     wxDECLARE_DYNAMIC_CLASS(wxBrush);
 };

--- a/include/wx/dfb/cursor.h
+++ b/include/wx/dfb/cursor.h
@@ -38,7 +38,7 @@ protected:
 
     // ref counting code
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     wxDECLARE_DYNAMIC_CLASS(wxCursor);
 };

--- a/include/wx/dfb/font.h
+++ b/include/wx/dfb/font.h
@@ -111,7 +111,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     virtual wxFontFamily DoGetFamily() const;
 

--- a/include/wx/dfb/pen.h
+++ b/include/wx/dfb/pen.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     wxDECLARE_DYNAMIC_CLASS(wxPen);
 };

--- a/include/wx/dfb/region.h
+++ b/include/wx/dfb/region.h
@@ -41,7 +41,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     // wxRegionBase pure virtuals
     virtual bool DoIsEqual(const wxRegion& region) const;

--- a/include/wx/dialog.h
+++ b/include/wx/dialog.h
@@ -389,7 +389,7 @@ public:
     int GetReturnCode() const
         { return GetDialog()->GetReturnCode(); }
 
-    virtual wxEvent *Clone() const override { return new wxWindowModalDialogEvent (*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxWindowModalDialogEvent (*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxWindowModalDialogEvent);

--- a/include/wx/dialup.h
+++ b/include/wx/dialup.h
@@ -177,7 +177,7 @@ public:
     bool IsOwnEvent() const { return m_id != 0; }
 
     // implement the base class pure virtual
-    virtual wxEvent *Clone() const override { return new wxDialUpEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxDialUpEvent(*this); }
 
 private:
     wxDECLARE_NO_ASSIGN_DEF_COPY(wxDialUpEvent);

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -276,7 +276,7 @@ template <typename T>
 class wxDefaultBaseObjectArrayTraits
 {
 public:
-    static T* Clone(const T& value) { return new T{value}; }
+    wxNODISCARD static T* Clone(const T& value) { return new T{value}; }
     static void Free(T* p) { delete p; }
 };
 
@@ -694,7 +694,7 @@ private:
     classdecl wxObjectArrayTraitsFor##name                                    \
     {                                                                         \
     public:                                                                   \
-        static T* Clone(T const& item);                                       \
+        wxNODISCARD static T* Clone(T const& item);                           \
         static void Free(T* p);                                               \
     };                                                                        \
     typedef wxBaseObjectArray<T, wxObjectArrayTraitsFor##name>                \

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -1002,7 +1002,7 @@ public:
     // This function is used to create a copy of the event polymorphically and
     // all derived classes must implement it because otherwise wxPostEvent()
     // for them wouldn't work (it needs to do a copy of the event)
-    virtual wxEvent *Clone() const = 0;
+    wxNODISCARD virtual wxEvent *Clone() const = 0;
 
     // this function is used to selectively process events in wxEventLoopBase::YieldFor
     // NOTE: by default it returns wxEVT_CATEGORY_UI just because the major
@@ -1339,7 +1339,7 @@ public:
     void RequestMore(bool needMore = true) { m_requestMore = needMore; }
     bool MoreRequested() const { return m_requestMore; }
 
-    virtual wxEvent *Clone() const override { return new wxIdleEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxIdleEvent(*this); }
 
     // Specify how wxWidgets will send idle events: to
     // all windows, or only to those which specify that they
@@ -1377,7 +1377,7 @@ public:
         SetString(GetString().Clone());
     }
 
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {
         return new wxThreadEvent(*this);
     }
@@ -1439,7 +1439,7 @@ public:
     {
     }
 
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {
         return new wxAsyncMethodCallEvent0(*this);
     }
@@ -1481,7 +1481,7 @@ public:
     {
     }
 
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {
         return new wxAsyncMethodCallEvent1(*this);
     }
@@ -1528,7 +1528,7 @@ public:
     {
     }
 
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {
         return new wxAsyncMethodCallEvent2(*this);
     }
@@ -1564,7 +1564,7 @@ public:
     {
     }
 
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {
         return new wxAsyncMethodCallEventFunctor(*this);
     }
@@ -1648,7 +1648,7 @@ public:
     // true if the listbox event was a selection.
     bool IsSelection() const { return (m_extraLong != 0); }
 
-    virtual wxEvent *Clone() const override { return new wxCommandEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxCommandEvent(*this); }
     virtual wxEventCategory GetEventCategory() const override { return wxEVT_CATEGORY_USER_INPUT; }
 
 protected:
@@ -1682,7 +1682,7 @@ public:
     // for implementation code only: is the operation allowed?
     bool IsAllowed() const { return m_bAllow; }
 
-    virtual wxEvent *Clone() const override { return new wxNotifyEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxNotifyEvent(*this); }
 
 private:
     bool m_bAllow;
@@ -1717,7 +1717,7 @@ public:
     void SetOrientation(int orient) { m_extraLong = (long) orient; }
     void SetPosition(int pos) { m_commandInt = pos; }
 
-    virtual wxEvent *Clone() const override { return new wxScrollEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxScrollEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxScrollEvent);
@@ -1750,7 +1750,7 @@ public:
     void SetOrientation(int orient) { m_extraLong = (long) orient; }
     void SetPosition(int pos) { m_commandInt = pos; }
 
-    virtual wxEvent *Clone() const override { return new wxScrollWinEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxScrollWinEvent(*this); }
 
 protected:
     int               m_commandInt;
@@ -1898,7 +1898,7 @@ public:
     bool IsSynthesized() const { return m_synthesized; }
 
     float GetMagnification() const { return m_magnification; }
-    virtual wxEvent *Clone() const override { return new wxMouseEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxMouseEvent(*this); }
     virtual wxEventCategory GetEventCategory() const override { return wxEVT_CATEGORY_USER_INPUT; }
 
     wxMouseEvent& operator=(const wxMouseEvent& event)
@@ -1955,7 +1955,7 @@ public:
     const wxCursor& GetCursor() const { return m_cursor; }
     bool HasCursor() const { return m_cursor.IsOk(); }
 
-    virtual wxEvent *Clone() const override { return new wxSetCursorEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSetCursorEvent(*this); }
 
 private:
     wxCoord  m_x, m_y;
@@ -1990,7 +1990,7 @@ public:
     const wxTouchSequenceId& GetSequenceId() const { return m_sequence; }
     void SetSequenceId(const wxTouchSequenceId& sequence) { m_sequence = sequence; }
 
-    virtual wxEvent *Clone() const override { return new wxMultiTouchEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxMultiTouchEvent(*this); }
 
 protected:
     wxPoint2DDouble m_pos;
@@ -2029,7 +2029,7 @@ public:
     bool IsGestureEnd() const { return m_isEnd; }
     void SetGestureEnd(bool isEnd = true) { m_isEnd = isEnd; }
 
-    virtual wxEvent *Clone() const override { return new wxGestureEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxGestureEvent(*this); }
 
 protected:
     wxPoint m_pos;
@@ -2062,7 +2062,7 @@ public:
     wxPoint GetDelta() const { return m_delta; }
     void SetDelta(const wxPoint& delta) { m_delta = delta; }
 
-    virtual wxEvent *Clone() const override { return new wxPanGestureEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxPanGestureEvent(*this); }
 
 private:
     wxPoint m_delta;
@@ -2091,7 +2091,7 @@ public:
     double GetZoomFactor() const { return m_zoomFactor; }
     void SetZoomFactor(double zoomFactor) { m_zoomFactor = zoomFactor; }
 
-    virtual wxEvent *Clone() const override { return new wxZoomGestureEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxZoomGestureEvent(*this); }
 
 private:
     double m_zoomFactor;
@@ -2120,7 +2120,7 @@ public:
     double GetRotationAngle() const { return m_rotationAngle; }
     void SetRotationAngle(double rotationAngle) { m_rotationAngle = rotationAngle; }
 
-    virtual wxEvent *Clone() const override { return new wxRotateGestureEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxRotateGestureEvent(*this); }
 
 private:
     double m_rotationAngle;
@@ -2144,7 +2144,7 @@ public:
     wxTwoFingerTapEvent(const wxTwoFingerTapEvent& event) : wxGestureEvent(event)
     { }
 
-    virtual wxEvent *Clone() const override { return new wxTwoFingerTapEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxTwoFingerTapEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxTwoFingerTapEvent);
@@ -2166,7 +2166,7 @@ public:
     wxLongPressEvent(const wxLongPressEvent& event) : wxGestureEvent(event)
     { }
 
-    virtual wxEvent *Clone() const override { return new wxLongPressEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxLongPressEvent(*this); }
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxLongPressEvent);
 };
@@ -2187,7 +2187,7 @@ public:
     wxPressAndTapEvent(const wxPressAndTapEvent& event) : wxGestureEvent(event)
     { }
 
-    virtual wxEvent *Clone() const override { return new wxPressAndTapEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxPressAndTapEvent(*this); }
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxPressAndTapEvent);
 };
@@ -2295,7 +2295,7 @@ public:
     bool IsNextEventAllowed() const { return m_allowNext; }
 
 
-    virtual wxEvent *Clone() const override { return new wxKeyEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxKeyEvent(*this); }
     virtual wxEventCategory GetEventCategory() const override { return wxEVT_CATEGORY_USER_INPUT; }
 
     // we do need to copy wxKeyEvent sometimes (in wxTreeCtrl code, for
@@ -2389,7 +2389,7 @@ public:
     wxRect GetRect() const { return m_rect; }
     void SetRect(const wxRect& rect) { m_rect = rect; }
 
-    virtual wxEvent *Clone() const override { return new wxSizeEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSizeEvent(*this); }
 
 public:
     // For internal usage only. Will be converted to protected members.
@@ -2429,7 +2429,7 @@ public:
     wxRect GetRect() const { return m_rect; }
     void SetRect(const wxRect& rect) { m_rect = rect; }
 
-    virtual wxEvent *Clone() const override { return new wxMoveEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxMoveEvent(*this); }
 
 protected:
     wxPoint m_pos;
@@ -2457,7 +2457,7 @@ public:
 public:
     // default copy ctor and dtor are fine
 
-    virtual wxEvent *Clone() const override { return new wxPaintEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxPaintEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxPaintEvent);
@@ -2473,7 +2473,7 @@ public:
     explicit wxNcPaintEvent(wxWindowBase* window = nullptr);
 
 public:
-    virtual wxEvent *Clone() const override { return new wxNcPaintEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxNcPaintEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxNcPaintEvent);
@@ -2499,7 +2499,7 @@ public:
 
     wxDC *GetDC() const { return m_dc; }
 
-    virtual wxEvent *Clone() const override { return new wxEraseEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxEraseEvent(*this); }
 
 protected:
     wxDC *m_dc;
@@ -2531,7 +2531,7 @@ public:
     wxWindow *GetWindow() const { return m_win; }
     void SetWindow(wxWindow *win) { m_win = win; }
 
-    virtual wxEvent *Clone() const override { return new wxFocusEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxFocusEvent(*this); }
 
 private:
     wxWindow *m_win;
@@ -2549,7 +2549,7 @@ public:
 
     wxWindow *GetWindow() const { return (wxWindow *)GetEventObject(); }
 
-    virtual wxEvent *Clone() const override { return new wxChildFocusEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxChildFocusEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxChildFocusEvent);
@@ -2590,7 +2590,7 @@ public:
     bool GetActive() const { return m_active; }
     Reason GetActivationReason() const { return m_activationReason;}
 
-    virtual wxEvent *Clone() const override { return new wxActivateEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxActivateEvent(*this); }
 
 private:
     bool m_active;
@@ -2612,7 +2612,7 @@ public:
         : wxEvent(Id, wxEVT_INIT_DIALOG)
         { }
 
-    virtual wxEvent *Clone() const override { return new wxInitDialogEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxInitDialogEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxInitDialogEvent);
@@ -2646,7 +2646,7 @@ public:
 
     wxMenuItem* GetMenuItem() const { return m_menuItem; }
 
-    virtual wxEvent *Clone() const override { return new wxMenuEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxMenuEvent(*this); }
 
 private:
     int         m_menuId;
@@ -2701,7 +2701,7 @@ public:
     bool CanVeto() const { return m_canVeto; }
     bool GetVeto() const { return m_canVeto && m_veto; }
 
-    virtual wxEvent *Clone() const override { return new wxCloseEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxCloseEvent(*this); }
 
 protected:
     bool m_loggingOff,
@@ -2731,7 +2731,7 @@ public:
     // return true if the window was shown, false if hidden
     bool IsShown() const { return m_show; }
 
-    virtual wxEvent *Clone() const override { return new wxShowEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxShowEvent(*this); }
 
 protected:
     bool m_show;
@@ -2757,7 +2757,7 @@ public:
     // return true if the frame was iconized, false if restored
     bool IsIconized() const { return m_iconized; }
 
-    virtual wxEvent *Clone() const override { return new wxIconizeEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxIconizeEvent(*this); }
 
 protected:
     bool m_iconized;
@@ -2776,7 +2776,7 @@ public:
         : wxEvent(winid, wxEVT_MAXIMIZE)
         { }
 
-    virtual wxEvent *Clone() const override { return new wxMaximizeEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxMaximizeEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxMaximizeEvent);
@@ -2797,7 +2797,7 @@ public:
 
     bool IsFullScreen() const { return m_fullscreen; }
 
-    virtual wxEvent *Clone() const override { return new wxFullScreenEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxFullScreenEvent(*this); }
 
 protected:
     bool m_fullscreen;
@@ -2900,7 +2900,7 @@ public:
     { return (((but == wxJOY_BUTTON_ANY) && (m_buttonState != 0)) ||
             ((m_buttonState & but) == but)); }
 
-    virtual wxEvent *Clone() const override { return new wxJoystickEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxJoystickEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxJoystickEvent);
@@ -2950,7 +2950,7 @@ public:
     int GetNumberOfFiles() const { return m_noFiles; }
     wxString *GetFiles() const { return m_files; }
 
-    virtual wxEvent *Clone() const override { return new wxDropFilesEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxDropFilesEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxDropFilesEvent);
@@ -3050,7 +3050,7 @@ public:
     // Returns the UI update mode
     static wxUpdateUIMode GetMode() { return sm_updateMode; }
 
-    virtual wxEvent *Clone() const override { return new wxUpdateUIEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxUpdateUIEvent(*this); }
 
 protected:
     wxCheckBoxState m_3checked;
@@ -3083,7 +3083,7 @@ public:
         : wxEvent(0, wxEVT_SYS_COLOUR_CHANGED)
         { }
 
-    virtual wxEvent *Clone() const override { return new wxSysColourChangedEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSysColourChangedEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxSysColourChangedEvent);
@@ -3108,7 +3108,7 @@ public:
           m_gainedCapture(event.m_gainedCapture)
         { }
 
-    virtual wxEvent *Clone() const override { return new wxMouseCaptureChangedEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxMouseCaptureChangedEvent(*this); }
 
     wxWindow* GetCapturedWindow() const { return m_gainedCapture; }
 
@@ -3136,7 +3136,7 @@ public:
         : wxEvent(event)
     {}
 
-    virtual wxEvent *Clone() const override { return new wxMouseCaptureLostEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxMouseCaptureLostEvent(*this); }
 
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxMouseCaptureLostEvent);
 };
@@ -3151,7 +3151,7 @@ public:
         : wxEvent(0, wxEVT_DISPLAY_CHANGED)
         { }
 
-    virtual wxEvent *Clone() const override { return new wxDisplayChangedEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxDisplayChangedEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxDisplayChangedEvent);
@@ -3186,7 +3186,7 @@ public:
     int ScaleX(int x) const { return Scale(wxSize(x, -1)).x; }
     int ScaleY(int y) const { return Scale(wxSize(-1, y)).y; }
 
-    virtual wxEvent *Clone() const override { return new wxDPIChangedEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxDPIChangedEvent(*this); }
 
 private:
     wxSize m_oldDPI;
@@ -3215,7 +3215,7 @@ public:
     void SetChangedWindow(wxWindow* win) { m_changedWindow = win; }
     wxWindow* GetChangedWindow() const { return m_changedWindow; }
 
-    virtual wxEvent *Clone() const override { return new wxPaletteChangedEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxPaletteChangedEvent(*this); }
 
 protected:
     wxWindow*     m_changedWindow;
@@ -3245,7 +3245,7 @@ public:
     void SetPaletteRealized(bool realized) { m_paletteRealized = realized; }
     bool GetPaletteRealized() const { return m_paletteRealized; }
 
-    virtual wxEvent *Clone() const override { return new wxQueryNewPaletteEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxQueryNewPaletteEvent(*this); }
 
 protected:
     bool m_paletteRealized;
@@ -3304,7 +3304,7 @@ public:
     // Set flags
     void SetFlags(long flags) { m_flags = flags; }
 
-    virtual wxEvent *Clone() const override { return new wxNavigationKeyEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxNavigationKeyEvent(*this); }
 
     enum wxNavigationKeyEventFlags
     {
@@ -3338,7 +3338,7 @@ public:
 
     wxWindow *GetWindow() const { return (wxWindow *)GetEventObject(); }
 
-    virtual wxEvent *Clone() const override { return new wxWindowCreateEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxWindowCreateEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxWindowCreateEvent);
@@ -3351,7 +3351,7 @@ public:
 
     wxWindow *GetWindow() const { return (wxWindow *)GetEventObject(); }
 
-    virtual wxEvent *Clone() const override { return new wxWindowDestroyEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxWindowDestroyEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxWindowDestroyEvent);
@@ -3402,7 +3402,7 @@ public:
     const wxString& GetTarget() const { return m_target; }
     void SetTarget(const wxString& target) { m_target = target; }
 
-    virtual wxEvent *Clone() const override { return new wxHelpEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxHelpEvent(*this); }
 
     // optional indication of the event source
     Origin GetOrigin() const { return m_origin; }
@@ -3444,7 +3444,7 @@ public:
         : wxCommandEvent(event)
     { }
 
-    virtual wxEvent *Clone() const override { return new wxClipboardTextEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxClipboardTextEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxClipboardTextEvent);
@@ -3476,7 +3476,7 @@ public:
     const wxPoint& GetPosition() const { return m_pos; }
     void SetPosition(const wxPoint& pos) { m_pos = pos; }
 
-    virtual wxEvent *Clone() const override { return new wxContextMenuEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxContextMenuEvent(*this); }
 
 protected:
     wxPoint   m_pos;

--- a/include/wx/fdrepdlg.h
+++ b/include/wx/fdrepdlg.h
@@ -155,7 +155,7 @@ public:
     void SetFindString(const wxString& str) { SetString(str); }
     void SetReplaceString(const wxString& str) { m_strReplace = str; }
 
-    virtual wxEvent *Clone() const override { return new wxFindDialogEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxFindDialogEvent(*this); }
 
 private:
     wxString m_strReplace;

--- a/include/wx/filectrl.h
+++ b/include/wx/filectrl.h
@@ -97,7 +97,7 @@ public:
     }
 
     // no need for the copy constructor as the default one will be fine.
-    virtual wxEvent *Clone() const override { return new wxFileCtrlEvent( *this ); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxFileCtrlEvent( *this ); }
 
     void SetFiles( const wxArrayString &files ) { m_files = files; }
     void SetDirectory( const wxString &directory ) { m_directory = directory; }

--- a/include/wx/filepicker.h
+++ b/include/wx/filepicker.h
@@ -49,7 +49,7 @@ public:
     void SetPath(const wxString &p) { m_path = p; }
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxFileDirPickerEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxFileDirPickerEvent(*this); }
 
 private:
     wxString m_path;

--- a/include/wx/fontpicker.h
+++ b/include/wx/fontpicker.h
@@ -212,7 +212,7 @@ public:
     void SetFont(const wxFont &c) { m_font = c; }
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxFontPickerEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxFontPickerEvent(*this); }
 
 private:
     wxFont m_font;

--- a/include/wx/fswatcher.h
+++ b/include/wx/fswatcher.h
@@ -160,7 +160,7 @@ public:
         return m_changeType;
     }
 
-    virtual wxEvent* Clone() const override
+    wxNODISCARD virtual wxEvent* Clone() const override
     {
         wxFileSystemWatcherEvent* evt = new wxFileSystemWatcherEvent(*this);
         evt->m_errorMsg = m_errorMsg.Clone();

--- a/include/wx/gdiobj.h
+++ b/include/wx/gdiobj.h
@@ -77,13 +77,13 @@ protected:
         return CreateGDIRefData();
     }
 
-    virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override
+    wxNODISCARD virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override
     {
         return CloneGDIRefData(static_cast<const wxGDIRefData *>(data));
     }
 
     virtual wxGDIRefData *CreateGDIRefData() const = 0;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const = 0;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const = 0;
 
     wxDECLARE_DYNAMIC_CLASS(wxGDIObject);
 };

--- a/include/wx/generic/accel.h
+++ b/include/wx/generic/accel.h
@@ -38,7 +38,7 @@ public:
 protected:
     // ref counting code
     virtual wxObjectRefData *CreateRefData() const override;
-    virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
+    wxNODISCARD virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxAcceleratorTable);

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -247,7 +247,7 @@ public:
     }
 
     // create a new object which is the copy of this one
-    virtual wxGridCellRenderer *Clone() const = 0;
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const = 0;
 
 
     // These functions still exist for compatibility and are the ones actually
@@ -504,7 +504,7 @@ public:
     virtual void Destroy();
 
     // create a new object which is the copy of this one
-    virtual wxGridCellEditor *Clone() const = 0;
+    wxNODISCARD virtual wxGridCellEditor *Clone() const = 0;
 
     // added GetValue so we can get the value which is in the control
     virtual wxString GetValue() const = 0;
@@ -821,7 +821,7 @@ public:
     }
 
     // creates a new copy of this object
-    wxGridCellAttr *Clone() const;
+    wxNODISCARD wxGridCellAttr *Clone() const;
     void MergeWith(wxGridCellAttr *mergefrom);
 
     // setters
@@ -3294,7 +3294,7 @@ public:
     wxPoint GetPosition() const { return wxPoint( m_x, m_y ); }
     bool Selecting() const { return m_selecting; }
 
-    virtual wxEvent *Clone() const override { return new wxGridEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxGridEvent(*this); }
 
 protected:
     int         m_row;
@@ -3354,7 +3354,7 @@ public:
     int GetRowOrCol() const { return m_rowOrCol; }
     wxPoint GetPosition() const { return wxPoint( m_x, m_y ); }
 
-    virtual wxEvent *Clone() const override { return new wxGridSizeEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxGridSizeEvent(*this); }
 
 protected:
     int         m_rowOrCol;
@@ -3418,7 +3418,7 @@ public:
     int GetRightCol() const { return m_bottomRight.GetCol(); }
     bool Selecting() const { return m_selecting; }
 
-    virtual wxEvent *Clone() const override { return new wxGridRangeSelectEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxGridRangeSelectEvent(*this); }
 
 protected:
     void Init(const wxGridCellCoords& topLeft,
@@ -3464,7 +3464,7 @@ public:
     wxControl* GetControl()             { return wxDynamicCast(m_window, wxControl); }
     void SetControl(wxControl* ctrl)    { m_window = ctrl; }
 
-    virtual wxEvent *Clone() const override { return new wxGridEditorCreatedEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxGridEditorCreatedEvent(*this); }
 
 private:
     int m_row;

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -46,7 +46,7 @@ public:
                                wxDC& dc,
                                int row, int col) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellStringRenderer(*this); }
 
 protected:
@@ -95,7 +95,7 @@ public:
     // Optional parameters for this renderer are "<min>,<max>".
     virtual void SetParameters(const wxString& params) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellNumberRenderer(*this); }
 
 protected:
@@ -146,7 +146,7 @@ public:
     // with format being one of f|e|g|E|F|G
     virtual void SetParameters(const wxString& params) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellFloatRenderer(*this); }
 
 protected:
@@ -193,7 +193,7 @@ public:
                                   wxGridCellAttr& attr,
                                   wxDC& dc) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellBoolRenderer(*this); }
 };
 
@@ -234,7 +234,7 @@ public:
                                   wxGridCellAttr& attr,
                                   wxDC& dc) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellDateRenderer(*this); }
 
     // output strptime()-like format string
@@ -265,7 +265,7 @@ public:
     {
     }
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellDateTimeRenderer(*this); }
 
 protected:
@@ -293,7 +293,7 @@ public:
     // Parameters string is a comma-separated list of values.
     virtual void SetParameters(const wxString& params) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
     {
         return new wxGridCellChoiceRenderer(*this);
     }
@@ -331,7 +331,7 @@ public:
                                wxDC& dc,
                                int row, int col) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellEnumRenderer(*this); }
 
 protected:
@@ -376,7 +376,7 @@ public:
                               int row, int col,
                               int height) override;
 
-    virtual wxGridCellRenderer *Clone() const override
+    wxNODISCARD virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellAutoWrapStringRenderer(*this); }
 
 private:

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -86,7 +86,7 @@ public:
     virtual void SetValidator(const wxValidator& validator);
 #endif
 
-    virtual wxGridCellEditor *Clone() const override
+    wxNODISCARD virtual wxGridCellEditor *Clone() const override
         { return new wxGridCellTextEditor(*this); }
 
     // added GetValue so we can get the value which is in the control
@@ -149,7 +149,7 @@ public:
     // parameters string format is "min,max"
     virtual void SetParameters(const wxString& params) override;
 
-    virtual wxGridCellEditor *Clone() const override
+    wxNODISCARD virtual wxGridCellEditor *Clone() const override
         { return new wxGridCellNumberEditor(*this); }
 
     // added GetValue so we can get the value which is in the control
@@ -244,7 +244,7 @@ public:
     virtual void Reset() override;
     virtual void StartingKey(wxKeyEvent& event) override;
 
-    virtual wxGridCellEditor *Clone() const override
+    wxNODISCARD virtual wxGridCellEditor *Clone() const override
         { return new wxGridCellFloatEditor(*this); }
 
     // parameters string format is "width[,precision[,format]]"
@@ -306,7 +306,7 @@ public:
     virtual void StartingClick() override;
     virtual void StartingKey(wxKeyEvent& event) override;
 
-    virtual wxGridCellEditor *Clone() const override
+    wxNODISCARD virtual wxGridCellEditor *Clone() const override
         { return new wxGridCellBoolEditor(*this); }
 
     // added GetValue so we can get the value which is in the control, see
@@ -384,7 +384,7 @@ public:
     // parameters string format is "item1[,item2[...,itemN]]"
     virtual void SetParameters(const wxString& params) override;
 
-    virtual wxGridCellEditor *Clone() const override
+    wxNODISCARD virtual wxGridCellEditor *Clone() const override
         { return new wxGridCellChoiceEditor(*this); }
 
     // added GetValue so we can get the value which is in the control
@@ -417,7 +417,7 @@ public:
 
     virtual ~wxGridCellEnumEditor() = default;
 
-    virtual wxGridCellEditor* Clone() const override
+    wxNODISCARD virtual wxGridCellEditor* Clone() const override
         { return new wxGridCellEnumEditor(*this); }
 
     virtual void BeginEdit(int row, int col, wxGrid* grid) override;
@@ -448,7 +448,7 @@ public:
                         wxWindowID id,
                         wxEvtHandler* evtHandler) override;
 
-    virtual wxGridCellEditor *Clone() const override
+    wxNODISCARD virtual wxGridCellEditor *Clone() const override
         { return new wxGridCellAutoWrapStringEditor(*this); }
 };
 
@@ -481,7 +481,7 @@ public:
 
     virtual void Reset() override;
 
-    virtual wxGridCellEditor *Clone() const override
+    wxNODISCARD virtual wxGridCellEditor *Clone() const override
         { return new wxGridCellDateEditor(*this); }
 
     virtual wxString GetValue() const override;

--- a/include/wx/generic/laywin.h
+++ b/include/wx/generic/laywin.h
@@ -88,7 +88,7 @@ public:
     void SetAlignment(wxLayoutAlignment align) { m_alignment = align; }
     wxLayoutAlignment GetAlignment() const { return m_alignment; }
 
-    virtual wxEvent *Clone() const override { return new wxQueryLayoutInfoEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxQueryLayoutInfoEvent(*this); }
 
 protected:
     int                     m_flags;
@@ -131,7 +131,7 @@ public:
     void SetRect(const wxRect& rect) { m_rect = rect; }
     wxRect GetRect() const { return m_rect; }
 
-    virtual wxEvent *Clone() const override { return new wxCalculateLayoutEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxCalculateLayoutEvent(*this); }
 
 protected:
     int                     m_flags;

--- a/include/wx/generic/paletteg.h
+++ b/include/wx/generic/paletteg.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxPalette);

--- a/include/wx/generic/region.h
+++ b/include/wx/generic/region.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     // wxRegionBase pure virtuals
     virtual bool DoIsEqual(const wxRegion& region) const;

--- a/include/wx/generic/sashwin.h
+++ b/include/wx/generic/sashwin.h
@@ -225,7 +225,7 @@ public:
     void SetDragStatus(wxSashDragStatus status) { m_dragStatus = status; }
     wxSashDragStatus GetDragStatus() const { return m_dragStatus; }
 
-    virtual wxEvent *Clone() const override { return new wxSashEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSashEvent(*this); }
 
 private:
     wxSashEdgePosition  m_edge;

--- a/include/wx/generic/splitter.h
+++ b/include/wx/generic/splitter.h
@@ -406,7 +406,7 @@ public:
         return m_data.pt.y;
     }
 
-    virtual wxEvent *Clone() const override { return new wxSplitterEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSplitterEvent(*this); }
 
 private:
     friend class WXDLLIMPEXP_FWD_CORE wxSplitterWindow;

--- a/include/wx/gifdecod.h
+++ b/include/wx/gifdecod.h
@@ -80,7 +80,7 @@ public:
 
     bool ConvertToImage(unsigned int frame, wxImage *image) const override;
 
-    wxAnimationDecoder *Clone() const override
+    wxNODISCARD wxAnimationDecoder *Clone() const override
         { return new wxGIFDecoder; }
     wxAnimationType GetType() const override
         { return wxANIMATION_TYPE_GIF; }

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -136,7 +136,7 @@ public:
     wxGraphicsObjectRefData* GetGraphicsData() const;
 protected:
     virtual wxObjectRefData* CreateRefData() const override;
-    virtual wxObjectRefData* CloneRefData(const wxObjectRefData* data) const override;
+    wxNODISCARD virtual wxObjectRefData* CloneRefData(const wxObjectRefData* data) const override;
 
     wxDECLARE_DYNAMIC_CLASS(wxGraphicsObject);
 };

--- a/include/wx/gtk/bitmap.h
+++ b/include/wx/gtk/bitmap.h
@@ -155,7 +155,7 @@ protected:
 #endif // wxUSE_IMAGE
 
     virtual wxGDIRefData* CreateGDIRefData() const override;
-    virtual wxGDIRefData* CloneGDIRefData(const wxGDIRefData* data) const override;
+    wxNODISCARD virtual wxGDIRefData* CloneGDIRefData(const wxGDIRefData* data) const override;
 
 #ifdef __WXGTK3__
     virtual bool DoCreate(const wxSize& sz, double scale, int depth) override;

--- a/include/wx/gtk/brush.h
+++ b/include/wx/gtk/brush.h
@@ -44,7 +44,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     wxDECLARE_DYNAMIC_CLASS(wxBrush);
 };

--- a/include/wx/gtk/cursor.h
+++ b/include/wx/gtk/cursor.h
@@ -45,7 +45,7 @@ protected:
 #endif
 
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxCursor);

--- a/include/wx/gtk/font.h
+++ b/include/wx/gtk/font.h
@@ -106,7 +106,7 @@ protected:
     virtual void DoSetNativeFontInfo( const wxNativeFontInfo& info ) override;
 
     virtual wxGDIRefData* CreateGDIRefData() const override;
-    virtual wxGDIRefData* CloneGDIRefData(const wxGDIRefData* data) const override;
+    wxNODISCARD virtual wxGDIRefData* CloneGDIRefData(const wxGDIRefData* data) const override;
 
     virtual wxFontFamily DoGetFamily() const override;
 

--- a/include/wx/gtk/pen.h
+++ b/include/wx/gtk/pen.h
@@ -53,7 +53,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     wxDECLARE_DYNAMIC_CLASS(wxPen);
 };

--- a/include/wx/gtk/region.h
+++ b/include/wx/gtk/region.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     // wxRegionBase pure virtuals
     virtual bool DoIsEqual(const wxRegion& region) const override;

--- a/include/wx/headerctrl.h
+++ b/include/wx/headerctrl.h
@@ -420,7 +420,7 @@ public:
     unsigned int GetNewOrder() const { return m_order; }
     void SetNewOrder(unsigned int order) { m_order = order; }
 
-    virtual wxEvent *Clone() const override { return new wxHeaderCtrlEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxHeaderCtrlEvent(*this); }
 
 protected:
     // the column affected by the event

--- a/include/wx/html/htmlwin.h
+++ b/include/wx/html/htmlwin.h
@@ -595,7 +595,7 @@ public:
     bool GetLinkClicked() const { return m_bLinkWasClicked; }
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxHtmlCellEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxHtmlCellEvent(*this); }
 
 private:
     wxHtmlCell *m_cell;
@@ -626,7 +626,7 @@ public:
     const wxHtmlLinkInfo &GetLinkInfo() const { return m_linkInfo; }
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxHtmlLinkEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxHtmlLinkEvent(*this); }
 
 private:
     wxHtmlLinkInfo m_linkInfo;

--- a/include/wx/hyperlink.h
+++ b/include/wx/hyperlink.h
@@ -113,7 +113,7 @@ public:
     void SetURL(const wxString &url) { m_url=url; }
 
     // default copy ctor, assignment operator and dtor are ok
-    virtual wxEvent *Clone() const override { return new wxHyperlinkEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxHyperlinkEvent(*this); }
 
 private:
 

--- a/include/wx/iconbndl.h
+++ b/include/wx/iconbndl.h
@@ -113,7 +113,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     // delete all icons

--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -608,7 +608,7 @@ protected:
     long XYToIndex(int x, int y) const;
 
     virtual wxObjectRefData* CreateRefData() const override;
-    virtual wxObjectRefData* CloneRefData(const wxObjectRefData* data) const override;
+    wxNODISCARD virtual wxObjectRefData* CloneRefData(const wxObjectRefData* data) const override;
 
 private:
     friend class WXDLLIMPEXP_FWD_CORE wxImageHandler;

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -561,7 +561,7 @@ public:
     bool IsEditCancelled() const { return m_editCancelled; }
     void SetEditCanceled(bool editCancelled) { m_editCancelled = editCancelled; }
 
-    virtual wxEvent *Clone() const override { return new wxListEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxListEvent(*this); }
 
 //protected: -- not for backwards compatibility
     int           m_code;

--- a/include/wx/mediactrl.h
+++ b/include/wx/mediactrl.h
@@ -107,7 +107,7 @@ public:
     // Allocates a copy of this object.
     // Required for wxEvtHandler::AddPendingEvent
     // ------------------------------------------------------------------------
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     {   return new wxMediaEvent(*this);     }
 
 

--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -215,7 +215,7 @@ public:
 
 protected:
     virtual wxGDIImageRefData *CreateData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     // creates an uninitialized bitmap, called from Create()s above
     bool DoCreate(int w, int h, int depth, WXHDC hdc);

--- a/include/wx/msw/brush.h
+++ b/include/wx/msw/brush.h
@@ -49,7 +49,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxBrush);

--- a/include/wx/msw/enhmeta.h
+++ b/include/wx/msw/enhmeta.h
@@ -75,7 +75,7 @@ protected:
     // we don't use these functions (but probably should) but have to implement
     // them as they're pure virtual in the base class
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxString m_filename;

--- a/include/wx/msw/font.h
+++ b/include/wx/msw/font.h
@@ -168,7 +168,7 @@ protected:
 
     // implement wxObject virtuals which are used by AllocExclusive()
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxFont);

--- a/include/wx/msw/icon.h
+++ b/include/wx/msw/icon.h
@@ -83,7 +83,7 @@ protected:
         return new wxIconRefData;
     }
 
-    virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
+    wxNODISCARD virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
 
     // create from XPM data
     void CreateIconFromXpm(const char* const* data);

--- a/include/wx/msw/metafile.h
+++ b/include/wx/msw/metafile.h
@@ -70,7 +70,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxMetafile);

--- a/include/wx/msw/ole/activex.h
+++ b/include/wx/msw/ole/activex.h
@@ -213,7 +213,7 @@ private:
     DISPID m_dispid;
 
 public:
-    virtual wxEvent *Clone() const override
+    wxNODISCARD virtual wxEvent *Clone() const override
     { return new wxActiveXEvent(*this); }
 
     size_t ParamCount() const;

--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -130,7 +130,7 @@ public:
 #endif
     virtual bool Write(wxString& str) const override;
 
-    wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataCurrency(m_value); }
+    wxNODISCARD wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataCurrency(m_value); }
     virtual wxString GetType() const override { return wxS("currency"); }
 
     DECLARE_WXANY_CONVERSION()
@@ -156,7 +156,7 @@ public:
 #endif
     virtual bool Write(wxString& str) const override;
 
-    wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataErrorCode(m_value); }
+    wxNODISCARD wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataErrorCode(m_value); }
     virtual wxString GetType() const override { return wxS("errorcode"); }
 
     DECLARE_WXANY_CONVERSION()
@@ -184,7 +184,7 @@ public:
 #endif
     virtual bool Write(wxString& str) const override;
 
-    wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataSafeArray(m_value); }
+    wxNODISCARD wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataSafeArray(m_value); }
     virtual wxString GetType() const override { return wxS("safearray"); }
 
     DECLARE_WXANY_CONVERSION()

--- a/include/wx/msw/palette.h
+++ b/include/wx/msw/palette.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxPalette);

--- a/include/wx/msw/pen.h
+++ b/include/wx/msw/pen.h
@@ -70,7 +70,7 @@ public:
 
 protected:
     virtual wxGDIRefData* CreateGDIRefData() const override;
-    virtual wxGDIRefData* CloneGDIRefData(const wxGDIRefData* data) const override;
+    wxNODISCARD virtual wxGDIRefData* CloneGDIRefData(const wxGDIRefData* data) const override;
 
     // same as FreeResource() + RealizeResource()
     bool Recreate();

--- a/include/wx/msw/region.h
+++ b/include/wx/msw/region.h
@@ -42,7 +42,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     virtual bool DoIsEqual(const wxRegion& region) const override;
     virtual bool DoGetBox(wxCoord& x, wxCoord& y, wxCoord& w, wxCoord& h) const override;

--- a/include/wx/object.h
+++ b/include/wx/object.h
@@ -395,7 +395,7 @@ protected:
     virtual wxObjectRefData *CreateRefData() const;
 
     // create a new m_refData initialized with the given one
-    virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const;
+    wxNODISCARD virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const;
 
     wxObjectRefData *m_refData;
 };

--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -228,7 +228,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     virtual bool DoCreate(const wxSize& sz, double scale, int depth) override;
 

--- a/include/wx/osx/brush.h
+++ b/include/wx/osx/brush.h
@@ -45,7 +45,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxBrush);

--- a/include/wx/osx/carbon/region.h
+++ b/include/wx/osx/carbon/region.h
@@ -44,7 +44,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     virtual bool DoIsEqual(const wxRegion& region) const override;
     virtual bool DoGetBox(wxCoord& x, wxCoord& y, wxCoord& w, wxCoord& h) const override;

--- a/include/wx/osx/core/colour.h
+++ b/include/wx/osx/core/colour.h
@@ -73,7 +73,7 @@ protected :
     InitRGBA(ChannelType r, ChannelType g, ChannelType b, ChannelType a) override;
 
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
 
@@ -96,7 +96,7 @@ public:
 
     virtual CGColorRef GetCGColor() const = 0;
 
-    virtual wxColourRefData* Clone() const = 0;
+    wxNODISCARD virtual wxColourRefData* Clone() const = 0;
 
 #if wxOSX_USE_COCOA
     virtual WX_NSColor GetNSColor() const;

--- a/include/wx/osx/core/private/strconv_cf.h
+++ b/include/wx/osx/core/private/strconv_cf.h
@@ -332,7 +332,7 @@ public:
     virtual size_t ToWChar(wchar_t * dst, size_t dstSize, const char * src, size_t srcSize = wxNO_LEN) const override;
     virtual size_t FromWChar(char *dst, size_t dstSize, const wchar_t *src, size_t srcSize = wxNO_LEN) const override;
 
-    virtual wxMBConv *Clone() const override { return new wxMBConv_cf(*this); }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConv_cf(*this); }
 
     bool IsOk() const
     {

--- a/include/wx/osx/cursor.h
+++ b/include/wx/osx/cursor.h
@@ -37,7 +37,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     void InitFromStock(wxStockCursor);

--- a/include/wx/osx/font.h
+++ b/include/wx/osx/font.h
@@ -146,7 +146,7 @@ protected:
     virtual wxFontFamily DoGetFamily() const override;
 
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
 

--- a/include/wx/osx/metafile.h
+++ b/include/wx/osx/metafile.h
@@ -56,7 +56,7 @@ public:
     void SetHMETAFILE(WXHMETAFILE mf) ;
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     wxDECLARE_DYNAMIC_CLASS(wxMetafile);
 };

--- a/include/wx/osx/palette.h
+++ b/include/wx/osx/palette.h
@@ -29,7 +29,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxPalette);

--- a/include/wx/osx/pen.h
+++ b/include/wx/osx/pen.h
@@ -63,7 +63,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     void Unshare();

--- a/include/wx/power.h
+++ b/include/wx/power.h
@@ -63,7 +63,7 @@ public:
 
     // default copy ctor, assignment operator and dtor are ok
 
-    virtual wxEvent *Clone() const override { return new wxPowerEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxPowerEvent(*this); }
 
 private:
     bool m_veto;

--- a/include/wx/private/graphics.h
+++ b/include/wx/private/graphics.h
@@ -20,7 +20,7 @@ class WXDLLIMPEXP_CORE wxGraphicsObjectRefData : public wxObjectRefData
     wxGraphicsObjectRefData( wxGraphicsRenderer* renderer );
     wxGraphicsObjectRefData( const wxGraphicsObjectRefData* data );
     wxGraphicsRenderer* GetRenderer() const ;
-    virtual wxGraphicsObjectRefData* Clone() const ;
+    wxNODISCARD virtual wxGraphicsObjectRefData* Clone() const ;
 
     protected :
     wxGraphicsRenderer* m_renderer;

--- a/include/wx/process.h
+++ b/include/wx/process.h
@@ -173,7 +173,7 @@ public:
     int GetExitCode() const { return m_exitcode; }
 
     // implement the base class pure virtual
-    virtual wxEvent *Clone() const override { return new wxProcessEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxProcessEvent(*this); }
 
 public:
     int m_pid,

--- a/include/wx/propgrid/property.h
+++ b/include/wx/propgrid/property.h
@@ -276,7 +276,7 @@ private:
     virtual wxObjectRefData *CreateRefData() const override
         { return new wxPGCellData(); }
 
-    virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
+    wxNODISCARD virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
 };
 
 // -----------------------------------------------------------------------

--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -1971,7 +1971,7 @@ public:
     ~wxPropertyGridEvent();
 
     // Copyer.
-    virtual wxEvent* Clone() const override;
+    wxNODISCARD virtual wxEvent* Clone() const override;
 
     // Returns the column index associated with this event.
     // For the column dragging events, it is the column to the left

--- a/include/wx/propgrid/propgriddefs.h
+++ b/include/wx/propgrid/propgriddefs.h
@@ -483,7 +483,7 @@ public:\
 \
     virtual wxString GetType() const override; \
 \
-    virtual wxVariantData* Clone() const override { return new classname##VariantData(m_value); } \
+    wxNODISCARD virtual wxVariantData* Clone() const override { return new classname##VariantData(m_value); } \
 \
     DECLARE_WXANY_CONVERSION() \
 protected:\

--- a/include/wx/qt/accel.h
+++ b/include/wx/qt/accel.h
@@ -53,7 +53,7 @@ public:
 protected:
     // ref counting code
     virtual wxObjectRefData *CreateRefData() const override;
-    virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
+    wxNODISCARD virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxAcceleratorTable);

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -84,7 +84,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     virtual bool DoCreate(const wxSize& sz, double scale, int depth) override;
 

--- a/include/wx/qt/brush.h
+++ b/include/wx/qt/brush.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxBrush);

--- a/include/wx/qt/cursor.h
+++ b/include/wx/qt/cursor.h
@@ -37,7 +37,7 @@ protected:
 private:
     void Init();
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     wxDECLARE_DYNAMIC_CLASS(wxCursor);
 };

--- a/include/wx/qt/font.h
+++ b/include/wx/qt/font.h
@@ -78,7 +78,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
     virtual wxFontFamily DoGetFamily() const override;
     virtual void DoSetNativeFontInfo(const wxNativeFontInfo& info) override;
 

--- a/include/wx/qt/pen.h
+++ b/include/wx/qt/pen.h
@@ -50,7 +50,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxPen);

--- a/include/wx/qt/region.h
+++ b/include/wx/qt/region.h
@@ -31,7 +31,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const override;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
     virtual bool DoIsEqual(const wxRegion& region) const override;
     virtual bool DoGetBox(wxCoord& x, wxCoord& y, wxCoord& w, wxCoord& h) const override;

--- a/include/wx/ribbon/art.h
+++ b/include/wx/ribbon/art.h
@@ -212,7 +212,7 @@ public:
     wxRibbonArtProvider();
     virtual ~wxRibbonArtProvider();
 
-    virtual wxRibbonArtProvider* Clone() const = 0;
+    wxNODISCARD virtual wxRibbonArtProvider* Clone() const = 0;
     virtual void SetFlags(long flags) = 0;
     virtual long GetFlags() const = 0;
 
@@ -423,7 +423,7 @@ public:
     wxRibbonMSWArtProvider(bool set_colour_scheme = true);
     virtual ~wxRibbonMSWArtProvider();
 
-    wxRibbonArtProvider* Clone() const override;
+    wxNODISCARD wxRibbonArtProvider* Clone() const override;
     void SetFlags(long flags) override;
     long GetFlags() const override;
 
@@ -796,7 +796,7 @@ public:
     wxRibbonAUIArtProvider();
     virtual ~wxRibbonAUIArtProvider();
 
-    wxRibbonArtProvider* Clone() const override;
+    wxNODISCARD wxRibbonArtProvider* Clone() const override;
 
     wxColour GetColour(int id) const override;
     void SetColour(int id, const wxColor& colour) override;

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -64,7 +64,7 @@ public:
     }
 
     wxRibbonBarEvent(const wxRibbonBarEvent& e) = default;
-    wxEvent *Clone() const override { return new wxRibbonBarEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxRibbonBarEvent(*this); }
 
     wxRibbonPage* GetPage() {return m_page;}
     void SetPage(wxRibbonPage* page) {m_page = page;}

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -230,7 +230,7 @@ public:
     }
 
     wxRibbonButtonBarEvent(const wxRibbonButtonBarEvent& e) = default;
-    wxEvent *Clone() const override { return new wxRibbonButtonBarEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxRibbonButtonBarEvent(*this); }
 
     wxRibbonButtonBar* GetBar() {return m_bar;}
     wxRibbonButtonBarButtonBase *GetButton() { return m_button; }

--- a/include/wx/ribbon/gallery.h
+++ b/include/wx/ribbon/gallery.h
@@ -139,7 +139,7 @@ public:
         m_item = e.m_item;
     }
 #endif
-    wxEvent *Clone() const override { return new wxRibbonGalleryEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxRibbonGalleryEvent(*this); }
 
     wxRibbonGallery* GetGallery() {return m_gallery;}
     wxRibbonGalleryItem* GetGalleryItem() {return m_item;}

--- a/include/wx/ribbon/panel.h
+++ b/include/wx/ribbon/panel.h
@@ -151,7 +151,7 @@ public:
     }
 
     wxRibbonPanelEvent(const wxRibbonPanelEvent& e) = default;
-    wxEvent *Clone() const override { return new wxRibbonPanelEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxRibbonPanelEvent(*this); }
 
     wxRibbonPanel* GetPanel() {return m_panel;}
     void SetPanel(wxRibbonPanel* panel) {m_panel = panel;}

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -212,7 +212,7 @@ public:
     }
 
     wxRibbonToolBarEvent(const wxRibbonToolBarEvent& e) = default;
-    wxEvent *Clone() const override { return new wxRibbonToolBarEvent(*this); }
+    wxNODISCARD wxEvent *Clone() const override { return new wxRibbonToolBarEvent(*this); }
 
     wxRibbonToolBar* GetBar() {return m_bar;}
     void SetBar(wxRibbonToolBar* bar) {m_bar = bar;}

--- a/include/wx/richtext/richtextbuffer.h
+++ b/include/wx/richtext/richtextbuffer.h
@@ -2993,7 +2993,7 @@ public:
     /**
         Clones the object.
     */
-    virtual wxRichTextObject* Clone() const { return nullptr; }
+    wxNODISCARD virtual wxRichTextObject* Clone() const { return nullptr; }
 
     /**
         Copies the object.
@@ -3685,7 +3685,7 @@ public:
     */
     virtual bool HasParagraphAttributes(const wxRichTextRange& range, const wxRichTextAttr& style) const;
 
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextParagraphLayoutBox(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextParagraphLayoutBox(*this); }
 
     /**
         Prepares the content just before insertion (or after buffer reset).
@@ -3867,7 +3867,7 @@ public:
 
 // Operations
 
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextBox(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextBox(*this); }
 
     void Copy(const wxRichTextBox& obj);
 
@@ -3975,7 +3975,7 @@ public:
      */
     virtual bool UpdateField(wxRichTextBuffer* buffer);
 
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextField(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextField(*this); }
 
     void Copy(const wxRichTextField& obj);
 
@@ -4453,7 +4453,7 @@ public:
     */
     void Copy(const wxRichTextLine& obj);
 
-    virtual wxRichTextLine* Clone() const { return new wxRichTextLine(*this); }
+    wxNODISCARD virtual wxRichTextLine* Clone() const { return new wxRichTextLine(*this); }
 
 protected:
 
@@ -4538,7 +4538,7 @@ public:
     */
     void Copy(const wxRichTextParagraph& obj);
 
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextParagraph(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextParagraph(*this); }
 
     /**
         Clears the cached lines.
@@ -4762,7 +4762,7 @@ public:
     void Copy(const wxRichTextPlainText& obj);
 
     // Clones the text object.
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextPlainText(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextPlainText(*this); }
 
 private:
     bool DrawTabbedString(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect, wxString& str, wxCoord& x, wxCoord& y, bool selected);
@@ -5058,7 +5058,7 @@ public:
     /**
         Clones the image object.
     */
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextImage(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextImage(*this); }
 
     /**
         Creates a cached image at the required size.
@@ -5621,7 +5621,7 @@ public:
     /**
         Clones the buffer.
     */
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextBuffer(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextBuffer(*this); }
 
     /**
         Submits a command to insert paragraphs.
@@ -5984,7 +5984,7 @@ public:
 
 // Operations
 
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextCell(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextCell(*this); }
 
     void Copy(const wxRichTextCell& obj);
 
@@ -6168,7 +6168,7 @@ public:
     virtual bool AddColumns(int startCol, int noCols = 1, const wxRichTextAttr& attr = wxRichTextAttr());
 
     // Makes a clone of this object.
-    virtual wxRichTextObject* Clone() const override { return new wxRichTextTable(*this); }
+    wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextTable(*this); }
 
     // Copies this object.
     void Copy(const wxRichTextTable& obj);

--- a/include/wx/richtext/richtextctrl.h
+++ b/include/wx/richtext/richtextctrl.h
@@ -2643,7 +2643,7 @@ public:
     */
     void SetOldContainer(wxRichTextParagraphLayoutBox* container) { m_oldContainer = container; }
 
-    virtual wxEvent *Clone() const override { return new wxRichTextEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxRichTextEvent(*this); }
 
 protected:
     int                             m_flags;

--- a/include/wx/richtext/richtextstyles.h
+++ b/include/wx/richtext/richtextstyles.h
@@ -77,7 +77,7 @@ public:
     bool operator ==(const wxRichTextStyleDefinition& def) const { return Eq(def); }
 
     /// Override to clone the object
-    virtual wxRichTextStyleDefinition* Clone() const = 0;
+    wxNODISCARD virtual wxRichTextStyleDefinition* Clone() const = 0;
 
     /// Sets and gets the name of the style
     void SetName(const wxString& name) { m_name = name; }
@@ -139,7 +139,7 @@ public:
     virtual ~wxRichTextCharacterStyleDefinition() = default;
 
     /// Clones the object
-    virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextCharacterStyleDefinition(*this); }
+    wxNODISCARD virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextCharacterStyleDefinition(*this); }
 
 protected:
 };
@@ -177,7 +177,7 @@ public:
     bool operator ==(const wxRichTextParagraphStyleDefinition& def) const;
 
     /// Clones the object
-    virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextParagraphStyleDefinition(*this); }
+    wxNODISCARD virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextParagraphStyleDefinition(*this); }
 
 protected:
 
@@ -214,7 +214,7 @@ public:
     bool operator ==(const wxRichTextListStyleDefinition& def) const;
 
     /// Clones the object
-    virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextListStyleDefinition(*this); }
+    wxNODISCARD virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextListStyleDefinition(*this); }
 
     /// Sets/gets the attributes for the given level
     void SetLevelAttributes(int i, const wxRichTextAttr& attr);
@@ -280,7 +280,7 @@ public:
     bool operator ==(const wxRichTextBoxStyleDefinition& def) const;
 
     /// Clones the object
-    virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextBoxStyleDefinition(*this); }
+    wxNODISCARD virtual wxRichTextStyleDefinition* Clone() const override { return new wxRichTextBoxStyleDefinition(*this); }
 
 protected:
 };

--- a/include/wx/sckaddr.h
+++ b/include/wx/sckaddr.h
@@ -53,7 +53,7 @@ public:
 
     // we need to be able to create copies of the addresses polymorphically
     // (i.e. without knowing the exact address class)
-    virtual wxSockAddress *Clone() const = 0;
+    wxNODISCARD virtual wxSockAddress *Clone() const = 0;
 
 
     // implementation only, don't use
@@ -116,7 +116,7 @@ class WXDLLIMPEXP_NET wxIPV4address : public wxIPaddress
 public:
     // implement wxSockAddress pure virtuals:
     virtual Family Type() override { return IPV4; }
-    virtual wxSockAddress *Clone() const override { return new wxIPV4address(*this); }
+    wxNODISCARD virtual wxSockAddress *Clone() const override { return new wxIPV4address(*this); }
 
 
     // implement wxIPaddress pure virtuals:
@@ -148,7 +148,7 @@ class WXDLLIMPEXP_NET wxIPV6address : public wxIPaddress
 public:
     // implement wxSockAddress pure virtuals:
     virtual Family Type() override { return IPV6; }
-    virtual wxSockAddress *Clone() const override { return new wxIPV6address(*this); }
+    wxNODISCARD virtual wxSockAddress *Clone() const override { return new wxIPV6address(*this); }
 
 
     // implement wxIPaddress pure virtuals:
@@ -184,7 +184,7 @@ public:
     wxString Filename() const;
 
     virtual Family Type() override { return UNIX; }
-    virtual wxSockAddress *Clone() const override { return new wxUNIXaddress(*this); }
+    wxNODISCARD virtual wxSockAddress *Clone() const override { return new wxUNIXaddress(*this); }
 
 private:
     wxSockAddressImpl& GetUNIX();

--- a/include/wx/socket.h
+++ b/include/wx/socket.h
@@ -434,7 +434,7 @@ public:
         { return (wxSocketBase *) GetEventObject(); }
     void *GetClientData() const { return m_clientData; }
 
-    virtual wxEvent *Clone() const override { return new wxSocketEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSocketEvent(*this); }
     virtual wxEventCategory GetEventCategory() const override { return wxEVT_CATEGORY_SOCKET; }
 
 public:

--- a/include/wx/spinbutt.h
+++ b/include/wx/spinbutt.h
@@ -107,7 +107,7 @@ public:
     int GetPosition() const { return m_commandInt; }
     void SetPosition(int pos) { m_commandInt = pos; }
 
-    virtual wxEvent *Clone() const override { return new wxSpinEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSpinEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxSpinEvent);

--- a/include/wx/spinctrl.h
+++ b/include/wx/spinctrl.h
@@ -81,7 +81,7 @@ public:
     double GetValue() const       { return m_value; }
     void   SetValue(double value) { m_value = value; }
 
-    virtual wxEvent *Clone() const override { return new wxSpinDoubleEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxSpinDoubleEvent(*this); }
 
 protected:
     double m_value;

--- a/include/wx/stc/stc.h
+++ b/include/wx/stc/stc.h
@@ -6196,7 +6196,7 @@ public:
     bool GetControl() const;
     bool GetAlt() const;
 
-    virtual wxEvent* Clone() const override { return new wxStyledTextEvent(*this); }
+    wxNODISCARD virtual wxEvent* Clone() const override { return new wxStyledTextEvent(*this); }
 
 #ifndef SWIG
 private:

--- a/include/wx/strconv.h
+++ b/include/wx/strconv.h
@@ -157,7 +157,7 @@ public:
 
 
     // make a heap-allocated copy of this object
-    virtual wxMBConv *Clone() const = 0;
+    wxNODISCARD virtual wxMBConv *Clone() const = 0;
 
     // virtual dtor for any base class
     virtual ~wxMBConv() = default;
@@ -179,7 +179,7 @@ public:
     virtual size_t MB2WC(wchar_t *outputBuf, const char *psz, size_t outputSize) const override;
     virtual size_t WC2MB(char *outputBuf, const wchar_t *psz, size_t outputSize) const override;
 
-    virtual wxMBConv *Clone() const override { return new wxMBConvLibc; }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvLibc; }
 
     virtual bool IsUTF8() const override { return wxLocaleIsUtf8; }
 };
@@ -222,7 +222,7 @@ public:
 
     virtual bool IsUTF8() const override { return m_conv->IsUTF8(); }
 
-    virtual wxMBConv *Clone() const override { return new wxConvBrokenFileNames(*this); }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxConvBrokenFileNames(*this); }
 
 private:
     // the conversion object we forward to
@@ -252,7 +252,7 @@ public:
 
     virtual size_t GetMaxCharLen() const override { return 4; }
 
-    virtual wxMBConv *Clone() const override { return new wxMBConvUTF7; }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvUTF7; }
 
 private:
     // UTF-7 decoder/encoder may be in direct mode or in shifted mode after a
@@ -341,7 +341,7 @@ public:
 
     virtual size_t GetMaxCharLen() const override { return 4; }
 
-    virtual wxMBConv *Clone() const override { return new wxMBConvStrictUTF8(); }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvStrictUTF8(); }
 
     // NB: other mapping modes are not, strictly speaking, UTF-8, so we can't
     //     take the shortcut in that case
@@ -367,7 +367,7 @@ public:
 
     virtual size_t GetMaxCharLen() const override { return 4; }
 
-    virtual wxMBConv *Clone() const override { return new wxMBConvUTF8(m_options); }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvUTF8(m_options); }
 
     // NB: other mapping modes are not, strictly speaking, UTF-8, so we can't
     //     take the shortcut in that case
@@ -408,7 +408,7 @@ public:
     virtual size_t FromWChar(char *dst, size_t dstLen,
                              const wchar_t *src, size_t srcLen = wxNO_LEN) const override;
     virtual size_t GetMaxCharLen() const override { return 4; }
-    virtual wxMBConv *Clone() const override { return new wxMBConvUTF16LE; }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvUTF16LE; }
 };
 
 // ----------------------------------------------------------------------------
@@ -423,7 +423,7 @@ public:
     virtual size_t FromWChar(char *dst, size_t dstLen,
                              const wchar_t *src, size_t srcLen = wxNO_LEN) const override;
     virtual size_t GetMaxCharLen() const override { return 4; }
-    virtual wxMBConv *Clone() const override { return new wxMBConvUTF16BE; }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvUTF16BE; }
 };
 
 // ----------------------------------------------------------------------------
@@ -456,7 +456,7 @@ public:
     virtual size_t FromWChar(char *dst, size_t dstLen,
                              const wchar_t *src, size_t srcLen = wxNO_LEN) const override;
     virtual size_t GetMaxCharLen() const override { return 4; }
-    virtual wxMBConv *Clone() const override { return new wxMBConvUTF32LE; }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvUTF32LE; }
 };
 
 // ----------------------------------------------------------------------------
@@ -471,7 +471,7 @@ public:
     virtual size_t FromWChar(char *dst, size_t dstLen,
                              const wchar_t *src, size_t srcLen = wxNO_LEN) const override;
     virtual size_t GetMaxCharLen() const override { return 4; }
-    virtual wxMBConv *Clone() const override { return new wxMBConvUTF32BE; }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxMBConvUTF32BE; }
 };
 
 // ----------------------------------------------------------------------------
@@ -501,7 +501,7 @@ public:
 
     virtual bool IsUTF8() const override;
 
-    virtual wxMBConv *Clone() const override { return new wxCSConv(*this); }
+    wxNODISCARD virtual wxMBConv *Clone() const override { return new wxCSConv(*this); }
 
     void Clear();
 
@@ -576,7 +576,7 @@ public:
     // as UTF-8 before giving up.
     virtual size_t GetMaxCharLen() const override { return 4; }
 
-    virtual wxMBConv *Clone() const override
+    wxNODISCARD virtual wxMBConv *Clone() const override
     {
         return new wxWhateverWorksConv();
     }

--- a/include/wx/tarstrm.h
+++ b/include/wx/tarstrm.h
@@ -114,7 +114,7 @@ public:
                                     wxPathFormat format = wxPATH_NATIVE,
                                     bool *pIsDir = nullptr);
 
-    wxTarEntry *Clone() const { return new wxTarEntry(*this); }
+    wxNODISCARD wxTarEntry *Clone() const { return new wxTarEntry(*this); }
 
     void SetNotifier(wxTarNotifier& WXUNUSED(notifier)) { }
 

--- a/include/wx/taskbar.h
+++ b/include/wx/taskbar.h
@@ -107,7 +107,7 @@ public:
         SetEventObject(tbIcon);
     }
 
-    virtual wxEvent *Clone() const override { return new wxTaskBarIconEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxTaskBarIconEvent(*this); }
 
 private:
     wxDECLARE_NO_ASSIGN_DEF_COPY(wxTaskBarIconEvent);

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -1008,7 +1008,7 @@ public:
     // get the end of the URL
     long GetURLEnd() const { return m_end; }
 
-    virtual wxEvent *Clone() const override { return new wxTextUrlEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxTextUrlEvent(*this); }
 
 protected:
     // the corresponding mouse event

--- a/include/wx/timer.h
+++ b/include/wx/timer.h
@@ -171,7 +171,7 @@ public:
     wxTimer& GetTimer() const { return *m_timer; }
 
     // implement the base class pure virtual
-    virtual wxEvent *Clone() const override { return new wxTimerEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxTimerEvent(*this); }
     virtual wxEventCategory GetEventCategory() const override { return wxEVT_CATEGORY_TIMER; }
 
     // default ctor creates an unusable event object and should not be used (in

--- a/include/wx/treebase.h
+++ b/include/wx/treebase.h
@@ -196,7 +196,7 @@ public:
                 const wxTreeItemId &item = wxTreeItemId());
     wxTreeEvent(const wxTreeEvent& event);
 
-    virtual wxEvent *Clone() const override { return new wxTreeEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxTreeEvent(*this); }
 
     // accessors
         // get the item on which the operation was performed or the newly

--- a/include/wx/treelist.h
+++ b/include/wx/treelist.h
@@ -471,7 +471,7 @@ public:
     // COLUMN_SORTED event.
     unsigned GetColumn() const { return m_column; }
 
-    virtual wxEvent* Clone() const override { return new wxTreeListEvent(*this); }
+    wxNODISCARD virtual wxEvent* Clone() const override { return new wxTreeListEvent(*this); }
 
 private:
     // Common part of all ctors.

--- a/include/wx/valgen.h
+++ b/include/wx/valgen.h
@@ -63,7 +63,7 @@ public:
     // if you're passing a reference to a validator.
     // Another possibility is to always pass a pointer to a new validator
     // (so the calling code can use a copy constructor of the relevant class).
-    virtual wxObject *Clone() const override { return new wxGenericValidator(*this); }
+    wxNODISCARD virtual wxObject *Clone() const override { return new wxGenericValidator(*this); }
     bool Copy(const wxGenericValidator& val);
 
     // Called when the value in the window must be validated: this is not used

--- a/include/wx/validate.h
+++ b/include/wx/validate.h
@@ -46,7 +46,7 @@ public:
     // if you're passing a reference to a validator.
     // Another possibility is to always pass a pointer to a new validator
     // (so the calling code can use a copy constructor of the relevant class).
-    virtual wxObject *Clone() const
+    wxNODISCARD virtual wxObject *Clone() const
         { return nullptr; }
     bool Copy(const wxValidator& val)
         { m_validatorWindow = val.m_validatorWindow; return true; }

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -385,7 +385,7 @@ public:
     this->SetMax(max);
   }
 
-    virtual wxObject *Clone() const override { return new wxIntegerValidator(*this); }
+    wxNODISCARD virtual wxObject *Clone() const override { return new wxIntegerValidator(*this); }
 
     virtual bool IsInRange(LongestValueType value) const override
     {
@@ -525,7 +525,7 @@ public:
         this->SetPrecision(precision);
     }
 
-    virtual wxObject *Clone() const override
+    wxNODISCARD virtual wxObject *Clone() const override
     {
         return new wxFloatingPointValidator(*this);
     }

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -57,7 +57,7 @@ public:
     // if you're passing a reference to a validator.
     // Another possibility is to always pass a pointer to a new validator
     // (so the calling code can use a copy constructor of the relevant class).
-    virtual wxObject *Clone() const override { return new wxTextValidator(*this); }
+    wxNODISCARD virtual wxObject *Clone() const override { return new wxTextValidator(*this); }
     bool Copy(const wxTextValidator& val);
 
     // Called when the value in the window must be validated.

--- a/include/wx/variant.h
+++ b/include/wx/variant.h
@@ -76,7 +76,7 @@ public:
 
     // Implement this to make wxVariant::UnShare work. Returns
     // a copy of the data.
-    virtual wxVariantData* Clone() const { return nullptr; }
+    wxNODISCARD virtual wxVariantData* Clone() const { return nullptr; }
 
 #if wxUSE_ANY
     // Converts value to wxAny, if possible. Return true if successful.
@@ -379,7 +379,7 @@ public:
 // Attributes
 protected:
     virtual wxObjectRefData *CreateRefData() const override;
-    virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
+    wxNODISCARD virtual wxObjectRefData *CloneRefData(const wxObjectRefData *data) const override;
 
     wxString        m_name;
 
@@ -505,7 +505,7 @@ public:\
     virtual wxString GetType() const override; \
     virtual wxClassInfo* GetValueClassInfo() override; \
 \
-    virtual wxVariantData* Clone() const override { return new classname##VariantData(m_value); } \
+    wxNODISCARD virtual wxVariantData* Clone() const override { return new classname##VariantData(m_value); } \
 \
     DECLARE_WXANY_CONVERSION() \
 protected:\

--- a/include/wx/variantbase.h
+++ b/include/wx/variantbase.h
@@ -129,7 +129,7 @@ public:
         { return GetTypeInfo()->GetTypeName(); }
 
     // return a heap allocated duplicate
-    //virtual wxVariantData* Clone() const { return new wxVariantDataT<T>( Get() ); }
+    wxNODISCARD //virtual wxVariantData* Clone() const { return new wxVariantDataT<T>( Get() ); }
 
     // returns the type info of the contentc
     virtual const wxTypeInfo* GetTypeInfo() const { return wxGetTypeInfo( (T*) nullptr ); }

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -492,7 +492,7 @@ public:
 
     void SetDataBuffer(const wxMemoryBuffer& dataBuf) { m_dataBuf = dataBuf; }
 
-    wxEvent* Clone() const override { return new wxWebRequestEvent(*this); }
+    wxNODISCARD wxEvent* Clone() const override { return new wxWebRequestEvent(*this); }
 
 private:
     wxWebRequest::State m_state;

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -426,7 +426,7 @@ public:
     const wxString& GetMessageHandler() const { return m_messageHandler; }
     wxWebViewWindowFeatures* GetTargetWindowFeatures() const { return (wxWebViewWindowFeatures*)m_clientData; }
 
-    virtual wxEvent* Clone() const override { return new wxWebViewEvent(*this); }
+    wxNODISCARD virtual wxEvent* Clone() const override { return new wxWebViewEvent(*this); }
 private:
     wxString m_url;
     wxString m_target;

--- a/include/wx/wizard.h
+++ b/include/wx/wizard.h
@@ -279,7 +279,7 @@ public:
 
     wxWizardPage*   GetPage() const { return m_page; }
 
-    virtual wxEvent *Clone() const override { return new wxWizardEvent(*this); }
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxWizardEvent(*this); }
 
 private:
     bool m_direction;

--- a/include/wx/x11/bitmap.h
+++ b/include/wx/x11/bitmap.h
@@ -124,7 +124,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxBitmap);

--- a/include/wx/x11/brush.h
+++ b/include/wx/x11/brush.h
@@ -53,7 +53,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     wxDECLARE_DYNAMIC_CLASS(wxBrush);
 };

--- a/include/wx/x11/colour.h
+++ b/include/wx/x11/colour.h
@@ -53,7 +53,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     virtual void
     InitRGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a);

--- a/include/wx/x11/cursor.h
+++ b/include/wx/x11/cursor.h
@@ -40,7 +40,7 @@ protected:
     void InitFromStock(wxStockCursor);
 
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxCursor);

--- a/include/wx/x11/font.h
+++ b/include/wx/x11/font.h
@@ -123,7 +123,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     virtual void DoSetNativeFontInfo( const wxNativeFontInfo& info );
     virtual wxFontFamily DoGetFamily() const;

--- a/include/wx/x11/palette.h
+++ b/include/wx/x11/palette.h
@@ -67,7 +67,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 };
 
 #endif // _WX_PALETTE_H_

--- a/include/wx/x11/pen.h
+++ b/include/wx/x11/pen.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     wxDECLARE_DYNAMIC_CLASS(wxPen);
 };

--- a/include/wx/x11/region.h
+++ b/include/wx/x11/region.h
@@ -60,7 +60,7 @@ public:
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
-    virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+    wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
     // wxRegionBase pure virtuals
     virtual bool DoIsEqual(const wxRegion& region) const;

--- a/include/wx/zipstrm.h
+++ b/include/wx/zipstrm.h
@@ -204,7 +204,7 @@ public:
     inline void SetIsReadOnly(bool isReadOnly = true) override;
     inline void SetIsText(bool isText = true);
 
-    wxZipEntry *Clone() const                   { return ZipClone(); }
+    wxNODISCARD wxZipEntry *Clone() const       { return ZipClone(); }
 
     void SetNotifier(wxZipNotifier& notifier);
     void UnsetNotifier() override;


### PR DESCRIPTION
Calling a Clone*() function without using its return value is in most (even all) cases a certain way to leak memory.