### PR TITLE
`wxHyperlinkCtrl` improvements

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -1378,6 +1378,14 @@ page.
 @endTable
 
 
+@subsubsection xrc_wxgenerichyperlinkctrl wxGenericHyperlinkCtrl
+
+This handler is identical to the one for @ref xrc_wxhyperlinkctrl
+"wxHyperlinkCtrl", please see it for more information. The only difference is
+that, for the platforms with a native wxHyperlinkCtrl implementation, using
+this handler creates a generic control rather than a native one.
+
+
 @subsubsection xrc_wxinfobar wxInfoBar
 
 @beginTable

--- a/include/wx/msw/hyperlink.h
+++ b/include/wx/msw/hyperlink.h
@@ -63,6 +63,8 @@ public:
     virtual void SetVisitedColour(const wxColour &colour) override;
 
     // overridden/inherited wxWindow methods
+    virtual bool SetForegroundColour(const wxColour& colour) override;
+
     virtual wxVisualAttributes GetDefaultAttributes() const override;
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);

--- a/include/wx/msw/hyperlink.h
+++ b/include/wx/msw/hyperlink.h
@@ -63,6 +63,7 @@ public:
     virtual void SetVisitedColour(const wxColour &colour) override;
 
     // overridden/inherited wxWindow methods
+    virtual bool Enable(bool enable = true) override;
     virtual bool SetForegroundColour(const wxColour& colour) override;
 
     virtual wxVisualAttributes GetDefaultAttributes() const override;
@@ -78,6 +79,10 @@ private:
 
     bool MSWAreCustomColoursEnabled() const;
     void MSWEnableCustomColours();
+
+    // This is set to the previously used colour when the control is disabled,
+    // to be able to restore it later when the control is enabled again.
+    wxColour m_savedEnabledColour;
 
     wxDECLARE_DYNAMIC_CLASS( wxHyperlinkCtrl );
 };

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -191,6 +191,7 @@ builtinWindowClasses =
     | wxGauge
     | wxGenericAnimationCtrl
     | wxGenericDirCtrl
+    | wxGenericHyperlinkCtrl
     | wxGrid
     | wxHtmlWindow
     | wxHyperlinkCtrl
@@ -297,6 +298,7 @@ builtinClassesNames =
     | "wxGauge"
     | "wxGenericAnimationCtrl"
     | "wxGenericDirCtrl"
+    | "wxGenericHyperlinkCtrl"
     | "wxGrid"
     | "wxHtmlWindow"
     | "wxHyperlinkCtrl"
@@ -1043,6 +1045,14 @@ wxGenericDirCtrl =
         [xrc:p="o"] element defaultfilter {_, t_integer }*
     }
 
+wxGenericHyperlinkCtrl =
+    element object {
+        attribute class { "wxGenericHyperlinkCtrl" } &
+        stdObjectNodeAttributes &
+        stdWindowProperties &
+        [xrc:p="important"] element label {_, t_text }* &
+        [xrc:p="important"] element url   {_, t_url }*
+    }
 
 wxGrid =
     element object {

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -77,6 +77,13 @@ public:
     virtual ~HyperlinkWidgetsPage() {}
 
     virtual wxWindow *GetWidget() const override { return m_hyperlink; }
+    virtual Widgets GetWidgets() const override
+    {
+        Widgets widgets(WidgetsPage::GetWidgets());
+        widgets.push_back(m_hyperlinkLong);
+        return widgets;
+    }
+
     virtual void RecreateWidget() override { CreateHyperlink(); }
 
     // lazy creation of the content

--- a/src/generic/hyperlinkg.cpp
+++ b/src/generic/hyperlinkg.cpp
@@ -200,6 +200,12 @@ void wxGenericHyperlinkCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);
 
+    if ( !IsThisEnabled() )
+    {
+        // Grey out the control when it is disabled.
+        dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    }
+
     dc.DrawText(GetLabel(), GetLabelRect().GetTopLeft());
     if (HasFocus())
     {

--- a/src/msw/hyperlink.cpp
+++ b/src/msw/hyperlink.cpp
@@ -185,6 +185,16 @@ wxColour wxHyperlinkCtrl::GetHoverColour() const
     return GetNormalColour();
 }
 
+bool wxHyperlinkCtrl::SetForegroundColour(const wxColour& colour)
+{
+    if ( !wxGenericHyperlinkCtrl::SetForegroundColour(colour) )
+        return false;
+
+    SetNormalColour(colour);
+
+    return true;
+}
+
 wxColour wxHyperlinkCtrl::GetNormalColour() const
 {
     if ( MSWAreCustomColoursEnabled() )

--- a/src/msw/hyperlink.cpp
+++ b/src/msw/hyperlink.cpp
@@ -150,6 +150,27 @@ void wxHyperlinkCtrl::SetLabel(const wxString &label)
     InvalidateBestSize();
 }
 
