### PR TITLE
Improve expander in wxPropertyGrid

### DIFF
--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -17,6 +17,7 @@
 #include "wx/scrolwin.h"
 #include "wx/recguard.h"
 #include "wx/time.h" // needed for wxMilliClock_t
+#include "wx/systhemectrl.h"
 
 #include "wx/propgrid/property.h"
 #include "wx/propgrid/propgridiface.h"
@@ -555,7 +556,7 @@ enum wxPG_KEYBOARD_ACTIONS
 // Use Freeze() and Thaw() respectively to disable and enable drawing. This
 // will also delay sorting etc. miscellaneous calculations to the last
 // possible moment.
-class WXDLLIMPEXP_PROPGRID wxPropertyGrid : public wxScrolled<wxControl>,
+class WXDLLIMPEXP_PROPGRID wxPropertyGrid : public wxSystemThemedControl<wxScrolled<wxControl>>,
                                             public wxPropertyGridInterface
 {
     friend class wxPropertyGridEvent;

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -420,7 +420,7 @@ void wxPropertyGrid::Init1()
 #endif
 
     m_gutterWidth = wxPG_GUTTER_MIN;
-    m_subgroup_extramargin = 10;
+    m_subgroup_extramargin = m_iconWidth + m_gutterWidth;
 
     m_lineHeight = 0;
 
@@ -1311,7 +1311,6 @@ void wxPropertyGrid::CalculateFontAndBitmapStuff( int vspacing )
     m_captionFont = wxControl::GetFont();
 
     GetTextExtent(wxS("jG"), &x, &y, nullptr, nullptr, &m_captionFont);
-    m_subgroup_extramargin = x + (x/2);
     m_fontHeight = y;
 
 #ifdef wxPG_ICON_WIDTH
@@ -1327,6 +1326,8 @@ void wxPropertyGrid::CalculateFontAndBitmapStuff( int vspacing )
     m_gutterWidth = m_iconWidth / wxPG_GUTTER_DIV;
     if ( m_gutterWidth < wxPG_GUTTER_MIN )
         m_gutterWidth = wxPG_GUTTER_MIN;
+
+    m_subgroup_extramargin = m_iconWidth + m_gutterWidth;
 
     int vdiv = 6;
     if ( vspacing <= 1 ) vdiv = 12;

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -306,7 +306,7 @@ wxEND_EVENT_TABLE()
 // -----------------------------------------------------------------------
 
 wxPropertyGrid::wxPropertyGrid()
-    : wxScrolled<wxControl>()
+    : wxSystemThemedControl<wxScrolled<wxControl>>()
 {
     Init1();
 }
@@ -319,7 +319,7 @@ wxPropertyGrid::wxPropertyGrid( wxWindow *parent,
                                 const wxSize& size,
                                 long style,
                                 const wxString& name )
-    : wxScrolled<wxControl>()
+    : wxSystemThemedControl<wxScrolled<wxControl>>()
 {
     Init1();
     Create(parent,id,pos,size,style,name);
@@ -350,6 +350,8 @@ bool wxPropertyGrid::Create( wxWindow *parent,
                       (style & wxWINDOW_STYLE_MASK) | wxScrolledWindowStyle,
                       wxDefaultValidator,
                       name);
+
+    EnableSystemThemeByDefault();
 
     m_windowStyle |= (style & wxPG_WINDOW_STYLE_MASK);
 
@@ -1286,7 +1288,7 @@ void wxPropertyGrid::SetScrollbars(int pixelsPerUnitX, int pixelsPerUnitY,
 {
     int oldX;
     CalcUnscrolledPosition(0, 0, &oldX, nullptr);
-    wxScrolled<wxControl>::SetScrollbars(pixelsPerUnitX, pixelsPerUnitY,
+    wxSystemThemedControl<wxScrolled<wxControl>>::SetScrollbars(pixelsPerUnitX, pixelsPerUnitY,
                                   noUnitsX, noUnitsY, xPos, yPos, noRefresh);
     int newX;
     CalcUnscrolledPosition(0, 0, &newX, nullptr);

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -81,8 +81,6 @@
 #endif
 
 
-#define wxPG_GUTTER_DIV                 3 // gutter is max(iconwidth/gutter_div,gutter_min)
-#define wxPG_GUTTER_MIN                 3 // gutter before and after image of [+] or [-]
 #define wxPG_YSPACING_MIN               1
 #define wxPG_DEFAULT_VSPACING           2 // This matches .NET propertygrid's value,
                                           // but causes normal combobox to spill out under MSW
@@ -419,7 +417,7 @@ void wxPropertyGrid::Init1()
     m_iconHeight = FromDIP(wxPG_ICON_WIDTH);
 #endif
 
-    m_gutterWidth = wxPG_GUTTER_MIN;
+    m_gutterWidth = wxMax(0, (FromDIP(16) - m_iconWidth) / 2);
     m_subgroup_extramargin = m_iconWidth + m_gutterWidth;
 
     m_lineHeight = 0;
@@ -1323,9 +1321,7 @@ void wxPropertyGrid::CalculateFontAndBitmapStuff( int vspacing )
     m_iconHeight = iconSize.GetHeight();
 #endif
 
-    m_gutterWidth = m_iconWidth / wxPG_GUTTER_DIV;
-    if ( m_gutterWidth < wxPG_GUTTER_MIN )
-        m_gutterWidth = wxPG_GUTTER_MIN;
+    m_gutterWidth = wxMax(0, (FromDIP(16) - m_iconWidth) / 2);
 
     m_subgroup_extramargin = m_iconWidth + m_gutterWidth;
 

--- a/tests/controls/propgridtest.cpp
+++ b/tests/controls/propgridtest.cpp
@@ -1460,11 +1460,7 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
 
     SECTION("SetSplitterPosition")
     {
-#ifndef __WXQT__
-        const int trySplitterPos = wxTheApp->GetTopWindow()->FromDIP(50);
-#else
-        const int trySplitterPos = 51; // FIXME!
-#endif
+        const int trySplitterPos = wxTheApp->GetTopWindow()->FromDIP(60);
         int style = wxPG_AUTO_SORT;  // wxPG_SPLITTER_AUTO_CENTER;
         ReplaceGrid(pgManager, style, -1);
 


### PR DESCRIPTION

* Make wxPropertyGrid a wxSystemThemedControl so it uses the default expander
* Don't use hard-coded expander sizes in wxPropertyGrid so the expander gets the correct size, fixes #25571
* Improve margin of sub-groups in wxPropertyGrid so the expander does not overlap with the margin
