### PR TITLE
Add wxGLCanvasX11::GLXSetSwapInterval()

### DIFF
--- a/include/wx/glcanvas.h
+++ b/include/wx/glcanvas.h
@@ -212,7 +212,15 @@ class WXDLLIMPEXP_GL wxGLCanvasBase : public wxWindow
 {
 public:
     // Disable changing swap interval or indicate that it is unknown.
-    static constexpr int DefaultSwapInterval = -1;
+    static constexpr int DefaultSwapInterval = INT_MAX;
+
+    // Return values of SetSwapInterval().
+    enum class SwapInterval
+    {
+        NotSet = 0,
+        Set = 1,
+        NonAdaptive = 2
+    };
 
 
     // default ctor doesn't initialize the window, use Create() later
@@ -245,12 +253,18 @@ public:
 
     // Set swap interval to the specified value.
     //
-    // Special value of 0 means to disable vsync and DefaultSwapInterval means
-    // to disable automatically disabling vsync by default, as needs to be done
+    // Special value of 0 means to disable VSync and DefaultSwapInterval means
+    // to disable automatically disabling VSync by default, as needs to be done
     // under some platforms currently.
     //
+    // Negative values may be used to enable adaptive VSync if supported by the
+    // implementation.
+    //
     // Return true if the swap interval was set successfully, false if not.
-    virtual bool SetSwapInterval(int WXUNUSED(interval)) { return false; }
+    virtual SwapInterval SetSwapInterval(int WXUNUSED(interval))
+    {
+        return SwapInterval::NotSet;
+    }
 
 
     // accessors

--- a/include/wx/glcanvas.h
+++ b/include/wx/glcanvas.h
@@ -211,6 +211,10 @@ protected:
 class WXDLLIMPEXP_GL wxGLCanvasBase : public wxWindow
 {
 public:
+    // Disable changing swap interval or indicate that it is unknown.
+    static constexpr int DefaultSwapInterval = -1;
+
+
     // default ctor doesn't initialize the window, use Create() later
     wxGLCanvasBase();
 
@@ -239,6 +243,15 @@ public:
     // flush the back buffer (if we have it)
     virtual bool SwapBuffers() = 0;
 
+    // Set swap interval to the specified value.
+    //
+    // Special value of 0 means to disable vsync and DefaultSwapInterval means
+    // to disable automatically disabling vsync by default, as needs to be done
+    // under some platforms currently.
+    //
+    // Return true if the swap interval was set successfully, false if not.
+    virtual bool SetSwapInterval(int WXUNUSED(interval)) { return false; }
+
 
     // accessors
     // ---------
@@ -250,6 +263,10 @@ public:
 #if wxUSE_PALETTE
     const wxPalette *GetPalette() const { return &m_palette; }
 #endif // wxUSE_PALETTE
+
+    // Return the current swap interval.
+    virtual int GetSwapInterval() const { return DefaultSwapInterval; }
+
 
     // miscellaneous helper functions
     // ------------------------------

--- a/include/wx/msw/glcanvas.h
+++ b/include/wx/msw/glcanvas.h
@@ -90,7 +90,7 @@ public:
 
     // implement wxGLCanvasBase methods
     virtual bool SwapBuffers() override;
-    virtual bool SetSwapInterval(int interval) override;
+    virtual SwapInterval SetSwapInterval(int interval) override;
     virtual int GetSwapInterval() const override;
 
 

--- a/include/wx/msw/glcanvas.h
+++ b/include/wx/msw/glcanvas.h
@@ -90,6 +90,8 @@ public:
 
     // implement wxGLCanvasBase methods
     virtual bool SwapBuffers() override;
+    virtual bool SetSwapInterval(int interval) override;
+    virtual int GetSwapInterval() const override;
 
 
     // MSW-specific helpers

--- a/include/wx/osx/glcanvas.h
+++ b/include/wx/osx/glcanvas.h
@@ -103,7 +103,7 @@ public:
     virtual bool SwapBuffers() override;
 
 #ifdef __WXOSX_MAC__
-    virtual bool SetSwapInterval(int interval) override;
+    virtual SwapInterval SetSwapInterval(int interval) override;
     virtual int GetSwapInterval() const override;
 #endif
 

--- a/include/wx/osx/glcanvas.h
+++ b/include/wx/osx/glcanvas.h
@@ -102,6 +102,11 @@ public:
     // implement wxGLCanvasBase methods
     virtual bool SwapBuffers() override;
 
+#ifdef __WXOSX_MAC__
+    virtual bool SetSwapInterval(int interval) override;
+    virtual int GetSwapInterval() const override;
+#endif
+
     // Mac-specific functions
     // ----------------------
 
@@ -129,6 +134,10 @@ protected:
 
     WXGLPixelFormat m_glFormat = nullptr;
     wxGLAttributes m_GLAttrs;
+
+private:
+    // The value of swap interval to set or DefaultSwapInterval.
+    int m_swapIntervalToSet = DefaultSwapInterval;
 
     wxDECLARE_CLASS(wxGLCanvas);
 };

--- a/include/wx/unix/glcanvas.h
+++ b/include/wx/unix/glcanvas.h
@@ -53,6 +53,8 @@ public:
     virtual ~wxGLCanvasUnix();
 
     virtual bool SwapBuffers() override;
+    virtual bool SetSwapInterval(int interval) override;
+    virtual int GetSwapInterval() const override;
 
     virtual bool IsShownOnScreen() const override;
 

--- a/include/wx/unix/glcanvas.h
+++ b/include/wx/unix/glcanvas.h
@@ -53,7 +53,7 @@ public:
     virtual ~wxGLCanvasUnix();
 
     virtual bool SwapBuffers() override;
-    virtual bool SetSwapInterval(int interval) override;
+    virtual SwapInterval SetSwapInterval(int interval) override;
     virtual int GetSwapInterval() const override;
 
     virtual bool IsShownOnScreen() const override;

--- a/include/wx/unix/private/glcanvas.h
+++ b/include/wx/unix/private/glcanvas.h
@@ -46,14 +46,18 @@ public:
 
     virtual bool SwapBuffers() = 0;
 
-    bool SetSwapInterval(int interval)
+    wxGLCanvas::SwapInterval SetSwapInterval(int interval)
     {
         if ( !HasWindow() )
         {
             // We don't have a window yet, so we can't set the swap interval
             // right now. Remember the value to set it later in SwapBuffers().
             m_swapIntervalToSet = interval;
-            return true;
+
+            // We don't know whether we will be able to set it or not, so
+            // optimistically report success just because returning failure
+            // would be even worse.
+            return wxGLCanvas::SwapInterval::Set;
         }
 
         // We will try to set it now and we shouldn't try setting it again in
@@ -62,7 +66,7 @@ public:
         m_swapIntervalToSet = wxGLCanvas::DefaultSwapInterval;
 
         if ( interval == wxGLCanvas::DefaultSwapInterval )
-            return true;
+            return wxGLCanvas::SwapInterval::Set;
 
         return DoSetSwapInterval(interval);
     }
@@ -83,7 +87,7 @@ protected:
 
     // This function is only called if the window already exists and if
     // interval is valid, i.e. not DefaultSwapInterval.
-    virtual bool DoSetSwapInterval(int interval) = 0;
+    virtual wxGLCanvas::SwapInterval DoSetSwapInterval(int interval) = 0;
 
 
     wxGLCanvasUnix* const m_canvas;

--- a/include/wx/unix/private/glcanvas.h
+++ b/include/wx/unix/private/glcanvas.h
@@ -46,6 +46,29 @@ public:
 
     virtual bool SwapBuffers() = 0;
 
+    bool SetSwapInterval(int interval)
+    {
+        if ( !HasWindow() )
+        {
+            // We don't have a window yet, so we can't set the swap interval
+            // right now. Remember the value to set it later in SwapBuffers().
+            m_swapIntervalToSet = interval;
+            return true;
+        }
+
+        // We will try to set it now and we shouldn't try setting it again in
+        // SwapBuffers(), even if it failed, as it will almost certainly just
+        // fail again if we retry.
+        m_swapIntervalToSet = wxGLCanvas::DefaultSwapInterval;
+
+        if ( interval == wxGLCanvas::DefaultSwapInterval )
+            return true;
+
+        return DoSetSwapInterval(interval);
+    }
+
+    virtual int GetSwapInterval() const = 0;
+
     virtual void OnRealized() = 0;
 
     virtual bool HasWindow() const = 0;
@@ -58,7 +81,15 @@ protected:
     {
     }
 
+    // This function is only called if the window already exists and if
+    // interval is valid, i.e. not DefaultSwapInterval.
+    virtual bool DoSetSwapInterval(int interval) = 0;
+
+
     wxGLCanvasUnix* const m_canvas;
+
+    // The value of swap interval to set or DefaultSwapInterval.
+    int m_swapIntervalToSet = 0;
 
     wxDECLARE_NO_COPY_CLASS(wxGLCanvasUnixImpl);
 };

