### PR TITLE
Use FreeBSD 14.2 image for Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
   matrix:
     - name: Cirrus CI / FreeBSD wxGTK 3
       freebsd_instance:
-        image_family: freebsd-15-0-snap
+        image_family: freebsd-14-2
       env:
         osname: FreeBSD
     - name: Cirrus CI / Debian ARM wxGTK 3


### PR DESCRIPTION
Using 15.0-snap doesn't seem to work any longer: all jobs fails with "Agent is not responding!" error and without any other information.