### PR TITLE
Allow running on systems without libsecret with wxUSE_SECRETSTORE

### DIFF
--- a/build/cmake/lib/base/CMakeLists.txt
+++ b/build/cmake/lib/base/CMakeLists.txt
@@ -42,6 +42,10 @@ if(wxUSE_LIBLZMA)
 endif()
 if(UNIX AND wxUSE_SECRETSTORE)
     wx_lib_include_directories(wxbase ${LIBSECRET_INCLUDE_DIRS})
+    # Avoid linking with libsecret-1.so directly, we load this
+    # library dynamically in wxSecretStoreLibSecretImpl to avoid
+    # requiring it being installed on the target system.
+    list(REMOVE_ITEM LIBSECRET_LIBRARIES secret-1)
     wx_lib_link_libraries(wxbase PRIVATE ${LIBSECRET_LIBRARIES})
 endif()
 if(wxUSE_LIBICONV)

--- a/configure
+++ b/configure
@@ -35917,7 +35917,7 @@ else
 $as_echo "yes" >&6; }
 
                 CXXFLAGS="$LIBSECRET_CFLAGS $CXXFLAGS"
-                LIBS="$LIBSECRET_LIBS $LIBS"
+                                                                LIBS="`echo $LIBSECRET_LIBS | sed s/-lsecret-1//g` $LIBS"
 
 fi
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -5088,7 +5088,10 @@ if test "$wxUSE_SECRETSTORE" = "yes"; then
         PKG_CHECK_MODULES(LIBSECRET, [libsecret-1],
             [
                 CXXFLAGS="$LIBSECRET_CFLAGS $CXXFLAGS"
-                LIBS="$LIBSECRET_LIBS $LIBS"
+                dnl Avoid linking with libsecret-1.so directly, we load this
+                dnl library dynamically in wxSecretStoreLibSecretImpl to avoid
+                dnl requiring it being installed on the target system.
+                LIBS="`echo $LIBSECRET_LIBS | sed s/-lsecret-1//g` $LIBS"
             ],
             [
                 AC_MSG_WARN([libsecret not found, wxSecretStore won't be available])


### PR DESCRIPTION
Load the library dynamically to allow binaries compiled using wxWidgets with wxUSE_SECRETSTORE==1 to run even on systems without this library, as it is an optional package which may not be always installed and its absence shouldn't prevent the applications from starting.