--- a/include/wx/unix/private/glegl.h
+++ b/include/wx/unix/private/glegl.h
@@ -59,6 +59,9 @@ public:
 
     virtual bool SwapBuffers() override;
 
+    virtual bool DoSetSwapInterval(int interval) override;
+    virtual int GetSwapInterval() const override;
+
     virtual void OnRealized() override;
 
     virtual bool HasWindow() const override;
@@ -117,7 +120,6 @@ private:
     wl_subsurface *m_wlSubsurface = nullptr;
 
     bool m_readyToDraw = false;
-    bool m_swapIntervalSet = false;
 
     // Called from GTK callbacks and needs access to private members.
     friend void wxEGLUpdateGeometry(GtkWidget* widget, wxGLCanvasEGL* win);

--- a/include/wx/unix/private/glegl.h
+++ b/include/wx/unix/private/glegl.h
@@ -59,7 +59,7 @@ public:
 
     virtual bool SwapBuffers() override;
 
-    virtual bool DoSetSwapInterval(int interval) override;
+    virtual wxGLCanvas::SwapInterval DoSetSwapInterval(int interval) override;
     virtual int GetSwapInterval() const override;
 
     virtual void OnRealized() override;

--- a/include/wx/unix/private/glx11.h
+++ b/include/wx/unix/private/glx11.h
@@ -47,6 +47,9 @@ public:
 
     virtual bool SwapBuffers() override;
 
