### PR TITLE
Implement GetMainWindowOfCompositeControl for wxDataViewCtrl

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -306,6 +306,9 @@ public:
     wxDataViewCtrl *GetOwner() const
         { return static_cast<wxDataViewCtrl *>(GetParent()); }
 
+    virtual wxWindow *GetMainWindowOfCompositeControl() override
+        { return GetOwner(); }
+
     // Add/Remove additional column to sorting columns
     void ToggleSortByColumn(int column)
     {
@@ -776,6 +779,9 @@ public:
 
     wxDataViewModel* GetModel() { return GetOwner()->GetModel(); }
     const wxDataViewModel* GetModel() const { return GetOwner()->GetModel(); }
+
+    virtual wxWindow *GetMainWindowOfCompositeControl() override
+        { return GetOwner(); }
 
 #if wxUSE_DRAG_AND_DROP
     wxBitmap CreateItemBitmap( unsigned int row, int &indent );


### PR DESCRIPTION
Implement `GetMainWindowOfCompositeControl()` in the generic version of `wxDataViewCtrl` so that focus is reported correctly.

AFAICT should be safe to backport to 3.2 as-is (well, sans `override`), as these are private classes not exposed in any headers, let alone public API ones.