### PR TITLE
Add wxRect2DDouble and wxPoint2DDouble wrappers to wxGraphicsContext

### DIFF
--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -699,11 +699,23 @@ public:
     // clips drawings to the rect intersected with the current clipping region
     virtual void Clip( wxDouble x, wxDouble y, wxDouble w, wxDouble h ) = 0;
 
+    void Clip(const wxRect2DDouble& rect)
+    {
+        Clip(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
+
     // resets the clipping to original extent
     virtual void ResetClip() = 0;
 
     // returns bounding box of the clipping region
     virtual void GetClipBox(wxDouble* x, wxDouble* y, wxDouble* w, wxDouble* h) = 0;
+
+    wxNODISCARD wxRect2DDouble GetClipBox()
+    {
+        wxDouble x, y, w, h;
+        GetClipBox(&x, &y, &w, &h);
+        return wxRect2DDouble{ x, y, w, h };
+    }
 
     // returns the native context
     virtual void * GetNativeContext() = 0;
@@ -782,6 +794,11 @@ public:
     // translate
     virtual void Translate( wxDouble dx , wxDouble dy ) = 0;
 
+    void Translate(wxPoint2DDouble pt)
+    {
+        Translate(pt.m_x, pt.m_y);
+    }
+
     // scale
     virtual void Scale( wxDouble xScale , wxDouble yScale ) = 0;
 
@@ -828,12 +845,20 @@ public:
     // paints a transparent rectangle (only useful for bitmaps or windows)
     virtual void ClearRectangle(wxDouble x, wxDouble y, wxDouble w, wxDouble h);
 
+    void ClearRectangle(const wxRect2DDouble& rect)
+    {
+        ClearRectangle(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
+
     //
     // text
     //
 
     void DrawText( const wxString &str, wxDouble x, wxDouble y )
         { DoDrawText(str, x, y); }
+
+    void DrawText( const wxString &str, wxPoint2DDouble pt)
+        { DoDrawText(str, pt.m_x, pt.m_y); }
 
     void DrawText( const wxString &str, wxDouble x, wxDouble y, wxDouble angle )
         { DoDrawRotatedText(str, x, y, angle); }
@@ -858,9 +883,19 @@ public:
 
     virtual void DrawBitmap( const wxGraphicsBitmap &bmp, wxDouble x, wxDouble y, wxDouble w, wxDouble h ) = 0;
 
+    void DrawBitmap(const wxGraphicsBitmap& bmp, const wxRect2DDouble& rect)
+    {
+        DrawBitmap(bmp, rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
+
     virtual void DrawBitmap( const wxBitmap &bmp, wxDouble x, wxDouble y, wxDouble w, wxDouble h ) = 0;
 
     virtual void DrawIcon( const wxIcon &icon, wxDouble x, wxDouble y, wxDouble w, wxDouble h ) = 0;
+
+    void DrawIcon(const wxIcon& icon, const wxRect2DDouble& rect)
+    {
+        DrawIcon(icon, rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
 
     //
     // convenience methods
@@ -868,6 +903,11 @@ public:
 
     // strokes a single line
     virtual void StrokeLine( wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2);
+
+    void StrokeLine(wxPoint2DDouble pt1, wxPoint2DDouble pt2)
+    {
+        StrokeLine(pt1.m_x, pt1.m_y, pt2.m_x, pt2.m_y);
+    }
 
     // stroke lines connecting each of the points
     virtual void StrokeLines( size_t n, const wxPoint2DDouble *points);
@@ -881,13 +921,26 @@ public:
     // draws a rectangle
     virtual void DrawRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h);
 
+    void DrawRectangle(const wxRect2DDouble& rect)
+    {
+        DrawRectangle(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
+
     // draws an ellipse
     virtual void DrawEllipse( wxDouble x, wxDouble y, wxDouble w, wxDouble h);
+
+    void DrawEllipse(const wxRect2DDouble& rect)
+    {
+        DrawEllipse(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
 
     // draws a rounded rectangle
     virtual void DrawRoundedRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h, wxDouble radius);
 
-     // wrappers using wxPoint2DDouble TODO
+    void DrawRoundedRectangle(const wxRect2DDouble& rect, wxDouble radius)
+    {
+        DrawRoundedRectangle(rect.m_x, rect.m_y, rect.m_width, rect.m_height, radius);
+    }
 
     // helper to determine if a 0.5 offset should be applied for the drawing operation
     virtual bool ShouldOffset() const { return false; }

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -523,6 +523,10 @@ public:
 
     // appends a rectangle as a new closed subpath
     virtual void AddRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h );
+    virtual void AddRectangle(const wxRect2DDouble& rect)
+    {
+        AddRectangle(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
 
     // appends an ellipsis as a new closed subpath fitting the passed rectangle
     virtual void AddCircle( wxDouble x, wxDouble y, wxDouble r );
@@ -532,9 +536,17 @@ public:
 
     // appends an ellipse
     virtual void AddEllipse( wxDouble x, wxDouble y, wxDouble w, wxDouble h);
+    void AddEllipse(const wxRect2DDouble& rect)
+    {
+        AddEllipse(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+    }
 
     // appends a rounded rectangle
     virtual void AddRoundedRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h, wxDouble radius);
+    void AddRoundedRectangle(const wxRect2DDouble& rect, wxDouble radius)
+    {
+        AddRoundedRectangle(rect.m_x, rect.m_y, rect.m_width, rect.m_height, radius);
+    }
 
     // returns the native path
     virtual void * GetNativePath() const;

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -531,7 +531,7 @@ public:
     // appends an ellipsis as a new closed subpath fitting the passed rectangle
     virtual void AddCircle( wxDouble x, wxDouble y, wxDouble r );
 
-    // appends a an arc to two tangents connecting (current) to (x1,y1) and (x1,y1) to (x2,y2), also a straight line from (current) to (x1,y1)
+    // appends an arc to two tangents connecting (current) to (x1,y1) and (x1,y1) to (x2,y2), also a straight line from (current) to (x1,y1)
     virtual void AddArcToPoint( wxDouble x1, wxDouble y1 , wxDouble x2, wxDouble y2, wxDouble r );
 
     // appends an ellipse

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -516,6 +516,10 @@ public:
 
     // adds a quadratic Bezier curve from the current point, using a control point and an end point
     virtual void AddQuadCurveToPoint( wxDouble cx, wxDouble cy, wxDouble x, wxDouble y );
+    void AddQuadCurveToPoint(const wxPoint2DDouble& cp, const wxPoint2DDouble& e)
+    {
+        AddQuadCurveToPoint(cp.m_x, cp.m_y, e.m_x, e.m_y);
+    }
 
     // appends a rectangle as a new closed subpath
     virtual void AddRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h );
@@ -794,7 +798,7 @@ public:
     // translate
     virtual void Translate( wxDouble dx , wxDouble dy ) = 0;
 
-    void Translate(wxPoint2DDouble pt)
+    void Translate(const wxPoint2DDouble& pt)
     {
         Translate(pt.m_x, pt.m_y);
     }
@@ -857,7 +861,7 @@ public:
     void DrawText( const wxString &str, wxDouble x, wxDouble y )
         { DoDrawText(str, x, y); }
 
-    void DrawText( const wxString &str, wxPoint2DDouble pt)
+    void DrawText( const wxString &str, const wxPoint2DDouble& pt)
         { DoDrawText(str, pt.m_x, pt.m_y); }
 
     void DrawText( const wxString &str, wxDouble x, wxDouble y, wxDouble angle )
@@ -904,7 +908,7 @@ public:
     // strokes a single line
     virtual void StrokeLine( wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2);
 
-    void StrokeLine(wxPoint2DDouble pt1, wxPoint2DDouble pt2)
+    void StrokeLine(const wxPoint2DDouble& pt1, const wxPoint2DDouble& pt2)
     {
         StrokeLine(pt1.m_x, pt1.m_y, pt2.m_x, pt2.m_y);
     }

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -882,7 +882,9 @@ public:
                           wxDouble w, wxDouble h) = 0;
 
     /**
-        Draws the icon.
+        @overload
+
+        @since 3.3
     */
     void DrawIcon(const wxIcon& icon, const wxRect2DDouble& rect);
 

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -624,6 +624,13 @@ public:
     virtual void Clip(wxDouble x, wxDouble y, wxDouble w, wxDouble h) = 0;
 
     /**
+        @overload
+
+        @since 3.3
+    */
+    void Clip(const wxRect2DDouble& rect);
+
+    /**
         Returns a bounding box of the current clipping region.
 
         This is useful for rolling back to a previous clipping region.
@@ -645,6 +652,13 @@ public:
         @since 3.1.1
     */
     virtual void GetClipBox(wxDouble* x, wxDouble* y, wxDouble* w, wxDouble* h) = 0;
+
+    /**
+        @overload
+
+        @since 3.3
+    */
+    wxRect2DDouble GetClipBox();
 
     /** @}
     */
@@ -843,15 +857,34 @@ public:
                             wxDouble w, wxDouble h) = 0;
 
     /**
+        @overload
+
+        @since 3.3
+    */
+    void DrawBitmap(const wxGraphicsBitmap& bmp, const wxRect2DDouble& rect);
+
+    /**
         Draws an ellipse.
     */
     virtual void DrawEllipse(wxDouble x, wxDouble y, wxDouble w, wxDouble h);
+
+    /**
+        @overload
+
+        @since 3.3
+    */
+    void DrawEllipse(const wxRect2DDouble& rect);
 
     /**
         Draws the icon.
     */
     virtual void DrawIcon(const wxIcon& icon, wxDouble x, wxDouble y,
                           wxDouble w, wxDouble h) = 0;
+
+    /**
+        Draws the icon.
+    */
+    void DrawIcon(const wxIcon& icon, const wxRect2DDouble& rect);
 
     /**
         Draws a polygon.
@@ -871,15 +904,36 @@ public:
     virtual void DrawRectangle(wxDouble x, wxDouble y, wxDouble w, wxDouble h);
 
     /**
+        @overload
+
+        @since 3.3
+    */
+    void DrawRectangle(const wxRect2DDouble& rect);
+
+    /**
         Draws a rounded rectangle.
     */
     virtual void DrawRoundedRectangle(wxDouble x, wxDouble y, wxDouble w,
                                       wxDouble h, wxDouble radius);
 
     /**
+        @overload
+
+        @since 3.3
+    */
+    void DrawRoundedRectangle(const wxRect2DDouble& rect, wxDouble radius);
+
+    /**
         Draws text at the defined position.
     */
     void DrawText(const wxString& str, wxDouble x, wxDouble y);
+
+    /**
+        @overload
+
+        @since 3.3
+    */
+    void DrawText(const wxString& str, wxPoint2DDouble pt);
 
     /**
         Draws text at the defined position.
@@ -929,6 +983,18 @@ public:
                   wxDouble angle, const wxGraphicsBrush& backgroundBrush);
 
     /**
+        Paints a transparent rectangle (only useful for bitmaps or windows).
+    */
+    virtual void ClearRectangle(wxDouble x, wxDouble y, wxDouble w, wxDouble h);
+
+    /**
+        @overload
+
+        @since 3.3
+    */
+    void ClearRectangle(const wxRect2DDouble& rect);
+
+    /**
         Creates a native graphics path which is initially empty.
     */
     wxGraphicsPath CreatePath() const;
@@ -943,6 +1009,13 @@ public:
         Strokes a single line.
     */
     virtual void StrokeLine(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2);
+
+    /**
+        @overload
+
+        @since 3.3
+    */
+    void StrokeLine(wxPoint2DDouble pt1, wxPoint2DDouble pt2);
 
     /**
         Stroke disconnected lines from begin to end points, using the
@@ -2161,6 +2234,13 @@ public:
         Translates this matrix.
     */
     virtual void Translate(wxDouble dx, wxDouble dy);
+
+    /**
+        @overload
+
+        @since 3.3
+    */
+    void Translate(wxPoint2DDouble pt);
 };
 
 /// An empty wxGraphicsPen object.

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -127,6 +127,13 @@ public:
     virtual void AddEllipse(wxDouble x, wxDouble y, wxDouble w, wxDouble h);
 
     /**
+        @overload
+
+        @since 3.3
+    */
+    void AddEllipse(const wxRect2DDouble& rect);
+
+    /**
         Adds a straight line from the current point to (@a x,@a y).
         If current point is not yet set before the call to AddLineToPoint(),
         then this function will behave as MoveToPoint().
@@ -184,6 +191,13 @@ public:
     virtual void AddRectangle(wxDouble x, wxDouble y, wxDouble w, wxDouble h);
 
     /**
+        @overload
+
+        @since 3.3
+    */
+    void AddRectangle(const wxRect2DDouble& rect);
+
+    /**
         Appends a rounded rectangle as a new closed subpath.
         If @a radius equals 0, then this function will behave as AddRectangle();
         otherwise, after this call, the current point will be at
@@ -191,6 +205,13 @@ public:
     */
     virtual void AddRoundedRectangle(wxDouble x, wxDouble y, wxDouble w,
                                      wxDouble h, wxDouble radius);
+
+    /**
+        @overload
+
+        @since 3.3
+    */
+    void AddRoundedRectangle(const wxRect2DDouble& rect, wxDouble radius);
 
     /**
         Closes the current sub-path. After this call, the current point will be

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -171,6 +171,13 @@ public:
                                      wxDouble x, wxDouble y);
 
     /**
+        @overload
+
+        @since 3.3
+    */
+    void AddQuadCurveToPoint(const wxPoint2DDouble& cp, const wxPoint2DDouble& e);
+
+    /**
         Appends a rectangle as a new closed subpath. After this call
         the current point will be at (@a x, @a y).
     */
@@ -935,7 +942,7 @@ public:
 
         @since 3.3
     */
-    void DrawText(const wxString& str, wxPoint2DDouble pt);
+    void DrawText(const wxString& str, const wxPoint2DDouble& pt);
 
     /**
         Draws text at the defined position.
@@ -1017,7 +1024,7 @@ public:
 
         @since 3.3
     */
-    void StrokeLine(wxPoint2DDouble pt1, wxPoint2DDouble pt2);
+    void StrokeLine(const wxPoint2DDouble& pt1, const wxPoint2DDouble& pt2);
 
     /**
         Stroke disconnected lines from begin to end points, using the
@@ -2242,7 +2249,7 @@ public:
 
         @since 3.3
     */
-    void Translate(wxPoint2DDouble pt);
+    void Translate(const wxPoint2DDouble& pt);
 };
 
 /// An empty wxGraphicsPen object.


### PR DESCRIPTION
Adds simplified wrappers to other functions.
Also, add missing documentation for `ClearRectangle()`.