### PR TITLE
Fix typo in wxWebViewChromium error message

### DIFF
--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -986,7 +986,7 @@ bool CheckCEFLoadOrder()
             if ( foundLibc )
             {
                 wxLogError(
-                    _("Chromium can't be used because libcef.so was't "
+                    _("Chromium can't be used because libcef.so wasn't "
                       "loaded early enough; please relink the application "
                       "or use LD_PRELOAD to load it earlier.")
                 );


### PR DESCRIPTION
Since the typo was in a `_()` string, fixing this should also include message catalogs being updated but I don't know the procedure (probably not triggered automatically?).