### PR TITLE
Add opacity state functions to wxColour

### DIFF
--- a/include/wx/colour.h
+++ b/include/wx/colour.h
@@ -127,6 +127,15 @@ public:
     virtual bool IsSolid() const
         { return true; }
 
+    bool IsTransparent() const
+        { return GetAlpha() == wxALPHA_TRANSPARENT; }
+
+    bool IsOpaque() const
+        { return GetAlpha() == wxALPHA_OPAQUE; }
+
+    bool IsTranslucent() const
+        { return GetAlpha() > wxALPHA_TRANSPARENT && GetAlpha() < wxALPHA_OPAQUE; }
+
     // implemented in colourcmn.cpp
     virtual wxString GetAsString(long flags = wxC2S_NAME | wxC2S_CSS_SYNTAX) const;
 

--- a/interface/wx/colour.h
+++ b/interface/wx/colour.h
@@ -256,6 +256,29 @@ public:
         @since 3.1.2
     */
     virtual bool IsSolid() const;
+
+    /**
+        Returns @true if the color is completely transparent (i.e., no opacity).
+
+        @since 3.3.1
+    */
+    bool IsTransparent() const;
+
+    /**
+        Returns @true if the color is completely opaque (i.e., full opacity).
+
+        @since 3.3.1
+    */
+    bool IsOpaque() const;
+
+    /**
+        Returns @true if the color has some translucency
+        (not fully opaque, but not transparent either).
+
+        @since 3.3.1
+    */
+    bool IsTranslucent() const;
+
     ///@{
     /**
         Sets the RGB intensity values using the given values (first overload),

--- a/tests/graphics/colour.cpp
+++ b/tests/graphics/colour.cpp
@@ -160,6 +160,20 @@ TEST_CASE("wxColour::GetLuminance", "[colour][luminance]")
     CHECK( wxRED->GetLuminance() < 1 );
 }
 
+TEST_CASE("wxColour::IsXXX", "[colour][opacity]")
+{
+    CHECK(wxColour{ 0, 0, 0, 0 }.IsTransparent());
+    CHECK_FALSE(wxColour{ 0, 0, 0, 1 }.IsTransparent());
+
+    CHECK(wxColour{ 0, 0, 0, 255 }.IsOpaque());
+    CHECK_FALSE(wxColour{ 0, 0, 0, 1 }.IsOpaque());
+
+    CHECK(wxColour{ 0, 0, 0, 254 }.IsTranslucent());
+    CHECK(wxColour{ 0, 0, 0, 10 }.IsTranslucent());
+    CHECK_FALSE(wxColour{ 0, 0, 0, 0 }.IsTranslucent());
+    CHECK_FALSE(wxColour{ 0, 0, 0, 255 }.IsTranslucent());
+}
+
 TEST_CASE("wxColour::Database", "[colour][database]")
 {
     wxColourDatabase db;


### PR DESCRIPTION
Adds `IsTransparent()`, `IsOpaque()`, and `IsTranslucent()` to `wxColour`.

These are trivial function, but can make code more readable IMO.