### PR TITLE
wxDisplay object becomes dangling after monitor disconnection on Windows

### DIFF
--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -57,7 +57,9 @@ public:
 
     // dtor is not virtual as this is a concrete class not meant to be derived
     // from
-
+    // dtor must not be inline because the implementation of
+    // wxDisplayImpl::DecRef() is unknown at this place 
+    ~wxDisplay();
 
     // return the number of available displays, valid parameters to
     // wxDisplay ctor are from 0 up to this number
@@ -78,6 +80,9 @@ public:
 
     // return true if the object was initialized successfully
     bool IsOk() const { return m_impl != nullptr; }
+
+    // return true if the display has not been unplugged yet
+    bool IsConnected() const;
 
     // get the full display size
     wxRect GetGeometry() const;
@@ -159,7 +164,7 @@ private:
 
 
     // the real implementation
-    wxDisplayImpl *m_impl;
+    wxObjectDataPtr<wxDisplayImpl> m_impl;
 
 
     wxDECLARE_NO_COPY_CLASS(wxDisplay);

--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -58,7 +58,7 @@ public:
     // dtor is not virtual as this is a concrete class not meant to be derived
     // from
     // dtor must not be inline because the implementation of
-    // wxDisplayImpl::DecRef() is unknown at this place 
+    // wxDisplayImpl::DecRef() is unknown at this place
     ~wxDisplay();
 
     // return the number of available displays, valid parameters to

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -68,9 +68,6 @@ private:
     // On-demand populated vector of wxDisplayImpl objects.
     wxVector<wxObjectDataPtr<wxDisplayImpl> > m_impls;
 
-    // The count of connected displays retrieved on last display access.
-    unsigned m_countOnLastAccess = 0u;
-
     wxDECLARE_NO_COPY_CLASS(wxDisplayFactory);
 };
 

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -26,38 +26,7 @@ public:
 
     // Create the display if necessary using CreateDisplay(), otherwise just
     // get it from cache.
-    wxObjectDataPtr<wxDisplayImpl> GetDisplay(unsigned n)
-    {
-        // Normally, m_impls should be cleared if the number of displays in the
-        // system changes because InvalidateCache() must be called. However in
-        // some ports (e.g. Mac right now, see #18318), cache invalidation never
-        // happens, so we can end up with m_impls size being out of sync with
-        // the actual number of monitors. Compensate for this here by checking
-        // if the index is invalid and invalidating the cache at least in this
-        // case.
-        //
-        // Note that this is still incorrect because we continue using outdated
-        // information if the first monitor is disconnected, for example. The
-        // only real solution is to ensure that InvalidateCache() is called,
-        // but for now this at least avoids crashes when a new display is
-        // connected.
-        if ( n >= m_impls.size() )
-        {
-            // This strange two-step resize is done to clear all the existing
-            // elements: they may not be valid any longer if the number of
-            // displays has changed.
-            m_impls.resize(0);
-            m_impls.resize(GetCount());
-        }
-        else if ( m_impls[n] )
-        {
-            // Just return the existing display if we have it.
-            return m_impls[n];
-        }
-
-        m_impls[n] = CreateDisplay(n);
-        return m_impls[n];
-    }
+    wxObjectDataPtr<wxDisplayImpl> GetDisplay(unsigned n);
 
     // Return the primary display object, creating it if necessary.
     wxObjectDataPtr<wxDisplayImpl> GetPrimaryDisplay();
@@ -102,6 +71,9 @@ private:
 
     // On-demand populated vector of wxDisplayImpl objects.
     wxVector<wxObjectDataPtr<wxDisplayImpl> > m_impls;
+
+    // The count of connected displays retrieved on last display access.
+    unsigned m_countOnLastAccess = 0u;
 
     wxDECLARE_NO_COPY_CLASS(wxDisplayFactory);
 };

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -90,7 +90,7 @@ protected:
     // if this is the case
     //
     // mark display as disconnected and return false otherwise
-    virtual bool UpdateDisplayChange(wxDisplayImpl *impl) const;
+    virtual bool UpdateDisplayChange(wxDisplayImpl &impl) const;
 
 private:
     // Delete all the elements of m_impls vector and clear it.

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -47,7 +47,7 @@ public:
     virtual int GetFromWindow(const wxWindow *window);
 
     // Trigger recreation of wxDisplayImpl when they're needed the next time.