+    virtual bool DoSetSwapInterval(int interval) override;
+    virtual int GetSwapInterval() const override;
+
     virtual void OnRealized() override { /* nothing to do here for GLX */ }
 
     virtual bool HasWindow() const override;
@@ -62,8 +65,6 @@ public:
 private:
     GLXFBConfig *m_fbc;
     XVisualInfo* m_vi;
-
-    bool m_swapIntervalSet = false;
 };
 
 // ----------------------------------------------------------------------------

--- a/include/wx/unix/private/glx11.h
+++ b/include/wx/unix/private/glx11.h
@@ -47,7 +47,7 @@ public:
 
     virtual bool SwapBuffers() override;
 
-    virtual bool DoSetSwapInterval(int interval) override;
+    virtual wxGLCanvas::SwapInterval DoSetSwapInterval(int interval) override;
     virtual int GetSwapInterval() const override;
 
     virtual void OnRealized() override { /* nothing to do here for GLX */ }

--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -807,7 +807,26 @@ public:
 
         @since 3.3.2
      */
-    static constexpr int DefaultSwapInterval = -1;
+    static constexpr int DefaultSwapInterval = INT_MAX;
+
+    /**
+        Return values of SetSwapInterval().
+
+        @since 3.3.2
+     */
+    enum class SwapInterval
+    {
+        /// SetSwapInterval() failed to set the requested swap interval.
+        NotSet = 0,
+
+        /// SetSwapInterval() successfully set the requested swap interval.
+        Set = 1,
+
+        /// SetSwapInterval() failed to enable adaptive VSync but successfully
+        /// enabled standard VSync instead.
+        NonAdaptive = 2
+    };
+
 
     /**
         Default constructor not creating the window.
@@ -1046,19 +1065,28 @@ public:
         buffer swap, i.e. for each call to SwapBuffers(). Using the value of 0
         means to disable synchronizing buffer swaps to video frames.
 
+        The value may be negative to enable adaptive VSync if supported by the
+        implementation, i.e. to allow swapping buffers without waiting for
+        VSync when the refresh late is too low.
+
         @param interval
             The swap interval to set or the special value DefaultSwapInterval
             which means to turn off automatically setting it to 0 by default,
-            as needs to be done under some platforms currently.
+            as needs to be done under some platforms currently. Typical values
+            are 1 to enable VSync, 0 to disable it and -1 to enable adaptive
+            VSync if supported.
 
-        @return @true if the swap interval was set successfully, @false if not,
-            e.g. if the function is not implemented for the current platform.
+        @return SwapInterval::Set if the swap interval was set successfully,
+            SwapInterval::NotSet if setting it failed completely, e.g. if the
+            function is not implemented for the current platform and
+            SwapInterval::NonAdaptive if the adaptive VSync was requested but
+            is not supported and standard VSync was enabled instead.
 
         @see GetSwapInterval()
 
         @since 3.3.2
      */
