### PR TITLE
Fix losing text of generic `wxListCtrl` items

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -96,9 +96,11 @@ static const int MARGIN_AROUND_CHECKBOX = 5;
 // ----------------------------------------------------------------------------
 
 wxListItemData::wxListItemData(wxListItemData&& other)
+              : m_image(other.m_image),
+                m_data(other.m_data),
+                m_owner(other.m_owner),
+                m_text(std::move(other.m_text))
 {
-    m_owner = other.m_owner;
-
     // Take ownership of the pointers from the other object and reset them.
     std::swap(m_attr, other.m_attr);
     std::swap(m_rect, other.m_rect);
@@ -109,6 +111,7 @@ wxListItemData& wxListItemData::operator=(wxListItemData&& other)
     m_image = other.m_image;
     m_data = other.m_data;
     m_owner = other.m_owner;
+    m_text = std::move(other.m_text);
 
     // Swap them to let our pointers be deleted by the other object if necessary.
     std::swap(m_attr, other.m_attr);

--- a/tests/controls/listbasetest.cpp
+++ b/tests/controls/listbasetest.cpp
@@ -1,9 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Name:        tests/controls/listbasetest.cpp
-// Purpose:     Base class for wxListCtrl and wxListView tests
+// Purpose:     Common wxListCtrl and wxListView tests
 // Author:      Steven Lamerton
 // Created:     2010-07-20
-// Copyright:   (c) 2008 Vadim Zeitlin <vadim@wxwidgets.org>,
+// Copyright:   (c) 2008,2025 Vadim Zeitlin <vadim@wxwidgets.org>,
 //              (c) 2010 Steven Lamerton
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -178,6 +178,8 @@ void ListBaseTestCase::ChangeMode()
 void ListBaseTestCase::MultiSelect()
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
 
 #if defined(__WXGTK__) && !defined(__WXGTK3__)
     // FIXME: This test fails on GitHub CI under wxGTK2 although works fine on
@@ -310,6 +312,8 @@ void ListBaseTestCase::MultiSelect()
 void ListBaseTestCase::ItemClick()
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
 
 #ifdef __WXMSW__
     // FIXME: This test fails on MSW buildbot slaves although works fine on
@@ -377,6 +381,9 @@ void ListBaseTestCase::ItemClick()
 void ListBaseTestCase::KeyDown()
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     wxListCtrl* const list = GetList();
 
     EventCounter keydown(list, wxEVT_LIST_KEY_DOWN);
@@ -526,6 +533,9 @@ void ListBaseTestCase::ItemFormatting()
 void ListBaseTestCase::EditLabel()
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     wxListCtrl* const list = GetList();
 
     list->SetWindowStyleFlag(wxLC_REPORT | wxLC_EDIT_LABELS);

--- a/tests/controls/listbasetest.cpp
+++ b/tests/controls/listbasetest.cpp
@@ -52,7 +52,7 @@ void ListBaseTestCase::ColumnsOrder()
     // check that the order is natural in the beginning
     const wxArrayInt orderOrig = list->GetColumnsOrder();
     for ( n = 0; n < NUM_COLS; n++ )
-        CPPUNIT_ASSERT_EQUAL( n, orderOrig[n] );
+        CHECK( orderOrig[n]  == n );
 
     // then rearrange them: using { 2, 0, 1 } order means that column 2 is
     // shown first, then column 0 and finally column 1
@@ -65,31 +65,31 @@ void ListBaseTestCase::ColumnsOrder()
     // check that we get back the same order as we set
     const wxArrayInt orderNew = list->GetColumnsOrder();
     for ( n = 0; n < NUM_COLS; n++ )
-        CPPUNIT_ASSERT_EQUAL( order[n], orderNew[n] );
+        CHECK( orderNew[n]  == order[n] );
 
     // and the order -> index mappings for individual columns
     for ( n = 0; n < NUM_COLS; n++ )
-        CPPUNIT_ASSERT_EQUAL( order[n], list->GetColumnIndexFromOrder(n) );
+        CHECK( list->GetColumnIndexFromOrder(n)  == order[n] );
 
     // and also the reverse mapping
-    CPPUNIT_ASSERT_EQUAL( 1, list->GetColumnOrder(0) );
-    CPPUNIT_ASSERT_EQUAL( 2, list->GetColumnOrder(1) );
-    CPPUNIT_ASSERT_EQUAL( 0, list->GetColumnOrder(2) );
+    CHECK( list->GetColumnOrder(0)  == 1 );
+    CHECK( list->GetColumnOrder(1)  == 2 );
+    CHECK( list->GetColumnOrder(2)  == 0 );
 
 
     // finally check that accessors still use indices, not order
-    CPPUNIT_ASSERT( list->GetColumn(0, li) );
-    CPPUNIT_ASSERT_EQUAL( "Column 0", li.GetText() );
+    CHECK( list->GetColumn(0, li) );
+    CHECK( li.GetText()  == "Column 0" );
 
     li.SetId(0);
     li.SetColumn(1);
-    CPPUNIT_ASSERT( list->GetItem(li) );
-    CPPUNIT_ASSERT_EQUAL( "first in first", li.GetText() );
+    CHECK( list->GetItem(li) );
+    CHECK( li.GetText()  == "first in first" );
 
     li.SetId(1);
     li.SetColumn(2);
-    CPPUNIT_ASSERT( list->GetItem(li) );
-    CPPUNIT_ASSERT_EQUAL( "second in second", li.GetText() );
+    CHECK( list->GetItem(li) );
+    CHECK( li.GetText()  == "second in second" );
 #endif // wxHAS_LISTCTRL_COLUMN_ORDER
 }
 
