### PR TITLE
Improvement to wxCursor ctors

### DIFF
--- a/include/wx/cursor.h
+++ b/include/wx/cursor.h
@@ -30,6 +30,7 @@ public:
 
     wxCursor();
     wxCursor(const wxImage& image);
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot);
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/cursor.h
+++ b/include/wx/cursor.h
@@ -30,6 +30,8 @@ public:
 
     wxCursor();
     wxCursor(const wxImage& image);
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot);
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
     wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot);
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,

--- a/include/wx/dfb/cursor.h
+++ b/include/wx/dfb/cursor.h
@@ -26,6 +26,8 @@ public:
     wxCursor(const wxImage& image);
     wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot)
+        : wxCursor(name, type, hotSpot.x, hotSpot.y) { }
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/dfb/cursor.h
+++ b/include/wx/dfb/cursor.h
@@ -22,6 +22,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     wxCursor() = default;
     wxCursor(wxStockCursor id) { InitFromStock(id); }
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot)
+        : wxCursor(bitmap, hotSpot.x, hotSpot.y) { }
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
 #if wxUSE_IMAGE
     wxCursor(const wxImage& image);
     wxCursor(const char* const* xpmData);

--- a/include/wx/gtk/cursor.h
+++ b/include/wx/gtk/cursor.h
@@ -24,9 +24,13 @@ public:
     wxCursor( const wxImage & image );
     wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot)
+        : wxCursor(name, type, hotSpot.x, hotSpot.y) { }
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);
+
+    // Non-portable wxGTK-specific ctor.
     wxCursor( const char bits[], int width, int height,
               int hotSpotX = -1, int hotSpotY = -1,
               const char maskBits[] = nullptr,

--- a/include/wx/gtk/cursor.h
+++ b/include/wx/gtk/cursor.h
@@ -20,6 +20,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     wxCursor();
     wxCursor(wxStockCursor id) { InitFromStock(id); }
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot)
+        : wxCursor(bitmap, hotSpot.x, hotSpot.y) { }
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
     wxCursor(const char* const* xpmData);
@@ -47,6 +50,9 @@ protected:
 #if wxUSE_IMAGE
     void InitFromImage(const wxImage& image);
 #endif
+    void
+    InitFromBitmap(const wxBitmap& bitmap, int hotSpotX, int hotSpotY,
+                   const wxColour *fg = nullptr, const wxColour *bg = nullptr);
 
     virtual wxGDIRefData *CreateGDIRefData() const override;
     wxNODISCARD virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;

--- a/include/wx/msw/cursor.h
+++ b/include/wx/msw/cursor.h
@@ -22,6 +22,8 @@ public:
     wxCursor(const wxImage& image);
     wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot)
+        : wxCursor(name, type, hotSpot.x, hotSpot.y) { }
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/msw/cursor.h
+++ b/include/wx/msw/cursor.h
@@ -18,6 +18,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     // constructors
     wxCursor();
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot)
+        : wxCursor(bitmap, hotSpot.x, hotSpot.y) { }
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
 #if wxUSE_IMAGE
     wxCursor(const wxImage& image);
     wxCursor(const char* const* xpmData);
@@ -41,6 +44,7 @@ protected:
     virtual wxGDIImageRefData *CreateData() const override;
 
 private:
+    void InitFromBitmap(const wxBitmap& bmp, int hotSpotX, int hotSpotY);
 #if wxUSE_IMAGE
     void InitFromImage(const wxImage& image);
 #endif // wxUSE_IMAGE

--- a/include/wx/osx/cursor.h
+++ b/include/wx/osx/cursor.h
@@ -22,6 +22,8 @@ public:
     wxCursor(const wxImage & image) ;
     wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot)
+        : wxCursor(name, type, hotSpot.x, hotSpot.y) { }
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/osx/cursor.h
+++ b/include/wx/osx/cursor.h
@@ -18,6 +18,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     wxCursor();
 
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot)
+        : wxCursor(bitmap, hotSpot.x, hotSpot.y) { }
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
 #if wxUSE_IMAGE
     wxCursor(const wxImage & image) ;
     wxCursor(const char* const* xpmData);
@@ -43,6 +46,7 @@ protected:
 
 private:
     void InitFromStock(wxStockCursor);
+    void InitFromBitmap(const wxBitmap& bitmap, int hotSpotX, int hotSpotY);
 
 #if wxUSE_IMAGE
     void InitFromImage(const wxImage & image) ;

