### PR TITLE
Store and retrieve PNG Description text chunk

### DIFF
--- a/include/wx/imagpng.h
+++ b/include/wx/imagpng.h
@@ -20,7 +20,8 @@
 #include "wx/image.h"
 #include "wx/versioninfo.h"
 
-#define wxIMAGE_OPTION_PNG_DESCRIPTION wxT("PngDescription")
+#define wxIMAGE_OPTION_PNG_DESCRIPTION     wxT("PngDescription")
+#define wxIMAGE_OPTION_PNG_DESCRIPTION_KEY wxString("Description")
 
 #define wxIMAGE_OPTION_PNG_FORMAT    wxT("PngFormat")
 #define wxIMAGE_OPTION_PNG_BITDEPTH  wxT("PngBitDepth")

--- a/include/wx/imagpng.h
+++ b/include/wx/imagpng.h
@@ -21,7 +21,6 @@
 #include "wx/versioninfo.h"
 
 #define wxIMAGE_OPTION_PNG_DESCRIPTION     wxT("PngDescription")
-#define wxIMAGE_OPTION_PNG_DESCRIPTION_KEY wxString("Description")
 
 #define wxIMAGE_OPTION_PNG_FORMAT    wxT("PngFormat")
 #define wxIMAGE_OPTION_PNG_BITDEPTH  wxT("PngBitDepth")

--- a/include/wx/imagpng.h
+++ b/include/wx/imagpng.h
@@ -20,6 +20,8 @@
 #include "wx/image.h"
 #include "wx/versioninfo.h"
 
+#define wxIMAGE_OPTION_PNG_DESCRIPTION wxT("PngDescription")
+
 #define wxIMAGE_OPTION_PNG_FORMAT    wxT("PngFormat")
 #define wxIMAGE_OPTION_PNG_BITDEPTH  wxT("PngBitDepth")
 #define wxIMAGE_OPTION_PNG_FILTER    wxT("PngF")

--- a/include/wx/imagpng.h
+++ b/include/wx/imagpng.h
@@ -20,8 +20,6 @@
 #include "wx/image.h"
 #include "wx/versioninfo.h"
 
-#define wxIMAGE_OPTION_PNG_DESCRIPTION     wxT("PngDescription")
-
 #define wxIMAGE_OPTION_PNG_FORMAT    wxT("PngFormat")
 #define wxIMAGE_OPTION_PNG_BITDEPTH  wxT("PngBitDepth")
 #define wxIMAGE_OPTION_PNG_FILTER    wxT("PngF")
@@ -29,6 +27,7 @@
 #define wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL   wxT("PngZM")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_STRATEGY    wxT("PngZS")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_BUFFER_SIZE wxT("PngZB")
