### PR TITLE
Make wxNumberFormatter's helper functions publically available

### DIFF
--- a/include/wx/numformatter.h
+++ b/include/wx/numformatter.h
@@ -68,10 +68,6 @@ public:
     // function returns true.
     static bool GetThousandsSeparatorIfUsed(wxChar *sep);
 
-private:
-    // Post-process the string representing an integer.
-    static wxString PostProcessIntString(wxString s, int style);
-
     // Add the thousands separators to a string representing a number without
     // the separators. This is used by ToString(Style_WithThousandsSep).
     static void AddThousandsSeparators(wxString& s);
@@ -83,6 +79,10 @@ private:
 
     // Remove all thousands separators from a string representing a number.
     static void RemoveThousandsSeparators(wxString& s);
+
+private:
+    // Post-process the string representing an integer.
+    static wxString PostProcessIntString(wxString s, int style);
 };
 
 #endif // _WX_NUMFORMATTER_H_

--- a/include/wx/numformatter.h
+++ b/include/wx/numformatter.h
@@ -68,21 +68,21 @@ public:
     // function returns true.
     static bool GetThousandsSeparatorIfUsed(wxChar *sep);
 
-    // Add the thousands separators to a string representing a number without
-    // the separators. This is used by ToString(Style_WithThousandsSep).
-    static void AddThousandsSeparators(wxString& s);
-
     // Remove trailing zeroes and, if there is nothing left after it, the
     // decimal separator itself from a string representing a floating point
     // number. Also used by ToString().
     static void RemoveTrailingZeroes(wxString& s);
 
-    // Remove all thousands separators from a string representing a number.
-    static void RemoveThousandsSeparators(wxString& s);
-
 private:
     // Post-process the string representing an integer.
     static wxString PostProcessIntString(wxString s, int style);
+
+    // Add the thousands separators to a string representing a number without
+    // the separators. This is used by ToString(Style_WithThousandsSep).
+    static void AddThousandsSeparators(wxString& s);
+
+    // Remove all thousands separators from a string representing a number.
+    static void RemoveThousandsSeparators(wxString& s);
 };
 
 #endif // _WX_NUMFORMATTER_H_

--- a/interface/wx/numformatter.h
+++ b/interface/wx/numformatter.h
@@ -149,4 +149,34 @@ public:
      */
     static bool GetThousandsSeparatorIfUsed(wxChar *sep);
 
+    /**
+        Add thousands separators to a string representing a number
+        that currently doesn't have any.
+
+        @param[in,out] str The string to add thousands separators to.
+
+        @since 3.3.1
+     */
+    static void AddThousandsSeparators(wxString& str);
+
+    /**
+        Remove all thousands separators from a string representing a number.
+
+        @param[in,out] str The string to remove thousands separators from.
+
+        @since 3.3.1
+     */
+    static void RemoveThousandsSeparators(wxString& str);
+
+    /**
+        Remove trailing zeroes and, if there is nothing left after it, the
+        decimal separator itself from a string representing a floating point
+        number.
+
+        @param[in,out] str The string to remove zeroes from.
+
+        @since 3.3.1
+     */
+    static void RemoveTrailingZeroes(wxString& str);
+
 };

--- a/interface/wx/numformatter.h
+++ b/interface/wx/numformatter.h
@@ -136,39 +136,6 @@ public:
     static wxChar GetDecimalSeparator();
 
     /**
-        Get the thousands separator if grouping of the digits is used by the
-        current UI locale.
-
-        The value returned in @a sep should be only used if the function
-        returns @true, otherwise no thousands separator should be used at all.
-
-        @param sep
-            Points to the variable receiving the thousands separator character
-            if it is used by the current UI locale. May be @NULL if only the
-            function return value is needed.
-     */
-    static bool GetThousandsSeparatorIfUsed(wxChar *sep);
-
-    /**
-        Add thousands separators to a string representing a number
-        that currently doesn't have any.
-
-        @param[in,out] str The string to add thousands separators to.
-
-        @since 3.3.1
-     */
-    static void AddThousandsSeparators(wxString& str);
-
-    /**
-        Remove all thousands separators from a string representing a number.
-
-        @param[in,out] str The string to remove thousands separators from.
-
-        @since 3.3.1
-     */
-    static void RemoveThousandsSeparators(wxString& str);
-
-    /**
         Remove trailing zeroes and, if there is nothing left after it, the
         decimal separator itself from a string representing a floating point
         number.

--- a/interface/wx/numformatter.h
+++ b/interface/wx/numformatter.h
@@ -136,6 +136,18 @@ public:
     static wxChar GetDecimalSeparator();
 
     /**
+        Get the thousands separator if grouping of the digits is used by the
+        current UI locale.
+        The value returned in @a sep should be only used if the function
+        returns @true, otherwise no thousands separator should be used at all.
+        @param sep
+            Points to the variable receiving the thousands separator character
+            if it is used by the current UI locale. May be @NULL if only the
+            function return value is needed.
+     */
+    static bool GetThousandsSeparatorIfUsed(wxChar *sep);
+
+    /**
         Remove trailing zeroes and, if there is nothing left after it, the
         decimal separator itself from a string representing a floating point
         number.


### PR DESCRIPTION
No real changes, just exposes `wxNumberFormatter`'s `AddThousandsSeparators`, `RemoveThousandsSeparators`, and `RemoveTrailingZeroes` publicly.

I could use `RemoveTrailingZeroes()` myself for cleaning up strings from my data importer, and IMO there is real value is making these functions available.