@@ -111,17 +111,17 @@ void ListBaseTestCase::ItemRect()
     // do test
     wxRect r;
     WX_ASSERT_FAILS_WITH_ASSERT( list->GetItemRect(1, r) );
-    CPPUNIT_ASSERT( list->GetItemRect(0, r) );
-    CPPUNIT_ASSERT_EQUAL( 150, r.GetWidth() );
+    CHECK( list->GetItemRect(0, r) );
+    CHECK( r.GetWidth()  == 150 );
 
-    CPPUNIT_ASSERT( list->GetSubItemRect(0, 0, r) );
-    CPPUNIT_ASSERT_EQUAL( 60, r.GetWidth() );
+    CHECK( list->GetSubItemRect(0, 0, r) );
+    CHECK( r.GetWidth()  == 60 );
 
-    CPPUNIT_ASSERT( list->GetSubItemRect(0, 1, r) );
-    CPPUNIT_ASSERT_EQUAL( 50, r.GetWidth() );
+    CHECK( list->GetSubItemRect(0, 1, r) );
+    CHECK( r.GetWidth()  == 50 );
 
-    CPPUNIT_ASSERT( list->GetSubItemRect(0, 2, r) );
-    CPPUNIT_ASSERT_EQUAL( 40, r.GetWidth() );
+    CHECK( list->GetSubItemRect(0, 2, r) );
+    CHECK( r.GetWidth()  == 40 );
 
     WX_ASSERT_FAILS_WITH_ASSERT( list->GetSubItemRect(0, 3, r) );
 
@@ -131,13 +131,13 @@ void ListBaseTestCase::ItemRect()
     //
     // Notice that we consider that the header can't be less than 10 pixels
     // because we don't know its exact height.
-    CPPUNIT_ASSERT( list->GetItemRect(0, r) );
-    CPPUNIT_ASSERT( r.y >= 10 );
+    CHECK( list->GetItemRect(0, r) );
+    CHECK( r.y >= 10 );
 
     // However if we remove the header now, the item should be at (0, 0).
     list->SetWindowStyle(wxLC_REPORT | wxLC_NO_HEADER);
-    CPPUNIT_ASSERT( list->GetItemRect(0, r) );
-    CPPUNIT_ASSERT_EQUAL( 0, r.y );
+    CHECK( list->GetItemRect(0, r) );
+    CHECK( r.y  == 0 );
 }
 
 void ListBaseTestCase::ItemText()
@@ -148,11 +148,11 @@ void ListBaseTestCase::ItemText()
     list->InsertColumn(1, "Second");
 
     list->InsertItem(0, "0,0");
-    CPPUNIT_ASSERT_EQUAL( "0,0", list->GetItemText(0) );
-    CPPUNIT_ASSERT_EQUAL( "", list->GetItemText(0, 1) );
+    CHECK( list->GetItemText(0) == "0,0" );
+    CHECK( list->GetItemText(0, 1)  == "" );
 
     list->SetItem(0, 1, "0,1");
-    CPPUNIT_ASSERT_EQUAL( "0,1", list->GetItemText(0, 1) );
+    CHECK( list->GetItemText(0, 1) == "0,1" );
 }
 
 void ListBaseTestCase::ChangeMode()
@@ -162,17 +162,17 @@ void ListBaseTestCase::ChangeMode()
     list->InsertColumn(0, "Header");
     list->InsertItem(0, "First");
     list->InsertItem(1, "Second");
-    CPPUNIT_ASSERT_EQUAL( 2, list->GetItemCount() );
+    CHECK( list->GetItemCount()  == 2 );
 
     // check that switching the mode preserves the items
     list->SetWindowStyle(wxLC_ICON);