+#define wxIMAGE_OPTION_PNG_DESCRIPTION             wxT("PngDescription")
 
 enum
 {

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -148,6 +148,18 @@ enum wxImagePNGType
 #define wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL        wxString("PngZM")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_STRATEGY         wxString("PngZS")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_BUFFER_SIZE      wxString("PngZB")
+
+/**
+Key used for setting an image option that, upon saving to a PNG file, will be
+converted to an iTXt chunk with the key: "Description", and stored in the file.
+
+Uncompressed tEXt and iTXt chunks with the key: "Description" are automatically
+retrieved upon loading of a PNG file, and stored in this image option. If
+multiple chunks with this key are present, only the first is retrieved.
+
+@since 3.3.1
+@see wxImage::GetOption()
+*/
 #define wxIMAGE_OPTION_PNG_DESCRIPTION                  wxString("PngDescription")
 
 #define wxIMAGE_OPTION_TIFF_BITSPERSAMPLE               wxString("BitsPerSample")

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -1324,8 +1324,14 @@ public:
             a GIF it will not be repeated in other frames.
 
         Options specific to wxPNGHandler:
-        @li @c wxIMAGE_OPTION_PNG_DESCRIPTION: The Description text chunk that
-            is read from or written to the PNG file.
+        @li @c wxIMAGE_OPTION_PNG_DESCRIPTION: The contents of this option will
+            be converted to an uncompressed iTXt chunk with the key: "Description",
+            and written to the PNG file upon saving.
+            Contents of uncompressed tXTt and iTXt chunks with the key: "Description"
+            are also automatically retrieved upon loading a PNG file, and stored in
+            this option. If multiple chunks with this key are present, only the first
+            is retrieved.
+            @since 3.3.1
 
         @param name
             The name of the option, case-insensitive.

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -148,18 +148,6 @@ enum wxImagePNGType
 #define wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL        wxString("PngZM")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_STRATEGY         wxString("PngZS")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_BUFFER_SIZE      wxString("PngZB")
-
-/**
-Key used for setting an image option that, upon saving to a PNG file, will be
-converted to an iTXt chunk with the key: "Description", and stored in the file.
-
-Uncompressed tEXt and iTXt chunks with the key: "Description" are automatically
-retrieved upon loading of a PNG file, and stored in this image option. If
-multiple chunks with this key are present, only the first is retrieved.
-
-@since 3.3.1
-@see wxImage::GetOption()
-*/
 #define wxIMAGE_OPTION_PNG_DESCRIPTION                  wxString("PngDescription")
 
 #define wxIMAGE_OPTION_TIFF_BITSPERSAMPLE               wxString("BitsPerSample")

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -1339,7 +1339,7 @@ public:
         @li @c wxIMAGE_OPTION_PNG_DESCRIPTION: The contents of this option will
             be converted to an uncompressed iTXt chunk with the key "Description",
             and written to the PNG file upon saving.
-            Contents of uncompressed tXTt and iTXt chunks with the key: "Description"
+            Contents of uncompressed tXTt and iTXt chunks with the key "Description"
             are also automatically retrieved upon loading a PNG file, and stored in
             this option. If multiple chunks with this key are present, only the first
             is retrieved.

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -148,6 +148,7 @@ enum wxImagePNGType
 #define wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL        wxString("PngZM")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_STRATEGY         wxString("PngZS")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_BUFFER_SIZE      wxString("PngZB")
+#define wxIMAGE_OPTION_PNG_DESCRIPTION                  wxString("PngDescription")
 
 #define wxIMAGE_OPTION_TIFF_BITSPERSAMPLE               wxString("BitsPerSample")
 #define wxIMAGE_OPTION_TIFF_SAMPLESPERPIXEL             wxString("SamplesPerPixel")
@@ -1321,6 +1322,10 @@ public:
             or written to the GIF file. In an animated GIF each frame can have
             its own comment. If there is only a comment in the first frame of
             a GIF it will not be repeated in other frames.
+
+        Options specific to wxPNGHandler:
+        @li @c wxIMAGE_OPTION_PNG_DESCRIPTION: The Description text chunk that
+            is read from or written to the PNG file.
 
         @param name
             The name of the option, case-insensitive.

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -1337,7 +1337,7 @@ public:
 
         Options specific to wxPNGHandler:
         @li @c wxIMAGE_OPTION_PNG_DESCRIPTION: The contents of this option will
-            be converted to an uncompressed iTXt chunk with the key: "Description",
+            be converted to an uncompressed iTXt chunk with the key "Description",
             and written to the PNG file upon saving.
             Contents of uncompressed tXTt and iTXt chunks with the key: "Description"
             are also automatically retrieved upon loading a PNG file, and stored in

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -1324,13 +1324,13 @@ public:
             a GIF it will not be repeated in other frames.
 
         Options specific to wxPNGHandler:
-        @li @c wxIMAGE_OPTION_PNG_DESCRIPTION: The contents of this option will
-            be converted to an uncompressed iTXt chunk with the key "Description",
-            and written to the PNG file upon saving.
-            Contents of uncompressed tXTt and iTXt chunks with the key "Description"
-            are also automatically retrieved upon loading a PNG file, and stored in
-            this option. If multiple chunks with this key are present, only the first
-            is retrieved.
+        @li @c wxIMAGE_OPTION_PNG_DESCRIPTION: The contents of this option
+            will be converted to an uncompressed iTXt chunk with the
+            key: "Description", and written to the PNG file upon saving.
+            Contents of tXTt and iTXt chunks with the key: "Description" are
+            also automatically retrieved upon loading a PNG file, and stored
+            in this option. If multiple chunks with this key are present,
+            only one is retrieved.
             @since 3.3.1
 
         @param name

--- a/interface/wx/imagpng.h
+++ b/interface/wx/imagpng.h
@@ -5,6 +5,16 @@
 // Licence:     wxWindows licence
 ////////////////////////////////////////////////////////////////////////////
 
+/**
+Key used for setting an image option that, upon saving to a PNG file, will be
+converted to an iTXt chunk with the key: "Description", and stored in the file.
+
+Uncompressed tEXt and iTXt chunks with the key: "Description" are automatically
+retrieved upon loading of a PNG file, and stored in this image option. If
+multiple chunks with this key are present, only the first is retrieved.
+
+@since 3.3.1
+*/
 #define wxIMAGE_OPTION_PNG_DESCRIPTION              wxT("PngDescription")
 
 #define wxIMAGE_OPTION_PNG_FORMAT                   wxT("PngFormat")

--- a/interface/wx/imagpng.h
+++ b/interface/wx/imagpng.h
@@ -5,6 +5,14 @@
 // Licence:     wxWindows licence
 ////////////////////////////////////////////////////////////////////////////
 
+#define wxIMAGE_OPTION_PNG_FORMAT                   wxT("PngFormat")
+#define wxIMAGE_OPTION_PNG_BITDEPTH                 wxT("PngBitDepth")
+#define wxIMAGE_OPTION_PNG_FILTER                   wxT("PngF")
+#define wxIMAGE_OPTION_PNG_COMPRESSION_LEVEL        wxT("PngZL")
+#define wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL    wxT("PngZM")
+#define wxIMAGE_OPTION_PNG_COMPRESSION_STRATEGY     wxT("PngZS")
+#define wxIMAGE_OPTION_PNG_COMPRESSION_BUFFER_SIZE  wxT("PngZB")
+
 /**
 Key used for setting an image option that, upon saving to a PNG file, will be
 converted to an iTXt chunk with the key: "Description", and stored in the file.
@@ -14,16 +22,9 @@ retrieved upon loading of a PNG file, and stored in this image option. If
 multiple chunks with this key are present, only the first is retrieved.
 
 @since 3.3.1
+@see wxImage::GetOption()
 */
 #define wxIMAGE_OPTION_PNG_DESCRIPTION              wxT("PngDescription")
-
-#define wxIMAGE_OPTION_PNG_FORMAT                   wxT("PngFormat")
-#define wxIMAGE_OPTION_PNG_BITDEPTH                 wxT("PngBitDepth")
-#define wxIMAGE_OPTION_PNG_FILTER                   wxT("PngF")
-#define wxIMAGE_OPTION_PNG_COMPRESSION_LEVEL        wxT("PngZL")
-#define wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL    wxT("PngZM")
-#define wxIMAGE_OPTION_PNG_COMPRESSION_STRATEGY     wxT("PngZS")
-#define wxIMAGE_OPTION_PNG_COMPRESSION_BUFFER_SIZE  wxT("PngZB")
 
 /* These are already in interface/wx/image.h
     They were likely put there as a stopgap, but they've been there long enough

--- a/interface/wx/imagpng.h
+++ b/interface/wx/imagpng.h
@@ -5,6 +5,8 @@
 // Licence:     wxWindows licence
 ////////////////////////////////////////////////////////////////////////////
 
+#define wxIMAGE_OPTION_PNG_DESCRIPTION              wxT("PngDescription")
+
 #define wxIMAGE_OPTION_PNG_FORMAT                   wxT("PngFormat")
 #define wxIMAGE_OPTION_PNG_BITDEPTH                 wxT("PngBitDepth")
 #define wxIMAGE_OPTION_PNG_FILTER                   wxT("PngF")

--- a/interface/wx/imagpng.h
+++ b/interface/wx/imagpng.h
@@ -12,18 +12,6 @@
 #define wxIMAGE_OPTION_PNG_COMPRESSION_MEM_LEVEL    wxT("PngZM")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_STRATEGY     wxT("PngZS")
 #define wxIMAGE_OPTION_PNG_COMPRESSION_BUFFER_SIZE  wxT("PngZB")
-
-/**
-Key used for setting an image option that, upon saving to a PNG file, will be
-converted to an iTXt chunk with the key: "Description", and stored in the file.
-
-Uncompressed tEXt and iTXt chunks with the key: "Description" are automatically
-retrieved upon loading of a PNG file, and stored in this image option. If
-multiple chunks with this key are present, only the first is retrieved.
-
-@since 3.3.1
-@see wxImage::GetOption()
-*/
 #define wxIMAGE_OPTION_PNG_DESCRIPTION              wxT("PngDescription")
 
 /* These are already in interface/wx/image.h

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -786,7 +786,8 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
         text.compression = PNG_ITXT_COMPRESSION_NONE;
         text.key =  const_cast<char*>(wxIMAGE_OPTION_PNG_DESCRIPTION_KEY.utf8_str().data());
         text.text = const_cast<char*>(description.utf8_str().data());
-        text.text_length = description.length();
+        text.text_length = 0;
+        text.itxt_length = description.length();
         png_set_text( png_ptr, info_ptr, &text, 1 );
     }
 

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -345,7 +345,7 @@ wxPNGImageData::DoLoadPNGFile(wxImage* image, wxPNGInfoStruct& wxinfo)
 
     // load "Description" text chunk
     png_textp text_ptr;
-    int num_comments = png_get_text(png_ptr, info_ptr, &text_ptr, NULL);
+    int num_comments = png_get_text(png_ptr, info_ptr, &text_ptr, nullptr);
     for (int i = 0; i < num_comments; ++i)
     {
         if (text_ptr[i].compression != PNG_TEXT_COMPRESSION_NONE) continue; // ignoring compressed ones cause I don't know how to handle them

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -773,7 +773,7 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
     {
         const wxString& text = image->GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION);
 
-        wxScopedPtr<png_text> text_ptr(new png_text[1]);
+        png_text text;
         text_ptr.get()[0].compression = PNG_ITXT_COMPRESSION_NONE;
         text_ptr.get()[0].key =  const_cast<char*>(wxIMAGE_OPTION_PNG_DESCRIPTION_KEY.utf8_str().data());
         text_ptr.get()[0].text = const_cast<char*>(text.utf8_str().data());

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -346,7 +346,7 @@ wxPNGImageData::DoLoadPNGFile(wxImage* image, wxPNGInfoStruct& wxinfo)
 
     // load "Description" text chunk
     png_textp text_ptr;
-    int num_comments = png_get_text( png_ptr, info_ptr, &text_ptr, nullptr );
+    const int num_comments = png_get_text( png_ptr, info_ptr, &text_ptr, nullptr );
     for (int i = 0; i < num_comments; ++i)
     {
         if (text_ptr[i].compression == PNG_TEXT_COMPRESSION_NONE) // Latin-1 encoding

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -346,7 +346,6 @@ wxPNGImageData::DoLoadPNGFile(wxImage* image, wxPNGInfoStruct& wxinfo)
     png_read_image( png_ptr, lines );
 
     // load "Description" text chunk
-#if defined(PNG_READ_iTXt_SUPPORTED) || defined(PNG_READ_tEXt_SUPPORTED)
     png_textp text_ptr;
     const int num_comments = png_get_text( png_ptr, info_ptr, &text_ptr, nullptr );
     for (int i = 0; i < num_comments; ++i)
@@ -378,7 +377,6 @@ wxPNGImageData::DoLoadPNGFile(wxImage* image, wxPNGInfoStruct& wxinfo)
                 image->SetOption(wxIMAGE_OPTION_PNG_DESCRIPTION, description);
         }
     }
-#endif // defined(PNG_READ_iTXt_SUPPORTED) || defined(PNG_READ_tEXt_SUPPORTED)
 
     png_read_end( png_ptr, info_ptr );
 
@@ -777,7 +775,6 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
     png_set_sBIT( png_ptr, info_ptr, &sig_bit );
 
     // save "Description" text chunk
-#if defined(PNG_WRITE_iTXt_SUPPORTED) || defined(PNG_WRITE_tEXt_SUPPORTED)
     if (image->HasOption(wxIMAGE_OPTION_PNG_DESCRIPTION))
     {
         const wxString& description = image->GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION);
@@ -786,22 +783,13 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
         text.key = const_cast<char*>(wxIMAGE_OPTION_PNG_DESCRIPTION_KEY);
         text.lang = nullptr;
         text.lang_key = nullptr;
-
-#ifdef PNG_WRITE_iTXt_SUPPORTED
         text.compression = PNG_ITXT_COMPRESSION_NONE;
-        text.text = const_cast<char*>(description.utf8_str().data());
+        const auto& buf = description.utf8_str();
+        text.text = const_cast<char*>(buf.data());
+        text.itxt_length = buf.length();
         text.text_length = 0;
-        text.itxt_length = strlen(text.text);
-#else
-        text.compression = PNG_TEXT_COMPRESSION_NONE;
-        text.text = const_cast<char*>(description.mb_str(wxConvISO8859_1).data());
-        text.text_length = strlen(text.text);
-        text.itxt_length = 0;
-#endif
-
         png_set_text( png_ptr, info_ptr, &text, 1 );
     }
-#endif // defined(PNG_WRITE_iTXt_SUPPORTED) || defined(PNG_WRITE_tEXt_SUPPORTED)
 
     png_write_info( png_ptr, info_ptr );
     png_set_shift( png_ptr, &sig_bit );

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -771,7 +771,7 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
     // save "Description" text chunk
     if (image->HasOption(wxIMAGE_OPTION_PNG_DESCRIPTION))
     {
-        wxString text = image->GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION);
+        const wxString& text = image->GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION);
 
         wxScopedPtr<png_text> text_ptr(new png_text[1]);
         text_ptr.get()[0].compression = PNG_ITXT_COMPRESSION_NONE;

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -762,7 +762,7 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
         wxSharedPtr<png_text> text_ptr(new png_text[1]); // is wxSharedPtr appropriate here?
         text_ptr.get()[0].compression = PNG_TEXT_COMPRESSION_NONE;
         text_ptr.get()[0].key =  const_cast<char*>((const char*)_("Description").mb_str(wxConvUTF8)); // again a hard coded string, is this fine?
-        text_ptr.get()[0].text = const_cast<char*>((const char*)value           .mb_str(wxConvUTF8));
+        text_ptr.get()[0].text = const_cast<char*>(value.utf8_str().data());
         text_ptr.get()[0].text_length = value.length();
         png_set_text(png_ptr, info_ptr, text_ptr.get(), 1);
     }

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -783,11 +783,22 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
         const wxString& description = image->GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION);
 
         png_text text;
+        text.key = const_cast<char*>(wxIMAGE_OPTION_PNG_DESCRIPTION_KEY.ToAscii().data());
+        text.lang = NULL;
+        text.lang_key = NULL;
+
+#ifdef PNG_iTXt_SUPPORTED
         text.compression = PNG_ITXT_COMPRESSION_NONE;
-        text.key =  const_cast<char*>(wxIMAGE_OPTION_PNG_DESCRIPTION_KEY.utf8_str().data());
         text.text = const_cast<char*>(description.utf8_str().data());
         text.text_length = 0;
-        text.itxt_length = description.length();
+        text.itxt_length = strlen(text.text);
+#else
+        text.compression = PNG_TEXT_COMPRESSION_NONE;
+        text.text = const_cast<char*>(description.ToAscii().data());
+        text.text_length = strlen(text.text);
+        text.itxt_length = 0;
+#endif // PNG_iTXt_SUPPORTED
+
         png_set_text( png_ptr, info_ptr, &text, 1 );
     }
 

--- a/src/common/imagpng.cpp
+++ b/src/common/imagpng.cpp
@@ -346,7 +346,7 @@ wxPNGImageData::DoLoadPNGFile(wxImage* image, wxPNGInfoStruct& wxinfo)
 
     // load "Description" text chunk
     png_textp text_ptr;
-    int num_comments = png_get_text(png_ptr, info_ptr, &text_ptr, nullptr);
+    int num_comments = png_get_text( png_ptr, info_ptr, &text_ptr, nullptr );
     for (int i = 0; i < num_comments; ++i)
     {
         if (text_ptr[i].compression == PNG_TEXT_COMPRESSION_NONE) // Latin-1 encoding
@@ -771,14 +771,14 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
     // save "Description" text chunk
     if (image->HasOption(wxIMAGE_OPTION_PNG_DESCRIPTION))
     {
-        wxString value = image->GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION);
+        wxString text = image->GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION);
 
         wxScopedPtr<png_text> text_ptr(new png_text[1]);
         text_ptr.get()[0].compression = PNG_ITXT_COMPRESSION_NONE;
         text_ptr.get()[0].key =  const_cast<char*>(wxIMAGE_OPTION_PNG_DESCRIPTION_KEY.utf8_str().data());
-        text_ptr.get()[0].text = const_cast<char*>(value.utf8_str().data());
-        text_ptr.get()[0].text_length = value.length();
-        png_set_text(png_ptr, info_ptr, text_ptr.get(), 1);
+        text_ptr.get()[0].text = const_cast<char*>(text.utf8_str().data());
+        text_ptr.get()[0].text_length = text.length();
+        png_set_text( png_ptr, info_ptr, text_ptr.get(), 1 );
     }
 
     png_write_info( png_ptr, info_ptr );

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1069,6 +1069,32 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::SavePNG", "[image]")
 
 }
 
+static void TestPNGDescription(const wxString& description)
+{
+    wxImage image("horse.png");
+
+    image.SetOption(wxIMAGE_OPTION_PNG_DESCRIPTION, description);
+    wxMemoryOutputStream memOut;
+    REQUIRE(image.SaveFile(memOut, wxBITMAP_TYPE_PNG));
+
+    wxMemoryInputStream memIn(memOut);
+    REQUIRE(image.LoadFile(memIn));
+
+    CHECK(image.GetOption(wxIMAGE_OPTION_PNG_DESCRIPTION) == description);
+}
+
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::PNGDescription", "[image]")
+{
+    // Test writing a description and reading it back.
+    TestPNGDescription("Providing the PNG a pneumatic puma as a present");
+
+
+    // Test writing and reading a description again but with a long description.
+    TestPNGDescription(wxString(wxT('a'), 256)
+        + wxString(wxT('b'), 256)
+        + wxString(wxT('c'), 256));
+}
+
 #if wxUSE_LIBTIFF
 static void TestTIFFImage(const wxString& option, int value,
     const wxImage *compareImage = nullptr)

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1088,10 +1088,8 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::PNGDescription", "[image]")
     // Test writing a description and reading it back.
     TestPNGDescription("Providing the PNG a pneumatic puma as a present");
 
-#ifdef PNG_iTXt_SUPPORTED
     // Test writing and reading a description again but with non-ASCII characters.
     TestPNGDescription("Тестирование 테스트 一 二 三");
-#endif
 
     // Test writing and reading a description again but with a long description.
     TestPNGDescription(wxString(wxT('a'), 256)

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1088,6 +1088,8 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::PNGDescription", "[image]")
     // Test writing a description and reading it back.
     TestPNGDescription("Providing the PNG a pneumatic puma as a present");
 
+    // Test writing and reading a description again but with non-ASCII characters.
+    TestPNGDescription("Тестирование 테스트 一 二 三");
 
     // Test writing and reading a description again but with a long description.
     TestPNGDescription(wxString(wxT('a'), 256)

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1088,8 +1088,10 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::PNGDescription", "[image]")
     // Test writing a description and reading it back.
     TestPNGDescription("Providing the PNG a pneumatic puma as a present");
 
+#ifdef PNG_iTXt_SUPPORTED
     // Test writing and reading a description again but with non-ASCII characters.
     TestPNGDescription("Тестирование 테스트 一 二 三");
+#endif
 
     // Test writing and reading a description again but with a long description.
     TestPNGDescription(wxString(wxT('a'), 256)


### PR DESCRIPTION
This is an attempt at implementing the suggestion in https://github.com/wxWidgets/wxWidgets/issues/25556

I'm a bit out of my depth here, so I'm hoping for some helpful suggestions.

This is inspired by the handling of `wxIMAGE_OPTION_GIF_COMMENT`, as well as by this PR: https://github.com/wxWidgets/wxWidgets/pull/792 , while trying to keep everything to the bare minimum.