### PR TITLE
Fix building webrequest and webview samples

### DIFF
--- a/samples/webrequest/webrequest.cpp
+++ b/samples/webrequest/webrequest.cpp
@@ -55,7 +55,7 @@ public:
         mainSizer->Add(new wxStaticText(this, wxID_ANY, "Request URL:"),
             wxSizerFlags().Border());
         m_urlTextCtrl = new wxTextCtrl(this, wxID_ANY,
-            url.empty() ? "https://www.wxwidgets.org/downloads/logos/blocks.png"
+            url.empty() ? wxString("https://www.wxwidgets.org/downloads/logos/blocks.png")
                         : url,
             wxDefaultPosition, wxDefaultSize,
             wxTE_PROCESS_ENTER);

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -1324,7 +1324,7 @@ void WebFrame::OnToolsClicked(wxCommandEvent& WXUNUSED(evt))
     // them at least some name if we don't have anything better.
     const auto makeLabel = [](const wxString& title)
     {
-        return title.empty() ? "(untitled)" : title;
+        return title.empty() ? wxString("(untitled)") : title;
     };
 
     wxMenuItem* item;


### PR DESCRIPTION
Using a const char* and a wxString in the two branches of the ternary
operator resulted in compile-time errors when using C++20 standard
since the result type of the conditional expression was ambiguous,
so add explicit conversions to fix it.

See also #19355.

---------
This should be backported to 3.2.