### PR TITLE
Fix wxGLCanvasEGL buffer scale desyncing from the GTK scale factor

### DIFF
--- a/include/wx/unix/glegl.h
+++ b/include/wx/unix/glegl.h
@@ -148,6 +148,7 @@ private:
     static EGLConfig ms_glEGLConfig;
 
     friend void wxEGLUpdatePosition(wxGLCanvasEGL* win);
+    friend void wxEGLSetScale(wxGLCanvasEGL* win, int scale);
 };
 
 // ----------------------------------------------------------------------------

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -430,6 +430,12 @@ void wxEGLUpdatePosition(wxGLCanvasEGL* win)
     wl_subsurface_set_position(win->m_wlSubsurface, x, y);
 }
 
+// Helper declared as friend in the header and so can access m_wlSurface.
+void wxEGLSetScale(wxGLCanvasEGL* win, int scale)
+{
+    wl_surface_set_buffer_scale(win->m_wlSurface, scale);
+}
+
 extern "C"
 {
 
@@ -490,6 +496,7 @@ static void gtk_glcanvas_size_callback(GtkWidget *widget,
                          win->m_height * scale, 0, 0);
 
     wxEGLUpdatePosition(win);
+    wxEGLSetScale(win, scale);
 }
 
 } // extern "C"


### PR DESCRIPTION
Previously, `wxGLCanvasEGL` only set the buffer scale of the `wl_surface` once during the creation of the canvas. However, the GTK widget scale factor may change at any time (for example when the window is moved across monitors), which results in the EGL window size becoming out-of-sync with the surface's buffer scale when the canvas is resized. This patch fixes this issue by updating the `wl_surface` buffer size when the canvas widget is resized.

This fixes #23733, which was also reported externally in https://github.com/visualboyadvance-m/visualboyadvance-m/issues/1364, https://github.com/flathub/org.kicad.KiCad/pull/276#issuecomment-1949303117 and on the [KiCad GitLab](https://gitlab.com/kicad/code/kicad/-/issues/18079) (there probably also are other reports I missed).