-    CPPUNIT_ASSERT_EQUAL( 2, list->GetItemCount() );
-    CPPUNIT_ASSERT_EQUAL( "First", list->GetItemText(0) );
+    CHECK( list->GetItemCount()  == 2 );
+    CHECK( list->GetItemText(0)  == "First" );
 
     // and so does switching back
     list->SetWindowStyle(wxLC_REPORT);
-    CPPUNIT_ASSERT_EQUAL( 2, list->GetItemCount() );
-    CPPUNIT_ASSERT_EQUAL( "First", list->GetItemText(0) );
+    CHECK( list->GetItemCount()  == 2 );
+    CHECK( list->GetItemText(0)  == "First" );
 }
 
 void ListBaseTestCase::MultiSelect()
@@ -226,10 +226,10 @@ void ListBaseTestCase::MultiSelect()
 
     // when the first item was selected the focus changes to it, but not
     // on subsequent clicks
-    CPPUNIT_ASSERT_EQUAL(4, list->GetSelectedItemCount()); // item 2 to 5 (inclusive) are selected
-    CPPUNIT_ASSERT_EQUAL(2, focused.GetCount()); // count the focus which was on the anchor
-    CPPUNIT_ASSERT_EQUAL(4, selected.GetCount());
-    CPPUNIT_ASSERT_EQUAL(0, deselected.GetCount());
+    CHECK( list->GetSelectedItemCount() == 4 ); // item 2 to 5 (inclusive) are selected
+    CHECK( focused.GetCount() == 2 ); // count the focus which was on the anchor
+    CHECK( selected.GetCount() == 4 );
+    CHECK( deselected.GetCount() == 0 );
 
     focused.Clear();
     selected.Clear();
@@ -238,10 +238,10 @@ void ListBaseTestCase::MultiSelect()
     sim.Char(WXK_END, wxMOD_SHIFT); // extend the selection to the last item
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(8, list->GetSelectedItemCount()); // item 2 to 9 (inclusive) are selected
-    CPPUNIT_ASSERT_EQUAL(1, focused.GetCount()); // focus is on the last item
-    CPPUNIT_ASSERT_EQUAL(4, selected.GetCount()); // only newly selected items got the event
-    CPPUNIT_ASSERT_EQUAL(0, deselected.GetCount());
+    CHECK( list->GetSelectedItemCount() == 8 ); // item 2 to 9 (inclusive) are selected
+    CHECK( focused.GetCount() == 1 ); // focus is on the last item
+    CHECK( selected.GetCount() == 4); // only newly selected items got the event
+    CHECK( deselected.GetCount() == 0 );
 
     focused.Clear();
     selected.Clear();
@@ -250,10 +250,10 @@ void ListBaseTestCase::MultiSelect()
     sim.Char(WXK_HOME, wxMOD_SHIFT); // select from anchor to the first item
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(3, list->GetSelectedItemCount()); // item 0 to 2 (inclusive) are selected
-    CPPUNIT_ASSERT_EQUAL(1, focused.GetCount()); // focus is on item 0
-    CPPUNIT_ASSERT_EQUAL(2, selected.GetCount()); // events are only generated for item 0 and 1
-    CPPUNIT_ASSERT_EQUAL(7, deselected.GetCount()); // item 2 (exclusive) to 9 are deselected
+    CHECK( list->GetSelectedItemCount() == 3 ); // item 0 to 2 (inclusive) are selected
+    CHECK( focused.GetCount() == 1 ); // focus is on item 0
+    CHECK( selected.GetCount() == 2 ); // events are only generated for item 0 and 1
+    CHECK( deselected.GetCount() == 7 ); // item 2 (exclusive) to 9 are deselected
 
     focused.Clear();
     selected.Clear();
@@ -271,10 +271,10 @@ void ListBaseTestCase::MultiSelect()
     sim.MouseClick();
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, list->GetSelectedItemCount()); // anchor is the only selected item
-    CPPUNIT_ASSERT_EQUAL(1, focused.GetCount()); // because the focus changed from item 0 to anchor
-    CPPUNIT_ASSERT_EQUAL(0, selected.GetCount()); // anchor is already in selection state
-    CPPUNIT_ASSERT_EQUAL(2, deselected.GetCount()); // items 0 and 1 are deselected
+    CHECK( list->GetSelectedItemCount() == 1 ); // anchor is the only selected item
+    CHECK( focused.GetCount() == 1 ); // because the focus changed from item 0 to anchor
+    CHECK( selected.GetCount() == 0 ); // anchor is already in selection state
+    CHECK( deselected.GetCount() == 2 ); // items 0 and 1 are deselected
 
     focused.Clear();
     selected.Clear();
