### PR TITLE
Fix wxINFOBAR_CHECKBOX style getting lost under MSW

### DIFF
--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -72,7 +72,6 @@ bool wxInfoBarGeneric::Create(wxWindow *parent, wxWindowID winid, long style)
     // calling Hide() before Create() ensures that we're created initially
     // hidden
     Hide();
-    SetWindowStyle(style);
     if ( !wxWindow::Create(parent, winid, wxDefaultPosition, wxDefaultSize, style) )
         return false;
 

--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -73,7 +73,7 @@ bool wxInfoBarGeneric::Create(wxWindow *parent, wxWindowID winid, long style)
     // hidden
     Hide();
     SetWindowStyle(style);
-    if ( !wxWindow::Create(parent, winid) )
+    if ( !wxWindow::Create(parent, winid, wxDefaultPosition, wxDefaultSize, style) )
         return false;
 
     // use special, easy to notice, colours


### PR DESCRIPTION
Apply the style when calling `wxWindow::Create()`. Otherwise, `wxINFOBAR_CHECKBOX` will get lost when the window is actually created and trigger an assert from `ShowCheckBox()` (under MSW).