### PR TITLE
Don't change invalid current `wxGrid` cell in `SetTable()`

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3135,7 +3135,12 @@ wxGrid::SetTable(wxGridTableBase *table,
 
     InvalidateBestSize();
 
-    UpdateCurrentCellOnRedim();
+    // If we already have a valid current cell, ensure that it is in valid
+    // range for the new table with a possibly different number of rows/columns
+    // but don't do anything if the current cell is invalid, setting the table
+    // shouldn't automatically select the cell at (0, 0).
+    if ( m_currentCellCoords != wxGridNoCellCoords )
+        UpdateCurrentCellOnRedim();
 
     return m_created;
 }

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -28,6 +28,8 @@
 
 #include "waitfor.h"
 
+#include <memory>
+
 // To disable tests which work locally, but not when run on GitHub CI.
 #if defined(__WXGTK__) && !defined(__WXGTK3__)
     #define wxSKIP_AUTOMATIC_TEST_IF_GTK2() \
@@ -2617,6 +2619,19 @@ TEST_CASE("GridBlockCoords::SymDifference", "[grid]")
         CHECK(result.m_parts[2] == wxGridNoBlockCoords);
         CHECK(result.m_parts[3] == wxGridNoBlockCoords);
     }
+}
+
+TEST_CASE("wxGrid::Events", "[grid][event]")
+{
+    const std::unique_ptr<wxGrid> grid(new wxGrid());
+
+    EventCounter selectEvents(grid.get(), wxEVT_GRID_SELECT_CELL);
+
+    REQUIRE( grid->Create(wxTheApp->GetTopWindow(), wxID_ANY) );
+    grid->CreateGrid(1, 1);
+
+    // Creating grid shouldn't result in any selection change events.
+    CHECK( selectEvents.GetCount() == 0 );
 }
 
 //


### PR DESCRIPTION
Changing the table shouldn't make the cell (0, 0) current if we hadn't had any current cell before, this was unintentional side effect of e570d85164 (Ensure current cell remains valid when wxGrid table changes, 2023-09-15) which resulted in an unwanted wxEVT_GRID_SELECT_CELL event when creating the grid.

Fix this by only calling UpdateCurrentCellOnRedim() if we have a valid current cell to update.

See #23751.

Closes #25498.

----

cc @CookieLau
