### PR TITLE
Use default locale for date/time picker controls in wxMSW by default

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -85,10 +85,6 @@ Changes in behaviour not resulting in compilation errors
   mode under MSW, use the new AreAppsDark() or IsSystemDark() to check if the
   other applications or the system are using dark mode.
 
-- Date/time picker controls are now locale-aware by default in wxMSW, which
-  means that they do _not_ use OS default date/time format any longer unless
-  wxUILocale::UseDefault() is called.
-
 - wxUILocale::IsSupported() now returns false for unavailable locales under
   Unix systems without trying to fall back on another locale using the same
   language in a different region, e.g. it doesn't use fr_FR if fr_BE is not

--- a/include/wx/uilocale.h
+++ b/include/wx/uilocale.h
@@ -133,7 +133,12 @@ public:
     // in the new code.
     static bool UseLocaleName(const wxString& localeName);
 
-    // Get the object corresponding to the currently used locale.
+    // Return true if the locale was set by calling either UseDefault() or
+    // UseLocaleName().
+    static bool IsSet();
+
+    // Get the object corresponding to the currently used locale, which is
+    // always valid: if IsSet() is false, "C" locale is returned.
     static const wxUILocale& GetCurrent();
 
     // A helper just to avoid writing wxUILocale(wxLocaleIdent::FromTag(...)).

--- a/interface/wx/calctrl.h
+++ b/interface/wx/calctrl.h
@@ -296,6 +296,12 @@ enum wxCalendarHitTestResult
     @note Changing the selected date will trigger an EVT_CALENDAR_DAY, MONTH or
           YEAR event as well as an EVT_CALENDAR_SEL_CHANGED event.
 
+    @note In wxMSW this control always uses the default user locale, i.e. the
+        month and weekday names are always displayed in the Windows display
+        language and are not affected by wxUILocale. This is a limitation of
+        the native control and wxGenericCalendarCtrl must be used if this is
+        undesirable.
+
     @library{wxcore}
     @category{ctrl}
     @appearance{calendarctrl}

--- a/interface/wx/datectrl.h
+++ b/interface/wx/datectrl.h
@@ -68,6 +68,13 @@ enum
     wxDP_SHOWCENTURY (this is also the style used by default if none is
     specified).
 
+    @note In wxMSW this control uses default user date format even if
+        wxUILocale::UseDefault() hasn't been called, while under the other
+        platforms it only does it if the default UI locale has been set.
+        For applications targeting international users, it is strongly
+        recommended to call wxUILocale::UseDefault() to ensure that the
+        behaviour is consistent across all platforms.
+
     @beginEventEmissionTable{wxDateEvent}
     @event{EVT_DATE_CHANGED(id, func)}
            Process a wxEVT_DATE_CHANGED event, which fires when the user

--- a/interface/wx/timectrl.h
+++ b/interface/wx/timectrl.h
@@ -36,6 +36,13 @@ enum
 
     This control currently doesn't have any specific flags.
 
+    @note In wxMSW this control uses default user date format even if
+        wxUILocale::UseDefault() hasn't been called, while under the other
+        platforms it only does it if the default UI locale has been set.
+        For applications targeting international users, it is strongly
+        recommended to call wxUILocale::UseDefault() to ensure that the
+        behaviour is consistent across all platforms.
+
     @beginEventEmissionTable{wxDateEvent}
     @event{EVT_TIME_CHANGED(id, func)}
            Process a wxEVT_TIME_CHANGED event, which fires when the user

