### PR TITLE
Fix appearance of `wxTextCtrl` with `wxTE_RICH` in dark mode in wxMSW

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -511,9 +511,6 @@ bool wxTextCtrl::MSWCreateText(const wxString& value,
                                const wxPoint& pos,
                                const wxSize& size)
 {
-    // translate wxWin style flags to MSW ones
-    WXDWORD msStyle = MSWGetCreateWindowFlags();
-
     // do create the control - either an EDIT or RICHEDIT
     wxString windowClass = wxT("EDIT");
 
@@ -634,7 +631,7 @@ bool wxTextCtrl::MSWCreateText(const wxString& value,
     // implementation detail
     m_updatesCount = -2;
 
-    if ( !MSWCreateControl(windowClass.t_str(), msStyle, pos, size, valueWin) )
+    if ( !MSWCreateControl(windowClass.t_str(), valueWin, pos, size) )
     {
         // There is one case in which window creation may realistically fail
         // and this is when we create a plain EDIT control with too long text,

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -50,6 +50,7 @@
 #include <windowsx.h>
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/winundef.h"
 
 #include <string.h>
@@ -473,9 +474,10 @@ bool wxTextCtrl::Create(wxWindow *parent,
     if ( !MSWCreateText(value, pos, size) )
         return false;
 
-#if wxUSE_DRAG_AND_DROP && wxUSE_RICHEDIT
+#if wxUSE_RICHEDIT
     if ( IsRich() )
     {
+#if wxUSE_DRAG_AND_DROP
         // rich text controls have a default associated drop target which
         // allows them to receive (rich) text dropped on them, which is nice,
         // but prevents us from associating a user-defined drop target with
@@ -484,8 +486,16 @@ bool wxTextCtrl::Create(wxWindow *parent,
         // to make it work, we set m_dropTarget to this special value initially
         // and check for it in our SetDropTarget()
         m_dropTarget = wxRICHTEXT_DEFAULT_DROPTARGET;
+#endif // wxUSE_DRAG_AND_DROP
+
+        if ( wxMSWDarkMode::IsActive() )
+        {
+            // We need to set the colours explicitly for rich text controls.
+            SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+            SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+        }
     }
-#endif // wxUSE_DRAG_AND_DROP && wxUSE_RICHEDIT
+#endif // wxUSE_RICHEDIT
 
     return true;
 }

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -654,6 +654,20 @@ bool wxTextCtrl::MSWCreateText(const wxString& value,
 #if wxUSE_RICHEDIT
     if (IsRich())
     {
+        // RICHEDIT50W automatically adds WS_EX_CLIENTEDGE to its style for
+        // some reason and while this isn't very noticeable in light mode, it
+        // looks really bad in dark mode, so forcibly remove it unless it was
+        // explicitly requested.
+        if ( GetBorder() != wxBORDER_SUNKEN && wxMSWDarkMode::IsActive() )
+        {
+            const auto origExStyle = ::GetWindowLongPtr(GetHwnd(), GWL_EXSTYLE);
+            if ( origExStyle & WS_EX_CLIENTEDGE )
+            {
+                ::SetWindowLongPtr(GetHwnd(), GWL_EXSTYLE,
+                                   origExStyle & ~WS_EX_CLIENTEDGE);
+            }
+        }
+
 #if wxUSE_INKEDIT
         if (IsInkEdit())
         {


### PR DESCRIPTION
Use correct (the same as for plain `EDIT`) colours for it and also fix the border.