--- a/include/wx/qt/cursor.h
+++ b/include/wx/qt/cursor.h
@@ -21,6 +21,8 @@ public:
     wxCursor( const wxImage & image );
     wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot)
+        : wxCursor(name, type, hotSpot.x, hotSpot.y) { }
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/qt/cursor.h
+++ b/include/wx/qt/cursor.h
@@ -17,6 +17,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     wxCursor() = default;
     wxCursor(wxStockCursor id) { InitFromStock(id); }
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot)
+        : wxCursor(bitmap, hotSpot.x, hotSpot.y) { }
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
     wxCursor(const char* const* xpmData);
@@ -32,6 +35,7 @@ public:
 
 protected:
     void InitFromStock( wxStockCursor cursorId );
+    void InitFromBitmap(const wxBitmap& bmp, int hotSpotX, int hotSpotY);
 #if wxUSE_IMAGE
     void InitFromImage( const wxImage & image );
 #endif

--- a/include/wx/x11/cursor.h
+++ b/include/wx/x11/cursor.h
@@ -23,6 +23,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     wxCursor();
     wxCursor(wxStockCursor id) { InitFromStock(id); }
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot)
+        : wxCursor(bitmap, hotSpot.x, hotSpot.y) { }
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
     wxCursor(const char* const* xpmData);

--- a/include/wx/x11/cursor.h
+++ b/include/wx/x11/cursor.h
@@ -28,6 +28,8 @@ public:
     wxCursor(const char* const* xpmData);
 #endif
 
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot)
+        : wxCursor(name, type, hotSpot.x, hotSpot.y) { }
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/interface/wx/cursor.h
+++ b/interface/wx/cursor.h
@@ -121,6 +121,13 @@ public:
              int hotSpotX = 0, int hotSpotY = 0);
 
     /**
+        @overload
+
+        @since 3.3.0
+     */
+    wxCursor(const wxString& name, wxBitmapType type, const wxPoint& hotSpot);
+
+    /**
         Constructs a cursor using a cursor identifier.
 
         @param cursorId

--- a/interface/wx/cursor.h
+++ b/interface/wx/cursor.h
@@ -88,6 +88,27 @@ public:
     wxCursor();
 
     /**
+        Constructs a cursor from the provided bitmap and hotspot position.
+
+        @param bitmap
+            The bitmap to use for the cursor, should be valid.
+        @param hotSpotX
+            Hotspot x coordinate (relative to the top left of the image).
+        @param hotSpotY
+            Hotspot y coordinate (relative to the top left of the image).
+
+        @since 3.3.0
+     */
+    wxCursor(const wxBitmap& bitmap, int hotSpotX = 0, int hotSpotY = 0);
+
+    /**
+        @overload
+
+        @since 3.3.0
+     */
+    wxCursor(const wxBitmap& bitmap, const wxPoint& hotSpot);
+
+    /**
         Constructs a cursor by passing a string resource name or filename.
 
         The arguments @a hotSpotX and @a hotSpotY are only used when there's no

--- a/interface/wx/cursor.h
+++ b/interface/wx/cursor.h
@@ -88,40 +88,6 @@ public:
     wxCursor();
 
     /**
-        Constructs a cursor by passing an array of bits (XBM data).
-
-        The parameters @a fg and @a bg have an effect only on GTK+, and force
-        the cursor to use particular background and foreground colours.
-
-        @param bits
-            An array of XBM data bits.
-        @param width
-            Cursor width.
-        @param height
-            Cursor height.
-        @param hotSpotX
-            Hotspot x coordinate (relative to the top left of the image).
-        @param hotSpotY
-            Hotspot y coordinate (relative to the top left of the image).
-        @param maskBits
-            Bits for a mask bitmap.
-        @param fg
-            Foreground colour.
-        @param bg
-            Background colour.
-
-        @onlyfor{wxgtk}
-
-        @beginWxPerlOnly
-        In wxPerl use Wx::Cursor->newData(bits, width, height, hotSpotX = -1, hotSpotY = -1, maskBits = 0).
-        @endWxPerlOnly
-    */
-    wxCursor(const char bits[], int width, int height,
-             int hotSpotX = -1, int hotSpotY = -1,
-             const char maskBits[] = nullptr,
-             const wxColour* fg = nullptr, const wxColour* bg = nullptr);
-
-    /**
         Constructs a cursor by passing a string resource name or filename.
 
         The arguments @a hotSpotX and @a hotSpotY are only used when there's no
@@ -198,6 +164,40 @@ public:
         though wxImage constructor from XPM is now @c explicit.
      */
     wxCursor(const char* const* xpmData);
