### PR TITLE
Do not draw Spinbutton when resized to zero

### DIFF
--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -176,7 +176,7 @@ void wxSpinButton::OnPaint(wxPaintEvent& event)
         const RECT rc = wxGetClientRect(GetHwnd());
         const wxSize size{rc.right - rc.left, rc.bottom - rc.top};
 
-        if ( size == wxSize() )
+        if ( !size.IsAtLeast(wxSize(1, 1)) )
             return;
 
         wxBitmap bmp(size);


### PR DESCRIPTION
With MSW DarkMode ONLY:

When you resize the parent frame of a spinbutton to zero (either width or height), then it crashes on creation of the Bitmap. 

The previous check only checked whether width and height are BOTH zero.

The new check returns when either one of those is 0.