### PR TITLE
Link libwebp when using MSVC-specific setup.h

### DIFF
--- a/include/msvc/wx/setup.h
+++ b/include/msvc/wx/setup.h
@@ -185,6 +185,9 @@
         #if wxUSE_LIBTIFF && !defined(wxNO_TIFF_LIB)
             #pragma comment(lib, wx3RD_PARTY_LIB_NAME("tiff"))
         #endif
+        #if wxUSE_LIBWEBP && !defined(wxNO_WEBP_LIB)
+            #pragma comment(lib, wx3RD_PARTY_LIB_NAME("webp"))
+        #endif
         #if wxUSE_STC && !defined(wxNO_STC_LIB)
             #pragma comment(lib, wx3RD_PARTY_LIB_NAME("scintilla"))
             #pragma comment(lib, wx3RD_PARTY_LIB_NAME("lexilla"))


### PR DESCRIPTION
Recently added libwebp was not added to the libraries MSVC automatically links with when adding "$(WXWIN)\include\msvc" to the include paths.

This should have been part of ad6f05a (Add support for WebP image format, including animations, 2025-05-11).