### PR TITLE
RTL layout fixes for wxMSW and wxGTK3

### DIFF
--- a/include/wx/gtk/dc.h
+++ b/include/wx/gtk/dc.h
@@ -100,6 +100,7 @@ public:
     virtual void DoSelect(const wxBitmap& bitmap) override;
     virtual const wxBitmap& GetSelectedBitmap() const override;
     virtual wxBitmap& GetSelectedBitmap() override;
+    virtual void SetLayoutDirection(wxLayoutDirection dir) override;
 
 private:
     void Setup();

--- a/include/wx/gtk/private/event.h
+++ b/include/wx/gtk/private/event.h
@@ -74,11 +74,11 @@ template<typename T> void InitMouseEvent(wxWindowGTK *win,
         event.m_y += posY - a.y;
     }
 
-    if ((win->m_wxwindow) && (win->GetLayoutDirection() == wxLayout_RightToLeft))
+    if (win->GetLayoutDirection() == wxLayout_RightToLeft)
     {
         // origin in the upper right corner
         GtkAllocation a;
-        gtk_widget_get_allocation(win->m_wxwindow, &a);
+        gtk_widget_get_allocation(win->m_wxwindow ? win->m_wxwindow : win->m_widget, &a);
         int window_width = a.width;
         event.m_x = window_width - event.m_x;
     }

--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -282,7 +282,7 @@ protected:
     void DrawAnyText(const wxString& text, wxCoord x, wxCoord y);
 
     // common part of DoSetClippingRegion() and DoSetDeviceClippingRegion()
-    void SetClippingHrgn(WXHRGN hrgn, bool doRtlOffset = false);
+    void SetClippingHrgn(WXHRGN hrgn);
 
     // implementation of DoGetSize() for wxScreen/PrinterDC: this simply
     // returns the size of the entire device this DC is associated with

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3478,11 +3478,13 @@ wxRect wxAuiManager::CalculateHintRect(wxWindow* pane_window,
 
     m_frame->ClientToScreen(&rect.x, &rect.y);
 
+#if !defined(__WXMSW__) && !defined(__WXGTK3__)
     if ( m_frame->GetLayoutDirection() == wxLayout_RightToLeft )
     {
         // Mirror rectangle in RTL mode
         rect.x -= rect.GetWidth();
     }
+#endif // !__WXMSW__ && !__WXGTK3__
 
     return rect;
 }

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1758,6 +1758,13 @@ gtk_wx_cell_renderer_activate(
             wxMouseEvent mouse_event(wxEVT_LEFT_DOWN);
             InitMouseEvent(ctrl, mouse_event, button_event);
 
+            if (ctrl->GetLayoutDirection() == wxLayout_RightToLeft)
+            {
+                int w;
+                ctrl->GetClientSize(&w, nullptr);
+                renderrect.x = w - (renderrect.x + renderrect.width);
+            }
+
             mouse_event.m_x -= renderrect.x;
             mouse_event.m_y -= renderrect.y;
 
@@ -4772,6 +4779,7 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
     m_parent->DoAddChild( this );
 
     PostCreation(size);
+    GTKSetLayout(m_treeview, GetLayoutDirection());
 
     g_signal_connect_after(gtk_tree_view_get_selection(GTK_TREE_VIEW(m_treeview)),
         "changed", G_CALLBACK(wxdataview_selection_changed_callback), this);

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -584,6 +584,13 @@ wxBitmap& wxMemoryDCImpl::GetSelectedBitmap()
     return m_bitmap;
 }
 
