### PR TITLE
Fix bugs in wxMSW menu item finding code

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -576,10 +576,6 @@ public:
 
     // Find the menu corresponding to the given handle.
     virtual wxMenu* MSWFindMenuFromHMENU(WXHMENU hMenu);
-
-    // Find the the current menu item using the given handle and the item id
-    virtual wxMenuItem* MSWFindMenuItemFromHMENU(WXHMENU hMenu, int nItem);
-
 #endif // wxUSE_MENUS && !__WXUNIVERSAL__
 
     // Return the default button for the TLW containing this window or nullptr if

--- a/samples/statbar/statbar.cpp
+++ b/samples/statbar/statbar.cpp
@@ -53,6 +53,10 @@
 //#define USE_MDI_PARENT_FRAME 1
 #ifdef USE_MDI_PARENT_FRAME
     #include "wx/mdi.h"
+
+    using BaseFrame = wxMDIParentFrame;
+#else
+    using BaseFrame = wxFrame;
 #endif // USE_MDI_PARENT_FRAME
 
 static const char *SAMPLE_DIALOGS_TITLE = "wxWidgets statbar sample";
@@ -125,15 +129,11 @@ private:
 };
 
 // Define a new frame type: this is going to be our main frame
-#ifdef USE_MDI_PARENT_FRAME
-class MyFrame : public wxMDIParentFrame
-#else
-class MyFrame : public wxFrame
-#endif
+class MyFrame : public BaseFrame
 {
 public:
     // ctor(s)
-    MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size);
+    explicit MyFrame(const wxString& title);
 
     // event handlers (these functions should _not_ be virtual)
     void OnQuit(wxCommandEvent& event);
@@ -230,11 +230,7 @@ enum
 // the event tables connect the wxWidgets events with the functions (event
 // handlers) which process them. It can be also done at run-time, but for the
 // simple menu events like this the static method is much simpler.
-#ifdef USE_MDI_PARENT_FRAME
-wxBEGIN_EVENT_TABLE(MyFrame, wxMDIParentFrame)
-#else
-wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
-#endif
+wxBEGIN_EVENT_TABLE(MyFrame, BaseFrame)
     EVT_MENU(StatusBar_Quit,  MyFrame::OnQuit)
     EVT_MENU(StatusBar_SetFields, MyFrame::OnSetStatusFields)
     EVT_MENU(StatusBar_SetField, MyFrame::OnSetStatusField)
@@ -300,8 +296,7 @@ bool MyApp::OnInit()
         return false;
 
     // create the main application window
-    MyFrame *frame = new MyFrame("wxStatusBar sample",
-                                 wxPoint(50, 50), wxSize(450, 340));
+    MyFrame *frame = new MyFrame("wxStatusBar sample");
 
     // and show it (the frames, unlike simple controls, are not shown when
     // created initially)
@@ -318,12 +313,8 @@ bool MyApp::OnInit()
 // ----------------------------------------------------------------------------
 
 // frame constructor
-MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
-#ifdef USE_MDI_PARENT_FRAME
-    : wxMDIParentFrame(nullptr, wxID_ANY, title, pos, size)
-#else
-    : wxFrame(nullptr, wxID_ANY, title, pos, size)
-#endif
+MyFrame::MyFrame(const wxString& title)
+    : BaseFrame(nullptr, wxID_ANY, title)
 {
     SetIcon(wxICON(sample));
 

--- a/samples/statbar/statbar.cpp
+++ b/samples/statbar/statbar.cpp
@@ -344,7 +344,7 @@ MyFrame::MyFrame(const wxString& title)
                                       "wxSTB_ELLIPSIZE_END",
                                       "Toggle wxSTB_ELLIPSIZE_END style");
     statbarMenu->Append(StatusBar_SetPaneStyle, "Status bar style",
-                        statbarStyleMenu);
+                        statbarStyleMenu, "Status bar choices");
     statbarMenu->AppendSeparator();
 
     statbarMenu->Append(StatusBar_SetField, "Set active field &number\tCtrl-N",
@@ -388,7 +388,7 @@ MyFrame::MyFrame(const wxString& title)
             "Sets the style of the first field to sunken look"
         );
     statbarMenu->Append(StatusBar_SetPaneStyle, "Field style",
-                        statbarPaneStyleMenu);
+                        statbarPaneStyleMenu, "Field style choices");
 
     statbarMenu->Append(StatusBar_ResetFieldsWidth, "Reset field widths",
                         "Sets all fields to the same width");

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2454,6 +2454,9 @@ bool wxWindowMSW::DoPopupMenu(wxMenu *menu, int x, int y)
 
 #if wxUSE_MENUS && !defined(__WXUNIVERSAL__)
 
