### PR TITLE
Fix wxPersistent(CheckBox|RadioButton) version availability in docs

### DIFF
--- a/interface/wx/persist/checkbox.h
+++ b/interface/wx/persist/checkbox.h
@@ -22,7 +22,7 @@
     If the checkbox is checked, it will be checked again after the application
     restart.
 
-    @since 3.3.0
+    @since 3.3.1
  */
 class wxPersistentCheckBox : public wxPersistentWindow<wxCheckBox>
 {

--- a/interface/wx/persist/radiobut.h
+++ b/interface/wx/persist/radiobut.h
@@ -34,7 +34,7 @@
     the user selects white pieces, this selection will be restored during the
     subsequent run.
 
-    @since 3.3.0
+    @since 3.3.1
  */
 class wxPersistentRadioButton : public wxPersistentWindow<wxRadioButton>
 {


### PR DESCRIPTION
wxPersistentCheckBox and wxPersistentRadioButton did not make it into wxWidgets 3.3.0, they are available only since 3.3.1.