### PR TITLE
Fix appearance of disabled `wxStaticText` in wxMSW dialogs in dark mode

### DIFF
--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -350,17 +350,13 @@ WXHBRUSH wxControl::DoMSWControlColor(WXHDC pDC, wxColour colBg, WXHWND hWnd)
 
         if ( !hbr )
         {
-            if ( wxMSWDarkMode::IsActive() )
-            {
-                colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
-            }
-            // if the control doesn't have any bg colour, foreground colour will be
-            // ignored as the return value would be 0 -- so forcefully give it a
-            // non default background brush in this case
-            else if ( m_hasFgCol )
-            {
+            // We always need to use custom background in dark mode. And in
+            // light mode, we have to use it if the control uses a non-default
+            // foreground too because if we didn't, this function would return
+            // 0 and everything done by it would be ignored -- so ensure we use
+            // a valid value in both of these cases.
+            if ( wxMSWDarkMode::IsActive() || m_hasFgCol )
                 colBg = GetBackgroundColour();
-            }
         }
     }
 

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -353,8 +353,6 @@ WXHBRUSH wxControl::DoMSWControlColor(WXHDC pDC, wxColour colBg, WXHWND hWnd)
             if ( wxMSWDarkMode::IsActive() )
             {
                 colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
-                if ( !m_hasFgCol )
-                    colFg = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
             }
             // if the control doesn't have any bg colour, foreground colour will be
             // ignored as the return value would be 0 -- so forcefully give it a


### PR DESCRIPTION
For the record, I've decided to fix this in `wxControl::DoMSWControlColor()` as it seems to make more sense, but this is more dangerous too, as it affects all controls. If it ends up breaking anything, we could apply the following, more limited, fix instead:

```diff
commit 15e34b99a46e7e9683bfe5cc1fb750c452a1f00d
Author: Vadim Zeitlin <vadim@wxwidgets.org>
Date:   2025-07-05 17:43:26 +0200

    Fix disabled wxStaticText inside a dialog in wxMSW dark mode
    
    The control wasn't rendered using the desired "disabled" colour because
    wxControl::DoMSWControlColor() didn't take it into account unless
    m_hasFgCol was set (except when the control also had an inherited
    background brush, as is the case when it's child of a wxFrame), but we
    were not setting it.
    
    Do set it now to fix its appearance.
    
    Closes #25574.

diff --git a/src/msw/stattext.cpp b/src/msw/stattext.cpp
index 023641e9a4..25a986c7c0 100644
--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -198,14 +198,20 @@ wxStaticText::MSWHandleMessage(WXLRESULT *result,
 
             // Don't use Get/SetForegroundColour() here as they do more than we
             // need, we just want to change m_foregroundColour temporarily
-            // without any side effects.
+            // without any side effects, but we need to set m_hasFgCol too for
+            // it to be taken into account by wxControl::DoMSWControlColor().
             const auto colFgOrig = m_foregroundColour;
+            const auto hasFgOrig = m_hasFgCol;
+
             wxDarkModeSettings darkModeSettings;
             m_foregroundColour = darkModeSettings.GetMenuColour(wxMenuColour::DisabledFg);
+            m_hasFgCol = true;
 
             *result = MSWDefWindowProc(WM_PAINT, wParam, lParam);
 
             updateStyle.TurnOn(WS_DISABLED).Apply();
+
+            m_hasFgCol = hasFgOrig;
             m_foregroundColour = colFgOrig;
 
             return true;```