### PR TITLE
Fixes for `wxComboCtrl` in dark mode under MSW

### DIFF
--- a/include/wx/combo.h
+++ b/include/wx/combo.h
@@ -435,9 +435,6 @@ public:
     // Return true if Create has finished
     bool IsCreated() const { return m_iFlags & wxCC_IFLAG_CREATED ? true : false; }
 
-    // Need to override to return text area background colour
-    wxColour GetBackgroundColour() const;
-
     // common code to be called on popup hide/dismiss
     void OnPopupDismiss(bool generateEvent);
 

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -1386,18 +1386,15 @@ bool wxComboCtrlBase::SetForegroundColour(const wxColour& colour)
 
 bool wxComboCtrlBase::SetBackgroundColour(const wxColour& colour)
 {
+    if ( !wxControl::SetBackgroundColour(colour) )
+        return false;
+
     if ( m_mainWindow )
         m_mainWindow->SetBackgroundColour(colour);
+
     m_tcBgCol = colour;
     m_hasTcBgCol = true;
     return true;
-}
-
-wxColour wxComboCtrlBase::GetBackgroundColour() const
-{
-    if ( m_mainWindow )
-        return m_mainWindow->GetBackgroundColour();
-    return m_tcBgCol;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -364,8 +364,8 @@ void wxComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
         RECT rBorder;
         wxCopyRectToRECT(borderRect, rBorder);
 
-        bool isNonStdButton = (m_iFlags & wxCC_IFLAG_BUTTON_OUTSIDE) ||
-                              (m_iFlags & wxCC_IFLAG_HAS_NONSTANDARD_BUTTON);
+        const bool usesStdButton = !(m_iFlags & wxCC_IFLAG_BUTTON_OUTSIDE) &&
+                                   !(m_iFlags & wxCC_IFLAG_HAS_NONSTANDARD_BUTTON);
 
         //
         // Get some states for themed drawing
@@ -397,7 +397,7 @@ void wxComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
         const bool isFocused = (FindFocus() == GetMainWindowOfCompositeControl()) ? true : false;
 
         // Draw the entire control as a single button?
-        if ( !isNonStdButton )
+        if ( usesStdButton )
         {
             if ( HasFlag(wxCB_READONLY) )
                 drawFullButton = true;
@@ -456,7 +456,7 @@ void wxComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
 
         //
         // Draw the drop-button
-        if ( !isNonStdButton )
+        if ( usesStdButton )
         {
             drawButFlags = Button_BitmapOnly;
 

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -411,6 +411,11 @@ void wxComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
             // It should be safe enough to update this flag here.
             m_iFlags |= wxCC_FULL_BUTTON;
         }
+        else if ( bgState == CBXS_DISABLED )
+        {
+            // Disable controls shouldn't have a border.
+            comboBoxPart = CP_READONLY;
+        }
         else
         {
             comboBoxPart = CP_BORDER;

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -36,6 +36,8 @@
 #include "wx/msw/uxtheme.h"
 #include "wx/msw/dc.h"
 
+#include <memory>
+
 #define NATIVE_TEXT_INDENT_XP       4
 #define NATIVE_TEXT_INDENT_CLASSIC  2
 
@@ -308,7 +310,7 @@ void wxComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
     // TODO: Convert drawing in this function to Windows API Code
 
     wxSize sz = GetClientSize();
-    wxDC* dcPtr = wxAutoBufferedPaintDCFactory(this);
+    std::unique_ptr<wxDC> dcPtr(wxAutoBufferedPaintDCFactory(this));
     wxDC& dc = *dcPtr;
 
     const wxRect& rectButton = m_btnArea;
@@ -500,8 +502,6 @@ void wxComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
         else
             wxComboPopup::DefaultPaintComboControl(this,dc,rectTextField);
     }
-
-    delete dcPtr;
 }
 
 void wxComboCtrl::OnMouseEvent( wxMouseEvent& event )

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -117,8 +117,11 @@ bool wxComboCtrl::Create(wxWindow *parent,
     // Create textctrl, if necessary
     CreateTextCtrl( wxNO_BORDER );
 
-    // Use the same theme as is used by wxChoice/wxComboBox.
-    wxMSWDarkMode::AllowForWindow(m_hWnd, L"CFD");
+    // Use the same theme as is used by wxChoice/wxComboBox, but specify the
+    // class name because it's not used automatically for a non-native
+    // combobox and without this combobox-specific parts, such as CB_BORDER
+    // used in the code below, wouldn't work.
+    wxMSWDarkMode::AllowForWindow(m_hWnd, L"CFD", L"COMBOBOX");
 
     // SetInitialSize should be called last
     SetInitialSize(size);

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -36,6 +36,8 @@
 #include "wx/msw/uxtheme.h"
 #include "wx/msw/dc.h"
 
+#include "wx/msw/private/darkmode.h"
+
 #include <memory>
 
 #define NATIVE_TEXT_INDENT_XP       4
@@ -114,6 +116,9 @@ bool wxComboCtrl::Create(wxWindow *parent,
 
     // Create textctrl, if necessary
     CreateTextCtrl( wxNO_BORDER );
+
+    // Use the same theme as is used by wxChoice/wxComboBox.
+    wxMSWDarkMode::AllowForWindow(m_hWnd, L"CFD");
 
     // SetInitialSize should be called last
     SetInitialSize(size);


### PR DESCRIPTION
See #23766.