+void wxMemoryDCImpl::SetLayoutDirection(wxLayoutDirection dir)
+{
+    wxGTKCairoDCImpl::SetLayoutDirection(dir);
+
+    Setup();
+}
+
 void wxMemoryDCImpl::Setup()
 {
     wxGraphicsContext* gc = nullptr;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4732,7 +4732,7 @@ void wxWindowGTK::DoScreenToClient( int *x, int *y ) const
     if (x)
     {
         if (GetLayoutDirection() == wxLayout_RightToLeft)
-            *x = (GetClientSize().x - *x) - org_x;
+            *x = (GetClientSize().x - *x) + org_x;
         else
             *x -= org_x;
     }

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6440,6 +6440,10 @@ void wxPopupMenuPositionCallback( GtkMenu *menu,
         rect = wxDisplay(data.menu->GetInvokingWindow()).GetClientArea();
 
     wxPoint pos = data.pos;
+
+    if ( wxWindowGTK::GTKGetLayout(GTK_WIDGET(menu)) == wxLayout_RightToLeft )
+        pos.x -= req.width;
+
     if ( pos.x < rect.x )
         pos.x = rect.x;
     if ( pos.y < rect.y )
@@ -6457,6 +6461,8 @@ void wxPopupMenuPositionCallback( GtkMenu *menu,
 bool wxWindowGTK::DoPopupMenu( wxMenu *menu, int x, int y )
 {
     wxCHECK_MSG( m_widget != nullptr, false, wxT("invalid window") );
+
+    GTKSetLayout(menu->m_menu, GetLayoutDirection());
 
     menu->SetupBitmaps(this);
 
@@ -6515,6 +6521,10 @@ bool wxWindowGTK::DoPopupMenu( wxMenu *menu, int x, int y )
             {
                 gdk_window_get_device_position(window, device, &x, &y, nullptr);
             }
+        }
+        else if (GetLayoutDirection() == wxLayout_RightToLeft)
+        {
+            x = gdk_window_get_width(window) - x;
         }
 
         const GdkRectangle rect = { x, y, 1, 1 };

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -408,17 +408,29 @@ void wxMSWDCImpl::SetClippingHrgn(WXHRGN hrgn)
 {
     wxCHECK_RET( hrgn, wxT("invalid clipping region") );
 
-    // note that we combine the new clipping region with the existing one: this
-    // is compatible with what the other ports do and is the documented
-    // behaviour now (starting with 2.3.3)
-    if ( ::ExtSelectClipRgn(GetHdc(), (HRGN)hrgn, RGN_AND) == ERROR )
+    if ( m_clipping )
     {
-        wxLogLastError(wxT("ExtSelectClipRgn"));
+        // note that we combine the new clipping region with the existing one: this
+        // is compatible with what the other ports do and is the documented
+        // behaviour now (starting with 2.3.3)
+        if ( ::ExtSelectClipRgn(GetHdc(), (HRGN)hrgn, RGN_AND) == ERROR )
+        {
+            wxLogLastError(wxT("ExtSelectClipRgn"));
 
-        return;
+            return;
+        }
     }
+    else
+    {
+        if ( ::SelectClipRgn(GetHdc(), (HRGN)hrgn) == ERROR )
+        {
+            wxLogLastError(wxT("SelectClipRgn"));
 
-    m_clipping = true;
+            return;
+        }
+
+        m_clipping = true;
+    }
 
     UpdateClipBox();
 }
@@ -449,18 +461,28 @@ void wxMSWDCImpl::DoSetClippingRegion(wxCoord x, wxCoord y, wxCoord w, wxCoord h
     // 4 corners of the rectangle to create a polygonal clipping region
     // in device coordinates.
     POINT rect[4];
-    wxPoint p = LogicalToDevice(x, y);
-    rect[0].x = p.x;
-    rect[0].y = p.y;
-    p = LogicalToDevice(x + w, y);
-    rect[1].x = p.x;
-    rect[1].y = p.y;
-    p = LogicalToDevice(x + w, y + h);
-    rect[2].x = p.x;
-    rect[2].y = p.y;
-    p = LogicalToDevice(x, y + h);
-    rect[3].x = p.x;
-    rect[3].y = p.y;
+    {
+        // Forcing LTR layout to calculate _rect_, otherwise the region created
+        // by CreatePolygonRgn() will not be correct in RTL layout.
+        const auto oldLayoutDir = GetLayoutDirection();
+        SetLayoutDirection(wxLayout_LeftToRight);
+
+        wxPoint p = LogicalToDevice(x, y);
+        rect[0].x = p.x;
+        rect[0].y = p.y;
+        p = LogicalToDevice(x + w, y);
+        rect[1].x = p.x;
+        rect[1].y = p.y;
+        p = LogicalToDevice(x + w, y + h);
+        rect[2].x = p.x;
+        rect[2].y = p.y;
+        p = LogicalToDevice(x, y + h);
+        rect[3].x = p.x;
+        rect[3].y = p.y;
+
+        SetLayoutDirection(oldLayoutDir);
+    }
+
     HRGN hrgn = ::CreatePolygonRgn(rect, WXSIZEOF(rect), WINDING);
     if ( !hrgn )
     {

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -404,52 +404,14 @@ bool wxMSWDCImpl::DoGetClippingRect(wxRect& rect) const
 }
 
 // common part of DoSetClippingRegion() and DoSetDeviceClippingRegion()
-void wxMSWDCImpl::SetClippingHrgn(WXHRGN hrgn, bool doRtlOffset)
+void wxMSWDCImpl::SetClippingHrgn(WXHRGN hrgn)
 {
     wxCHECK_RET( hrgn, wxT("invalid clipping region") );
-
-    HRGN hRgnRTL = nullptr;
-    // DC with enabled RTL layout needs a mirrored region
-    // so we have to create such a region temporarily.
-    if ( GetLayoutDirection() == wxLayout_RightToLeft )
-    {
-        DWORD bufLen = ::GetRegionData(hrgn, 0, nullptr);  // Get the storage size
-        wxScopedArray<char> pDataBuf(bufLen);
-        RGNDATA* const rgndata = reinterpret_cast<RGNDATA*>(pDataBuf.get());
-        if ( ::GetRegionData(hrgn, bufLen, rgndata) != bufLen )
-        {
-            wxLogLastError("GetRegionData");
-            return;
-        }
-        int dcw, dch;
-        DoGetSize(&dcw, &dch);
-        XFORM tr;
-        tr.eM11 = -1;
-        tr.eM12 = 0;
-        tr.eM21 = 0;
-        tr.eM22 = 1;
-        // For region created directly with device coordinates
-        // (regions passed to DoSetDeviceClippingRegion) we have to
-        // apply additional 1-pixel offset because original right edge
-        // passed to e.g. CreateRectRgn() (in wxRegion) is actually
-        // not included in the clipping area but this edge will become
-        // a left edge after mirroring and therefore its x-coordinates
-        // shoulde be adjusted.
-        tr.eDx = doRtlOffset ? dcw : dcw-1; // max X
-        tr.eDy = 0;
-        hRgnRTL = ::ExtCreateRegion(&tr, bufLen, rgndata);
-        if ( !hRgnRTL )
-        {
-            wxLogLastError("ExtCreateRegion");
-            return;
-        }
-    }
-    AutoHRGN rgnRTL(hRgnRTL);
 
     // note that we combine the new clipping region with the existing one: this
     // is compatible with what the other ports do and is the documented
     // behaviour now (starting with 2.3.3)
-    if ( ::ExtSelectClipRgn(GetHdc(), (HRGN)rgnRTL ? (HRGN)rgnRTL : (HRGN)hrgn, RGN_AND) == ERROR )
+    if ( ::ExtSelectClipRgn(GetHdc(), (HRGN)hrgn, RGN_AND) == ERROR )
     {
         wxLogLastError(wxT("ExtSelectClipRgn"));
 
@@ -506,7 +468,7 @@ void wxMSWDCImpl::DoSetClippingRegion(wxCoord x, wxCoord y, wxCoord w, wxCoord h
     }
     else
     {
-        SetClippingHrgn((WXHRGN)hrgn, false);
+        SetClippingHrgn((WXHRGN)hrgn);
 
         ::DeleteObject(hrgn);
     }
@@ -514,7 +476,7 @@ void wxMSWDCImpl::DoSetClippingRegion(wxCoord x, wxCoord y, wxCoord w, wxCoord h
 
 void wxMSWDCImpl::DoSetDeviceClippingRegion(const wxRegion& region)
 {
-    SetClippingHrgn(region.GetHRGN(), true);
+    SetClippingHrgn(region.GetHRGN());
 }
 
 void wxMSWDCImpl::DestroyClippingRegion()

--- a/src/msw/dcclient.cpp
+++ b/src/msw/dcclient.cpp
@@ -259,10 +259,6 @@ wxPaintDCImpl::wxPaintDCImpl( wxDC *owner, wxWindow *window ) :
 
     // (re)set the DC parameters.
     InitDC();
-
-    // the HDC can have a clipping box (which we didn't set), make sure our
-    // DoGetClippingRect() checks for it
-    m_clipping = true;
 }
 
 wxPaintDCImpl::~wxPaintDCImpl()

--- a/tests/graphics/clippingbox.cpp
+++ b/tests/graphics/clippingbox.cpp
@@ -852,10 +852,6 @@ static void OneRegionRTL(wxDC& dc, const wxBitmap& bmp)
         return;
     }
 
-#ifdef __WXGTK__
-    wxUnusedVar(bmp);
-    WARN("Skipping test known to fail in wxGTK");
-#else
     // Setting one clipping region inside DC area.
     const int x = 10;
     const int y = 20;
@@ -869,7 +865,6 @@ static void OneRegionRTL(wxDC& dc, const wxBitmap& bmp)
     CheckClipBox(dc, bmp,
         x, y, w, h,
         (s_dcSize.x-1)-x2, y, w, h);
-#endif
 }
 
 static void TwoRegionsOverlapping(wxDC& dc, const wxBitmap& bmp, const wxPoint& parentDcOrigin)
@@ -1033,13 +1028,9 @@ static void OneDevRegionRTL(wxDC& dc, const wxBitmap& bmp, bool useTransformMatr
         return;
     }
 
-#ifdef __WXGTK__
-    wxUnusedVar(bmp);
-    WARN("Skipping test known to fail in wxGTK");
-#else
     // Setting one clipping region in device coordinates
     // inside transformed DC area.
-    const int x = 10;
+    const int x = 11;
     const int y = 21;
     const int w = 79;
     const int h = 75;
@@ -1064,12 +1055,21 @@ static void OneDevRegionRTL(wxDC& dc, const wxBitmap& bmp, bool useTransformMatr
     dc.SetDeviceClippingRegion(reg);
     dc.SetBackground(wxBrush(s_fgColour, wxBRUSHSTYLE_SOLID));
     dc.Clear();
-    wxPoint pos = dc.DeviceToLogical(x+w-1, y); // right physical edge becomes left logical edge
+    // right physical edge becomes left logical edge in a mirrored DC.
+    const int x2 = s_dcSize.x - (x + w);
+    // In a mirrored DC, the device origin (0, 0) is always at the top left
+    // of the DC under wxMSW, but under wxGTK3 is at the top right.
+#if defined(__WXGTK3__)
+    wxPoint pos = dc.DeviceToLogical(x, y);
+    wxSize dim = dc.DeviceToLogicalRel(w, h);
+#else
+    wxPoint pos = dc.DeviceToLogical((s_dcSize.x-1)-x, y);
     wxSize dim = dc.DeviceToLogicalRel(-w, h);
+#endif
+
     CheckClipBox(dc, bmp,
                  pos.x, pos.y, dim.x, dim.y,
-                 x, y, w, h);
-#endif
+                 x2, y, w, h);
 }
 
 static void OneLargeDevRegion(wxDC& dc, const wxBitmap& bmp, bool checkExtCoords, bool useTransformMatrix, const wxPoint& parentDcOrigin)


### PR DESCRIPTION
Currently `wxMSW` is broken in RTL layout:
- Try scrolling `wxGrid` (in griddemo)
- Try switching to Regions screen in drawing sample to see the problem.

I tested this PR in RTL layout and it works correctly for me.
