### PR TITLE
Check result of downloading WebView2 from CMake

### DIFF
--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -68,8 +68,8 @@ elseif(WXMSW)
             # Check that the download was successful.
             list(GET DOWNLOAD_RESULT 0 DOWNLOAD_RESULT_NUM)
             if(NOT ${DOWNLOAD_RESULT_NUM} EQUAL 0)
-              list(GET DOWNLOAD_RESULT 1 DOWNLOAD_RESULT_STR)
-              message(FATAL_ERROR "Error ${DOWNLOAD_RESULT_NUM} downloading WebView2 SDK: ${DOWNLOAD_RESULT_STR}.")
+                list(GET DOWNLOAD_RESULT 1 DOWNLOAD_RESULT_STR)
+                message(FATAL_ERROR "Error ${DOWNLOAD_RESULT_NUM} downloading WebView2 SDK: ${DOWNLOAD_RESULT_STR}.")
             endif()
             file(MAKE_DIRECTORY ${WEBVIEW2_PACKAGE_DIR})
             execute_process(COMMAND

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -66,9 +66,10 @@ elseif(WXMSW)
                 EXPECTED_HASH SHA256=${WEBVIEW2_SHA256}
                 STATUS DOWNLOAD_RESULT)
             # Check that the download was successful.
-            string(REGEX MATCH "^[0-9]+" STATUS_CODE ${DOWNLOAD_RESULT})
-            if(NOT ${STATUS_CODE} EQUAL 0)
-                message(FATAL_ERROR "Error downloading WebView2 SDK. Please ensure that you are connected to the internet.")
+            list(GET DOWNLOAD_RESULT 0 DOWNLOAD_RESULT_NUM)
+            if(NOT ${DOWNLOAD_RESULT_NUM} EQUAL 0)
+              list(GET DOWNLOAD_RESULT 1 DOWNLOAD_RESULT_STR)
+              message(FATAL_ERROR "Error ${DOWNLOAD_RESULT_NUM} downloading WebView2 SDK: ${DOWNLOAD_RESULT_STR}.")
             endif()
             file(MAKE_DIRECTORY ${WEBVIEW2_PACKAGE_DIR})
             execute_process(COMMAND

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -63,7 +63,13 @@ elseif(WXMSW)
             file(DOWNLOAD
                 ${WEBVIEW2_URL}
                 ${CMAKE_CURRENT_BINARY_DIR}/webview2.nuget
-                EXPECTED_HASH SHA256=${WEBVIEW2_SHA256})
+                EXPECTED_HASH SHA256=${WEBVIEW2_SHA256}
+                STATUS DOWNLOAD_RESULT)
+            # Check that the download was successful.
+            string(REGEX MATCH "^[0-9]+" STATUS_CODE ${DOWNLOAD_RESULT})
+            if(NOT ${STATUS_CODE} EQUAL 0)
+                message(FATAL_ERROR "Error downloading WebView2 SDK. Please ensure that you are connected to the internet.")
+            endif()
             file(MAKE_DIRECTORY ${WEBVIEW2_PACKAGE_DIR})
             execute_process(COMMAND
                 "${CMAKE_COMMAND}" -E tar x "${CMAKE_CURRENT_BINARY_DIR}/webview2.nuget"


### PR DESCRIPTION
Immediately fail if the result of the SDK downloading wasn't `0` (success).

This will prevent making an empty SDK folder that will later confuse CMake into thinking the SDK was downloaded. Now you will keep getting the same error about failing to download the SDK when configuring CMake (at least until you actually download it).