+
+    /**
+        wxGTK-specific constructor from data in XBM format.
+
+        The parameters @a fg and @a bg have an effect only on GTK+, and force
+        the cursor to use particular background and foreground colours.
+
+        @param bits
+            An array of XBM data bits.
+        @param width
+            Cursor width.
+        @param height
+            Cursor height.
+        @param hotSpotX
+            Hotspot x coordinate (relative to the top left of the image).
+        @param hotSpotY
+            Hotspot y coordinate (relative to the top left of the image).
+        @param maskBits
+            Bits for a mask bitmap.
+        @param fg
+            Foreground colour.
+        @param bg
+            Background colour.
+
+        @onlyfor{wxgtk}
+
+        @beginWxPerlOnly
+        In wxPerl use Wx::Cursor->newData(bits, width, height, hotSpotX = -1, hotSpotY = -1, maskBits = 0).
+        @endWxPerlOnly
+    */
+    wxCursor(const char bits[], int width, int height,
+             int hotSpotX = -1, int hotSpotY = -1,
+             const char maskBits[] = nullptr,
+             const wxColour* fg = nullptr, const wxColour* bg = nullptr);
 
     /**
         Copy constructor, uses @ref overview_refcount "reference counting".

--- a/src/dfb/cursor.cpp
+++ b/src/dfb/cursor.cpp
@@ -53,6 +53,11 @@ void wxCursor::InitFromStock(wxStockCursor cursorId)
 #warning "FIXME -- implement the cursor as bitmaps (that's what DFB uses)"
 }
 
+wxCursor::wxCursor(const wxBitmap& bitmap, int hotSpotX, int hotSpotY)
+{
+#warning "FIXME"
+}
+
 #if wxUSE_IMAGE
 
 wxCursor::wxCursor(const wxImage& image)

--- a/src/msw/cursor.cpp
+++ b/src/msw/cursor.cpp
@@ -150,6 +150,24 @@ wxCursor::wxCursor()
 {
 }
 
+wxCursor::wxCursor(const wxBitmap& bitmap, int hotSpotX, int hotSpotY)
+{
+    InitFromBitmap(bitmap, hotSpotX, hotSpotY);
+}
+
+void wxCursor::InitFromBitmap(const wxBitmap& bmp, int hotSpotX, int hotSpotY)
+{
+    HCURSOR hcursor = wxBitmapToHCURSOR( bmp, hotSpotX, hotSpotY );
+
+    if ( !hcursor )
+    {
+        wxLogWarning(_("Failed to create cursor."));
+        return;
+    }
+
+    m_refData = new wxCursorRefData(hcursor, true /* delete it later */);
+}
+
 #if wxUSE_IMAGE
 wxCursor::wxCursor(const wxImage& image)
 {
@@ -196,16 +214,7 @@ void wxCursor::InitFromImage(const wxImage& image)
         imageSized = image.Scale(w, h);
     }
 
-    HCURSOR hcursor = wxBitmapToHCURSOR( wxBitmap(imageSized),
-                                         hotSpotX, hotSpotY );
-
-    if ( !hcursor )
-    {
-        wxLogWarning(_("Failed to create cursor."));
-        return;
-    }
-
-    m_refData = new wxCursorRefData(hcursor, true /* delete it later */);
+    InitFromBitmap(imageSized, hotSpotX, hotSpotY);
 }
 #endif // wxUSE_IMAGE
 

--- a/src/osx/carbon/cursor.cpp
+++ b/src/osx/carbon/cursor.cpp
@@ -226,6 +226,11 @@ wxCursor::wxCursor()
 {
 }
 
+wxCursor::wxCursor(const wxBitmap& bitmap, int hotSpotX, int hotSpotY)
+{
+    InitFromBitmap(bitmap, hotSpotX, hotSpotY);
+}
+
 #if wxUSE_IMAGE
 wxCursor::wxCursor( const wxImage &image )
 {
@@ -253,15 +258,11 @@ WXHCURSOR wxCursor::GetHCURSOR() const
     return (M_CURSORDATA ? M_CURSORDATA->m_hCursor : nullptr);
 }
 
