### PR TITLE
Turn on NSScrollView borders for listbox, dataview and textctrl on macOS #25560

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -230,6 +230,9 @@ public :
     virtual void                UseClippingView() override;
     virtual WXWidget            GetContainer() const override { return m_osxClipView ? m_osxClipView : m_osxView; }
 
+    // enables scrollview borders on native controls with scrollview superviews
+    virtual void                ApplyScrollViewBorderType() override;
+
 protected:
     WXWidget m_osxView;
     WXWidget m_osxClipView;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -375,6 +375,8 @@ public :
     // returns native view which acts as a parent for native children
     virtual WXWidget    GetContainer() const;
 
+    virtual void        ApplyScrollViewBorderType() { }
+
     // Mechanism used to keep track of whether a change should send an event
     // Do SendEvents(false) when starting actions that would trigger programmatic events
     // and SendEvents(true) at the end of the block.

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1985,8 +1985,13 @@ wxCocoaDataViewControl::wxCocoaDataViewControl(wxWindow* peer,
 {
     // initialize scrollview (the outline view is part of a scrollview):
     NSScrollView* scrollview = (NSScrollView*) GetWXWidget();
+    wxBorder border = (wxBorder)(style & wxBORDER_MASK);
 
-    [scrollview setBorderType:NSNoBorder];
+    if ( (border == wxBORDER_DEFAULT) || (border == wxBORDER_THEME) )
+        [scrollview setBorderType:NSBezelBorder];
+    else
+        [scrollview setBorderType:NSNoBorder];
+
     [scrollview setHasVerticalScroller:YES];
     [scrollview setHasHorizontalScroller:YES];
     [scrollview setAutohidesScrollers:YES];

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1985,17 +1985,13 @@ wxCocoaDataViewControl::wxCocoaDataViewControl(wxWindow* peer,
 {
     // initialize scrollview (the outline view is part of a scrollview):
     NSScrollView* scrollview = (NSScrollView*) GetWXWidget();
-    wxBorder border = (wxBorder)(style & wxBORDER_MASK);
-
-    if ( (border == wxBORDER_DEFAULT) || (border == wxBORDER_THEME) )
-        [scrollview setBorderType:NSBezelBorder];
-    else
-        [scrollview setBorderType:NSNoBorder];
 
     [scrollview setHasVerticalScroller:YES];
     [scrollview setHasHorizontalScroller:YES];
     [scrollview setAutohidesScrollers:YES];
     [scrollview setDocumentView:m_OutlineView];
+
+    ApplyScrollViewBorderType();
 
     // initialize the native control itself too
     InitOutlineView(style);

--- a/src/osx/cocoa/listbox.mm
+++ b/src/osx/cocoa/listbox.mm
@@ -440,7 +440,7 @@ wxListWidgetColumn* wxListWidgetCocoaImpl::InsertCheckColumn( unsigned pos , con
 
         [[col1 dataCell] setControlSize:size];
         // although there is no text, it may help to get the correct vertical layout
-        [[col1 dataCell] setFont:list->GetFont().OSXGetNSFont()];        
+        [[col1 dataCell] setFont:list->GetFont().OSXGetNSFont()];
     }
 
     [checkbox release];
@@ -638,6 +638,7 @@ wxWidgetImplType* wxWidgetImpl::CreateListBox( wxWindowMac* wxpeer,
 {
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
     NSScrollView* scrollview = [[NSScrollView alloc] initWithFrame:r];
+    wxBorder border = (wxBorder)(style & wxBORDER_MASK);
 
     // use same scroll flags logic as msw
 
@@ -647,6 +648,11 @@ wxWidgetImplType* wxWidgetImpl::CreateListBox( wxWindowMac* wxpeer,
         [scrollview setHasHorizontalScroller:YES];
 
     [scrollview setAutohidesScrollers: ((style & wxLB_ALWAYS_SB) ? NO : YES)];
+
+    if ( (border == wxBORDER_DEFAULT) || (border == wxBORDER_THEME) )
+        [scrollview setBorderType:NSBezelBorder];
+    else
+        [scrollview setBorderType:NSNoBorder];
 
     // setting up the true table
 

--- a/src/osx/cocoa/listbox.mm
+++ b/src/osx/cocoa/listbox.mm
@@ -638,7 +638,6 @@ wxWidgetImplType* wxWidgetImpl::CreateListBox( wxWindowMac* wxpeer,
 {
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
     NSScrollView* scrollview = [[NSScrollView alloc] initWithFrame:r];
-    wxBorder border = (wxBorder)(style & wxBORDER_MASK);
 
     // use same scroll flags logic as msw
 
@@ -648,11 +647,6 @@ wxWidgetImplType* wxWidgetImpl::CreateListBox( wxWindowMac* wxpeer,
         [scrollview setHasHorizontalScroller:YES];
 
     [scrollview setAutohidesScrollers: ((style & wxLB_ALWAYS_SB) ? NO : YES)];
-
-    if ( (border == wxBORDER_DEFAULT) || (border == wxBORDER_THEME) )
-        [scrollview setBorderType:NSBezelBorder];
-    else
-        [scrollview setBorderType:NSNoBorder];
 
     // setting up the true table
 
@@ -677,6 +671,7 @@ wxWidgetImplType* wxWidgetImpl::CreateListBox( wxWindowMac* wxpeer,
     [tableview release];
 
     wxListWidgetCocoaImpl* c = new wxListWidgetCocoaImpl( wxpeer, scrollview, tableview, ds );
+    c->ApplyScrollViewBorderType();
 
     // temporary hook for dnd
  //   [tableview registerForDraggedTypes:[NSArray arrayWithObjects:

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -747,11 +747,17 @@ bool wxNSTextBase::ShouldHandleKeyNavigation(const wxKeyEvent &event) const
 wxNSTextViewControl::wxNSTextViewControl( wxTextCtrl *wxPeer, WXWidget w, long style )
     : wxNSTextBase(wxPeer, w)
 {
+    wxBorder border = (wxBorder)(style & wxBORDER_MASK);
     wxNSTextScrollView* sv = (wxNSTextScrollView*) w;
     m_scrollView = sv;
 
     const bool hasHScroll = (style & wxHSCROLL) != 0;
     m_useCharWrapping = (style & wxTE_CHARWRAP) != 0;
+
+    if ( (border == wxBORDER_DEFAULT) || (border == wxBORDER_THEME) )
+        [m_scrollView setBorderType:NSBezelBorder];
+    else
+        [m_scrollView setBorderType:NSNoBorder];
 
     [m_scrollView setHasVerticalScroller:YES];
     [m_scrollView setHasHorizontalScroller:hasHScroll];

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -747,7 +747,6 @@ bool wxNSTextBase::ShouldHandleKeyNavigation(const wxKeyEvent &event) const
 wxNSTextViewControl::wxNSTextViewControl( wxTextCtrl *wxPeer, WXWidget w, long style )
     : wxNSTextBase(wxPeer, w)
 {
-    wxBorder border = (wxBorder)(style & wxBORDER_MASK);
     wxNSTextScrollView* sv = (wxNSTextScrollView*) w;
     m_scrollView = sv;
 

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -754,11 +754,6 @@ wxNSTextViewControl::wxNSTextViewControl( wxTextCtrl *wxPeer, WXWidget w, long s
     const bool hasHScroll = (style & wxHSCROLL) != 0;
     m_useCharWrapping = (style & wxTE_CHARWRAP) != 0;
 
-    if ( (border == wxBORDER_DEFAULT) || (border == wxBORDER_THEME) )
-        [m_scrollView setBorderType:NSBezelBorder];
-    else
-        [m_scrollView setBorderType:NSNoBorder];
-
     [m_scrollView setHasVerticalScroller:YES];
     [m_scrollView setHasHorizontalScroller:hasHScroll];
     [m_scrollView setHasVerticalScroller:(style & wxTE_NO_VSCROLL)? NO: YES];
@@ -1878,6 +1873,7 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
         c = t;
 
         t->SetStringValue(str);
+        t->ApplyScrollViewBorderType();
     }
     else
     {

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -152,6 +152,27 @@ NSRect wxOSXGetFrameForControl( wxWindowMac* window , const wxPoint& pos , const
     return wxToNSRect( sv, bounds );
 }
 
+
+void wxWidgetCocoaImpl::ApplyScrollViewBorderType()
+{
+    wxWindowMac* peer = GetWXPeer();
+
+    if ( peer && [m_osxView isKindOfClass:[NSScrollView class]] )
+    {
+        wxBorder border = peer->GetBorder();
+
+        // Enable the scrollview border for native behavior
+        // otherwise turn off the border and allow WX to draw
+        // the borders using wxWindowMac::MacPaintBorders
+
+        if ( border == wxBORDER_DEFAULT || border == wxBORDER_THEME )
+            [(NSScrollView*)m_osxView setBorderType:NSBezelBorder];
+        else
+            [(NSScrollView*)m_osxView setBorderType:NSNoBorder];
+    }
+}
+
+
 @interface wxNSView : NSView
 {
 }

--- a/src/osx/listbox_osx.cpp
+++ b/src/osx/listbox_osx.cpp
@@ -72,8 +72,10 @@ bool wxListBox::Create(
     DontCreatePeer();
     m_blockEvents = false;
 
+#if !defined(__WXOSX_COCOA__)
     if ( ! (style & wxNO_BORDER) )
         style = (style & ~wxBORDER_MASK) | wxSUNKEN_BORDER ;
+#endif
 
     wxASSERT_MSG( !(style & wxLB_MULTIPLE) || !(style & wxLB_EXTENDED),
                   wxT("only a single listbox selection mode can be specified") );
@@ -131,10 +133,10 @@ void wxListBox::FreeData()
 
 void wxListBox::DoSetFirstItem(int n)
 {
-    // osx actually only has an implementation for ensuring the visibility of a row, it does so  
+    // osx actually only has an implementation for ensuring the visibility of a row, it does so
     // by scrolling the minimal amount necessary from the current scrolling position.
-    // in order to get the same behaviour I'd have to make sure first that the last line is visible, 
-    // followed by a scrollRowToVisible for the desired line 
+    // in order to get the same behaviour I'd have to make sure first that the last line is visible,
+    // followed by a scrollRowToVisible for the desired line
     GetListPeer()->ListScrollTo( GetCount()-1 );
     GetListPeer()->ListScrollTo( n );
 }

--- a/src/osx/listbox_osx.cpp
+++ b/src/osx/listbox_osx.cpp
@@ -72,11 +72,6 @@ bool wxListBox::Create(
     DontCreatePeer();
     m_blockEvents = false;
 
-#if !defined(__WXOSX_COCOA__)
-    if ( ! (style & wxNO_BORDER) )
-        style = (style & ~wxBORDER_MASK) | wxSUNKEN_BORDER ;
-#endif
-
     wxASSERT_MSG( !(style & wxLB_MULTIPLE) || !(style & wxLB_EXTENDED),
                   wxT("only a single listbox selection mode can be specified") );
 

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -89,11 +89,6 @@ bool wxTextCtrl::Create( wxWindow *parent,
     DontCreatePeer();
     m_editable = true ;
 
-#if !defined(__WXOSX_COCOA__)
-    if ( ! (style & wxNO_BORDER) )
-        style = (style & ~wxBORDER_MASK) | wxSUNKEN_BORDER ;
-#endif
-
     if ( !wxTextCtrlBase::Create( parent, id, pos, size, style & ~(wxHSCROLL | wxVSCROLL), validator, name ) )
         return false;
 

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -89,8 +89,10 @@ bool wxTextCtrl::Create( wxWindow *parent,
     DontCreatePeer();
     m_editable = true ;
 
+#if !defined(__WXOSX_COCOA__)
     if ( ! (style & wxNO_BORDER) )
         style = (style & ~wxBORDER_MASK) | wxSUNKEN_BORDER ;
+#endif
 
     if ( !wxTextCtrlBase::Create( parent, id, pos, size, style & ~(wxHSCROLL | wxVSCROLL), validator, name ) )
         return false;


### PR DESCRIPTION
Resolves #25560 by enabling the scrollview borders by default on macOS.