-    bool SetSwapInterval(int interval);
+    SwapInterval SetSwapInterval(int interval);
 
     /**
         Swaps the double-buffer of this window, making the back-buffer the

--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -799,6 +799,17 @@ class wxGLCanvas : public wxWindow
 {
 public:
     /**
+        Constant used with SetSwapInterval() and GetSwapInterval().
+
+        When used with SetSwapInterval(), it disables changing the default swap
+        interval. When returned by GetSwapInterval(), it indicates that the
+        swap interval value couldn't be retrieved.
+
+        @since 3.3.2
+     */
+    static constexpr int DefaultSwapInterval = -1;
+
+    /**
         Default constructor not creating the window.
 
         Create() must be used to actually create it later.
@@ -935,6 +946,21 @@ public:
     static int GetGLXVersion();
 
     /**
+        Return the current swap interval.
+
+        Note that the swap interval is not necessarily the same as the one set
+        by SetSwapInterval() as the implementation may clamp it to the maximum
+        supported value.
+
+        @return
+            The current swap interval or DefaultSwapInterval if the function is
+            not implemented for the current platform or an error occurred.
+
+        @since 3.3.2
+     */
+    int GetSwapInterval() const;
+
+    /**
         Determines if a canvas having the specified attributes is available.
         This only applies for visual attributes, not rendering context attributes.
 
@@ -1012,6 +1038,27 @@ public:
         @return @false if an error occurred.
     */
     bool SetCurrent(const wxGLContext& context) const;
