### PR TITLE
Fix tests build when using built-in CATCH

### DIFF
--- a/configure
+++ b/configure
@@ -43975,7 +43975,7 @@ $as_echo "no" >&6; }
         fi
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-        CATCH2_CFLAGS="-I$wx_top_builddir/3rdparty/catch/single_include"
+        CATCH2_CFLAGS="-I\$(top_srcdir)/3rdparty/catch/single_include"
     fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -8318,7 +8318,7 @@ will use built-in instead])
     to fix this.])
         fi
         AC_MSG_RESULT([yes])
-        CATCH2_CFLAGS="-I$wx_top_builddir/3rdparty/catch/single_include"
+        CATCH2_CFLAGS="-I\$(top_srcdir)/3rdparty/catch/single_include"
     fi
 
     AC_SUBST(CATCH2_CFLAGS)


### PR DESCRIPTION
This was broken in 01ca081d57 (Allow using system CATCH2 library in configure, 2023-06-15) where a wrong include path was used in this case.

See #23654.