+// Find the menu item with the given ID in the given menu.
+static wxMenuItem* MSWFindMenuItemFromHMENU(WXHMENU hMenu, int nItem);
+
 bool
 wxWindowMSW::HandleMenuSelect(WXWORD nItem, WXWORD flags, WXHMENU hMenu)
 {
@@ -2526,7 +2529,7 @@ wxMenu* wxWindowMSW::MSWFindMenuFromHMENU(WXHMENU hMenu)
     return nullptr;
 }
 
-wxMenuItem* wxWindowMSW::MSWFindMenuItemFromHMENU(WXHMENU hMenu, int item)
+static wxMenuItem* MSWFindMenuItemFromHMENU(WXHMENU hMenu, int item)
 {
     WinStruct<MENUITEMINFO> mii;
     mii.fMask = MIIM_ID | MIIM_DATA; // Include MIIM_DATA to access dwItemData

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2481,13 +2481,27 @@ wxWindowMSW::HandleMenuSelect(WXWORD nItem, WXWORD flags, WXHMENU hMenu)
     wxMenuItem* menuItem = nullptr;
     if ( menu )
     {
+        int pos = 0;
         for ( auto& mi : menu->GetMenuItems() )
         {
+            // If there is a normal menu item with the same ID as the position
+            // of a submenu we give precedence to the normal item, as this
+            // seems more useful.
             if ( mi->GetId() == item )
             {
                 menuItem = mi;
                 break;
             }
+
+            // We don't get the ID for submenus, but their position in the
+            // parent window, so this is how we identify them.
+            if ( mi->IsSubMenu() && item == pos )
+            {
+                menuItem = mi;
+                break;
+            }
+
+            ++pos;
         }
     }
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2454,9 +2454,6 @@ bool wxWindowMSW::DoPopupMenu(wxMenu *menu, int x, int y)
 
 #if wxUSE_MENUS && !defined(__WXUNIVERSAL__)
 
-// Find the menu item with the given ID in the given menu.
-static wxMenuItem* MSWFindMenuItemFromHMENU(wxMenu& menu, int nItem);
-
 bool
 wxWindowMSW::HandleMenuSelect(WXWORD nItem, WXWORD flags, WXHMENU hMenu)
 {
@@ -2481,8 +2478,18 @@ wxWindowMSW::HandleMenuSelect(WXWORD nItem, WXWORD flags, WXHMENU hMenu)
 
     // Don't try to look for the menu item if it's not our menu at all, e.g. if
     // it's the per-window system menu in MDI applications.
-    wxMenuItem* const menuItem = menu ? MSWFindMenuItemFromHMENU(*menu, item)
-                                      : nullptr;
+    wxMenuItem* menuItem = nullptr;
+    if ( menu )
+    {
+        for ( auto& mi : menu->GetMenuItems() )
+        {
+            if ( mi->GetId() == item )
+            {
+                menuItem = mi;
+                break;
+            }
+        }
+    }
 
     wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, item, menu, menuItem);
     if ( wxMenu::ProcessMenuEvent(menu, event, this) )
@@ -2531,19 +2538,6 @@ wxMenu* wxWindowMSW::MSWFindMenuFromHMENU(WXHMENU hMenu)
         return wxCurrentPopupMenu;
 
     return nullptr;
-}
-
-static wxMenuItem* MSWFindMenuItemFromHMENU(wxMenu& menu, int itemId)
-{
-    for ( auto& item : menu.GetMenuItems() )
-    {
-        if ( item->GetId() == itemId )
-        {
-            return item;
-        }
-    }
-
-    return nullptr; // Not found
 }
 
 #endif // wxUSE_MENUS && !defined(__WXUNIVERSAL__)


### PR DESCRIPTION
This fixes a crash introduced in c1e2acd9e6 (MSW: Find a wxMenuItem object corresponding to a given ID [...], 2024-10-11), see #25522, and also makes this really work as expected, fixing #25505 as well.