+
+    /**
+        Set swap interval to the specified value.
+
+        @a interval specifies the minimum number of video frame periods per
+        buffer swap, i.e. for each call to SwapBuffers(). Using the value of 0
+        means to disable synchronizing buffer swaps to video frames.
+
+        @param interval
+            The swap interval to set or the special value DefaultSwapInterval
+            which means to turn off automatically setting it to 0 by default,
+            as needs to be done under some platforms currently.
+
+        @return @true if the swap interval was set successfully, @false if not,
+            e.g. if the function is not implemented for the current platform.
+
+        @see GetSwapInterval()
+
+        @since 3.3.2
+     */
+    bool SetSwapInterval(int interval);
 
     /**
         Swaps the double-buffer of this window, making the back-buffer the

--- a/samples/opengl/cube/cube.cpp
+++ b/samples/opengl/cube/cube.cpp
@@ -450,6 +450,11 @@ wxString glGetwxString(GLenum name)
 wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(wxID_NEW, MyFrame::OnNewWindow)
     EVT_MENU(NEW_STEREO_WINDOW, MyFrame::OnNewStereoWindow)
+
+    EVT_MENU(SET_SWAP_INTERVAL_0, MyFrame::OnSetSwapInterval0)
+    EVT_MENU(SET_SWAP_INTERVAL_1, MyFrame::OnSetSwapInterval1)
+    EVT_MENU(GET_SWAP_INTERVAL, MyFrame::OnGetSwapInterval)
+
     EVT_MENU(wxID_ABOUT, MyFrame::OnAbout)
     EVT_MENU(wxID_CLOSE, MyFrame::OnClose)
 wxEND_EVENT_TABLE()
@@ -457,7 +462,7 @@ wxEND_EVENT_TABLE()
 MyFrame::MyFrame( bool stereoWindow )
        : wxFrame(nullptr, wxID_ANY, "wxWidgets OpenGL Cube Sample")
 {
-    new TestGLCanvas(this, stereoWindow);
+    m_canvas = new TestGLCanvas(this, stereoWindow);
 
     SetIcon(wxICON(sample));
 
@@ -465,6 +470,10 @@ MyFrame::MyFrame( bool stereoWindow )
     wxMenu *menu = new wxMenu;
     menu->Append(wxID_NEW);
     menu->Append(NEW_STEREO_WINDOW, "New Stereo Window");
+    menu->AppendSeparator();
+    menu->Append(SET_SWAP_INTERVAL_0, "&Disable VSync");
+    menu->Append(SET_SWAP_INTERVAL_1, "Set Swap Interval to &1");
+    menu->Append(GET_SWAP_INTERVAL, "Display Swap &Interval\tCtrl+I");
     menu->AppendSeparator();
     menu->Append(wxID_ABOUT, "&About...\tF1");
     menu->AppendSeparator();
@@ -560,4 +569,29 @@ void MyFrame::OnNewStereoWindow( wxCommandEvent& WXUNUSED(event) )
     {
         wxLogError("Stereo not supported by OpenGL on this system, sorry.");
     }
+}
+
+void MyFrame::OnSetSwapInterval0( wxCommandEvent& WXUNUSED(event) )
+{
+    if ( m_canvas->SetSwapInterval(0) )
+        wxLogStatus("VSync disabled.");
+    else
+        wxLogStatus("Couldn't disable VSync.");
+}
+
+void MyFrame::OnSetSwapInterval1( wxCommandEvent& WXUNUSED(event) )
+{
+    if ( m_canvas->SetSwapInterval(1) )
+        wxLogStatus("Swap interval set to 1.");
+    else
+        wxLogStatus("Couldn't set swap interval to 1.");
+}
+
+void MyFrame::OnGetSwapInterval( wxCommandEvent& WXUNUSED(event) )
+{
+    const int swapInterval = m_canvas->GetSwapInterval();
+    if ( swapInterval != wxGLCanvas::DefaultSwapInterval )
+        wxLogMessage("Current swap interval is %d.", swapInterval);
+    else
+        wxLogMessage("Couldn't get current swap interval.");
 }

--- a/samples/opengl/cube/cube.cpp
+++ b/samples/opengl/cube/cube.cpp
@@ -451,8 +451,9 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(wxID_NEW, MyFrame::OnNewWindow)
     EVT_MENU(NEW_STEREO_WINDOW, MyFrame::OnNewStereoWindow)
 
-    EVT_MENU(SET_SWAP_INTERVAL_0, MyFrame::OnSetSwapInterval0)
-    EVT_MENU(SET_SWAP_INTERVAL_1, MyFrame::OnSetSwapInterval1)
+    EVT_MENU(DISABLE_VSYNC, MyFrame::OnDisableVSync)
+    EVT_MENU(ENABLE_VSYNC, MyFrame::OnEnableVSync)
+    EVT_MENU(ENABLE_ADAPTIVE_VSYNC, MyFrame::OnEnableAdaptiveVSync)
     EVT_MENU(GET_SWAP_INTERVAL, MyFrame::OnGetSwapInterval)
 
     EVT_MENU(wxID_ABOUT, MyFrame::OnAbout)
@@ -471,8 +472,9 @@ MyFrame::MyFrame( bool stereoWindow )
     menu->Append(wxID_NEW);
     menu->Append(NEW_STEREO_WINDOW, "New Stereo Window");
     menu->AppendSeparator();
-    menu->Append(SET_SWAP_INTERVAL_0, "&Disable VSync");
-    menu->Append(SET_SWAP_INTERVAL_1, "Set Swap Interval to &1");
+    menu->Append(DISABLE_VSYNC, "&Disable VSync");
+    menu->Append(ENABLE_VSYNC, "&Enable VSync");
+    menu->Append(ENABLE_ADAPTIVE_VSYNC, "Enable &adaptive VSync");
     menu->Append(GET_SWAP_INTERVAL, "Display Swap &Interval\tCtrl+I");
     menu->AppendSeparator();
     menu->Append(wxID_ABOUT, "&About...\tF1");
@@ -571,20 +573,38 @@ void MyFrame::OnNewStereoWindow( wxCommandEvent& WXUNUSED(event) )
     }
 }
 
-void MyFrame::OnSetSwapInterval0( wxCommandEvent& WXUNUSED(event) )
+void MyFrame::OnDisableVSync( wxCommandEvent& WXUNUSED(event) )
 {
-    if ( m_canvas->SetSwapInterval(0) )
+    if ( m_canvas->SetSwapInterval(0) == wxGLCanvas::SwapInterval::Set )
         wxLogStatus("VSync disabled.");
     else
         wxLogStatus("Couldn't disable VSync.");
 }
 
-void MyFrame::OnSetSwapInterval1( wxCommandEvent& WXUNUSED(event) )
+void MyFrame::OnEnableVSync( wxCommandEvent& WXUNUSED(event) )
 {
-    if ( m_canvas->SetSwapInterval(1) )
-        wxLogStatus("Swap interval set to 1.");
+    if ( m_canvas->SetSwapInterval(1) == wxGLCanvas::SwapInterval::Set )
+        wxLogStatus("VSync enabled.");
     else
-        wxLogStatus("Couldn't set swap interval to 1.");
+        wxLogStatus("Couldn't enable VSync.");
+}
+
+void MyFrame::OnEnableAdaptiveVSync( wxCommandEvent& WXUNUSED(event) )
+{
+    switch ( m_canvas->SetSwapInterval(-1) )
+    {
+        case wxGLCanvas::SwapInterval::Set:
+            wxLogStatus("Adaptive VSync enabled.");
+            break;
+
+        case wxGLCanvas::SwapInterval::NonAdaptive:
+            wxLogStatus("Adaptive VSync not supported, but VSync enabled.");
+            break;
+
+        case wxGLCanvas::SwapInterval::NotSet:
+            wxLogStatus("Couldn't enable VSync.");
+            break;
+    }
 }
 
 void MyFrame::OnGetSwapInterval( wxCommandEvent& WXUNUSED(event) )

--- a/samples/opengl/cube/cube.h
+++ b/samples/opengl/cube/cube.h
@@ -59,6 +59,12 @@ private:
     void OnNewWindow(wxCommandEvent& event);
     void OnNewStereoWindow(wxCommandEvent& event);
 
+    void OnSetSwapInterval0(wxCommandEvent& event);
+    void OnSetSwapInterval1(wxCommandEvent& event);
+    void OnGetSwapInterval(wxCommandEvent& event);
+
+    wxGLCanvas* m_canvas = nullptr;
+
     wxDECLARE_EVENT_TABLE();
 };
 
@@ -86,7 +92,10 @@ private:
 
 enum
 {
-    NEW_STEREO_WINDOW = wxID_HIGHEST
+    NEW_STEREO_WINDOW = wxID_HIGHEST,
+    SET_SWAP_INTERVAL_0,
+    SET_SWAP_INTERVAL_1,
+    GET_SWAP_INTERVAL
 };
 
 #endif // _WX_CUBE_H_

--- a/samples/opengl/cube/cube.h
+++ b/samples/opengl/cube/cube.h
@@ -59,8 +59,9 @@ private:
     void OnNewWindow(wxCommandEvent& event);
     void OnNewStereoWindow(wxCommandEvent& event);
 
-    void OnSetSwapInterval0(wxCommandEvent& event);
-    void OnSetSwapInterval1(wxCommandEvent& event);
+    void OnDisableVSync(wxCommandEvent& event);
+    void OnEnableVSync(wxCommandEvent& event);
+    void OnEnableAdaptiveVSync(wxCommandEvent& event);
     void OnGetSwapInterval(wxCommandEvent& event);
 
     wxGLCanvas* m_canvas = nullptr;
@@ -93,8 +94,9 @@ private:
 enum
 {
     NEW_STEREO_WINDOW = wxID_HIGHEST,
-    SET_SWAP_INTERVAL_0,
-    SET_SWAP_INTERVAL_1,
+    DISABLE_VSYNC,
+    ENABLE_VSYNC,
+    ENABLE_ADAPTIVE_VSYNC,
     GET_SWAP_INTERVAL
 };
 

--- a/src/msw/glcanvas.cpp
+++ b/src/msw/glcanvas.cpp
@@ -788,6 +788,39 @@ bool wxGLCanvas::SwapBuffers()
     return true;
 }
 
+bool wxGLCanvas::SetSwapInterval(int interval)
+{
+    if ( !IsExtensionSupported("WGL_EXT_swap_control") )
+        return false;
+
+    typedef BOOL (WINAPI * wglSwapIntervalEXT_t)(int interval);
+
+    wxDEFINE_WGL_FUNC(wglSwapIntervalEXT);
+    if ( !wglSwapIntervalEXT )
+        return false;
+
+    if ( !wglSwapIntervalEXT(interval) )
+    {
+        wxLogLastError(wxT("wglSwapIntervalEXT"));
+        return false;
+    }
+
+    return true;
+}
+
+int wxGLCanvas::GetSwapInterval() const
+{
+    if ( !IsExtensionSupported("WGL_EXT_swap_control") )
+        return DefaultSwapInterval;
+
+    typedef int (WINAPI * wglGetSwapIntervalEXT_t) (void);
+    wxDEFINE_WGL_FUNC(wglGetSwapIntervalEXT);
+
+    if ( !wglGetSwapIntervalEXT )
+        return DefaultSwapInterval;
+
+    return wglGetSwapIntervalEXT();
+}
 
 /* static */
 bool wxGLCanvasBase::IsExtensionSupported(const char *extension)

