### PR TITLE
Add missing includes in include/wx/longlong.h

### DIFF
--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -260,6 +260,7 @@ public:
     wxString& operator<<(wxString&, const wxLongLong&);
 
 #if wxUSE_STREAMS
+    #include "wx/txtstrm.h"
     friend WXDLLIMPEXP_BASE
     class wxTextOutputStream& operator<<(class wxTextOutputStream&, const wxLongLong&);
     friend WXDLLIMPEXP_BASE
@@ -486,6 +487,7 @@ public:
     wxString& operator<<(wxString&, const wxULongLong&);
 
 #if wxUSE_STREAMS
+    #include "wx/txtstrm.h"
     friend WXDLLIMPEXP_BASE
     class wxTextOutputStream& operator<<(class wxTextOutputStream&, const wxULongLong&);
     friend WXDLLIMPEXP_BASE

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -14,6 +14,7 @@
 #include "wx/defs.h"
 #include "wx/iosfwrap.h"
 #include "wx/string.h"
+#include "wx/txtstrm.h"
 
 #include <limits.h>     // for LONG_MAX
 
@@ -260,7 +261,6 @@ public:
     wxString& operator<<(wxString&, const wxLongLong&);
 
 #if wxUSE_STREAMS
-    #include "wx/txtstrm.h"
     friend WXDLLIMPEXP_BASE
     class wxTextOutputStream& operator<<(class wxTextOutputStream&, const wxLongLong&);
     friend WXDLLIMPEXP_BASE
@@ -487,7 +487,6 @@ public:
     wxString& operator<<(wxString&, const wxULongLong&);
 
 #if wxUSE_STREAMS
-    #include "wx/txtstrm.h"
     friend WXDLLIMPEXP_BASE
     class wxTextOutputStream& operator<<(class wxTextOutputStream&, const wxULongLong&);
     friend WXDLLIMPEXP_BASE


### PR DESCRIPTION
Added `#include "wx/txtstrm.h"` ~in `#if wxUSE_STREAMS` blocks~

Otherwise, it would lead to compile errors:
- wxTextInputStream/wxTextOutputStream has not been declared
- wxTextInputStream/wxTextOutputStream does not name a type

~p.s. The new lines are put in the conditional blocks to avoid unnecessary includes. Maintainers, please advise if the include lines should be put at the top of the file for simplicity.~ fixed thanks to the reminder from @lanurmi!