### PR TITLE
draw custom toolbar item background in dark mode if nmcd.uItemState is CDIS_SELECTED

### DIFF
--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1719,6 +1719,11 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                     ::FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, br);
                     *result |= TBCDRF_NOBACKGROUND;
                 }
+                else if (nmtbcd->nmcd.uItemState == CDIS_SELECTED) {
+                    AutoHBRUSH br(wxColourToRGB(colBg.ChangeLightness(110)));
+                    ::FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, br);
+                    *result |= TBCDRF_NOBACKGROUND;
+                }
 
                 return true;
             }


### PR DESCRIPTION
I think in MSW toolbar.cpp, we should handle the case if `nmtbcd->nmcd.uItemState == CDIS_SELECTED` to draw a custom background in dark mode. Otherwise a light blue background is draw.

Before the change:
![msw_cds_selected_dark_color](https://github.com/user-attachments/assets/c1ebae5b-5b0d-4b87-8d1f-d5707a66905f)

After the change:
![msw_cds_selected_dark_color_fix](https://github.com/user-attachments/assets/8a14d38e-6fa8-43ce-8aa4-69bcd36d804a)

How to get the state CDIS_SELECTED:
Click on a toolbar item and open a popup menu inside the item click handler as shown in the images.