--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -45,11 +45,6 @@ void WXGLDestroyContext( WXGLContext context )
     }
 }
 
-void WXGLSwapBuffers( WXGLContext context )
-{
-    [context flushBuffer];
-}
-
 WXGLContext WXGLGetCurrentContext()
 {
     return [NSOpenGLContext currentContext];

--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -197,23 +197,34 @@ bool wxGLCanvas::SwapBuffers()
     return true;
 }
 
-bool wxGLCanvas::SetSwapInterval(int interval)
+wxGLCanvas::SwapInterval wxGLCanvas::SetSwapInterval(int interval)
 {
     WXGLContext context = WXGLGetCurrentContext();
     if ( !context )
     {
         // Set it later in SwapBuffers().
         m_swapIntervalToSet = interval;
-        return true;
+        return SwapInterval::Set;
     }
 
     // Try setting it below and don't do it again in SwapBuffers().
     m_swapIntervalToSet = DefaultSwapInterval;
 
+    wxGLCanvas::SwapInterval result = wxGLCanvas::SwapInterval::Set;
     if ( interval != DefaultSwapInterval )
-        [context setValues: &interval forParameter: NSOpenGLCPSwapInterval];
+    {
+        if ( interval < 0 )
+        {
+            // This parameter doesn't support adaptive VSync, so enable
+            // standard VSync instead.
+            interval = -interval;
+            result = wxGLCanvas::SwapInterval::NonAdaptive;
+        }
 
-    return true;
+        [context setValues: &interval forParameter: NSOpenGLCPSwapInterval];
+    }
+
+    return result;
 }
 
 int wxGLCanvas::GetSwapInterval() const