@@ -302,10 +302,10 @@ void ListBaseTestCase::MultiSelect()
     sim.MouseClick();
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, list->GetSelectedItemCount()); // item 3 is the only selected item
-    CPPUNIT_ASSERT_EQUAL(1, focused.GetCount()); // because the focus changed from anchor to item 3
-    CPPUNIT_ASSERT_EQUAL(2, selected.GetCount()); // item 3 was selected twice
-    CPPUNIT_ASSERT_EQUAL(2, deselected.GetCount()); // anchor and item 3 were each deselected once
+    CHECK( list->GetSelectedItemCount() == 1 ); // item 3 is the only selected item
+    CHECK( focused.GetCount() == 1 ); // because the focus changed from anchor to item 3
+    CHECK( selected.GetCount() == 2 ); // item 3 was selected twice
+    CHECK( deselected.GetCount() == 2 ); // anchor and item 3 were each deselected once
 #endif // wxUSE_UIACTIONSIMULATOR
 }
 
@@ -370,11 +370,11 @@ void ListBaseTestCase::ItemClick()
 
     // when the first item was selected the focus changes to it, but not
     // on subsequent clicks
-    CPPUNIT_ASSERT_EQUAL(1, focused.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1, selected.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1, deselected.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1, activated.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1, rclick.GetCount());
+    CHECK( focused.GetCount() == 1 );
+    CHECK( selected.GetCount() == 1 );
+    CHECK( deselected.GetCount() == 1 );
+    CHECK( activated.GetCount() == 1 );
+    CHECK( rclick.GetCount() == 1 );
 #endif // wxUSE_UIACTIONSIMULATOR
 }
 
@@ -395,7 +395,7 @@ void ListBaseTestCase::KeyDown()
     sim.Text("aAbB"); // 4 letters + 2 shift mods.
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(6, keydown.GetCount());
+    CHECK( keydown.GetCount() == 6 );
 #endif
 }
 
@@ -433,8 +433,8 @@ void ListBaseTestCase::DeleteItems()
     list->ClearAll();
     list->DeleteAllItems();
 
-    CPPUNIT_ASSERT_EQUAL(2, deleteitem.GetCount());
-    CPPUNIT_ASSERT_EQUAL(2, deleteall.GetCount());
+    CHECK( deleteitem.GetCount() == 2 );
+    CHECK( deleteall.GetCount() == 2 );
 #endif
 }
 
@@ -453,7 +453,7 @@ void ListBaseTestCase::InsertItem()
     list->InsertItem(item);
     list->InsertItem(1, "more text");
 
-    CPPUNIT_ASSERT_EQUAL(2, insert.GetCount());
+    CHECK( insert.GetCount() == 2 );
 }
 
 void ListBaseTestCase::Find()
@@ -476,10 +476,10 @@ void ListBaseTestCase::Find()
     list->InsertItem(3, "ITEM 01");
     list->SetItem(3, 1, "first column");
 
-    CPPUNIT_ASSERT_EQUAL(1, list->FindItem(-1, "Item 1"));
-    CPPUNIT_ASSERT_EQUAL(2, list->FindItem(-1, "Item 4", true));
-    CPPUNIT_ASSERT_EQUAL(2, list->FindItem(1, "Item 40"));
-    CPPUNIT_ASSERT_EQUAL(3, list->FindItem(2, "Item 0", true));
+    CHECK( list->FindItem(-1, "Item 1") == 1 );
+    CHECK( list->FindItem(-1, "Item 4", true) == 2 );
+    CHECK( list->FindItem(1, "Item 40") == 2 );
+    CHECK( list->FindItem(2, "Item 0", true) == 3 );
 }
 
 void ListBaseTestCase::Visible()
@@ -496,16 +496,16 @@ void ListBaseTestCase::Visible()
         list->InsertItem(i, wxString::Format("string %d", i));
     }
 
-    CPPUNIT_ASSERT_EQUAL(count + 10, list->GetItemCount());
-    CPPUNIT_ASSERT_EQUAL(0, list->GetTopItem());
-    CPPUNIT_ASSERT(list->IsVisible(0));
-    CPPUNIT_ASSERT(!list->IsVisible(count + 1));
+    CHECK( list->GetItemCount() == count + 10 );
+    CHECK( list->GetTopItem() == 0 );
+    CHECK(list->IsVisible(0));
+    CHECK(!list->IsVisible(count + 1));
 
-    CPPUNIT_ASSERT(list->EnsureVisible(count + 9));
-    CPPUNIT_ASSERT(list->IsVisible(count + 9));
-    CPPUNIT_ASSERT(!list->IsVisible(9));
+    CHECK(list->EnsureVisible(count + 9));
+    CHECK(list->IsVisible(count + 9));
+    CHECK(!list->IsVisible(9));
 
-    CPPUNIT_ASSERT(list->GetTopItem() != 0);
+    CHECK(list->GetTopItem() != 0);
 }
 
 void ListBaseTestCase::ItemFormatting()
