### PR TITLE
Improve wxRect2DDouble

### DIFF
--- a/include/wx/geometry.h
+++ b/include/wx/geometry.h
@@ -519,7 +519,7 @@ inline bool wxPoint2DDouble::operator!=(const wxPoint2DDouble& pt) const
     return !(*this == pt);
 }
 
-// wxRect2Ds are an axis-aligned rectangles, each side of the rect is parallel to the x- or m_y- axis. The rectangle is either defined by the
+// wxRect2Ds are axis-aligned rectangles, each side of the rect is parallel to the x- or m_y- axis. The rectangle is either defined by the
 // top left and bottom right corner, or by the top left corner and size. A point is contained within the rectangle if
 // left <= x < right  and top <= m_y < bottom , thus it is a half open interval.
 
@@ -529,6 +529,20 @@ public:
     wxRect2DDouble() = default;
     wxRect2DDouble(wxDouble x, wxDouble y, wxDouble w, wxDouble h)
         { m_x = x; m_y = y; m_width = w;  m_height = h; }
+
+    explicit wxRect2DDouble(const wxRect& rect)
+    {
+        m_x = static_cast<wxDouble>(rect.x);
+        m_y = static_cast<wxDouble>(rect.y);
+        m_width = static_cast<wxDouble>(rect.width);
+        m_height = static_cast<wxDouble>(rect.height);
+    }
+
+    wxNODISCARD wxRect ToRect() const
+    {
+        return wxRect(static_cast<int>(m_x), static_cast<int>(m_y),
+                      static_cast<int>(m_width), static_cast<int>(m_height));
+    }
 /*
     wxRect2DDouble(const wxPoint2DDouble& topLeft, const wxPoint2DDouble& bottomRight);
     wxRect2DDouble(const wxPoint2DDouble& pos, const wxSize& size);
@@ -536,72 +550,88 @@ public:
 */
         // single attribute accessors
 
-    wxPoint2DDouble GetPosition() const
+    wxNODISCARD wxPoint2DDouble GetPosition() const
         { return wxPoint2DDouble(m_x, m_y); }
-    wxSize GetSize() const
+    wxNODISCARD wxSize GetSize() const
         { return wxSize((int) m_width, (int) m_height); }
+
+    wxNODISCARD wxDouble GetX() const
+        { return m_x; }
+
+    wxNODISCARD wxDouble GetY() const
+        { return m_y; }
+
+    wxNODISCARD wxDouble GetWidth() const
+        { return m_width; }
+
+    void SetWidth(wxDouble w) { m_width = w; }
+
+    wxNODISCARD wxDouble GetHeight() const
+        { return m_height; }
+
+    void SetHeight(wxDouble h) { m_height = h; }
 
     // for the edge and corner accessors there are two setters counterparts, the Set.. functions keep the other corners at their
         // position whenever sensible, the Move.. functions keep the size of the rect and move the other corners appropriately
 
-    inline wxDouble GetLeft() const { return m_x; }
+    inline wxNODISCARD wxDouble GetLeft() const { return m_x; }
     inline void SetLeft( wxDouble n ) { m_width += m_x - n; m_x = n; }
     inline void MoveLeftTo( wxDouble n ) { m_x = n; }
     inline wxDouble GetTop() const { return m_y; }
     inline void SetTop( wxDouble n ) { m_height += m_y - n; m_y = n; }
     inline void MoveTopTo( wxDouble n ) { m_y = n; }
-    inline wxDouble GetBottom() const { return m_y + m_height; }
+    inline wxNODISCARD wxDouble GetBottom() const { return m_y + m_height; }
     inline void SetBottom( wxDouble n ) { m_height += n - (m_y+m_height);}
     inline void MoveBottomTo( wxDouble n ) { m_y = n - m_height; }
-    inline wxDouble GetRight() const { return m_x + m_width; }
+    inline wxNODISCARD wxDouble GetRight() const { return m_x + m_width; }
     inline void SetRight( wxDouble n ) { m_width += n - (m_x+m_width) ; }
     inline void MoveRightTo( wxDouble n ) { m_x = n - m_width; }
 
-    inline wxPoint2DDouble GetLeftTop() const
+    inline wxNODISCARD wxPoint2DDouble GetLeftTop() const
         { return wxPoint2DDouble( m_x , m_y ); }
     inline void SetLeftTop( const wxPoint2DDouble &pt )
         { m_width += m_x - pt.m_x; m_height += m_y - pt.m_y; m_x = pt.m_x; m_y = pt.m_y; }
     inline void MoveLeftTopTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x; m_y = pt.m_y; }
-    inline wxPoint2DDouble GetLeftBottom() const
+    inline wxNODISCARD wxPoint2DDouble GetLeftBottom() const
         { return wxPoint2DDouble( m_x , m_y + m_height ); }
     inline void SetLeftBottom( const wxPoint2DDouble &pt )
         { m_width += m_x - pt.m_x; m_height += pt.m_y - (m_y+m_height) ; m_x = pt.m_x; }
     inline void MoveLeftBottomTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x; m_y = pt.m_y - m_height; }