--- a/interface/wx/uilocale.h
+++ b/interface/wx/uilocale.h
@@ -97,6 +97,18 @@ public:
     static bool UseDefault();
 
     /**
+        Return true if the locale was set by calling either UseDefault() or
+        UseLocaleName().
+
+        It is typically not necessary to call this function, as GetCurrent()
+        always returns a valid object, but it can be used to check whether an
+        application-set locale or the default one is being used.
+
+        @since 3.3.1
+     */
+    static bool IsSet();
+
+    /**
         Get the object corresponding to the currently used locale.
 
         If UseDefault() had been called, this object corresponds to the default

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -399,18 +399,21 @@ MyFrame::MyFrame()
 
     // create some controls affected by the locale
 
+    const int border = wxSizerFlags::GetDefaultBorder();
+    auto* const sizerInput = new wxFlexGridSizer(2, wxSize(border, border));
+    sizerInput->AddGrowableCol(1);
+
     // this demonstrates RTL layout mirroring for Arabic locales and using
     // locale-specific decimal separator in wxSpinCtrlDouble.
-    wxSizer *sizer = new wxBoxSizer(wxHORIZONTAL);
-    sizer->Add(new wxStaticText(panel, wxID_ANY, _("Numeric input:")),
-               wxSizerFlags().Center().Border());
+    sizerInput->Add(new wxStaticText(panel, wxID_ANY, _("Numeric input:")),
+                    wxSizerFlags().CenterVertical().Right());
 
     wxSpinCtrlDouble* const spin = new wxSpinCtrlDouble(panel, wxID_ANY);
     spin->SetDigits(2);
     spin->SetValue(12.34);
-    sizer->Add(spin, wxSizerFlags().Center().Border());
+    sizerInput->Add(spin, wxSizerFlags().CenterVertical().Expand());
 
-    topSizer->Add(sizer, wxSizerFlags().Center());
+    topSizer->Add(sizerInput, wxSizerFlags().Center());
 
     // show that week days and months names are translated too
     topSizer->Add(new wxCalendarCtrl(panel, wxID_ANY),

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "wx/calctrl.h"
+#include "wx/datectrl.h"
 #include "wx/intl.h"
 #include "wx/file.h"
 #include "wx/grid.h"
@@ -36,6 +37,7 @@
 #include "wx/numformatter.h"
 #include "wx/platinfo.h"
 #include "wx/spinctrl.h"
+#include "wx/timectrl.h"
 #include "wx/translation.h"
 #include "wx/uilocale.h"
 
@@ -412,6 +414,18 @@ MyFrame::MyFrame()
     spin->SetDigits(2);
     spin->SetValue(12.34);
     sizerInput->Add(spin, wxSizerFlags().CenterVertical().Expand());
+
+    // this one demonstrates the locale-specific date format
+    sizerInput->Add(new wxStaticText(panel, wxID_ANY, _("Date input:")),
+                    wxSizerFlags().CenterVertical().Right());
+    sizerInput->Add(new wxDatePickerCtrl(panel, wxID_ANY),
+                    wxSizerFlags().CenterVertical().Expand());
+
+    // and this one does the same for time format
+    sizerInput->Add(new wxStaticText(panel, wxID_ANY, _("Time input:")),
+                    wxSizerFlags().CenterVertical().Right());
+    sizerInput->Add(new wxTimePickerCtrl(panel, wxID_ANY),
+                    wxSizerFlags().CenterVertical().Expand());
 
     topSizer->Add(sizerInput, wxSizerFlags().Center());
 

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -77,6 +77,8 @@ inline bool IsDefaultCLocale(const wxString& locale)
 /* static */
 wxUILocale wxUILocale::ms_current;
 
+static bool wxUILocaleIsSet = false;
+
 // ============================================================================
 // implementation
 // ============================================================================
@@ -817,6 +819,7 @@ bool wxUILocale::UseDefault()
 
     impl->Use();
     ms_current = wxUILocale(impl);
+    wxUILocaleIsSet = true;
 
     return true;
 }
@@ -851,8 +854,15 @@ bool wxUILocale::UseLocaleName(const wxString& localeName)
 
     impl->Use();
     ms_current = wxUILocale(impl);
+    wxUILocaleIsSet = true;
 
     return true;
+}
+
+/* static */
+bool wxUILocale::IsSet()
+{
+    return wxUILocaleIsSet;
 }
 
 /* static */
@@ -862,6 +872,9 @@ const wxUILocale& wxUILocale::GetCurrent()
     if ( !ms_current.m_impl )
     {
         ms_current = wxUILocale(wxUILocaleImpl::CreateStdC());
+
+        // Do _not_ set wxUILocaleIsSet to true here, as this is just the
+        // default locale and not something really chosen by the user.
     }
 
     return ms_current;

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -145,6 +145,16 @@ LCTYPE wxGetLCTYPEFormatFromLocalInfo(wxLocaleInfo index)
 
 WXDLLIMPEXP_BASE wxString wxGetMSWDateTimeFormat(wxLocaleInfo index)
 {
+    if ( !wxUILocale::IsSet() )
+    {
+        // We don't want to use the date/time formats of "C" locale here
+        // because this is incompatible with the behaviour in the previous
+        // wxWidgets versions and inconsistent with the behaviour of
+        // wxCalendarCtrl (which uses default user locale format), so let the
+        // date/time controls keep using their default format.
+        return wxString{};
+    }
+
     wxString format;
     wxString localeName = wxUILocale::GetCurrent().GetName();
     if (localeName.IsSameAs("C"))


### PR DESCRIPTION
This is the solution I propose for #25511, finally.

I'm almost sure that this is the best/least bad compromise, but if anybody has really strong (and new, i.e. not already expressed in the previous discussions) arguments against doing this, please let me know. TIA!