@@ -523,11 +523,11 @@ void ListBaseTestCase::ItemFormatting()
     list->SetItemTextColour(0, *wxRED);
     list->SetItemBackgroundColour(1, *wxBLUE);
 
-    CPPUNIT_ASSERT_EQUAL(*wxGREEN, list->GetBackgroundColour());
-    CPPUNIT_ASSERT_EQUAL(*wxBLUE,list->GetItemBackgroundColour(1));
+    CHECK( list->GetBackgroundColour() == *wxGREEN );
+    CHECK( list->GetItemBackgroundColour(1) == *wxBLUE );
 
-    CPPUNIT_ASSERT_EQUAL(*wxYELLOW, list->GetTextColour());
-    CPPUNIT_ASSERT_EQUAL(*wxRED, list->GetItemTextColour(0));
+    CHECK( list->GetTextColour() == *wxYELLOW );
+    CHECK( list->GetItemTextColour(0) == *wxRED );
 }
 
 void ListBaseTestCase::EditLabel()
@@ -560,8 +560,8 @@ void ListBaseTestCase::EditLabel()
 
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, beginedit.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1, endedit.GetCount());
+    CHECK( beginedit.GetCount() == 1 );
+    CHECK( endedit.GetCount() == 1 );
 #endif
 }
 
@@ -578,7 +578,7 @@ void ListBaseTestCase::ImageList()
 
     list->AssignImageList(imglist, wxIMAGE_LIST_NORMAL);
 
-    CPPUNIT_ASSERT_EQUAL(imglist, list->GetImageList(wxIMAGE_LIST_NORMAL));
+    CHECK( list->GetImageList(wxIMAGE_LIST_NORMAL) == imglist );
 }
 
 void ListBaseTestCase::HitTest()
@@ -618,22 +618,19 @@ void ListBaseTestCase::HitTest()
     int xCheckBox = rectSubItem0.GetLeft() + (rectIcon.GetLeft() -
                     rectSubItem0.GetLeft()) / 2;
     list->HitTest(wxPoint(xCheckBox, y), flags);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Expected wxLIST_HITTEST_ONITEMSTATEICON",
-        wxLIST_HITTEST_ONITEMSTATEICON, flags);
+    CHECK( flags == wxLIST_HITTEST_ONITEMSTATEICON );
 
     // icon
     int xIcon = rectIcon.GetLeft() + (rectIcon.GetRight() - rectIcon.GetLeft()) / 2;
     list->HitTest(wxPoint(xIcon, y), flags);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Expected wxLIST_HITTEST_ONITEMICON",
-        wxLIST_HITTEST_ONITEMICON, flags);
+    CHECK( flags == wxLIST_HITTEST_ONITEMICON );
 
     // label, beyond column 0
     wxRect rectItem;
     list->GetItemRect(0, rectItem); // entire item
     int xHit = rectSubItem0.GetRight() + (rectItem.GetRight() - rectSubItem0.GetRight()) / 2;
     list->HitTest(wxPoint(xHit, y), flags);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Expected wxLIST_HITTEST_ONITEMLABEL",
-        wxLIST_HITTEST_ONITEMLABEL, flags);
+    CHECK( flags == wxLIST_HITTEST_ONITEMLABEL );
 #endif // __WXMSW__
 }
 
@@ -667,8 +664,8 @@ void ListBaseTestCase::Sort()
 
     list->SortItems(MyCompareFunction, 0);
 
-    CPPUNIT_ASSERT_EQUAL("Item 1", list->GetItemText(0));
-    CPPUNIT_ASSERT_EQUAL("Item 0", list->GetItemText(1));
+    CHECK( list->GetItemText(0) == "Item 1" );
+    CHECK( list->GetItemText(1) == "Item 0" );
 }
 
 #endif //wxUSE_LISTCTRL

--- a/tests/controls/listbasetest.h
+++ b/tests/controls/listbasetest.h
@@ -1,9 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Name:        tests/controls/listbasetest.cpp
-// Purpose:     Base class for wxListCtrl and wxListView tests
+// Purpose:     Common wxListCtrl and wxListView tests
 // Author:      Steven Lamerton
 // Created:     2010-07-20
-// Copyright:   (c) 2008 Vadim Zeitlin <vadim@wxwidgets.org>,
+// Copyright:   (c) 2008,2025 Vadim Zeitlin <vadim@wxwidgets.org>,
 //              (c) 2010 Steven Lamerton
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -18,24 +18,6 @@ public:
 
 protected:
     virtual wxListCtrl *GetList() const = 0;