-    inline wxPoint2DDouble GetRightTop() const
+    inline wxNODISCARD wxPoint2DDouble GetRightTop() const
         { return wxPoint2DDouble( m_x+m_width , m_y ); }
     inline void SetRightTop( const wxPoint2DDouble &pt )
         { m_width += pt.m_x - ( m_x + m_width ); m_height += m_y - pt.m_y; m_y = pt.m_y; }
     inline void MoveRightTopTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x - m_width; m_y = pt.m_y; }
-    inline wxPoint2DDouble GetRightBottom() const
+    inline wxNODISCARD wxPoint2DDouble GetRightBottom() const
         { return wxPoint2DDouble( m_x+m_width , m_y + m_height ); }
     inline void SetRightBottom( const wxPoint2DDouble &pt )
         { m_width += pt.m_x - ( m_x + m_width ); m_height += pt.m_y - (m_y+m_height);}
     inline void MoveRightBottomTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x - m_width; m_y = pt.m_y - m_height; }
-    inline wxPoint2DDouble GetCentre() const
+    inline wxNODISCARD wxPoint2DDouble GetCentre() const
         { return wxPoint2DDouble( m_x+m_width/2 , m_y+m_height/2 ); }
     inline void SetCentre( const wxPoint2DDouble &pt )
         { MoveCentreTo( pt ); }    // since this is impossible without moving...
     inline void MoveCentreTo( const wxPoint2DDouble &pt )
         { m_x += pt.m_x - (m_x+m_width/2); m_y += pt.m_y -(m_y+m_height/2); }
-    inline wxOutCode GetOutCode( const wxPoint2DDouble &pt ) const
+    inline wxNODISCARD wxOutCode GetOutCode( const wxPoint2DDouble &pt ) const
         { return (wxOutCode) (( ( pt.m_x < m_x ) ? wxOutLeft : 0 ) +
                      ( ( pt.m_x > m_x + m_width ) ? wxOutRight : 0 ) +
                      ( ( pt.m_y < m_y ) ? wxOutTop : 0 )  +
                      ( ( pt.m_y > m_y + m_height ) ? wxOutBottom : 0 )); }
-    inline wxOutCode GetOutcode(const wxPoint2DDouble &pt) const
+    inline wxNODISCARD wxOutCode GetOutcode(const wxPoint2DDouble &pt) const
         { return GetOutCode(pt) ; }
-    inline bool Contains( const wxPoint2DDouble &pt ) const
+    inline wxNODISCARD bool Contains( const wxPoint2DDouble &pt ) const
         { return  GetOutCode( pt ) == wxInside; }
-    inline bool Contains( const wxRect2DDouble &rect ) const
+    inline wxNODISCARD bool Contains( const wxRect2DDouble &rect ) const
         { return ( ( ( m_x <= rect.m_x ) && ( rect.m_x + rect.m_width <= m_x + m_width ) ) &&
                 ( ( m_y <= rect.m_y ) && ( rect.m_y + rect.m_height <= m_y + m_height ) ) ); }
-    inline bool IsEmpty() const
+    inline wxNODISCARD bool IsEmpty() const
         { return m_width <= 0 || m_height <= 0; }
-    inline bool HaveEqualSize( const wxRect2DDouble &rect ) const
+    inline wxNODISCARD bool HaveEqualSize( const wxRect2DDouble &rect ) const
         { return wxIsSameDouble(rect.m_width, m_width) && wxIsSameDouble(rect.m_height, m_height); }
 
     inline void Inset( wxDouble x , wxDouble y )
@@ -610,18 +640,42 @@ public:
         { m_x += left; m_y += top; m_width -= left + right; m_height -= top + bottom;}
     inline void Offset( const wxPoint2DDouble &pt )
         { m_x += pt.m_x; m_y += pt.m_y; }
+    inline void Offset(wxDouble dx, wxDouble dy)
+        { Offset({ dx, dy }); }
+
+    wxRect2DDouble& Inflate(wxDouble dx, wxDouble dy);
+    wxRect2DDouble& Inflate(const wxSize& d)
+        { return Inflate(static_cast<double>(d.x), static_cast<double>(d.y)); }
+    wxRect2DDouble& Inflate(wxDouble d) { return Inflate(d, d); }
+    wxRect2DDouble Inflate(wxDouble dx, wxDouble dy) const
+    {
+        wxRect2DDouble r = *this;
+        r.Inflate(dx, dy);
+        return r;
+    }
+
+    wxRect2DDouble& Deflate(wxDouble dx, wxDouble dy) { return Inflate(-dx, -dy); }
+    wxRect2DDouble& Deflate(const wxSize& d)
+        { return Inflate(-static_cast<double>(d.x), -static_cast<double>(d.y)); }
+    wxRect2DDouble& Deflate(wxDouble d) { return Inflate(-d); }
+    wxRect2DDouble Deflate(wxDouble dx, wxDouble dy) const
+    {
+        wxRect2DDouble r = *this;
+        r.Deflate(dx, dy);
+        return r;
+    }
 
     void ConstrainTo( const wxRect2DDouble &rect );
 