-#if wxUSE_IMAGE
-
-void wxCursor::InitFromImage(const wxImage & image)
+void wxCursor::InitFromBitmap(const wxBitmap& bmp, int hotSpotX, int hotSpotY)
 {
     m_refData = new wxCursorRefData;
-    int hotSpotX = image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_X);
-    int hotSpotY = image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_Y);
+
 #if wxOSX_USE_COCOA
-    wxBitmap bmp( image );
     CGImageRef cgimage = bmp.CreateCGImage();
     if ( cgimage )
     {
@@ -269,6 +270,15 @@ void wxCursor::InitFromImage(const wxImage & image)
         CFRelease( cgimage );
     }
 #endif
+}
+
+#if wxUSE_IMAGE
+
+void wxCursor::InitFromImage(const wxImage & image)
+{
+    int hotSpotX = image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_X);
+    int hotSpotY = image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_Y);
+    InitFromBitmap(image, hotSpotX, hotSpotY);
 }
 
 #endif //wxUSE_IMAGE

--- a/src/qt/cursor.cpp
+++ b/src/qt/cursor.cpp
@@ -60,6 +60,11 @@ public:
 wxIMPLEMENT_DYNAMIC_CLASS(wxCursor, wxGDIObject);
 
 
+wxCursor::wxCursor(const wxBitmap& bitmap, int hotSpotX, int hotSpotY)
+{
+    InitFromBitmap(bitmap, hotSpotX, hotSpotY);
+}
+
 wxCursor::wxCursor(const wxString& cursor_file,
                    wxBitmapType type,
                    int hotSpotX, int hotSpotY)
@@ -154,20 +159,25 @@ void wxCursor::InitFromStock( wxStockCursor cursorId )
     GetHandle().setShape(qt_cur);
 }
 
+void wxCursor::InitFromBitmap(const wxBitmap& bmp, int hotSpotX, int hotSpotY)
+{
+    AllocExclusive();
+
+    GetHandle() = QCursor(*bmp.GetHandle(), hotSpotX, hotSpotY);
+}
+
 #if wxUSE_IMAGE
 
 void wxCursor::InitFromImage( const wxImage & image )
 {
-    AllocExclusive();
-
     wxBitmap bmp(image);
     bmp.QtBlendMaskWithAlpha();
 
-    GetHandle() = QCursor(*bmp.GetHandle(),
-                           image.HasOption(wxIMAGE_OPTION_CUR_HOTSPOT_X) ?
-                           image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_X) : 0,
-                           image.HasOption(wxIMAGE_OPTION_CUR_HOTSPOT_Y) ?
-                           image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_Y) : 0);
+    InitFromBitmap(bmp,
+                   image.HasOption(wxIMAGE_OPTION_CUR_HOTSPOT_X) ?
+                   image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_X) : 0,
+                   image.HasOption(wxIMAGE_OPTION_CUR_HOTSPOT_Y) ?
+                   image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_Y) : 0);
 }
 
 #endif // wxUSE_IMAGE

--- a/src/x11/cursor.cpp
+++ b/src/x11/cursor.cpp
@@ -69,6 +69,12 @@ wxCursor::wxCursor()
 
 }
 
+wxCursor::wxCursor(const wxBitmap& WXUNUSED(bitmap),
+                   int WXUNUSED(hotSpotX), int WXUNUSED(hotSpotY))
+{
+    wxFAIL_MSG( "wxCursor creation from bitmaps not implemented" );
+}
+
 void wxCursor::InitFromStock( wxStockCursor cursorId )
 {
     m_refData = new wxCursorRefData();

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -2599,7 +2599,12 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::Cursor", "[image][cursor]")
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
 
-    wxImage img = wxBitmap((const char*)xbm_horse, 32, 32).ConvertToImage();
+    wxBitmap bmp((const char*)xbm_horse, 32, 32);
+    REQUIRE( bmp.IsOk() );
+    wxCursor cursorFromBmp(bmp, 16, 23);
+    CHECK( cursorFromBmp.IsOk() );
+
+    wxImage img = bmp.ConvertToImage();
     REQUIRE( img.IsOk() );
     img.SetOption(wxIMAGE_OPTION_CUR_HOTSPOT_X, 16);
     img.SetOption(wxIMAGE_OPTION_CUR_HOTSPOT_Y, 23);


### PR DESCRIPTION
Allow passing hotspot coordinates as a single wxPoint instead of a pair of ints and also allow creating cursors directly from wxBitmap, without passing by wxImage.