### PR TITLE
Make errors shown to the users more readable

### DIFF
--- a/src/common/imagbmp.cpp
+++ b/src/common/imagbmp.cpp
@@ -1177,9 +1177,8 @@ bool wxBMPHandler::LoadDib(wxImage *image, wxInputStream& stream,
         {
             if ( verbose )
             {
-                wxLogError(
-                    _("BMP: header has biClrUsed=%d when biBitCount=%d."),
-                    desc.ncolors, desc.bpp);
+                wxLogError(_("BMP Header: Invalid number of colors (%d)."),
+                           desc.ncolors);
             }
             return false;
         }

--- a/src/common/imagwebp.cpp
+++ b/src/common/imagwebp.cpp
@@ -53,7 +53,7 @@ bool DecodeWebPDataIntoImage(wxImage* image, WebPData* webp_data, bool verbose)
     {
         if (verbose)
         {
-            wxLogError(_("WebP: GetFeatures not OK."));
+            wxLogError(_("WebP: Invalid data (failed to get features)."));
         }
         return false;
     }
@@ -62,7 +62,7 @@ bool DecodeWebPDataIntoImage(wxImage* image, WebPData* webp_data, bool verbose)
     {
         if (verbose)
         {
-            wxLogError(_("WebP: wxImage::Create failed."));
+            wxLogError(_("WebP: Allocating image memory failed."));
         }
         return false;
     }
@@ -79,7 +79,7 @@ bool DecodeWebPDataIntoImage(wxImage* image, WebPData* webp_data, bool verbose)
         {
             if (verbose)
             {
-                wxLogError(_("WebP: WebPDecodeRGBA failed."));
+                wxLogError(_("WebP: Decoding RGBA image data failed."));
             }
             return false;
         }
@@ -95,7 +95,7 @@ bool DecodeWebPDataIntoImage(wxImage* image, WebPData* webp_data, bool verbose)
         {
             if (verbose)
             {
-                wxLogError(_("WebP: WebPDecodeRGBInto failed."));
+                wxLogError(_("WebP: Decoding RGB image data failed."));
             }
             return false;
         }
@@ -110,7 +110,7 @@ WebPDemuxerPtr CreateDemuxer(wxMemoryOutputStream& mos, bool verbose = false)
     {
         if (verbose)
         {
-            wxLogError(_("WebP: CreateDemuxer wxStreamBuffer failed."));
+            wxLogError(_("WebP: Allocating stream buffer failed."));
         }
         return nullptr;
     }
@@ -128,7 +128,7 @@ WebPDemuxerPtr CreateDemuxer(wxMemoryOutputStream& mos, bool verbose = false)
     {
         if (verbose)
         {
-            wxLogError(_("WebP: CreateDemuxer WebPDemux failed."));
+            wxLogError(_("WebP: Failed to parse container data."));
         }
     }
     return demux;
@@ -198,7 +198,7 @@ bool wxWEBPHandler::LoadAnimation(std::vector<wxWebPAnimationFrame>& frames, wxI
     {
         if (verbose)
         {
-            wxLogError(_("WebP: LoadAnimation wxStreamBuffer failed."));
+            wxLogError(_("WebP: Allocating stream buffer failed."));
         }
         return false;
     }
@@ -219,7 +219,7 @@ bool wxWEBPHandler::LoadAnimation(std::vector<wxWebPAnimationFrame>& frames, wxI
     {
         if (verbose)
         {
-            wxLogError(_("WebP: WebPAnimDecoderNew failed."));
+            wxLogError(_("WebP: Error decoding animation."));
         }
         return false;
     }
@@ -237,7 +237,7 @@ bool wxWEBPHandler::LoadAnimation(std::vector<wxWebPAnimationFrame>& frames, wxI
         {
             if (verbose)
             {
-                wxLogError(_("WebP: WebPAnimDecoderGetNext failed."));
+                wxLogError(_("WebP: Error getting next animation frame."));
             }
             break;
         }


### PR DESCRIPTION
Don't use internal function names in the error messages that can be seen by the end user.

----

I'd like to ask translators to update the existing translations, but before doing it I'd like to fix some of the new messages that don't make much sense to me IMO. I've tried to make them at least somewhat understandable for the end user while keeping them specific enough — please let me know if anybody sees anything wrong with it or can provide better messages.