### PR TITLE
Add copyright info to libpng and libjpeg's GetLibraryVersionInfo(), fix libtiff's

### DIFF
--- a/src/common/imagjpeg.cpp
+++ b/src/common/imagjpeg.cpp
@@ -506,7 +506,6 @@ bool wxJPEGHandler::DoCanRead( wxInputStream& stream )
 {
     struct jpeg_error_mgr err{};
     jpeg_std_error(&err);
-    err.last_jpeg_message = JMSG_COPYRIGHT;
 
 #if defined(JPEG_LIB_VERSION_MAJOR) && defined(JPEG_LIB_VERSION_MINOR)
     return wxVersionInfo("libjpeg", JPEG_LIB_VERSION_MAJOR, JPEG_LIB_VERSION_MINOR,

--- a/src/common/imagjpeg.cpp
+++ b/src/common/imagjpeg.cpp
@@ -35,7 +35,9 @@
 #endif
 
 #include "jpeglib.h"
+#if wxHAS_CXX17_INCLUDE("jversion.h")
 #include "jversion.h"
+#endif
 
 #include "wx/filefn.h"
 #include "wx/wfstream.h"

--- a/src/common/imagjpeg.cpp
+++ b/src/common/imagjpeg.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include "jpeglib.h"
+#include "jversion.h"
 
 #include "wx/filefn.h"
 #include "wx/wfstream.h"
@@ -503,10 +504,19 @@ bool wxJPEGHandler::DoCanRead( wxInputStream& stream )
 
 /*static*/ wxVersionInfo wxJPEGHandler::GetLibraryVersionInfo()
 {
-#if defined(JPEG_LIB_VERSION_MAJOR) && defined(JPEG_LIB_VERSION_MINOR)
-    return wxVersionInfo("libjpeg", JPEG_LIB_VERSION_MAJOR, JPEG_LIB_VERSION_MINOR);
+    const wxString copyRight =
+#ifdef JCOPYRIGHT
+    JCOPYRIGHT;
 #else
-    return wxVersionInfo("libjpeg", JPEG_LIB_VERSION / 10, JPEG_LIB_VERSION % 10);
+    "";
+#endif
+
+#if defined(JPEG_LIB_VERSION_MAJOR) && defined(JPEG_LIB_VERSION_MINOR)
+    return wxVersionInfo("libjpeg", JPEG_LIB_VERSION_MAJOR, JPEG_LIB_VERSION_MINOR,
+                         0, 0, wxString{}, copyRight);
+#else
+    return wxVersionInfo("libjpeg", JPEG_LIB_VERSION / 10, JPEG_LIB_VERSION % 10,
+                         0, 0, wxString{}, copyRight);
 #endif
 }
 

--- a/src/common/imagjpeg.cpp
+++ b/src/common/imagjpeg.cpp
@@ -35,9 +35,7 @@
 #endif
 
 #include "jpeglib.h"
-#if wxHAS_CXX17_INCLUDE("jversion.h")
-#include "jversion.h"
-#endif
+#include "jerror.h"
 
 #include "wx/filefn.h"
 #include "wx/wfstream.h"
@@ -506,19 +504,16 @@ bool wxJPEGHandler::DoCanRead( wxInputStream& stream )
 
 /*static*/ wxVersionInfo wxJPEGHandler::GetLibraryVersionInfo()
 {
-    const wxString copyRight =
-#ifdef JCOPYRIGHT
-    JCOPYRIGHT;
-#else
-    "";
-#endif
+    struct jpeg_error_mgr err{};
+    jpeg_std_error(&err);
+    err.last_jpeg_message = JMSG_COPYRIGHT;
 
 #if defined(JPEG_LIB_VERSION_MAJOR) && defined(JPEG_LIB_VERSION_MINOR)
     return wxVersionInfo("libjpeg", JPEG_LIB_VERSION_MAJOR, JPEG_LIB_VERSION_MINOR,
-                         0, 0, wxString{}, copyRight);
+                         0, 0, wxString{}, err.jpeg_message_table[JMSG_COPYRIGHT]);
 #else
     return wxVersionInfo("libjpeg", JPEG_LIB_VERSION / 10, JPEG_LIB_VERSION % 10,
-                         0, 0, wxString{}, copyRight);
+                         0, 0, wxString{}, err.jpeg_message_table[JMSG_COPYRIGHT]);
 #endif
 }
 

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -856,6 +856,17 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
 
     wxString copyRight = png_get_copyright(nullptr);
     copyRight.Trim(true).Trim(false);
