### PR TITLE
Make wxPlatformInfo::Get() thread-safe

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -281,6 +281,7 @@ All:
 - Fix wxWebResponse::GetMimeType(), add GetContentType() (Blake-Madden, #23461).
 - Improve locale matching algorithm (Ulrich Telle, #24855)
 - Make wxLogXXX(string) safe to use (#25414).
+- Make wxPlatformInfo::Get() thread-safe (#25459).
 - Make wxString {To,From}CDouble() faster and more robust (#23287).
 - Make wxrc-generated code faster to build (DoctorNoobingstoneIPresume, #24579).
 - Multiple headers with same name in wxWebRequest (Stefan Dinkelacker, #24878).

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -270,6 +270,9 @@ public:
     /**
         Returns the global wxPlatformInfo object, initialized with the values
         for the currently running platform.
+
+        Note that this function is thread-safe, i.e. it can be called
+        concurrently from multiple threads without locking.
     */
     static const wxPlatformInfo& Get();
 


### PR DESCRIPTION
Protect gs_platInfo initialization with a critical section to ensure that we don't try to do it in parallel from more than one thread, resulting in crashes.

Closes #25459.