-    wxPoint2DDouble Interpolate( wxInt32 widthfactor, wxInt32 heightfactor ) const
+    wxNODISCARD wxPoint2DDouble Interpolate( wxInt32 widthfactor, wxInt32 heightfactor ) const
         { return wxPoint2DDouble( m_x + m_width * widthfactor , m_y + m_height * heightfactor ); }
 
     static void Intersect( const wxRect2DDouble &src1 , const wxRect2DDouble &src2 , wxRect2DDouble *dest );
     inline void Intersect( const wxRect2DDouble &otherRect )
         { Intersect( *this , otherRect , this ); }
-    inline wxRect2DDouble CreateIntersection( const wxRect2DDouble &otherRect ) const
+    inline wxNODISCARD wxRect2DDouble CreateIntersection( const wxRect2DDouble &otherRect ) const
         { wxRect2DDouble result; Intersect( *this , otherRect , &result); return result; }
-    bool Intersects( const wxRect2DDouble &rect ) const;
+    wxNODISCARD bool Intersects( const wxRect2DDouble &rect ) const;
 
     static void Union( const wxRect2DDouble &src1 , const wxRect2DDouble &src2 , wxRect2DDouble *dest );
     void Union( const wxRect2DDouble &otherRect )

--- a/include/wx/geometry.h
+++ b/include/wx/geometry.h
@@ -577,7 +577,7 @@ public:
     inline wxNODISCARD wxDouble GetLeft() const { return m_x; }
     inline void SetLeft( wxDouble n ) { m_width += m_x - n; m_x = n; }
     inline void MoveLeftTo( wxDouble n ) { m_x = n; }
-    inline wxDouble GetTop() const { return m_y; }
+    inline wxNODISCARD wxDouble GetTop() const { return m_y; }
     inline void SetTop( wxDouble n ) { m_height += m_y - n; m_y = n; }
     inline void MoveTopTo( wxDouble n ) { m_y = n; }
     inline wxNODISCARD wxDouble GetBottom() const { return m_y + m_height; }
@@ -645,7 +645,7 @@ public:
 
     wxRect2DDouble& Inflate(wxDouble dx, wxDouble dy);
     wxRect2DDouble& Inflate(const wxSize& d)
