### PR TITLE
Avoid repainting when windows are being destroyed in wxMSW

### DIFF
--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -311,6 +311,11 @@ int wxNotebook::MSWGetToolTipMessage() const
 
 wxNotebook::~wxNotebook()
 {
+    // Make sure we don't try to repaint the notebook any more: not only is
+    // this useless, it can also crash when calling member functions of a
+    // half-destroyed object.
+    Unbind(wxEVT_PAINT, &wxNotebook::OnPaint, this);
+
 #if wxUSE_UXTHEME
     if ( m_hbrBackground )
         ::DeleteObject((HBRUSH)m_hbrBackground);

--- a/src/msw/statbmp.cpp
+++ b/src/msw/statbmp.cpp
@@ -161,8 +161,6 @@ void wxStaticBitmap::Free()
 {
     m_bitmap.UnRef();
 
-    MSWReplaceImageHandle(0);
-
     if ( m_ownsCurrentHandle )
     {
         ::DeleteObject(m_currentHandle);


### PR DESCRIPTION
This fixes #25499 twice over.