-
-    #define wxLIST_BASE_TESTS() \
-        CPPUNIT_TEST( ColumnsOrder ); \
-        CPPUNIT_TEST( ItemRect ); \
-        CPPUNIT_TEST( ItemText ); \
-        CPPUNIT_TEST( ChangeMode ); \
-        WXUISIM_TEST( ItemClick ); \
-        WXUISIM_TEST( KeyDown ); \
-        WXUISIM_TEST( MultiSelect ); \
-        CPPUNIT_TEST( DeleteItems ); \
-        CPPUNIT_TEST( InsertItem ); \
-        CPPUNIT_TEST( Find ); \
-        CPPUNIT_TEST( Visible ); \
-        CPPUNIT_TEST( ItemFormatting ); \
-        WXUISIM_TEST( EditLabel ); \
-        CPPUNIT_TEST( ImageList ); \
-        CPPUNIT_TEST( HitTest ); \
-        CPPUNIT_TEST( Sort )
 
     void ColumnsOrder();
     void ItemRect();
@@ -56,5 +38,37 @@ protected:
 
     wxDECLARE_NO_COPY_CLASS(ListBaseTestCase);
 };
+
+// In the macros below, ClassName is the name of the class (without "wx"
+// prefix), i.e. an identifier, and ClassTag is the string containing the
+// tag to be used in the test registration macro.
+
+// Define a test case delegating to ListBaseTestCase.
+#define wxLIST_TEST_CASE(ClassName, ClassTag, TestName) \
+    TEST_CASE_METHOD(ClassName ## TestCase, \
+                     #ClassName "::" #TestName, \
+                     ClassTag) \
+    { \
+        TestName(); \
+    }
+
+// Define all common test cases.
+#define wxLIST_BASE_TESTS(ClassName, TagName) \
+    wxLIST_TEST_CASE(ClassName, TagName, ColumnsOrder) \
+    wxLIST_TEST_CASE(ClassName, TagName, ItemRect) \
+    wxLIST_TEST_CASE(ClassName, TagName, ItemText) \
+    wxLIST_TEST_CASE(ClassName, TagName, ChangeMode) \
+    wxLIST_TEST_CASE(ClassName, TagName, ItemClick) \
+    wxLIST_TEST_CASE(ClassName, TagName, KeyDown) \
+    wxLIST_TEST_CASE(ClassName, TagName, MultiSelect) \
+    wxLIST_TEST_CASE(ClassName, TagName, DeleteItems) \
+    wxLIST_TEST_CASE(ClassName, TagName, InsertItem) \
+    wxLIST_TEST_CASE(ClassName, TagName, Find) \
+    wxLIST_TEST_CASE(ClassName, TagName, Visible) \
+    wxLIST_TEST_CASE(ClassName, TagName, ItemFormatting) \
+    wxLIST_TEST_CASE(ClassName, TagName, EditLabel) \
+    wxLIST_TEST_CASE(ClassName, TagName, ImageList) \
+    wxLIST_TEST_CASE(ClassName, TagName, HitTest) \
+    wxLIST_TEST_CASE(ClassName, TagName, Sort)
 
 #endif

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -186,9 +186,9 @@ TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::ColumnDrag", "[listctrl]")
     sim.MouseUp();
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, begindrag.GetCount());
-    CPPUNIT_ASSERT(dragging.GetCount() > 0);
-    CPPUNIT_ASSERT_EQUAL(1, enddrag.GetCount());
+    CHECK( begindrag.GetCount() == 1 );
+    CHECK( dragging.GetCount() > 0 );
+    CHECK( enddrag.GetCount() == 1 );
 
     m_list->ClearAll();
 }
@@ -213,8 +213,8 @@ TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::ColumnClick", "[listctrl]")
     sim.MouseClick(wxMOUSE_BTN_RIGHT);
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, colclick.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1, colrclick.GetCount());
+    CHECK( colclick.GetCount() == 1 );
+    CHECK( colrclick.GetCount() == 1 );
 
     m_list->ClearAll();
 }

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -31,52 +31,25 @@
 // test class
 // ----------------------------------------------------------------------------
 
