### PR TITLE
Fix calling wxTextCtrl::GTKSetPangoMarkup() with GTK < 3.16

### DIFF
--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -118,7 +118,7 @@ public:
     GtkEditable *GTKGetEditable() const { return GetEditable(); }
 
 #ifdef __WXGTK3__
-    void GTKSetPangoMarkup(const wxString& str);
+    bool GTKSetPangoMarkup(const wxString& str);
 #endif // __WXGTK3__
 
     // Implementation from now on

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -2185,13 +2185,18 @@ public:
         This offers more granular control of content formatting, as well as a
         significant performance benefit with larger content.
 
-        This is the GTK analogy to SetRTFValue().
+        This is the GTK equivalent of SetRTFValue().
+
+        This functionality is only available in GTK versions greater than 3.16,
+        the function does nothing and returns @false when using older GTK
+        version, the application should handle this case and fall back to some
+        other way of setting the control contents.
 
         @onlyfor{wxgtk}
 
         @since 3.3
     */
-    void GTKSetPangoMarkup(const wxString& str);
+    bool GTKSetPangoMarkup(const wxString& str);
 
     ///@}
 


### PR DESCRIPTION
Just return false from this function instead of crashing due to gtk_text_buffer_insert_markup() not being available in older GTK libraries.

See #24912.

Closes #25416.