### PR TITLE
Update MSW dark mode and wxWebViewEdge docs

### DIFF
--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1429,12 +1429,13 @@ public:
         - The following dialogs wrapping common windows dialogs don't support
           dark mode: wxColourDialog, wxFindReplaceDialog, wxFontDialog,
           wxPageSetupDialog, wxPrintDialog.
-        - wxDatePickerCtrl and wxTimePickerCtrl don't support dark mode and
-          use the same (light) background as by default in it.
+        - wxTimePickerCtrl, wxDatePickerCtrl and wxCalendarCtrl don't support dark mode
+          and use the same (light) background as by default in it.
         - Toolbar items for which wxToolBar::SetDropdownMenu() was called
           don't draw the menu drop-down correctly, making it almost
           invisible.
-        - Calling wxMenu::Break() will result in the menu being light.
+        - Calling wxMenu::Break() or wxMenuItem::SetDisabledBitmap() will result
+          in the menu being light.
 
         @param flags Can include @c wxApp::DarkMode_Always to force enabling
             dark mode for the application, even if the system doesn't use the

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -839,19 +839,21 @@ public:
     wxWebViewHandler::SetVirtualHost() for more details on how to access
     handler provided URLs.
 
-    This backend is not enabled by default, to build it follow these steps:
-    - With CMake just enable @c wxUSE_WEBVIEW_EDGE
+    This backend is enabled by default only when using CMake. To build it follow these steps:
     - When not using CMake:
         - Download the <a href="https://aka.ms/webviewnuget">WebView2 SDK</a>
-        nuget package (Version 1.0.864.35 or newer)
-        - Extract the package (it's a zip archive) to @c wxWidgets/3rdparty/webview2
+        NuGet package (Version 1.0.864.35 or newer)
+        - Extract the package (it's a zip archive) to @c WX_SRCDIR/3rdparty/webview2
         (you should have @c 3rdparty/webview2/build/native/include/WebView2.h
         file after unpacking it)
         - Enable @c wxUSE_WEBVIEW_EDGE in @c setup.h
+    - When using CMake, the backend is enabled by default. It can be disabled by setting
+      @c wxUSE_WEBVIEW_EDGE to @c OFF. If a WebView2 SDK is found in @c WX_SRCDIR/3rdparty/webview2
+      (see the bullet above), that SDK is used. Otherwise, the SDK is downloaded and extracted
+      by CMake during the configure phase (into directory @c WX_BUILDDIR/libs/webview/packages)
     - Build wxWidgets webview library
-    - Copy @c WebView2Loader.dll from the subdirectory corresponding to the
-      architecture used (x86 or x64) of @c wxWidgets/3rdparty/webview2/build/
-      to your applications executable
+    - From the WebView2 SDK @c build subdirectory copy @c WebView2Loader.dll corresponding
+      to the architecture used (x86 or x64) to the directory with your application executable
     - At runtime you can use wxWebView::IsBackendAvailable() to check if the
       backend can be used (it will be available if @c WebView2Loader.dll can be
       loaded and Edge (Chromium) is installed)


### PR DESCRIPTION
Extend the list of MSW dark mode limitations and improve documentation for building wxWebViewEdge.

Regarding `wxWebViewEdge` building instruction, it seems that the procedure for _configure_ is missing.