### PR TITLE
Ensure that all ports call wxEventLoop::OnExit()

### DIFF
--- a/include/wx/evtloop.h
+++ b/include/wx/evtloop.h
@@ -103,7 +103,7 @@ public:
     // ask the event loop to exit with the given exit code, can be used even if
     // this loop is not running right now but the loop must have been started,
     // i.e. Run() should have been already called
-    virtual void ScheduleExit(int rc = 0) = 0;
+    void ScheduleExit(int rc = 0);
 
     // return true if any events are available
     virtual bool Pending() const = 0;
@@ -184,6 +184,9 @@ protected:
     // real implementation of Run()
     virtual int DoRun() = 0;
 
+    // Stop the (known to be currently running) loop.
+    virtual void DoStop(int rc) = 0;
+
     // And the real, port-specific, implementation of YieldFor().
     //
     // The base class version is pure virtual to ensure that it is overridden
@@ -235,14 +238,13 @@ class WXDLLIMPEXP_BASE wxEventLoopManual : public wxEventLoopBase
 public:
     wxEventLoopManual();
 
-    // sets the "should exit" flag and wakes up the loop so that it terminates
-    // soon
-    virtual void ScheduleExit(int rc = 0) override;
-
 protected:
     // enters a loop calling OnNextIteration(), Pending() and Dispatch() and
     // terminating when Exit() is called
     virtual int DoRun() override;
+
+    // asks for the loop to stop, called from ScheduleExit()
+    virtual void DoStop(int rc) override;
 
     // may be overridden to perform some action at the start of each new event
     // loop iteration
@@ -312,7 +314,6 @@ public:
     wxGUIEventLoop() { m_impl = nullptr; }
     virtual ~wxGUIEventLoop();
 
-    virtual void ScheduleExit(int rc = 0);
     virtual bool Pending() const;
     virtual bool Dispatch();
     virtual int DispatchTimeout(unsigned long timeout)
@@ -333,6 +334,7 @@ public:
 
 protected:
     virtual int DoRun();
+    virtual void DoStop(int rc);
     virtual void DoYieldFor(long eventsToProcess);
 
     // the pointer to the port specific implementation class

--- a/include/wx/gtk/evtloop.h
+++ b/include/wx/gtk/evtloop.h
@@ -24,7 +24,6 @@ public:
     wxGUIEventLoop();
     virtual ~wxGUIEventLoop();
 
-    virtual void ScheduleExit(int rc = 0) override;
     virtual bool Pending() const override;
     virtual bool Dispatch() override;
     virtual int DispatchTimeout(unsigned long timeout) override;
@@ -41,6 +40,7 @@ public:
 
 protected:
     virtual int DoRun() override;
+    virtual void DoStop(int rc) override;
     virtual void DoYieldFor(long eventsToProcess) override;
 
 private:

--- a/include/wx/osx/core/evtloop.h
+++ b/include/wx/osx/core/evtloop.h
@@ -22,10 +22,6 @@ public:
     wxCFEventLoop();
     virtual ~wxCFEventLoop();
 
-    // sets the "should exit" flag and wakes up the loop so that it terminates
-    // soon
-    virtual void ScheduleExit(int rc = 0) override;
-
     // return true if any events are available
     virtual bool Pending() const override;
 
@@ -53,6 +49,9 @@ protected:
     // enters a loop calling OnNextIteration(), Pending() and Dispatch() and
     // terminating when Exit() is called
     virtual int DoRun() override;
+
+    // actually stops the currently running loop
+    virtual void DoStop(int rc) override;
 
     // may be overridden to perform some action at the start of each new event
     // loop iteration

--- a/include/wx/qt/evtloop.h
+++ b/include/wx/qt/evtloop.h
@@ -18,7 +18,7 @@ public:
     ~wxQtEventLoopBase();
 
     virtual int DoRun() override;
-    virtual void ScheduleExit(int rc = 0) override;
+    virtual void DoStop(int rc) override;
     virtual bool Pending() const override;
     virtual bool Dispatch() override;
     virtual int DispatchTimeout(unsigned long timeout) override;

--- a/interface/wx/evtloop.h
+++ b/interface/wx/evtloop.h
@@ -127,7 +127,7 @@ public:
 
         @since 2.9.5
      */
