### PR TITLE
Call OnExit to receive the OnEventLoopExit notification

### DIFF
--- a/src/osx/core/evtloop_cf.cpp
+++ b/src/osx/core/evtloop_cf.cpp
@@ -325,6 +325,8 @@ int wxCFEventLoop::DoRun()
 
             OSXDoRun();
 
+            OnExit();
+
 #if wxUSE_EXCEPTIONS
             // exit the outer loop as well
             break;


### PR DESCRIPTION
Unless I'm missing something `OnExit()` is not called after `OSXDoRun()` finishes and we don't get the `OnEventLoopExit` notification.
`OnExit()` is called only if an exception is thrown.

The corresponding code on linux is this:
https://github.com/wxWidgets/wxWidgets/blob/8b6deb74cf6795b4a4a343609efdb577a3b622b7/src/gtk/evtloop.cpp#L58-L92

Here `OnExit()` is called from wxScopeGuard:
https://github.com/wxWidgets/wxWidgets/blob/8b6deb74cf6795b4a4a343609efdb577a3b622b7/src/common/evtloopcmn.cpp#L336-L374