### PR TITLE
Set proposed drop index in wxGTK wxDataViewCtrl

### DIFF
--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -944,8 +944,7 @@ public:
     int GetDragFlags() const { return m_dragFlags; }
     void SetDropEffect( wxDragResult effect ) { m_dropEffect = effect; }
     wxDragResult GetDropEffect() const { return m_dropEffect; }
-    // For platforms (currently generic and OSX) that support Drag/Drop
-    // insertion of items, this is the proposed child index for the insertion.
+    // Proposed child index for the insertion under the parent item.
     void SetProposedDropIndex(int index) { m_proposedDropIndex = index; }
     int GetProposedDropIndex() const { return m_proposedDropIndex;}
 

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -4054,11 +4054,10 @@ public:
         Returns the index of the child item at which an item currently being
         dragged would be dropped.
 
-        This function can be used from wxEVT_DATAVIEW_ITEM_DROP_POSSIBLE
-        handlers to determine the exact position of the item being dropped.
-
-        Note that it currently always returns wxNOT_FOUND when using native GTK
-        implementation of this control.
+        This function can be used from wxEVT_DATAVIEW_ITEM_DROP (in all ports)
+        and wxEVT_DATAVIEW_ITEM_DROP_POSSIBLE (except when using native GTK
+        implementation) handlers to determine the exact position of the item
+        being dropped.
 
         @since 3.1.2
      */


### PR DESCRIPTION
Use "drag-data-received" signal instead of GtkTreeDragDestIface vfunc to be notified about drops on GtkTreeView, as the signal provides more information, notably the exact position of the drop and not just the nearest item to it, which allows to provide the proposed drop index in wxGTK too.

Closes #2240.