-    virtual void InvalidateCache() { UpdateDisplayChanges(); }
+    virtual void UpdateOnDisplayChange();
 
 protected:
     // create a new display object
@@ -59,15 +59,11 @@ protected:
     // if this is the case
     //
     // mark display as disconnected and return false otherwise
-    virtual bool UpdateDisplayChange(wxDisplayImpl &impl) const;
+    virtual bool UpdateOnDisplayChange(wxDisplayImpl &impl) const;
 
 private:
     // Delete all the elements of m_impls vector and clear it.
     void ClearImpls();
-
-    // Trigger recreation of wxDisplayImpl or update its properties if
-    // a reference to it is still in scope.
-    void UpdateDisplayChanges();
 
     // On-demand populated vector of wxDisplayImpl objects.
     wxVector<wxObjectDataPtr<wxDisplayImpl> > m_impls;

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -162,14 +162,14 @@ public:
 
 protected:
     // create the object providing access to the display with the given index
-    wxDisplayImpl(unsigned n) : m_index(n), m_isConnected(true) { }
+    wxDisplayImpl(unsigned n) : m_index(n) { }
 
 
     // the index of this display (0 is always the primary one)
     unsigned m_index;
 
     // true, if this display is still connected physically to system
-    bool m_isConnected;
+    bool m_isConnected = true;
 
     friend class wxDisplayFactory;
 

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -127,10 +127,10 @@ public:
 #endif // wxUSE_DISPLAY
 
     // return true, if this display is still connected physically to system
-    virtual bool IsConnected() const { return m_isConnected; }
+    bool IsConnected() const { return m_isConnected; }
 
     // indicate that this display is not connected to system anymore
