### PR TITLE
Fix `wxBitmapComboBox` best size

### DIFF
--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -451,16 +451,26 @@ void BitmapComboBoxWidgetsPage::CreateCombo()
             break;
     }
 
-    wxArrayString items;
-    wxArrayPtrVoid bitmaps;
+    struct Item
+    {
+        Item(const wxString& text, const wxBitmap& bitmap)
+            : text(text), bitmap(bitmap)
+        {
+        }
+
+        wxString text;
+        wxBitmap bitmap;
+    };
+    std::vector<Item> items;
     if ( m_combobox )
     {
         unsigned int count = m_combobox->GetCount();
+        items.reserve(count);
+
         for ( unsigned int n = 0; n < count; n++ )
         {
-            items.Add(m_combobox->GetString(n));
-            wxBitmap bmp = m_combobox->GetItemBitmap(n);
-            bitmaps.Add(new wxBitmap(bmp));
+            items.push_back(Item{m_combobox->GetString(n),
+                                 m_combobox->GetItemBitmap(n)});
         }
 
         m_sizerCombo->Detach( m_combobox );
@@ -480,12 +490,9 @@ void BitmapComboBoxWidgetsPage::CreateCombo()
 
     NotifyWidgetRecreation(m_combobox);
 
-    unsigned int count = items.GetCount();
-    for ( unsigned int n = 0; n < count; n++ )
+    for ( const Item& item : items )
     {
-        wxBitmap* bmp = (wxBitmap*) bitmaps[n];
-        m_combobox->Append(items[n], *bmp);
-        delete bmp;
+        m_combobox->Append(item.text, item.bitmap);
     }
 
     m_sizerCombo->Add(m_combobox, 0, wxGROW | wxALL, 5);

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -432,7 +432,17 @@ wxSize wxChoice::DoGetSizeFromTextSize(int xlen, int ylen) const
         if (gtk_tree_model_get_iter_first(model, &iter))
             model = nullptr;
         else
-            gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(m_widget), "Gg");
+        {
+            gtk_list_store_insert_with_values
+            (
+                GTK_LIST_STORE(model),
+                nullptr,                // No output iterator.
+                -1,                     // Position: append.
+                m_stringCellIndex,      // Text column index.
+                "Gg",                   // This column value.
+                -1                      // Terminate the list of values.
+            );
+        }
     }
 #endif
 


### PR DESCRIPTION
This fixes the problem with the text being truncated when using big font.

I had originally thought to add some new virtual `GTKAddDummyItem()` that would be implemented differently in `wxBitmapComboBox` and add both a dummy bitmap and dummy text there, but it finally seems like this is not really needed because we can insert the dummy text in the base class and we already account for the bitmap higher than text in `wxBitmapComboBox::DoGetBestSize()` itself. Please let me know if I'm missing anything.