### PR TITLE
Fix wxFilePickerCtrl with GTK >= 3.20

### DIFF
--- a/include/wx/gtk/filedlg.h
+++ b/include/wx/gtk/filedlg.h
@@ -64,6 +64,7 @@ public:
 
     // Implementation only.
     void GTKSelectionChanged(const wxString& filename);
+    void GTKDropNative();
 
 
 protected:


### PR DESCRIPTION
GtkFileChooserNative will not be used when wxFileDialog is used by wxFilePickerCtrl, so make sure values will be retrieved from GtkFileChooserDialog and not the unused "native" chooser.
See #25590