### PR TITLE
Return correct cursor size

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -1948,6 +1948,7 @@ public:
           m_cursor(event.m_cursor)
         { }
 
+    wxPoint GetPosition() const { return wxPoint(m_x, m_y); }
     wxCoord GetX() const { return m_x; }
     wxCoord GetY() const { return m_y; }
 

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -5042,12 +5042,27 @@ public:
     const wxCursor& GetCursor() const;
 
     /**
+        Returns the mouse position for which the cursor is requested.
+
+        This position is expressed in the client coordinates of the window.
+
+        @see GetX(), GetY()
+
+        @since 3.3.0
+    */
+    wxPoint GetPosition() const;
+
+    /**
         Returns the X coordinate of the mouse in client coordinates.
+
+        @see GetPosition()
     */
     wxCoord GetX() const;
 
     /**
         Returns the Y coordinate of the mouse in client coordinates.
+
+        @see GetPosition()
     */
     wxCoord GetY() const;
 

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -152,8 +152,8 @@ enum wxSystemMetric
     wxSYS_MOUSE_BUTTONS,      //!< Number of buttons on mouse, or zero if no mouse was installed.
     wxSYS_BORDER_X,           //!< Width of single border.
     wxSYS_BORDER_Y,           //!< Height of single border.
-    wxSYS_CURSOR_X,           //!< Width of cursor.
-    wxSYS_CURSOR_Y,           //!< Height of cursor.
+    wxSYS_CURSOR_X,           //!< Width of cursor in physical pixels.
+    wxSYS_CURSOR_Y,           //!< Height of cursor in physical pixels.
     wxSYS_DCLICK_X,           //!< Width in pixels of rectangle within which two successive mouse clicks must fall to generate a double-click.
     wxSYS_DCLICK_Y,           //!< Height in pixels of rectangle within which two successive mouse clicks must fall to generate a double-click.
     wxSYS_DRAG_X,             //!< Width in pixels of a rectangle centered on a drag point to allow for limited movement of the mouse pointer before a drag operation begins.

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -176,6 +176,7 @@ protected:
     void DrawGradients(wxDC& dc);
     void DrawSystemColours(wxDC& dc);
     void DrawDatabaseColours(wxDC& dc);
+    void DrawCursors(wxDC& dc);
     void DrawColour(wxDC& dc, const wxFont& mono, wxCoord x, const wxRect& r, const wxString& colourName, const wxColour& col);
 
     void DrawRegionsHelper(wxDC& dc, wxCoord x, bool firstTime);
@@ -331,6 +332,7 @@ enum
 #endif
     File_ShowSystemColours,
     File_ShowDatabaseColours,
+    File_ShowCursors,
     File_ShowGradients,
     MenuShow_Last = File_ShowGradients,
 
@@ -1883,6 +1885,18 @@ void MyCanvas::DrawDatabaseColours(wxDC& dc)
     }
 }
 
+void MyCanvas::DrawCursors(wxDC& dc)
+{
+    wxCoord x(FromDIP(10));
+    wxCoord y = x;
+
+    dc.SetBackgroundMode(wxTRANSPARENT);
+    dc.DrawText(wxString::Format("System cursor size: %dx%d",
+                                 wxSystemSettings::GetMetric(wxSYS_CURSOR_X, this),
+                                 wxSystemSettings::GetMetric(wxSYS_CURSOR_Y, this)),
+                x, y);
+}
+
 void MyCanvas::DrawColour(wxDC& dc, const wxFont& mono, wxCoord x, const wxRect& r, const wxString& colourName, const wxColour& col)
 {
     {
@@ -2111,6 +2125,10 @@ void MyCanvas::Draw(wxDC& pdc)
 
         case File_ShowDatabaseColours:
             DrawDatabaseColours(dc);
+            break;
+
+        case File_ShowCursors:
+            DrawCursors(dc);
             break;
 
         default:
@@ -2411,6 +2429,7 @@ MyFrame::MyFrame(const wxString& title)
 #endif
     menuScreen->Append(File_ShowSystemColours, "System &colours");
     menuScreen->Append(File_ShowDatabaseColours, "Databa&se colours");
+    menuScreen->Append(File_ShowCursors, "C&ursors screen");
 
     wxMenu *menuFile = new wxMenu;
 #if wxUSE_GRAPHICS_CONTEXT

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -1237,9 +1237,17 @@ int wxSystemSettingsNative::GetMetric( wxSystemMetric index, const wxWindow* win
 
         case wxSYS_CURSOR_X:
         case wxSYS_CURSOR_Y:
+            {
+                gint cursor_size = 0;
+                g_object_get(GetSettingsForWindowScreen(window),
+                                "gtk-cursor-theme-size", &cursor_size, nullptr);
+                if (cursor_size)
+                    return cursor_size;
+
                 return gdk_display_get_default_cursor_size(
                             window ? gdk_window_get_display(window)
                                    : gdk_display_get_default());
+            }
 
         case wxSYS_DCLICK_X:
         case wxSYS_DCLICK_Y:

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -18,6 +18,7 @@
     #include "wx/module.h"
 #endif
 
+#include "wx/display.h"
 #include "wx/fontutil.h"
 #include "wx/fontenum.h"
 
@@ -1242,7 +1243,15 @@ int wxSystemSettingsNative::GetMetric( wxSystemMetric index, const wxWindow* win
                 g_object_get(GetSettingsForWindowScreen(window),
                                 "gtk-cursor-theme-size", &cursor_size, nullptr);
                 if (cursor_size)
-                    return cursor_size;
+                {
+                    // Cursor size should be expressed in physical pixels, as
+                    // it is similar to a bitmap size, so we need to scale it
+                    // by the DPI scaling factor.
+                    double scale = window ? win->GetDPIScaleFactor()
+                                          : wxDisplay().GetScaleFactor();
+
+                    return wxRound(cursor_size * scale);
+                }
 
                 return gdk_display_get_default_cursor_size(
                             window ? gdk_window_get_display(window)


### PR DESCRIPTION
Also show the different stock cursors in the drawing sample.

Closes #25328.