### PR TITLE
Reduce overhead of checking for  "catch-unhandled-exceptions"

### DIFF
--- a/include/wx/private/safecall.h
+++ b/include/wx/private/safecall.h
@@ -14,7 +14,11 @@
 
 #if wxUSE_EXCEPTIONS
 
-#include "wx/sysopt.h"
+// Returns true if a special system option disabling catching unhandled
+// exceptions is set.
+//
+// This function is implemented in sysopt.cpp.
+extern bool WXDLLIMPEXP_BASE wxIsCatchUnhandledExceptionsDisabled();
 
 // General version calls the given function or function-like object and
 // executes the provided handler if an exception is thrown.
@@ -24,12 +28,12 @@
 template <typename R, typename T1, typename T2>
 inline R wxSafeCall(const T1& func, const T2& handler)
 {
-    // This special option exists in order to avoid having try/catch blocks
-    // around potentially throwing code.
-    if ( wxSystemOptions::IsFalse("catch-unhandled-exceptions") )
+#if wxUSE_SYSTEM_OPTIONS
+    if ( wxIsCatchUnhandledExceptionsDisabled() )
     {
         return func();
     }
+#endif // wxUSE_SYSTEM_OPTIONS
 
     try
     {

--- a/src/common/sysopt.cpp
+++ b/src/common/sysopt.cpp
@@ -60,15 +60,11 @@ void wxSystemOptions::SetOption(const wxString& name, int value)
 
 wxString wxSystemOptions::GetOption(const wxString& name)
 {
-    auto it = gs_options.find(name.Lower());
+    const auto& key = name.Lower();
 
-    wxString val;
+    auto it = gs_options.find(key);
 
-    if ( it != gs_options.end() )
-    {
-        val = it->second;
-    }
-    else // not set explicitly
+    if ( it == gs_options.end() )
     {
         // look in the environment: first for a variable named "wx_appname_name"
         // which can be set to affect the behaviour or just this application
@@ -81,14 +77,19 @@ wxString wxSystemOptions::GetOption(const wxString& name)
         if ( wxTheApp )
             appname = wxTheApp->GetAppName();
 
+        wxString val;
         if ( !appname.empty() )
             val = wxGetenv(wxT("wx_") + appname + wxT('_') + var);
 
         if ( val.empty() )
             val = wxGetenv(wxT("wx_") + var);
+
+        // save it even if it is empty to avoid calling wxGetenv() in the
+        // future if this option is requested again
+        it = gs_options.insert({key, val}).first;
     }
 
-    return val;
+    return it->second;
 }
 
 int wxSystemOptions::GetOptionInt(const wxString& name)

--- a/src/common/sysopt.cpp
+++ b/src/common/sysopt.cpp
@@ -29,12 +29,19 @@
     #include "wx/arrstr.h"
 #endif
 
+#include <unordered_map>
+
 // ----------------------------------------------------------------------------
 // private globals
 // ----------------------------------------------------------------------------
 
-static wxArrayString gs_optionNames,
-                     gs_optionValues;
+namespace
+{
+
+// Keys of this map are lower case option names.
+std::unordered_map<wxString, wxString> gs_options;
+
+} // anonymous namespace
 
 // ============================================================================
 // wxSystemOptions implementation
@@ -43,17 +50,7 @@ static wxArrayString gs_optionNames,
 // Option functions (arbitrary name/value mapping)
 void wxSystemOptions::SetOption(const wxString& name, const wxString& value)
 {
-    int idx = gs_optionNames.Index(name, false);
-    if (idx == wxNOT_FOUND)
-    {
-        gs_optionNames.Add(name);
-        gs_optionValues.Add(value);
-    }
-    else
-    {
-        gs_optionNames[idx] = name;
-        gs_optionValues[idx] = value;
-    }
+    gs_options[name.Lower()] = value;
 }
 
 void wxSystemOptions::SetOption(const wxString& name, int value)
@@ -63,12 +60,13 @@ void wxSystemOptions::SetOption(const wxString& name, int value)
 
 wxString wxSystemOptions::GetOption(const wxString& name)
 {
+    auto it = gs_options.find(name.Lower());
+
     wxString val;
 
-    int idx = gs_optionNames.Index(name, false);
-    if ( idx != wxNOT_FOUND )
+    if ( it != gs_options.end() )
     {
-        val = gs_optionValues[idx];
+        val = it->second;
     }
     else // not set explicitly
     {

--- a/src/common/sysopt.cpp
+++ b/src/common/sysopt.cpp
@@ -38,7 +38,8 @@
 namespace
 {
 
-// Keys of this map are lower case option names.
+// Keys of this map are option names and values are their (potentially empty)
+// values.
 std::unordered_map<wxString, wxString> gs_options;
 
 } // anonymous namespace
@@ -50,7 +51,7 @@ std::unordered_map<wxString, wxString> gs_options;
 // Option functions (arbitrary name/value mapping)
 void wxSystemOptions::SetOption(const wxString& name, const wxString& value)
 {
-    gs_options[name.Lower()] = value;
+    gs_options[name] = value;
 }
 
 void wxSystemOptions::SetOption(const wxString& name, int value)
@@ -60,9 +61,7 @@ void wxSystemOptions::SetOption(const wxString& name, int value)
 
 wxString wxSystemOptions::GetOption(const wxString& name)
 {
-    const auto& key = name.Lower();
-
-    auto it = gs_options.find(key);
+    auto it = gs_options.find(name);
 
     if ( it == gs_options.end() )
     {
@@ -86,7 +85,7 @@ wxString wxSystemOptions::GetOption(const wxString& name)
 
         // save it even if it is empty to avoid calling wxGetenv() in the
         // future if this option is requested again
-        it = gs_options.insert({key, val}).first;
+        it = gs_options.insert({name, val}).first;
     }
 
     return it->second;


### PR DESCRIPTION
Also optimize `wxSystemOptions` more generally (at the cost of not taking into account changes to the environment variables while the program is running).