--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -184,9 +184,47 @@ bool wxGLCanvas::SwapBuffers()
     WXGLContext context = WXGLGetCurrentContext();
     wxCHECK_MSG(context, false, wxT("should have current context"));
 
+    if ( m_swapIntervalToSet != DefaultSwapInterval )
+    {
+        [context setValues: &m_swapIntervalToSet forParameter: NSOpenGLCPSwapInterval];
+
+        // It's enough to do it only once.
+        m_swapIntervalToSet = DefaultSwapInterval;
+    }
+
     [context flushBuffer];
 
     return true;
+}
+
+bool wxGLCanvas::SetSwapInterval(int interval)
+{
+    WXGLContext context = WXGLGetCurrentContext();
+    if ( !context )
+    {
+        // Set it later in SwapBuffers().
+        m_swapIntervalToSet = interval;
+        return true;
+    }
+
+    // Try setting it below and don't do it again in SwapBuffers().
+    m_swapIntervalToSet = DefaultSwapInterval;
+
+    if ( interval != DefaultSwapInterval )
+        [context setValues: &interval forParameter: NSOpenGLCPSwapInterval];
+
+    return true;
+}
+
+int wxGLCanvas::GetSwapInterval() const
+{
+    int interval = DefaultSwapInterval;
+
+    WXGLContext context = WXGLGetCurrentContext();
+    if ( context )
+        [context getValues: &interval forParameter: NSOpenGLCPSwapInterval];
+
+    return interval;
 }
 
 bool wxGLContext::SetCurrent(const wxGLCanvas& win) const

