### PR TITLE
Add wxOwnerDrawnComboBox ctor overload not taking any items

### DIFF
--- a/include/wx/odcombo.h
+++ b/include/wx/odcombo.h
@@ -258,6 +258,20 @@ public:
                      choices, style, validator, name);
     }
 
+    wxOwnerDrawnComboBox(wxWindow *parent,
+                wxWindowID id,
+                const wxString& value = wxEmptyString,
+                const wxPoint& pos = wxDefaultPosition,
+                const wxSize& size = wxDefaultSize,
+                long style = 0,
+                const wxValidator& validator = wxDefaultValidator,
+                const wxString& name = wxASCII_STR(wxComboBoxNameStr))
+    {
+        Init();
+
+        Create(parent, id, value, pos, size, style, validator, name);
+    }
+
     bool Create(wxWindow *parent,
                 wxWindowID id,
                 const wxString& value = wxEmptyString,
@@ -269,10 +283,10 @@ public:
 
     wxOwnerDrawnComboBox(wxWindow *parent,
                          wxWindowID id,
-                         const wxString& value = wxEmptyString,
-                         const wxPoint& pos = wxDefaultPosition,
-                         const wxSize& size = wxDefaultSize,
-                         const wxArrayString& choices = wxArrayString(),
+                         const wxString& value,
+                         const wxPoint& pos,
+                         const wxSize& size,
+                         const wxArrayString& choices,
                          long style = 0,
                          const wxValidator& validator = wxDefaultValidator,
                          const wxString& name = wxASCII_STR(wxComboBoxNameStr));

--- a/interface/wx/odcombo.h
+++ b/interface/wx/odcombo.h
@@ -159,6 +159,41 @@ public:
                          const wxString& name = "comboBox");
 
     /**
+        Constructor, creating and showing a owner-drawn combobox.
+
+        This overload creates a combobox with no initial items. It has been
+        added in wxWindow 3.3.1.
+
+        @param parent
+            Parent window. Must not be @NULL.
+        @param id
+            Window identifier. The value @c wxID_ANY indicates a default value.
+        @param value
+            Initial selection string. An empty string indicates no selection.
+        @param pos
+            Window position.
+        @param size
+            Window size.
+            If ::wxDefaultSize is specified then the window is sized appropriately.
+        @param style
+            Window style. See wxOwnerDrawnComboBox.
+        @param validator
+            Window validator.
+        @param name
+            Window name.
+
+        @see Create(), wxValidator
+     */
+    wxOwnerDrawnComboBox(wxWindow *parent,
+                         wxWindowID id,
+                         const wxString& value = wxEmptyString,
+                         const wxPoint& pos = wxDefaultPosition,
+                         const wxSize& size = wxDefaultSize,
+                         long style = 0,
+                         const wxValidator& validator = wxDefaultValidator,
+                         const wxString& name = wxComboBoxNameStr);
+
+    /**
         Destructor, destroying the owner-drawn combobox.
     */
     virtual ~wxOwnerDrawnComboBox();


### PR DESCRIPTION
Surprisingly, similar Create() overload already existed, but ctor one did not.

Fix this inconsistency and provide ctor with the same signature as Create() too.