-class ListCtrlTestCase : public ListBaseTestCase, public CppUnit::TestCase
+class ListCtrlTestCase : public ListBaseTestCase
 {
 public:
-    ListCtrlTestCase() { }
-
-    virtual void setUp() override;
-    virtual void tearDown() override;
+    ListCtrlTestCase();
+    virtual ~ListCtrlTestCase() override;
 
     virtual wxListCtrl *GetList() const override { return m_list; }
 
-private:
-    CPPUNIT_TEST_SUITE( ListCtrlTestCase );
-        wxLIST_BASE_TESTS();
-        CPPUNIT_TEST( EditLabel );
-        WXUISIM_TEST( ColumnClick );
-        WXUISIM_TEST( ColumnDrag );
-        CPPUNIT_TEST( SubitemRect );
-        CPPUNIT_TEST( ColumnCount );
-    CPPUNIT_TEST_SUITE_END();
-
-    void EditLabel();
-    void SubitemRect();
-    void ColumnCount();
-#if wxUSE_UIACTIONSIMULATOR
-    // Column events are only supported in wxListCtrl currently so we test them
-    // here rather than in ListBaseTest
-    void ColumnClick();
-    void ColumnDrag();
-#endif // wxUSE_UIACTIONSIMULATOR
-
+protected:
     wxListCtrl *m_list;
 
     wxDECLARE_NO_COPY_CLASS(ListCtrlTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( ListCtrlTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( ListCtrlTestCase, "ListCtrlTestCase" );
-
 // ----------------------------------------------------------------------------
 // test initialization
 // ----------------------------------------------------------------------------
 
-void ListCtrlTestCase::setUp()
+ListCtrlTestCase::ListCtrlTestCase()
 {
     m_list = new wxListCtrl(wxTheApp->GetTopWindow());
     m_list->SetWindowStyle(wxLC_REPORT | wxLC_EDIT_LABELS);
@@ -85,13 +58,15 @@ void ListCtrlTestCase::setUp()
     wxTheApp->GetTopWindow()->Raise();
 }
 
-void ListCtrlTestCase::tearDown()
+ListCtrlTestCase::~ListCtrlTestCase()
 {
     DeleteTestWindow(m_list);
-    m_list = nullptr;
 }
 
-void ListCtrlTestCase::EditLabel()
+wxLIST_BASE_TESTS(ListCtrl, "[listctrl]")
+
+// Note that wxLIST_BASE_TESTS() already defines "ListCtrl::EditLabel" test.
+TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::CallEditLabel", "[listctrl]")
 {
     EventCounter editItem(m_list, wxEVT_LIST_BEGIN_LABEL_EDIT);
     EventCounter endEditItem(m_list, wxEVT_LIST_END_LABEL_EDIT);
@@ -106,7 +81,7 @@ void ListCtrlTestCase::EditLabel()
     CHECK(endEditItem.GetCount() == 1);
 }
 
-void ListCtrlTestCase::SubitemRect()
+TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::SubitemRect", "[listctrl]")
 {
     wxBitmap bmp = wxArtProvider::GetBitmap(wxART_ERROR);
 
@@ -151,7 +126,7 @@ void ListCtrlTestCase::SubitemRect()
     CHECK(rectLabel.GetRight() == rectItem.GetRight());
 }
 
-void ListCtrlTestCase::ColumnCount()
+TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::ColumnCount", "[listctrl]")
 {
     CHECK(m_list->GetColumnCount() == 0);
     m_list->InsertColumn(0, "Column 0");
@@ -179,8 +154,12 @@ void ListCtrlTestCase::ColumnCount()
 }
 
 #if wxUSE_UIACTIONSIMULATOR
-void ListCtrlTestCase::ColumnDrag()
+
+TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::ColumnDrag", "[listctrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     EventCounter begindrag(m_list, wxEVT_LIST_COL_BEGIN_DRAG);
     EventCounter dragging(m_list, wxEVT_LIST_COL_DRAGGING);
     EventCounter enddrag(m_list, wxEVT_LIST_COL_END_DRAG);
@@ -214,8 +193,11 @@ void ListCtrlTestCase::ColumnDrag()
     m_list->ClearAll();
 }
 
-void ListCtrlTestCase::ColumnClick()
+TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::ColumnClick", "[listctrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     EventCounter colclick(m_list, wxEVT_LIST_COL_CLICK);
     EventCounter colrclick(m_list, wxEVT_LIST_COL_RIGHT_CLICK);
 

--- a/tests/controls/listviewtest.cpp
+++ b/tests/controls/listviewtest.cpp
@@ -105,4 +105,19 @@ TEST_CASE_METHOD(ListViewTestCase, "ListView::Focus", "[listctrl][listview]")
     CHECK( m_list->GetFocusedItem() == 0 );
 }
 
+TEST_CASE_METHOD(ListViewTestCase, "ListView::AppendColumn", "[listctrl][listview]")
+{
+    m_list->AppendColumn("Column 0");
+    m_list->AppendColumn("Column 1");
+
+    m_list->InsertItem(0, "First item");
+    m_list->SetItem(0, 1, "First subitem");
+
+    // Appending a column shouldn't change the existing items.
+    m_list->AppendColumn("Column 2");
+
+    CHECK( m_list->GetItemText(0) == "First item" );
+    CHECK( m_list->GetItemText(0, 1) == "First subitem" );
+}
+
 #endif

--- a/tests/controls/listviewtest.cpp
+++ b/tests/controls/listviewtest.cpp
@@ -19,51 +19,35 @@
 #include "listbasetest.h"
 #include "testableframe.h"
 
-class ListViewTestCase : public ListBaseTestCase, public CppUnit::TestCase
+class ListViewTestCase : public ListBaseTestCase
 {
 public:
-    ListViewTestCase() { }
-
-    virtual void setUp() override;
-    virtual void tearDown() override;
+    ListViewTestCase();
+    virtual ~ListViewTestCase() override;
 
     virtual wxListCtrl *GetList() const override { return m_list; }
 
-private:
-    CPPUNIT_TEST_SUITE( ListViewTestCase );
-        wxLIST_BASE_TESTS();
-        CPPUNIT_TEST( Selection );
-        CPPUNIT_TEST( Focus );
-    CPPUNIT_TEST_SUITE_END();
-
-    void Selection();
-    void Focus();
-
+protected:
     wxListView *m_list;
 
     wxDECLARE_NO_COPY_CLASS(ListViewTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( ListViewTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( ListViewTestCase, "ListViewTestCase" );
-
-void ListViewTestCase::setUp()
+ListViewTestCase::ListViewTestCase()
 {
     m_list = new wxListView(wxTheApp->GetTopWindow());
     m_list->SetWindowStyle(wxLC_REPORT);
     m_list->SetSize(400, 200);
 }
 
-void ListViewTestCase::tearDown()
+ListViewTestCase::~ListViewTestCase()
 {
     DeleteTestWindow(m_list);
-    m_list = nullptr;
 }
 
-void ListViewTestCase::Selection()
+wxLIST_BASE_TESTS(ListView, "[listctrl][listview]")
+
+TEST_CASE_METHOD(ListViewTestCase, "ListView::Selection", "[listctrl][listview]")
 {
     m_list->InsertColumn(0, "Column 0");
 
@@ -101,7 +85,7 @@ void ListViewTestCase::Selection()
     CPPUNIT_ASSERT_EQUAL(2, m_list->GetFirstSelected());
 }
 
-void ListViewTestCase::Focus()
+TEST_CASE_METHOD(ListViewTestCase, "ListView::Focus", "[listctrl][listview]")
 {
     EventCounter focused(m_list, wxEVT_LIST_ITEM_FOCUSED);
 

--- a/tests/controls/listviewtest.cpp
+++ b/tests/controls/listviewtest.cpp
@@ -60,29 +60,29 @@ TEST_CASE_METHOD(ListViewTestCase, "ListView::Selection", "[listctrl][listview]"
     m_list->Select(2);
     m_list->Select(3);
 
-    CPPUNIT_ASSERT(m_list->IsSelected(0));
-    CPPUNIT_ASSERT(!m_list->IsSelected(1));
+    CHECK(m_list->IsSelected(0));
+    CHECK(!m_list->IsSelected(1));
 
     long sel = m_list->GetFirstSelected();
 
-    CPPUNIT_ASSERT_EQUAL(0, sel);
+    CHECK( sel == 0 );
 
     sel = m_list->GetNextSelected(sel);
 
-    CPPUNIT_ASSERT_EQUAL(2, sel);
+    CHECK( sel == 2 );
 
     sel = m_list->GetNextSelected(sel);
 
-    CPPUNIT_ASSERT_EQUAL(3, sel);
+    CHECK( sel == 3 );
 
     sel = m_list->GetNextSelected(sel);
 
-    CPPUNIT_ASSERT_EQUAL(-1, sel);
+    CHECK( sel == -1 );
 
     m_list->Select(0, false);
 
-    CPPUNIT_ASSERT(!m_list->IsSelected(0));
-    CPPUNIT_ASSERT_EQUAL(2, m_list->GetFirstSelected());
+    CHECK(!m_list->IsSelected(0));
+    CHECK( m_list->GetFirstSelected() == 2 );
 }
 
 TEST_CASE_METHOD(ListViewTestCase, "ListView::Focus", "[listctrl][listview]")
@@ -96,13 +96,13 @@ TEST_CASE_METHOD(ListViewTestCase, "ListView::Focus", "[listctrl][listview]")
     m_list->InsertItem(2, "Item 2");
     m_list->InsertItem(3, "Item 3");
 
-    CPPUNIT_ASSERT_EQUAL(0, focused.GetCount());
-    CPPUNIT_ASSERT_EQUAL(-1, m_list->GetFocusedItem());
+    CHECK( focused.GetCount() == 0 );
+    CHECK( m_list->GetFocusedItem() == -1 );
 
     m_list->Focus(0);
 
-    CPPUNIT_ASSERT_EQUAL(1, focused.GetCount());
-    CPPUNIT_ASSERT_EQUAL(0, m_list->GetFocusedItem());
+    CHECK( focused.GetCount() == 1 );
+    CHECK( m_list->GetFocusedItem() == 0 );
 }
 
 #endif


### PR DESCRIPTION
Fixes #25519 and also refactors/simplifies the unit tests for this class.