-    virtual void Disconnect() { m_isConnected = false; }
+    void Disconnect() { m_isConnected = false; }
 
 protected:
     // create the object providing access to the display with the given index

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -208,6 +208,21 @@ public:
     static wxSize GetStdPPI();
 
     /**
+        Returns @true if the display has not been unplugged.
+
+        This function is only implemented on MSW. After the display is unplugged,
+        or if the corresponding laptop lid is closed, the display object becomes
+        invalid on the next event queue execution if the object is still in scope.
+        All display property access functions will then return fallback values.
+
+        To receive notifications about display unplugging or other display changes,
+        connect a top-level window to the wxDisplayChangedEvent.
+
+        @since 3.3.0
+    */
+    bool IsConnected() const;
+
+    /**
         Returns @true if the display is the primary display. The primary
         display is the one whose index is 0.
     */

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -210,15 +210,16 @@ public:
     /**
         Returns @true if the display has not been unplugged.
 
-        This function is only full implemented in MSW and just always returns
-        @true under the other platforms currently.
-
-        Under MSW, it returns @false if the physical display that this C++
-        object corresponds to has become unavailable, e.g. because it was
+        On MSW, this function returns @false if the physical display that this
+        C++ object corresponds to has become unavailable, e.g. because it was
         unplugged or otherwise removed from the system. Such disconnected
         display object can still be used by the program, but all its accessor
         functions return special fallback values (e.g. 0 for the width and
         height).
+
+        This function is fully implemented only on MSW. On Apple devices, it always
+        returns @false when a display configuration change is detected. On other
+        platforms, it currently always returns @true.
 
         To receive notifications about display unplugging or other display changes,
         connect a top-level window to the wxDisplayChangedEvent.

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -210,10 +210,15 @@ public:
     /**
         Returns @true if the display has not been unplugged.
 
-        This function is only implemented on MSW. After the display is unplugged,
-        or if the corresponding laptop lid is closed, the display object becomes
-        invalid on the next event queue execution if the object is still in scope.
-        All display property access functions will then return fallback values.
+        This function is only full implemented in MSW and just always returns
+        @true under the other platforms currently.
+        
+        Under MSW, it returns @false if the physical display that this C++
+        object corresponds to has become unavailable, e.g. because it was
+        unplugged or otherwise removed from the system. Such disconnected
+        display object can still be used by the program, but all its accessor
+        functions return special fallback values (e.g. 0 for the width and
+        height).
 
         To receive notifications about display unplugging or other display changes,
         connect a top-level window to the wxDisplayChangedEvent.

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -212,7 +212,7 @@ public:
 
         This function is only full implemented in MSW and just always returns
         @true under the other platforms currently.
-        
+
         Under MSW, it returns @false if the physical display that this C++
         object corresponds to has become unavailable, e.g. because it was
         unplugged or otherwise removed from the system. Such disconnected

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -269,7 +269,7 @@ void wxDisplayFactory::UpdateDisplayChanges()
         if ( UpdateDisplayChange(*impl) )
             impls.push_back(impl);
     }
-    m_impls = impls;
+    m_impls = std::move(impls);
 }
 
 wxObjectDataPtr<wxDisplayImpl> wxDisplayFactory::GetDisplay(unsigned n)

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -242,11 +242,11 @@ bool wxDisplay::ChangeMode(const wxVideoMode& mode)
 // wxDisplayFactory implementation
 // ============================================================================
 
-bool wxDisplayFactory::UpdateDisplayChange(wxDisplayImpl *impl) const
+bool wxDisplayFactory::UpdateDisplayChange(wxDisplayImpl &impl) const
 {
     // If the factory is not able to detect connection state of the
     // input display we assume that it is disconnected now.
-    impl->Disconnect();
+    impl.Disconnect();
     return false;
 }
 
@@ -268,7 +268,7 @@ void wxDisplayFactory::UpdateDisplayChanges()
         if ( impl && impl->GetRefCount() > 1 )
         {
             // Try to update display state or mark it as disconnected.
-            if ( UpdateDisplayChange(impl.get()) && impl->GetIndex() < newCount )
+            if ( UpdateDisplayChange(*impl) && impl->GetIndex() < newCount )
                 impls[impl->GetIndex()] = impl;
         }
     }

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -352,17 +352,14 @@ void wxDisplayFactory::UpdateOnDisplayChange()
     // Enforce the lookup range to be the new number of displays.
     wxVector<wxObjectDataPtr<wxDisplayImpl> > impls(GetCount());
 
-    for ( size_t n = 0; n < m_impls.size(); ++n )
+    for ( auto& impl : m_impls )
     {
-        wxObjectDataPtr<wxDisplayImpl> &impl = m_impls[n];
-
         // Object may be empty if not accessed yet.
         // Try to update display state or mark it as disconnected.
         if ( impl && UpdateOnDisplayChange(*impl) )
         {
             // If display is still connected put it on the new index position.
-            if ( impl->GetIndex() < (unsigned) impls.size() )
-                impls[impl->GetIndex()] = impl;
+            impls[impl->GetIndex()] = impl;
         }
     }
     m_impls = std::move(impls);

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -138,54 +138,54 @@ wxRect wxDisplay::GetGeometry() const
 {
     wxCHECK_MSG( IsOk(), wxRect(), wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetGeometry();
-    return wxRect();
+    if ( !m_impl->IsConnected() )
+        return wxRect();
+    return m_impl->GetGeometry();
 }
 
 wxRect wxDisplay::GetClientArea() const
 {
     wxCHECK_MSG( IsOk(), wxRect(), wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetClientArea();
-    return wxRect();
+    if ( !m_impl->IsConnected() )
+        return wxRect();
+    return m_impl->GetClientArea();
 }
 
 wxSize wxDisplay::GetPPI() const
 {
     wxCHECK_MSG( IsOk(), wxSize(), wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetPPI();
-    return wxSize();
+    if ( !m_impl->IsConnected() )
+        return wxSize();
+    return m_impl->GetPPI();
 }
 
 double wxDisplay::GetScaleFactor() const
 {
-    wxCHECK_MSG( IsOk(), 0, wxT("invalid wxDisplay object") );
+    wxCHECK_MSG( IsOk(), 0.0, wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetScaleFactor();
-    return 0.0;
+    if ( !m_impl->IsConnected() )
+        return 0.0;
+    return m_impl->GetScaleFactor();
 }
 
 int wxDisplay::GetDepth() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetDepth();
-    return 0;
+    if ( !m_impl->IsConnected() )
+        return 0;
+    return m_impl->GetDepth();
 }
 
 wxString wxDisplay::GetName() const
 {
     wxCHECK_MSG( IsOk(), wxString(), wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetName();
-    return wxString();
+    if ( !m_impl->IsConnected() )
+        return wxString();
+    return m_impl->GetName();
 }
 
 bool wxDisplay::IsPrimary() const
@@ -199,27 +199,27 @@ wxArrayVideoModes wxDisplay::GetModes(const wxVideoMode& mode) const
 {
     wxCHECK_MSG( IsOk(), wxArrayVideoModes(), wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetModes(mode);
-    return wxArrayVideoModes();
+    if ( !m_impl->IsConnected() )
+        return wxArrayVideoModes();
+    return m_impl->GetModes(mode);
 }
 
 wxVideoMode wxDisplay::GetCurrentMode() const
 {
     wxCHECK_MSG( IsOk(), wxVideoMode(), wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->GetCurrentMode();
-    return wxVideoMode();
+    if ( !m_impl->IsConnected() )
+        return wxVideoMode();
+    return m_impl->GetCurrentMode();
 }
 
 bool wxDisplay::ChangeMode(const wxVideoMode& mode)
 {
     wxCHECK_MSG( IsOk(), false, wxT("invalid wxDisplay object") );
 
-    if ( m_impl->IsConnected() )
-        return m_impl->ChangeMode(mode);
-    return false;
+    if ( !m_impl->IsConnected() )
+        return false;
+    return m_impl->ChangeMode(mode);
 }
 
 #endif // wxUSE_DISPLAY

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -678,7 +678,7 @@ bool wxDisplayFactoryMSW::UpdateDisplayChange(wxDisplayImpl *impl) const
             if (implMsw->UpdateStateIfHandleMatches((unsigned) n, m_displays[n]))
                 return true;
         }
-    }    
+    }
     impl->Disconnect();
     return false;
 }

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -192,7 +192,7 @@ public:
         wxDisplayFactory::InvalidateCache();
     }
 
-    virtual bool UpdateDisplayChange(wxDisplayImpl *impl) const override;
+    virtual bool UpdateDisplayChange(wxDisplayImpl &impl) const override;
 
     // Declare the second argument as int to avoid problems with older SDKs not
     // declaring MONITOR_DPI_TYPE enum.
@@ -668,18 +668,17 @@ int wxDisplayFactoryMSW::GetFromWindow(const wxWindow *window)
 #endif
 }
 
-bool wxDisplayFactoryMSW::UpdateDisplayChange(wxDisplayImpl *impl) const
+bool wxDisplayFactoryMSW::UpdateDisplayChange(wxDisplayImpl &impl) const
 {
-    wxDisplayMSW *implMsw = dynamic_cast<wxDisplayMSW *>(impl);
-    if (implMsw)
+    wxDisplayMSW &implMsw = static_cast<wxDisplayMSW &>(impl);
+
+    for ( size_t n = 0; n < m_displays.size(); ++n )
     {
-        for ( size_t n = 0; n < m_displays.size(); ++n )
-        {
-            if (implMsw->UpdateStateIfHandleMatches((unsigned) n, m_displays[n]))
-                return true;
-        }
+        if (implMsw.UpdateStateIfHandleMatches((unsigned) n, m_displays[n]))
+            return true;
     }
-    impl->Disconnect();
+
+    impl.Disconnect();
     return false;
 }
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5116,6 +5116,10 @@ bool wxWindowMSW::HandleDisplayChange()
     wxDisplayChangedEvent event;
     event.SetEventObject(this);
 
+    // trigger display cache update to ensure the user receives the most
+    // recent display properties on event handling after change.
+    wxDisplay::InvalidateCache();
+
     return HandleWindowEvent(event);
 }
 


### PR DESCRIPTION
This is a PR for the solution discussed in #25396:

- `wxDisplayImpl` derives now from `wxObjectRefData`
- The raw pointers `wxDisplay::m_impl` and `wxDisplayFactory::m_impls` are replaced with shared pointers
- `wxDisplayImpl` has a new member `m_isConnected` with access functions
- `wxDisplay` returns default values if the connection to the monitor is broken
- `wxDisplayFactor::InvidalidateCache` will not delete the display objects, if the displays are still connected but update display information