### PR TITLE
Enable -Wcast-qual in the CI builds using gcc or clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
 
           if [ -z ${{ matrix.allow_warnings }} ]; then
             if [ -z ${{ matrix.allow_extra_warnings }} ]; then
-              error_opts="-Wextra ${{ matrix.extra_warnings }}"
+              error_opts="-DwxENABLE_EXTRA_WARNINGS ${{ matrix.extra_warnings }}"
             fi
             error_opts="$error_opts -Werror $allow_warn_opt"
             echo "wxMAKEFILE_ERROR_CXXFLAGS=$error_opts" >> $GITHUB_ENV

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -141,7 +141,7 @@ jobs:
             ;;
         esac
         if [ -z ${{ matrix.allow_warnings }} ]; then
-          error_opts="-Werror -Wsuggest-override $allow_warn_opt"
+          error_opts="-DwxENABLE_EXTRA_WARNINGS -Werror -Wsuggest-override $allow_warn_opt"
           echo "wxMAKEFILE_ERROR_CXXFLAGS=$error_opts" >> $GITHUB_ENV
           echo "wxMAKEFILE_CXXFLAGS=$wxMAKEFILE_CXXFLAGS $error_opts" >> $GITHUB_ENV
         fi

--- a/.github/workflows/ci_msw.yml
+++ b/.github/workflows/ci_msw.yml
@@ -176,7 +176,7 @@ jobs:
           cmake -G "MinGW Makefiles" \
                 -DCMAKE_C_COMPILER=clang.exe \
                 -DCMAKE_CXX_COMPILER=clang++.exe \
-                -DCMAKE_CXX_FLAGS="-Werror -Wsuggest-override" \
+                -DCMAKE_CXX_FLAGS="-DwxENABLE_EXTRA_WARNINGS -Werror -Wsuggest-override" \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DwxBUILD_SAMPLES=ALL \
                 -DwxBUILD_TESTS=ALL \

--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -429,6 +429,12 @@ more details.
 @itemdef{wxICON_IS_BITMAP,
          defined in the ports where wxIcon inherits from wxBitmap (all but
          wxMSW currently)}
+@itemdef{wxENABLE_EXTRA_WARNINGS,
+         this symbol can be predefined before including wxWidgets headers to
+         enable extra compilers warnings. This is mostly useful for wxWidgets
+         developers, but can also be used by the applications if they want to
+         opt in into getting more help from compiler. Support for this symbol
+         appeared in wxWidgets 3.3.0.}
 @endDefList
 
 */

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -144,6 +144,14 @@
 #   define wxSUPPRESS_GCC_PRIVATE_DTOR_WARNING(name)
 #endif
 
+/* Enable some warnings not enabled by default if requested. */
+#ifdef wxENABLE_EXTRA_WARNINGS
+#   ifdef __GNUC__
+#       pragma GCC diagnostic warning "-Wcast-qual"
+#       pragma GCC diagnostic warning "-Wextra"
+#   endif
+#endif
+
 /*
    Clang Support
  */

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -148,6 +148,7 @@
 #ifdef wxENABLE_EXTRA_WARNINGS
 #   ifdef __GNUC__
 #       pragma GCC diagnostic warning "-Wcast-qual"
+#       pragma GCC diagnostic warning "-Wdouble-promotion"
 #       pragma GCC diagnostic warning "-Wextra"
 #   endif
 #endif

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -51,6 +51,8 @@
     #pragma warning(disable:4702)
 #endif
 
+wxGCC_WARNING_SUPPRESS(cast-qual)
+
 #if !wxUSE_NANOSVG_EXTERNAL || defined(wxUSE_NANOSVG_EXTERNAL_ENABLE_IMPL)
     #define NANOSVG_IMPLEMENTATION
     #define NANOSVGRAST_IMPLEMENTATION
@@ -64,6 +66,8 @@
     #include "../../3rdparty/nanosvg/src/nanosvg.h"
     #include "../../3rdparty/nanosvg/src/nanosvgrast.h"
 #endif
+
+wxGCC_WARNING_RESTORE(cast-qual)
 
 #ifdef __VISUALC__
     #pragma warning(pop)

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -52,6 +52,7 @@
 #endif
 
 wxGCC_WARNING_SUPPRESS(cast-qual)
+wxGCC_WARNING_SUPPRESS(double-promotion)
 
 #if !wxUSE_NANOSVG_EXTERNAL || defined(wxUSE_NANOSVG_EXTERNAL_ENABLE_IMPL)
     #define NANOSVG_IMPLEMENTATION
@@ -67,6 +68,7 @@ wxGCC_WARNING_SUPPRESS(cast-qual)
     #include "../../3rdparty/nanosvg/src/nanosvgrast.h"
 #endif
 
+wxGCC_WARNING_RESTORE(double-promotion)
 wxGCC_WARNING_RESTORE(cast-qual)
 
 #ifdef __VISUALC__


### PR DESCRIPTION
This is a useful warning not enabled by -Wextra, so enable it separately.