-    virtual void ScheduleExit(int rc = 0) = 0;
+    void ScheduleExit(int rc = 0);
 
     /**
         Return true if any events are available.

--- a/src/common/evtloopcmn.cpp
+++ b/src/common/evtloopcmn.cpp
@@ -94,6 +94,18 @@ void wxEventLoopBase::Exit(int rc)
 
     ScheduleExit(rc);
 }
+
+void wxEventLoopBase::ScheduleExit(int rc)
+{
+    wxCHECK_RET( IsInsideRun(), wxT("can't call ScheduleExit() if not running") );
+
+    m_shouldExit = true;
+
+    OnExit();
+
+    DoStop(rc);
+}
+
 void wxEventLoopBase::OnExit()
 {
     if (wxTheApp)
@@ -373,14 +385,9 @@ int wxEventLoopManual::DoRun()
     return m_exitcode;
 }
 
-void wxEventLoopManual::ScheduleExit(int rc)
+void wxEventLoopManual::DoStop(int rc)
 {
-    wxCHECK_RET( IsInsideRun(), wxT("can't call ScheduleExit() if not running") );
-
     m_exitcode = rc;
-    m_shouldExit = true;
-
-    OnExit();
 
     // all we have to do to exit from the loop is to (maybe) wake it up so that
     // it can notice that Exit() had been called

--- a/src/gtk/evtloop.cpp
+++ b/src/gtk/evtloop.cpp
@@ -79,8 +79,6 @@ int wxGUIEventLoop::DoRun()
         gtk_main_quit();
     }
 
-    OnExit();
-
 #if wxUSE_EXCEPTIONS
     // Rethrow any exceptions which could have been produced by the handlers
     // ran by the event loop.
@@ -91,13 +89,9 @@ int wxGUIEventLoop::DoRun()
     return m_exitcode;
 }
 
-void wxGUIEventLoop::ScheduleExit(int rc)
+void wxGUIEventLoop::DoStop(int rc)
 {
-    wxCHECK_RET( IsInsideRun(), wxT("can't call ScheduleExit() if not started") );
-
     m_exitcode = rc;
-
-    m_shouldExit = true;
 
     gtk_main_quit();
 }

--- a/src/osx/core/evtloop_cf.cpp
+++ b/src/osx/core/evtloop_cf.cpp
@@ -355,12 +355,9 @@ int wxCFEventLoop::DoRun()
     return m_exitcode;
 }
 
-// sets the "should exit" flag and wakes up the loop so that it terminates
-// soon
-void wxCFEventLoop::ScheduleExit(int rc)
+void wxCFEventLoop::DoStop(int rc)
 {
     m_exitcode = rc;
-    m_shouldExit = true;
     OSXDoStop();
 }
 

--- a/src/qt/evtloop.cpp
+++ b/src/qt/evtloop.cpp
@@ -110,18 +110,14 @@ wxQtEventLoopBase::~wxQtEventLoopBase()
     delete m_qtEventLoop;
 }
 
-void wxQtEventLoopBase::ScheduleExit(int rc)
+void wxQtEventLoopBase::DoStop(int rc)
 {
-    wxCHECK_RET( IsInsideRun(), wxT("can't call ScheduleExit() if not started") );
-    m_shouldExit = true;
     m_qtEventLoop->exit(rc);
 }
 
 int wxQtEventLoopBase::DoRun()
 {
-    const int ret = m_qtEventLoop->exec();
-    OnExit();
-    return ret;
+    return m_qtEventLoop->exec();
 }
 
 bool wxQtEventLoopBase::Pending() const

--- a/src/x11/evtloop.cpp
+++ b/src/x11/evtloop.cpp
@@ -159,7 +159,7 @@ int wxGUIEventLoop::DoRun()
     return exitcode;
 }
 
-void wxGUIEventLoop::ScheduleExit(int rc)
+void wxGUIEventLoop::DoStop(int rc)
 {
     if ( m_impl )
     {


### PR DESCRIPTION
Make ScheduleExit() non-virtual and call a new virtual DoStop() from it and update all ports to override the new virtual function and not override ScheduleExit() itself to ensure that the base class version, which calls OnExit(), is used.

See #25397.