### PR TITLE
Restore compatibility with overriding wxApp::OnAssert()

### DIFF
--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -103,6 +103,9 @@
                           const wxString& cond,
                           const wxString& msg,
                           wxAppTraits *traits = nullptr);
+
+    // Used to pass the function name from wxDefaultAssertHandler().
+    static wxString gs_assertFunc;
 #endif // wxDEBUG_LEVEL
 
 #ifdef __WXDEBUG__
@@ -887,7 +890,11 @@ void wxAppConsoleBase::OnAssert(const wxChar *file,
                                 const wxChar *cond,
                                 const wxChar *msg)
 {
+#if wxDEBUG_LEVEL
+    OnAssertFailure(file, line, gs_assertFunc.wc_str(), cond, msg);
+#else
     OnAssertFailure(file, line, nullptr, cond, msg);
+#endif
 }
 
 // ----------------------------------------------------------------------------
@@ -1184,8 +1191,11 @@ wxDefaultAssertHandler(const wxString& file,
     else
     {
         // let the app process it as it wants
-        wxTheApp->OnAssertFailure(file.wc_str(), line, func.wc_str(),
-                                  cond.wc_str(), msg.wc_str());
+
+        // for compatibility, call the old function after stashing the function
+        // name into a global, so that it could pass it to the new one
+        gs_assertFunc = func;
+        wxTheApp->OnAssert(file.wc_str(), line, cond.wc_str(), msg.wc_str());
     }
 }
 


### PR DESCRIPTION
The changes of 3ec4a23f50 (show the function in which the assert failure occured if the compiler supports it, 2006-03-21) left the old OnAssert() function for compatibility, but it was never called since then as the code only called the new function.

Fix this only 19 years later by calling the old function and using a global variable to help it pass the function name to the new one by default.

Note that GitHub code search shows that there are a few different projects overriding OnAssert() in their wxApp-derived class, so this fix is not as useless as could be believed.