+    // The copyright string may include the version info in the first line.
+    // If it does, then remove it.
+    if (copyRight.starts_with("libpng"))
+    {
+        size_t firstNewLine = copyRight.find(L'\n');
+        if (firstNewLine != wxString::npos)
+        {
+            copyRight.erase(0, firstNewLine);
+            copyRight.Trim(false);
+        }
+    }
 
     return wxVersionInfo("libpng",
                          PNG_LIBPNG_VER_MAJOR,

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -851,14 +851,19 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
 {
     // The version string seems to always have a leading space and a trailing
     // new line, get rid of them both.
-    wxString str = png_get_header_version(nullptr) + 1;
-    str.Replace("\n", "");
+    wxString str = png_get_header_version(nullptr);
+    str.Trim(true).Trim(false);
+
+    wxString copyRight = png_get_copyright(nullptr);
+    copyRight.Trim(true).Trim(false);
 
     return wxVersionInfo("libpng",
                          PNG_LIBPNG_VER_MAJOR,
                          PNG_LIBPNG_VER_MINOR,
                          PNG_LIBPNG_VER_RELEASE,
-                         str);
+                         0,
+                         str,
+                         copyRight);
 }
 
 #endif  // wxUSE_LIBPNG

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -863,8 +863,7 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
         size_t firstNewLine = copyRight.find(L'\n');
         if (firstNewLine != wxString::npos)
         {
-            copyRight.erase(0, firstNewLine);
-            copyRight.Trim(false);
+            copyRight.erase(0, firstNewLine + 1);
         }
     }
 

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -872,7 +872,7 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
                          PNG_LIBPNG_VER_MAJOR,
                          PNG_LIBPNG_VER_MINOR,
                          PNG_LIBPNG_VER_RELEASE,
-                         0,
+                         PNG_LIBPNG_VER_BUILD,
                          str,
                          copyRight);
 }

--- a/src/common/imagtiff.cpp
+++ b/src/common/imagtiff.cpp
@@ -918,7 +918,7 @@ bool wxTIFFHandler::DoCanRead( wxInputStream& stream )
 
     wxString copyright;
     const wxString desc = ver.BeforeFirst('\n', &copyright);
-    copyright.Replace("\n", wxString());
+    copyright.Trim(false).Trim(true);
 
     return wxVersionInfo("libtiff", major, minor, micro, desc, copyright);
 }

--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -1334,7 +1334,8 @@ wxVersionInfo wxRegEx::GetLibraryVersionInfo()
     wxRegChar buf[64];
     pcre2_config(PCRE2_CONFIG_VERSION, buf);
 
-    return wxVersionInfo("PCRE2", PCRE2_MAJOR, PCRE2_MINOR, 0, buf);
+    return wxVersionInfo("PCRE2", PCRE2_MAJOR, PCRE2_MINOR, 0,
+                         wxString{ "PCRE2 " } + buf);
 }
 
 #endif // wxUSE_REGEX


### PR DESCRIPTION
Also adds lib name to PCRE's description to make it consistent with other libraries. Below are how the current descriptions appear:

![image](https://github.com/user-attachments/assets/c12c15b5-17cb-442b-bd9b-b18c5ccf19c8)

Also, fixes libtiff's copyright. Currently, it looks like this:

"Copyright (c) 1988-1996 Sam LefflerCopyright (c) 1991-1996 Silicon Graphics, Inc."

Note the "LefflerCopyright". Newlines will now be preserved.

Also, use `wxString::Trim` instead of using pointer arithmetic that makes assumptions when getting _libpng_ description.