-        { return Inflate(static_cast<double>(d.x), static_cast<double>(d.y)); }
+        { return Inflate(static_cast<wxDouble>(d.x), static_cast<wxDouble>(d.y)); }
     wxRect2DDouble& Inflate(wxDouble d) { return Inflate(d, d); }
     wxRect2DDouble Inflate(wxDouble dx, wxDouble dy) const
     {
@@ -656,7 +656,7 @@ public:
 
     wxRect2DDouble& Deflate(wxDouble dx, wxDouble dy) { return Inflate(-dx, -dy); }
     wxRect2DDouble& Deflate(const wxSize& d)
-        { return Inflate(-static_cast<double>(d.x), -static_cast<double>(d.y)); }
+        { return Inflate(-static_cast<wxDouble>(d.x), -static_cast<wxDouble>(d.y)); }
     wxRect2DDouble& Deflate(wxDouble d) { return Inflate(-d); }
     wxRect2DDouble Deflate(wxDouble dx, wxDouble dy) const
     {

--- a/include/wx/geometry.h
+++ b/include/wx/geometry.h
@@ -540,8 +540,8 @@ public:
 
     wxNODISCARD wxRect ToRect() const
     {
-        return wxRect(static_cast<int>(m_x), static_cast<int>(m_y),
-                      static_cast<int>(m_width), static_cast<int>(m_height));
+        return wxRect(wxRound(m_x), wxRound(m_y),
+                      wxRound(m_width), wxRound(m_height));
     }
 /*
     wxRect2DDouble(const wxPoint2DDouble& topLeft, const wxPoint2DDouble& bottomRight);

--- a/include/wx/geometry.h
+++ b/include/wx/geometry.h
@@ -574,64 +574,64 @@ public:
     // for the edge and corner accessors there are two setters counterparts, the Set.. functions keep the other corners at their
         // position whenever sensible, the Move.. functions keep the size of the rect and move the other corners appropriately
 
-    inline wxNODISCARD wxDouble GetLeft() const { return m_x; }
+    inline wxDouble GetLeft() const { return m_x; }
     inline void SetLeft( wxDouble n ) { m_width += m_x - n; m_x = n; }
     inline void MoveLeftTo( wxDouble n ) { m_x = n; }
-    inline wxNODISCARD wxDouble GetTop() const { return m_y; }
+    inline wxDouble GetTop() const { return m_y; }
     inline void SetTop( wxDouble n ) { m_height += m_y - n; m_y = n; }
     inline void MoveTopTo( wxDouble n ) { m_y = n; }
-    inline wxNODISCARD wxDouble GetBottom() const { return m_y + m_height; }
+    inline wxDouble GetBottom() const { return m_y + m_height; }
     inline void SetBottom( wxDouble n ) { m_height += n - (m_y+m_height);}
     inline void MoveBottomTo( wxDouble n ) { m_y = n - m_height; }
-    inline wxNODISCARD wxDouble GetRight() const { return m_x + m_width; }
+    inline wxDouble GetRight() const { return m_x + m_width; }
     inline void SetRight( wxDouble n ) { m_width += n - (m_x+m_width) ; }
     inline void MoveRightTo( wxDouble n ) { m_x = n - m_width; }
 
-    inline wxNODISCARD wxPoint2DDouble GetLeftTop() const
+    inline wxPoint2DDouble GetLeftTop() const
         { return wxPoint2DDouble( m_x , m_y ); }
     inline void SetLeftTop( const wxPoint2DDouble &pt )
         { m_width += m_x - pt.m_x; m_height += m_y - pt.m_y; m_x = pt.m_x; m_y = pt.m_y; }
     inline void MoveLeftTopTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x; m_y = pt.m_y; }
-    inline wxNODISCARD wxPoint2DDouble GetLeftBottom() const
+    inline wxPoint2DDouble GetLeftBottom() const
         { return wxPoint2DDouble( m_x , m_y + m_height ); }
     inline void SetLeftBottom( const wxPoint2DDouble &pt )
         { m_width += m_x - pt.m_x; m_height += pt.m_y - (m_y+m_height) ; m_x = pt.m_x; }
     inline void MoveLeftBottomTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x; m_y = pt.m_y - m_height; }
-    inline wxNODISCARD wxPoint2DDouble GetRightTop() const
+    inline wxPoint2DDouble GetRightTop() const
         { return wxPoint2DDouble( m_x+m_width , m_y ); }
     inline void SetRightTop( const wxPoint2DDouble &pt )
         { m_width += pt.m_x - ( m_x + m_width ); m_height += m_y - pt.m_y; m_y = pt.m_y; }
     inline void MoveRightTopTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x - m_width; m_y = pt.m_y; }
-    inline wxNODISCARD wxPoint2DDouble GetRightBottom() const
+    inline wxPoint2DDouble GetRightBottom() const
         { return wxPoint2DDouble( m_x+m_width , m_y + m_height ); }
     inline void SetRightBottom( const wxPoint2DDouble &pt )
         { m_width += pt.m_x - ( m_x + m_width ); m_height += pt.m_y - (m_y+m_height);}
     inline void MoveRightBottomTo( const wxPoint2DDouble &pt )
         { m_x = pt.m_x - m_width; m_y = pt.m_y - m_height; }
-    inline wxNODISCARD wxPoint2DDouble GetCentre() const
+    inline wxPoint2DDouble GetCentre() const
         { return wxPoint2DDouble( m_x+m_width/2 , m_y+m_height/2 ); }
     inline void SetCentre( const wxPoint2DDouble &pt )
         { MoveCentreTo( pt ); }    // since this is impossible without moving...
     inline void MoveCentreTo( const wxPoint2DDouble &pt )
         { m_x += pt.m_x - (m_x+m_width/2); m_y += pt.m_y -(m_y+m_height/2); }
-    inline wxNODISCARD wxOutCode GetOutCode( const wxPoint2DDouble &pt ) const
+    inline wxOutCode GetOutCode( const wxPoint2DDouble &pt ) const
         { return (wxOutCode) (( ( pt.m_x < m_x ) ? wxOutLeft : 0 ) +
                      ( ( pt.m_x > m_x + m_width ) ? wxOutRight : 0 ) +
                      ( ( pt.m_y < m_y ) ? wxOutTop : 0 )  +
                      ( ( pt.m_y > m_y + m_height ) ? wxOutBottom : 0 )); }
-    inline wxNODISCARD wxOutCode GetOutcode(const wxPoint2DDouble &pt) const
+    inline wxOutCode GetOutcode(const wxPoint2DDouble &pt) const
         { return GetOutCode(pt) ; }
-    inline wxNODISCARD bool Contains( const wxPoint2DDouble &pt ) const
+    inline bool Contains( const wxPoint2DDouble &pt ) const
         { return  GetOutCode( pt ) == wxInside; }
-    inline wxNODISCARD bool Contains( const wxRect2DDouble &rect ) const
+    inline bool Contains( const wxRect2DDouble &rect ) const
         { return ( ( ( m_x <= rect.m_x ) && ( rect.m_x + rect.m_width <= m_x + m_width ) ) &&
                 ( ( m_y <= rect.m_y ) && ( rect.m_y + rect.m_height <= m_y + m_height ) ) ); }
-    inline wxNODISCARD bool IsEmpty() const
+    inline bool IsEmpty() const
         { return m_width <= 0 || m_height <= 0; }
-    inline wxNODISCARD bool HaveEqualSize( const wxRect2DDouble &rect ) const
+    inline bool HaveEqualSize( const wxRect2DDouble &rect ) const
         { return wxIsSameDouble(rect.m_width, m_width) && wxIsSameDouble(rect.m_height, m_height); }
 
     inline void Inset( wxDouble x , wxDouble y )
@@ -673,7 +673,7 @@ public:
     static void Intersect( const wxRect2DDouble &src1 , const wxRect2DDouble &src2 , wxRect2DDouble *dest );
     inline void Intersect( const wxRect2DDouble &otherRect )
         { Intersect( *this , otherRect , this ); }
-    inline wxNODISCARD wxRect2DDouble CreateIntersection( const wxRect2DDouble &otherRect ) const
+    inline wxRect2DDouble CreateIntersection( const wxRect2DDouble &otherRect ) const
         { wxRect2DDouble result; Intersect( *this , otherRect , &result); return result; }
     wxNODISCARD bool Intersects( const wxRect2DDouble &rect ) const;
 

--- a/interface/wx/geometry.h
+++ b/interface/wx/geometry.h
@@ -161,7 +161,7 @@ public:
 
         @since 3.3.0
     */
-    wxRect2DDouble(const wxRect& rect);
+    explicit wxRect2DDouble(const wxRect& rect);
 
     /**
         Returns the position.

--- a/interface/wx/geometry.h
+++ b/interface/wx/geometry.h
@@ -68,8 +68,9 @@ wxPoint2DInt operator/(const wxPoint2DInt& pt , wxDouble n);
 wxPoint2DInt operator/(const wxPoint2DInt& pt , wxInt32 n);
 
 
-// wxPoint2Ds represent a point or a vector in a 2d coordinate system
-
+/**
+    wxPoint2Ds represent a point or a vector in a 2D coordinate system.
+ */
 class wxPoint2DDouble
 {
 public :
@@ -126,79 +127,383 @@ wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxInt32 n);
 
 
 
-// wxRect2Ds are a axis-aligned rectangles, each side of the rect is parallel to the x- or m_y- axis. The rectangle is either defined by the
-// top left and bottom right corner, or by the top left corner and size. A point is contained within the rectangle if
-// left <= x < right  and top <= m_y < bottom , thus it is a half open interval.
+/**
+    wxRect2DDouble is an axis-aligned rectangle;
+    each side of the rect is parallel to the x - or m_y - axis.
 
+    The rectangle is either defined by the top left and bottom right corner,
+    or by the top left corner and size.
+
+    A point is contained within the rectangle if left <= x < right
+    and top <= m_y < bottom; thus, it is a half open interval.
+
+    @note wxRect2DDouble has subtle differences from wxRect in how its edge
+     and corner functions work. With wxRect2DDouble, there are two counterparts:
+    - `SetXXX` functions, which keep the other corners at their position whenever sensible
+    - `MoveXXX` functions, which keep the size of the rectangle and move the other
+       corners appropriately
+ */
 class wxRect2DDouble
 {
 public:
+    /**
+        Default constructor.
+        Initializes to zero the internal @a m_x, @a m_y, @a m_width and @a m_height members.
+    */
     wxRect2DDouble();
-    wxRect2DDouble(wxDouble x, wxDouble y, wxDouble w, wxDouble h);
+    /**
+        Creates a wxRect2DDouble object from @a x, @a y, @a width and @a height values.
+    */
+    wxRect2DDouble(wxDouble x, wxDouble y, wxDouble width, wxDouble height);
 
-    // single attribute accessors
+    /**
+        Constructs a wxRect2DDouble from a wxRect.
 
+        @since 3.3.0
+    */
+    wxRect2DDouble(const wxRect& rect);
+
+    /**
+        Returns the position.
+    */
     wxPoint2DDouble GetPosition() const;
+    /**
+        Returns the size.
+   */
     wxSize GetSize() const;
 
-    // for the edge and corner accessors there are two setters counterparts, the Set.. functions keep the other corners at their
-        // position whenever sensible, the Move.. functions keep the size of the rect and move the other corners appropriately
+    /**
+        Returns the left position of the rectangle.
 
+        @since 3.3.0
+    */
+    wxDouble GetX() const;
+
+    /**
+        Returns the top position of the rect.
+
+        @since 3.3.0
+    */
+    wxDouble GetY() const;
+
+    /**
+        Returns the width.
+
+        @since 3.3.0
+    */
+    wxDouble GetWidth() const;
+
+    /**
+        Sets the width.
+
+        @since 3.3.0
+    */
+    void SetWidth(wxDouble w);
+
+    /**
+        Returns the height.
+
+        @since 3.3.0
+    */
+    wxDouble GetHeight() const;
+
+    /**
+        Sets the height.
+
+        @since 3.3.0
+    */
+    void SetHeight(wxDouble h) { m_height = h; }
+
+    /**
+        Returns the left point of the rectangle (the same as GetX()).
+    */
     wxDouble GetLeft() const;
+    /**
+       Set the left side of the rectangle.
+
+       @note This will preserve the width of the rectangle.
+       Use MoveLeftTo() to change the left position
+       of the rectangle, adjusting its width accordingly.
+    */
     void SetLeft( wxDouble n );
+    /**
+        Sets the left position, which may adjust the width of the rectangle.
+    */
     void MoveLeftTo( wxDouble n );
+    /**
+        Returns the top point of the rectangle (the same as GetY()).
+    */
     wxDouble GetTop() const;
+    /**
+        Set the top edge of the rectangle.
+
+        @note This will alter the height of the rectangle.
+        Use MoveTopTo() to only move the top.
+    */
     void SetTop( wxDouble n );
+    /**
+        Set the top edge of the rectangle, preserving the height.
+    */
     void MoveTopTo( wxDouble n );
+    /**
+        Returns the bottom point of the rectangle.
+    */
     wxDouble GetBottom() const;
+    /**
+       Set the bottom edge of the rectangle.
+
+       @note This will alter the height of the rectangle.
+        Use MoveBottomTo() to only move the bottom.
+     */
     void SetBottom( wxDouble n );
+    /**
+       Set the bottom edge of the rectangle.
+
+       @note This will affect the height of the rectangle.
+     */
     void MoveBottomTo( wxDouble n );
+    /**
+        Returns the right point of the rectangle.
+    */
     wxDouble GetRight() const;
+    /**
+       Set the right side of the rectangle.
+
+       @note This will alter the width of the rectangle.
+        Use MoveRightTo() to only move the bottom.
+     */
     void SetRight( wxDouble n );
+    /**
+       Set the right side of the rectangle.
+
+       @note This will affect the width of the rectangle.
+     */
     void MoveRightTo( wxDouble n );
 
+    /**
+        Returns the position of the top left corner of the rectangle, same as
+        GetPosition().
+    */
     wxPoint2DDouble GetLeftTop() const;
+    /**
+       Set the top-left point of the rectangle.
+
+       @note This will alter the height of the rectangle.
+       Use MoveLeftTopTo() to only move the top.
+     */
     void SetLeftTop( const wxPoint2DDouble &pt );
+    /**
+       Set the top-left point of the rectangle, while preserving the
+       width and height of the rectangle.
+     */
     void MoveLeftTopTo( const wxPoint2DDouble &pt );
+    /**
+        Returns the position of the bottom left corner.
+    */
     wxPoint2DDouble GetLeftBottom() const;
+    /**
+       Set the bottom-left point of the rectangle.
+
+       @note This will alter the width and height of the rectangle.
+        Use MoveLeftBottomTo() to only move the left bottom corner.
+     */
     void SetLeftBottom( const wxPoint2DDouble &pt );
+    /**
+       Set the bottom-left point of the rectangle, while preserving the
+       width and height of the rectangle.
+     */
     void MoveLeftBottomTo( const wxPoint2DDouble &pt );
+    /**
+        Returns the position of the top right corner.
+    */
     wxPoint2DDouble GetRightTop() const;
+    /**
+       Set the top-right point of the rectangle.
+
+       @note This will alter the width and height of the rectangle.
+       Use MoveRightTopTo() to only move the right top corner.
+     */
     void SetRightTop( const wxPoint2DDouble &pt );
+    /**
+       Set the top-right point of the rectangle, while preserving the
+       width and height of the rectangle.
+     */
     void MoveRightTopTo( const wxPoint2DDouble &pt );
+    /**
+        Returns the position of the bottom right corner.
+    */
     wxPoint2DDouble GetRightBottom() const;
+    /**
+       Set the bottom-right point of the rectangle.
+
+       @note This will alter the width and height of the rectangle.
+       Use MoveRightBottomTo() to only move the right bottom corner.
+     */
     void SetRightBottom( const wxPoint2DDouble &pt );
+    /**
+       Set the bottom-right point of the rectangle, while preserving the
+       width and height of the rectangle.
+     */
     void MoveRightBottomTo( const wxPoint2DDouble &pt );
+    /**
+       Returns the centre point of the rectangle.
+     */
     wxPoint2DDouble GetCentre() const;
+    /**
+       Recenters (i.e., moves) the rectangle to the given point.
+     */
     void SetCentre( const wxPoint2DDouble &pt );
+    /**
+       An alias for MoveCentreTo().
+     */
     void MoveCentreTo( const wxPoint2DDouble &pt );
+    /**
+       Returns the relative location of a point to the rectangle
+       (e.g., inside or to the left of it).
+     */
     wxOutCode GetOutCode( const wxPoint2DDouble &pt ) const;
-    wxOutCode GetOutcode(const wxPoint2DDouble &pt) const;
+    /**
+        Returns @true if the given point is inside the rectangle (or on its
+        boundary) and @false otherwise.
+    */
     bool Contains( const wxPoint2DDouble &pt ) const;
+    /**
+        Returns @true if the given rectangle is completely inside this
+        rectangle (or touches its boundary) and @false otherwise.
+    */
     bool Contains( const wxRect2DDouble &rect ) const;
+    /**
+        Returns @true if this rectangle has a width or height less than or
+        equal to 0 and @false otherwise.
+    */
     bool IsEmpty() const;
+    /**
+        Returns @true if another rectangle has the same width and height.
+    */
     bool HaveEqualSize( const wxRect2DDouble &rect ) const;
 
     void Inset( wxDouble x , wxDouble y );
     void Inset( wxDouble left , wxDouble top ,wxDouble right , wxDouble bottom  );
+    /**
+        Moves the rectangle by the specified offset. If X of @a pt is positive, the
+        rectangle is moved to the right, if Y of @a pt is positive, it is moved to the
+        bottom, otherwise it is moved to the left or top respectively.
+    */
     void Offset( const wxPoint2DDouble &pt );
+    /**
+        @overload
+        @since 3.3.0
+    */
+    void Offset( wxDouble dx, wxDouble dy );
 
+    /**
+        Resizes the rectangle to fit within the dimensions of another rectangle.
+    */
     void ConstrainTo( const wxRect2DDouble &rect );
 
     wxPoint2DDouble Interpolate( wxInt32 widthfactor, wxInt32 heightfactor ) const;
 
+    /**
+        Returns the intersecting rectangle of two rectangles.
+    */
     static void Intersect( const wxRect2DDouble &src1 , const wxRect2DDouble &src2 , wxRect2DDouble *dest );
+    /**
+        Constrains the rectangle to the intersection of another rectangle.
+    */
     void Intersect( const wxRect2DDouble &otherRect );
+    /**
+        Returns the intersecting rectangle of this rectangle with another one.
+    */
     wxRect2DDouble CreateIntersection( const wxRect2DDouble &otherRect ) const;
+    /**
+        Returns @true if this rectangle has a non-empty intersection with the
+        rectangle @a rect and @false otherwise.
+    */
     bool Intersects( const wxRect2DDouble &rect ) const;
 
+    /**
+        Returns the union rectangle of two rectangles.
+    */
     static void Union( const wxRect2DDouble &src1 , const wxRect2DDouble &src2 , wxRect2DDouble *dest );
+    /**
+        Expands the rectangle to the union with another rectangle.
+    */
     void Union( const wxRect2DDouble &otherRect );
+    /**
+        Expands the rectangle to include the point at @c pt.
+    */
     void Union( const wxPoint2DDouble &pt );
+    /**
+        Returns the union of this rectangle with another one.
+    */
     wxRect2DDouble CreateUnion( const wxRect2DDouble &otherRect ) const;
 
     void Scale( wxDouble f );
     void Scale( wxInt32 num , wxInt32 denum );
+
+    ///@{
+    /**
+        Increases the size of the rectangle.
+
+        The left border is moved farther left and the right border is moved
+        farther right by @a dx. The upper border is moved farther up and the
+        bottom border is moved farther down by @a dy. (Note that the width and
+        height of the rectangle thus change by 2*dx and 2*dy, respectively.) If
+        one or both of @a dx and @a dy are negative, the opposite happens: the
+        rectangle size decreases in the respective direction.
+
+        Inflating and deflating behaves "naturally". Defined more precisely,
+        that means:
+        -# "Real" inflates (that is, @a dx and/or @a dy = 0) are not
+           constrained. Thus inflating a rectangle can cause its upper left
+           corner to move into the negative numbers. (2.5.4 and older forced
+           the top left coordinate to not fall below (0, 0), which implied a
+           forced move of the rectangle.)
+        -# Deflates are clamped to not reduce the width or height of the
+           rectangle below zero. In such cases, the top-left corner is
+           nonetheless handled properly. For example, a rectangle at (10, 10)
+           with size (20, 40) that is inflated by (-15, -15) will become
+           located at (20, 25) at size (0, 10). Finally, observe that the width
+           and height are treated independently. In the above example, the
+           width is reduced by 20, whereas the height is reduced by the full 30
+           (rather than also stopping at 20, when the width reached zero).
+
+        @see Deflate()
+        @since 3.3.0
+    */
+    wxRect2DDouble& Inflate(wxDouble dx, wxDouble dy);
+    /// @overload
+    wxRect2DDouble& Inflate(const wxSize& d);
+    /// @overload
+    wxRect2DDouble& Inflate(wxDouble d);
+    /// @overload
+    wxRect2DDouble Inflate(wxDouble dx, wxDouble dy) const;
+    ///@}
+
+    ///@{
+    /**
+        Decrease the rectangle size.
+
+        This method is the opposite from Inflate(): Deflate(a, b) is equivalent
+        to Inflate(-a, -b). Please refer to Inflate() for full description.
+
+        @since 3.3.0
+    */
+    wxRect2DDouble& Deflate(wxDouble dx, wxDouble dy);
+    /// @overload
+    wxRect2DDouble& Deflate(const wxSize& d);
+    /// @overload
+    wxRect2DDouble& Deflate(wxDouble d);
+    /// @overload
+    wxRect2DDouble Deflate(wxDouble dx, wxDouble dy) const;
+    ///@}
+
+    /**
+        Returns the rectangle as a wxRect.
+
+        @since 3.3.0
+    */
+    wxRect ToRect() const;
 
     wxRect2DDouble& operator = (const wxRect2DDouble& rect);
     bool operator == (const wxRect2DDouble& rect) const;

--- a/interface/wx/geometry.h
+++ b/interface/wx/geometry.h
@@ -129,13 +129,13 @@ wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxInt32 n);
 
 /**
     wxRect2DDouble is an axis-aligned rectangle;
-    each side of the rect is parallel to the x - or m_y - axis.
+    each side of the rect is parallel to the X or Y axis.
 
     The rectangle is either defined by the top left and bottom right corner,
     or by the top left corner and size.
 
-    A point is contained within the rectangle if left <= x < right
-    and top <= m_y < bottom; thus, it is a half open interval.
+    A point is contained within the rectangle if left <= @c @c m_x < right
+    and top <= @c m_y < bottom; thus, it is a half open interval.
 
     @note wxRect2DDouble has subtle differences from wxRect in how its edge
      and corner functions work. With wxRect2DDouble, there are two counterparts:
@@ -382,6 +382,11 @@ public:
     */
     bool HaveEqualSize( const wxRect2DDouble &rect ) const;
 
+    /**
+        Offsets the rectangle by @c x and @c y, but maintains the bottom right corner.
+
+        @note This will affect the width and height of the rectangle.
+    */
     void Inset( wxDouble x , wxDouble y );
     void Inset( wxDouble left , wxDouble top ,wxDouble right , wxDouble bottom  );
     /**
@@ -505,9 +510,23 @@ public:
     */
     wxRect ToRect() const;
 
+    /**
+        @name Miscellaneous operators
+    */
+    ///@{
+    /**
+        Assignment operator.
+    */
     wxRect2DDouble& operator = (const wxRect2DDouble& rect);
+    /**
+        Equality operator.
+    */
     bool operator == (const wxRect2DDouble& rect) const;
+    /**
+        Inequality operator.
+    */
     bool operator != (const wxRect2DDouble& rect) const;
+    ///@}
 
     wxDouble  m_x;
     wxDouble  m_y;

--- a/src/common/geometry.cpp
+++ b/src/common/geometry.cpp
@@ -134,6 +134,39 @@ void wxRect2DDouble::ConstrainTo( const wxRect2DDouble &rect )
         SetTop( rect.GetTop() );
 }
 
+wxRect2DDouble& wxRect2DDouble::Inflate(wxDouble dx, wxDouble dy)
+{
+    if (-2 * dx > m_width)
+    {
+        // Don't allow deflate to eat more width than we have,
+        // a well-defined rectangle cannot have negative width.
+        m_x += m_width / 2;
+        m_width = 0;
+    }
+    else
+    {
+        // The inflate is valid.
+        m_x -= dx;
+        m_width += 2 * dx;
+    }
+
+    if (-2 * dy > m_height)
+    {
+        // Don't allow deflate to eat more height than we have,
+        // a well-defined rectangle cannot have negative height.
+        m_y += m_height / 2;
+        m_height = 0;
+    }
+    else
+    {
+        // The inflate is valid.
+        m_y -= dy;
+        m_height += 2 * dy;
+    }
+
+    return *this;
+}
+
 // integer version
 
 // for the following calculations always remember


### PR DESCRIPTION
Add functions to give it parity with `wxRect`: explicit `wxRect `CTOR, `GetX`, `GetY`, `Set/GetWidth`, `Set/GetHeight`, `Offset` overload, `Inflate`, `Deflate`, `ToRect` conversion helper.

Add `wxNODISCARD `where appropriate.

Added as much documentation as I could to interface file.

Behaviour differing from `wxRect` is now explained.