### PR TITLE
Fix desync button events

### DIFF
--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -2266,7 +2266,6 @@ typedef wxBitmapButton wxPGEditorBitmapButton;
 
 void wxPGMultiButton::Add( const wxBitmapBundle& bitmap, int itemid )
 {
-    itemid = GenId(itemid);
     wxSize sz = GetSize();
 
     // Internal margins around the bitmap inside the button
@@ -2311,7 +2310,6 @@ void wxPGMultiButton::Add( const wxBitmapBundle& bitmap, int itemid )
 
 void wxPGMultiButton::Add( const wxString& label, int itemid )
 {
-    itemid = GenId(itemid);
     wxSize sz = GetSize();
     wxButton* button = new wxButton(this, itemid, label,
                     wxPoint(sz.x, 0), wxSize(wxDefaultCoord, sz.y), wxBU_EXACTFIT);


### PR DESCRIPTION
When adding a button to wxPGMultiButton via Add(..., XRCID("text")) the text's corresponding id is added to XRCID_Records array, but the id gets reset in wxPGMultiButton::GenId and recalculated in wxWindowBase::CreateBase.

Avoid regenerating the id if itemid < 0.