### PR TITLE
Fix SetSortFunction documentation

### DIFF
--- a/interface/wx/propgrid/propgrid.h
+++ b/interface/wx/propgrid/propgrid.h
@@ -434,7 +434,8 @@ enum class wxPGKeyboardAction
     Call wxPropertyGrid::SetSortFunction() to set it.
 
     Sort function should return a value greater than 0 if position of @a p1 is
-    after @a p2. So, for instance, when comparing property names, you can use
+    after @a p2, negative if position of @a p1 is before @a p2 and 0 if they are
+    equivalent. So, for instance, when comparing property names, you can use the
     following implementation:
 
         @code


### PR DESCRIPTION
Information about the value returned by the sort function (from wxPropertyGrid) is incorrect, see discussion [here](https://forums.wxwidgets.org/viewtopic.php?f=1&t=52045).

This applies also to wx3.2