--- a/src/unix/glcanvas.cpp
+++ b/src/unix/glcanvas.cpp
@@ -287,7 +287,7 @@ bool wxGLCanvasUnix::SwapBuffers()
     return m_impl->SwapBuffers();
 }
 
-bool wxGLCanvasUnix::SetSwapInterval(int interval)
+wxGLCanvas::SwapInterval wxGLCanvasUnix::SetSwapInterval(int interval)
 {
     return m_impl->SetSwapInterval(interval);
 }

--- a/src/unix/glcanvas.cpp
+++ b/src/unix/glcanvas.cpp
@@ -287,6 +287,16 @@ bool wxGLCanvasUnix::SwapBuffers()
     return m_impl->SwapBuffers();
 }
 
+bool wxGLCanvasUnix::SetSwapInterval(int interval)
+{
+    return m_impl->SetSwapInterval(interval);
+}
+
+int wxGLCanvasUnix::GetSwapInterval() const
+{
+    return m_impl->GetSwapInterval();
+}
+
 bool wxGLCanvasUnix::IsShownOnScreen() const
 {
     return m_impl->HasWindow() && wxGLCanvasBase::IsShownOnScreen();


### PR DESCRIPTION
Allow setting the swap interval value or not setting it at all instead of always forcing it to 0.

The changes of 3dde6bdeb0 (Disable swap interval in GLX wxGLCanvas implementation too, 2023-12-25) are not always desirable, so allow to customize the behaviour.

See #24163, #24165.