+bool wxHyperlinkCtrl::Enable(bool enable)
+{
+    if ( !wxGenericHyperlinkCtrl::Enable(enable) )
+        return false;
+
+    wxColour colour;
+    if ( enable )
+    {
+        colour = m_savedEnabledColour;
+    }
+    else
+    {
+        m_savedEnabledColour = GetNormalColour();
+        colour = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
+    }
+
+    SetForegroundColour(colour);
+
+    return true;
+}
+
 bool wxHyperlinkCtrl::MSWAreCustomColoursEnabled() const
 {
     LITEM litem = { };

--- a/src/msw/hyperlink.cpp
+++ b/src/msw/hyperlink.cpp
@@ -96,6 +96,10 @@ bool wxHyperlinkCtrl::Create(wxWindow *parent,
         return false;
     }
 
+    // Make sure our GetLabel() returns the label that was specified and not
+    // the HTML fragment used as the label by the native control.
+    m_labelOrig = label;
+
     if ( wxSystemSettings::GetAppearance().IsDark() )
     {
         // Override the colour used by default by the native control with the
@@ -136,7 +140,7 @@ void wxHyperlinkCtrl::SetURL(const wxString &url)
     if ( GetURL() != url )
         SetVisited( false );
     wxGenericHyperlinkCtrl::SetURL( url );
-    wxWindow::SetLabel( GetLabelForSysLink(m_labelOrig, url) );
+    SetLabel(m_labelOrig);
 }
 
 void wxHyperlinkCtrl::SetLabel(const wxString &label)

--- a/src/xrc/xh_hyperlink.cpp
+++ b/src/xrc/xh_hyperlink.cpp
@@ -57,18 +57,42 @@ wxHyperlinkCtrlXmlHandler::wxHyperlinkCtrlXmlHandler()
 
 wxObject *wxHyperlinkCtrlXmlHandler::DoCreateResource()
 {
-    XRC_MAKE_INSTANCE(control, wxHyperlinkCtrl)
+    wxHyperlinkCtrlBase* control = nullptr;
+    if ( m_instance )
+        control = wxStaticCast(m_instance, wxHyperlinkCtrlBase);
 
-    control->Create
-             (
-                m_parentAsWindow,
-                GetID(),
-                GetText(wxT("label")),
-                GetParamValue(wxT("url")),
-                GetPosition(), GetSize(),
-                GetStyle(wxT("style"), wxHL_DEFAULT_STYLE),
-                GetName()
-             );
+    if ( !control )
+    {
+        if ( m_class == "wxHyperlinkCtrl" )
+        {
+            control = new wxHyperlinkCtrl
+                          (
+                           m_parentAsWindow,
+                           GetID(),
+                           GetText(wxT("label")),
+                           GetParamValue(wxT("url")),
+                           GetPosition(), GetSize(),
+                           GetStyle(wxT("style"), wxHL_DEFAULT_STYLE),
+                           GetName()
+                          );
+        }
+        else // m_class must be "wxGenericHyperlinkCtrl"
+        {
+            control = new wxGenericHyperlinkCtrl
+                          (
+                           m_parentAsWindow,
+                           GetID(),
+                           GetText(wxT("label")),
+                           GetParamValue(wxT("url")),
+                           GetPosition(), GetSize(),
+                           GetStyle(wxT("style"), wxHL_DEFAULT_STYLE),
+                           GetName()
+                          );
+        }
+    }
+
+    if ( GetBool("hidden", 0) == 1 )
+        control->Hide();
 
     SetupWindow(control);
 
@@ -77,7 +101,8 @@ wxObject *wxHyperlinkCtrlXmlHandler::DoCreateResource()
 
 bool wxHyperlinkCtrlXmlHandler::CanHandle(wxXmlNode *node)
 {
-    return IsOfClass(node, wxT("wxHyperlinkCtrl"));
+    return IsOfClass(node, wxT("wxHyperlinkCtrl")) ||
+           IsOfClass(node, wxT("wxGenericHyperlinkCtrl"));
 }
 
 #endif // wxUSE_XRC && wxUSE_HYPERLINKCTRL


### PR DESCRIPTION
The main change here is that we now grey out native MSW `wxHyperlinkCtrl` and `wxGenericHyperlinkCtrl` when they're disabled too.

The main new thing is that we now handle `wxGenericHyperlinkCtrl` in XRC too.