### PR TITLE
Keep wxUSE_WEBVIEW_EDGE turned off in CMake Preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,7 @@
             "hidden": true,
             "inherits": "common",
             "cacheVariables": {
-                "wxUSE_WEBVIEW_EDGE": "ON"
+                "wxUSE_WEBVIEW_EDGE": "OFF"
             },
             "condition": {
                 "type": "equals",

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -840,14 +840,13 @@ public:
     handler provided URLs.
 
     This backend is not enabled by default, to build it follow these steps:
-    - With CMake just enable @c wxUSE_WEBVIEW_EDGE
-    - When not using CMake:
-        - Download the <a href="https://aka.ms/webviewnuget">WebView2 SDK</a>
-        nuget package (Version 1.0.864.35 or newer)
-        - Extract the package (it's a zip archive) to @c wxWidgets/3rdparty/webview2
-        (you should have @c 3rdparty/webview2/build/native/include/WebView2.h
-        file after unpacking it)
-        - Enable @c wxUSE_WEBVIEW_EDGE in @c setup.h
+    - Download the <a href="https://aka.ms/webviewnuget">WebView2 SDK</a>
+      nuget package (Version 1.0.864.35 or newer)
+    - Extract the package (it's a zip archive) to @c wxWidgets/3rdparty/webview2
+      (you should have @c 3rdparty/webview2/build/native/include/WebView2.h
+       file after unpacking it)
+    - With CMake, enable @c wxUSE_WEBVIEW_EDGE
+    - When not using CMake, enable @c wxUSE_WEBVIEW_EDGE in @c setup.h
     - Build wxWidgets webview library
     - Copy @c WebView2Loader.dll from the subdirectory corresponding to the
       architecture used (x86 or x64) of @c wxWidgets/3rdparty/webview2/build/


### PR DESCRIPTION
When I compile out-of-the-box with Visual Studio 2022 (Windows 11) using its CMake capabilities (I just open the folder from VS), I get this error:

> Cannot open include file: 'WebView2.h': No such file or directory

My process is:

- Clone from VS2022 (this will get all submodules)
- Open the wxWidgets folder in VS2022
- Select the "MSW Visual Studio 2022" target
- Build All or Install wxWidgets

The new CMake preset file is enabling `wxUSE_WEBVIEW_EDGE` by default, which I don't believe was the default before. Setting this to `OFF` fixes the error and I build fine after that.

Also, the docs imply that when using CMake, the WebView2 SDK will be somehow be installed for you and you don't need to do anything to manage it. Is it supposed to work that way, because that is not my experience (hence, the build error)? I do see code in "webview/CMake.txt" that should download the SDK, but it doesn't seem to be working for me or this CMake.txt isn't being included in the build process?