### PR TITLE
Restore compatibility with code using wxPG_XXX flags

### DIFF
--- a/include/wx/propgrid/advprops.h
+++ b/include/wx/propgrid/advprops.h
@@ -159,7 +159,7 @@ protected:
 
 #if WXWIN_COMPATIBILITY_3_2
 // If set, then match from list is searched for a custom colour.
-constexpr int wxPG_PROP_TRANSLATE_CUSTOM = static_cast<int>(wxPGPropertyFlags::Reserved_1);
+constexpr int wxPG_PROP_TRANSLATE_CUSTOM = wxPG_PROP_CLASS_SPECIFIC_1;
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Has dropdown list of wxWidgets system colours. Value used is

--- a/include/wx/propgrid/advprops.h
+++ b/include/wx/propgrid/advprops.h
@@ -159,8 +159,7 @@ protected:
 
 #if WXWIN_COMPATIBILITY_3_2
 // If set, then match from list is searched for a custom colour.
-wxDEPRECATED_MSG("wxPG_PROP_TRANSLATE_CUSTOM is intended for internal use.")
-constexpr wxPGPropertyFlags wxPG_PROP_TRANSLATE_CUSTOM = wxPGPropertyFlags::Reserved_1;
+constexpr int wxPG_PROP_TRANSLATE_CUSTOM = static_cast<int>(wxPGPropertyFlags::Reserved_1);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Has dropdown list of wxWidgets system colours. Value used is

--- a/include/wx/propgrid/private.h
+++ b/include/wx/propgrid/private.h
@@ -188,29 +188,29 @@ wxDECLARE_EVENT(wxEVT_PG_COLS_RESIZED, wxPropertyGridEvent);
 // Flags used only internally
 
 // wxBoolProperty, wxFlagsProperty specific flags
-constexpr wxPGPropertyFlags wxPGPropertyFlags_UseCheckBox = wxPGPropertyFlags::Reserved_1;
+constexpr wxPGFlags wxPGPropertyFlags_UseCheckBox = wxPGFlags::Reserved_1;
 // DCC = Double Click Cycles
-constexpr wxPGPropertyFlags wxPGPropertyFlags_UseDCC = wxPGPropertyFlags::Reserved_2;
+constexpr wxPGFlags wxPGPropertyFlags_UseDCC = wxPGFlags::Reserved_2;
 
 // wxStringProperty flag
-constexpr wxPGPropertyFlags wxPGPropertyFlags_Password = wxPGPropertyFlags::Reserved_2;
+constexpr wxPGFlags wxPGPropertyFlags_Password = wxPGFlags::Reserved_2;
 
 // wxColourProperty flag - if set, then match from list is searched for a custom colour.
-constexpr wxPGPropertyFlags wxPGPropertyFlags_TranslateCustom = wxPGPropertyFlags::Reserved_1;
+constexpr wxPGFlags wxPGPropertyFlags_TranslateCustom = wxPGFlags::Reserved_1;
 
 // wxCursorProperty, wxSystemColourProperty - If set, then selection of choices is static
 // and should not be changed (i.e. returns nullptr in GetPropertyChoices).
-constexpr wxPGPropertyFlags wxPGPropertyFlags_StaticChoices = wxPGPropertyFlags::Reserved_1;
+constexpr wxPGFlags wxPGPropertyFlags_StaticChoices = wxPGFlags::Reserved_1;
 
-// wxSystemColourProperty - wxEnumProperty based classes cannot use wxPGPropertyFlags::Reserved_1
-constexpr wxPGPropertyFlags wxPGPropertyFlags_HideCustomColour = wxPGPropertyFlags::Reserved_2;
-constexpr wxPGPropertyFlags wxPGPropertyFlags_ColourHasAlpha = wxPGPropertyFlags::Reserved_3;
+// wxSystemColourProperty - wxEnumProperty based classes cannot use wxPGFlags::Reserved_1
+constexpr wxPGFlags wxPGPropertyFlags_HideCustomColour = wxPGFlags::Reserved_2;
+constexpr wxPGFlags wxPGPropertyFlags_ColourHasAlpha = wxPGFlags::Reserved_3;
 
 // wxFileProperty - if set, full path is shown in wxFileProperty.
-constexpr wxPGPropertyFlags wxPGPropertyFlags_ShowFullFileName = wxPGPropertyFlags::Reserved_1;
+constexpr wxPGFlags wxPGPropertyFlags_ShowFullFileName = wxPGFlags::Reserved_1;
 
 // wxLongStringProperty - flag used to mark that edit button
 // should be enabled even in the read-only mode.
-constexpr wxPGPropertyFlags wxPGPropertyFlags_ActiveButton = wxPGPropertyFlags::Reserved_3;
+constexpr wxPGFlags wxPGPropertyFlags_ActiveButton = wxPGFlags::Reserved_3;
 
 #endif // _WX_PROPGRID_PRIVATE_H_

--- a/include/wx/propgrid/property.h
+++ b/include/wx/propgrid/property.h
@@ -304,7 +304,7 @@ protected:
     std::unordered_map<wxString, wxVariantData*> m_map;
 };
 
-enum class wxPGPropertyFlags : int
+enum class wxPGFlags : int
 {
     // No flags.
     Null = 0,
@@ -415,37 +415,37 @@ enum class wxPGPropertyFlags : int
     StringStoredFlags = Disabled | Hidden | NoEditor | Collapsed
 };
 
-constexpr wxPGPropertyFlags operator|(wxPGPropertyFlags a, wxPGPropertyFlags b)
+constexpr wxPGFlags operator|(wxPGFlags a, wxPGFlags b)
 {
-    return static_cast<wxPGPropertyFlags>(static_cast<int>(a) | static_cast<int>(b));
+    return static_cast<wxPGFlags>(static_cast<int>(a) | static_cast<int>(b));
 }
 
-inline wxPGPropertyFlags operator|=(wxPGPropertyFlags & a, wxPGPropertyFlags b)
+inline wxPGFlags operator|=(wxPGFlags & a, wxPGFlags b)
 {
     return a = a | b;
 }
 
-constexpr wxPGPropertyFlags operator&(wxPGPropertyFlags a, wxPGPropertyFlags b)
+constexpr wxPGFlags operator&(wxPGFlags a, wxPGFlags b)
 {
-    return static_cast<wxPGPropertyFlags>(static_cast<int>(a) & static_cast<int>(b));
+    return static_cast<wxPGFlags>(static_cast<int>(a) & static_cast<int>(b));
 }
 
-inline wxPGPropertyFlags operator&=(wxPGPropertyFlags & a, wxPGPropertyFlags b)
+inline wxPGFlags operator&=(wxPGFlags & a, wxPGFlags b)
 {
     return a = a & b;
 }
 
-constexpr wxPGPropertyFlags operator^(wxPGPropertyFlags a, wxPGPropertyFlags b)
+constexpr wxPGFlags operator^(wxPGFlags a, wxPGFlags b)
 {
-    return static_cast<wxPGPropertyFlags>(static_cast<int>(a) ^ static_cast<int>(b));
+    return static_cast<wxPGFlags>(static_cast<int>(a) ^ static_cast<int>(b));
 }
 
-constexpr wxPGPropertyFlags operator~(wxPGPropertyFlags a)
+constexpr wxPGFlags operator~(wxPGFlags a)
 {
-    return static_cast<wxPGPropertyFlags>(~static_cast<int>(a));
+    return static_cast<wxPGFlags>(~static_cast<int>(a));
 }
 
-constexpr bool operator!(wxPGPropertyFlags a)
+constexpr bool operator!(wxPGFlags a)
 {
     return static_cast<int>(a) == 0;
 }
@@ -453,22 +453,22 @@ constexpr bool operator!(wxPGPropertyFlags a)
 // We need these operators with int arguments for interoperability
 // with wxPG_ITERATOR_FLAGS as plain enumeration).
 // =====
-constexpr int operator<<(wxPGPropertyFlags a, int n)
+constexpr int operator<<(wxPGFlags a, int n)
 {
     return static_cast<int>(a) << n;
 }
 
-constexpr int operator|(wxPGPropertyFlags a, int b)
+constexpr int operator|(wxPGFlags a, int b)
 {
     return static_cast<int>(a) | b;
 }
 
-constexpr int operator|(int a, wxPGPropertyFlags b)
+constexpr int operator|(int a, wxPGFlags b)
 {
     return a | static_cast<int>(b);
 }
 
-constexpr int operator&(int a, wxPGPropertyFlags b)
+constexpr int operator&(int a, wxPGFlags b)
 {
     return a & static_cast<int>(b);
 }
@@ -477,34 +477,35 @@ constexpr int operator&(int a, wxPGPropertyFlags b)
 #if WXWIN_COMPATIBILITY_3_2
 // These constants themselves intentionally don't use wxDEPRECATED_MSG()
 // because one will be given whenever they are used with any function now
-// taking wxPGPropertyFlags anyhow and giving multiple deprecation warnings for
+// taking wxPGFlags anyhow and giving multiple deprecation warnings for
 // the same line of code is more annoying than helpful.
-constexpr int wxPG_PROP_MODIFIED = static_cast<int>(wxPGPropertyFlags::Modified);
-constexpr int wxPG_PROP_DISABLED = static_cast<int>(wxPGPropertyFlags::Disabled);
-constexpr int wxPG_PROP_HIDDEN = static_cast<int>(wxPGPropertyFlags::Hidden);
-constexpr int wxPG_PROP_CUSTOMIMAGE = static_cast<int>(wxPGPropertyFlags::CustomImage);
-constexpr int wxPG_PROP_NOEDITOR = static_cast<int>(wxPGPropertyFlags::NoEditor);
-constexpr int wxPG_PROP_COLLAPSED = static_cast<int>(wxPGPropertyFlags::Collapsed);
-constexpr int wxPG_PROP_INVALID_VALUE = static_cast<int>(wxPGPropertyFlags::InvalidValue);
-constexpr int wxPG_PROP_WAS_MODIFIED = static_cast<int>(wxPGPropertyFlags::WasModified);
-constexpr int wxPG_PROP_AGGREGATE = static_cast<int>(wxPGPropertyFlags::Aggregate);
-constexpr int wxPG_PROP_CHILDREN_ARE_COPIES = static_cast<int>(wxPGPropertyFlags::ChildrenAreCopies);
-constexpr int wxPG_PROP_PROPERTY = static_cast<int>(wxPGPropertyFlags::Property);
-constexpr int wxPG_PROP_CATEGORY = static_cast<int>(wxPGPropertyFlags::Category);
-constexpr int wxPG_PROP_MISC_PARENT = static_cast<int>(wxPGPropertyFlags::MiscParent);
-constexpr int wxPG_PROP_READONLY = static_cast<int>(wxPGPropertyFlags::ReadOnly);
-constexpr int wxPG_PROP_COMPOSED_VALUE = static_cast<int>(wxPGPropertyFlags::ComposedValue);
-constexpr int wxPG_PROP_USES_COMMON_VALUE = static_cast<int>(wxPGPropertyFlags::UsesCommonValue);
-constexpr int wxPG_PROP_AUTO_UNSPECIFIED = static_cast<int>(wxPGPropertyFlags::AutoUnspecified);
-constexpr int wxPG_PROP_BEING_DELETED = static_cast<int>(wxPGPropertyFlags::BeingDeleted);
-constexpr int wxPG_PROP_PARENTAL_FLAGS = static_cast<int>(wxPGPropertyFlags::ParentalFlags);
-constexpr int wxPG_STRING_STORED_FLAGS = static_cast<int>(wxPGPropertyFlags::StringStoredFlags);
-constexpr int wxPG_PROP_MAX = static_cast<int>(wxPGPropertyFlags::Max);
-
-// Indicates bits usable by derived properties.
-constexpr int wxPG_PROP_CLASS_SPECIFIC_1 = static_cast<int>(wxPGPropertyFlags::Reserved_1);
-constexpr int wxPG_PROP_CLASS_SPECIFIC_2 = static_cast<int>(wxPGPropertyFlags::Reserved_2);
-constexpr int wxPG_PROP_CLASS_SPECIFIC_3 = static_cast<int>(wxPGPropertyFlags::Reserved_3);
+enum wxPGPropertyFlags
+{
+    wxPG_PROP_MODIFIED = static_cast<int>(wxPGFlags::Modified),
+    wxPG_PROP_DISABLED = static_cast<int>(wxPGFlags::Disabled),
+    wxPG_PROP_HIDDEN = static_cast<int>(wxPGFlags::Hidden),
+    wxPG_PROP_CUSTOMIMAGE = static_cast<int>(wxPGFlags::CustomImage),
+    wxPG_PROP_NOEDITOR = static_cast<int>(wxPGFlags::NoEditor),
+    wxPG_PROP_COLLAPSED = static_cast<int>(wxPGFlags::Collapsed),
+    wxPG_PROP_INVALID_VALUE = static_cast<int>(wxPGFlags::InvalidValue),
+    wxPG_PROP_WAS_MODIFIED = static_cast<int>(wxPGFlags::WasModified),
+    wxPG_PROP_AGGREGATE = static_cast<int>(wxPGFlags::Aggregate),
+    wxPG_PROP_CHILDREN_ARE_COPIES = static_cast<int>(wxPGFlags::ChildrenAreCopies),
+    wxPG_PROP_PROPERTY = static_cast<int>(wxPGFlags::Property),
+    wxPG_PROP_CATEGORY = static_cast<int>(wxPGFlags::Category),
+    wxPG_PROP_MISC_PARENT = static_cast<int>(wxPGFlags::MiscParent),
+    wxPG_PROP_READONLY = static_cast<int>(wxPGFlags::ReadOnly),
+    wxPG_PROP_COMPOSED_VALUE = static_cast<int>(wxPGFlags::ComposedValue),
+    wxPG_PROP_USES_COMMON_VALUE = static_cast<int>(wxPGFlags::UsesCommonValue),
+    wxPG_PROP_AUTO_UNSPECIFIED = static_cast<int>(wxPGFlags::AutoUnspecified),
+    wxPG_PROP_BEING_DELETED = static_cast<int>(wxPGFlags::BeingDeleted),
+    wxPG_PROP_PARENTAL_FLAGS = static_cast<int>(wxPGFlags::ParentalFlags),
+    wxPG_STRING_STORED_FLAGS = static_cast<int>(wxPGFlags::StringStoredFlags),
+    wxPG_PROP_MAX = static_cast<int>(wxPGFlags::Max),
+    wxPG_PROP_CLASS_SPECIFIC_1 = static_cast<int>(wxPGFlags::Reserved_1),
+    wxPG_PROP_CLASS_SPECIFIC_2 = static_cast<int>(wxPGFlags::Reserved_2),
+    wxPG_PROP_CLASS_SPECIFIC_3 = static_cast<int>(wxPGFlags::Reserved_3),
+};
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------
@@ -1033,7 +1034,7 @@ public:
 #if WXWIN_COMPATIBILITY_3_0
     typedef wxUint32 FlagType;
 #elif WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use wxPGPropertyFlags type instead")
+    wxDEPRECATED_MSG("use wxPGFlags type instead")
     typedef wxUint32 FlagType;
 #endif // WXWIN_COMPATIBILITY_3_0, WXWIN_COMPATIBILITY_3_2
 
@@ -1325,7 +1326,7 @@ public:
     // values of a font).
     bool AreChildrenComponents() const
     {
-        return !!(m_flags & (wxPGPropertyFlags::ComposedValue|wxPGPropertyFlags::Aggregate));
+        return !!(m_flags & (wxPGFlags::ComposedValue|wxPGFlags::Aggregate));
     }
 
     // Deletes children of the property.
@@ -1347,7 +1348,7 @@ public:
     // Common values are disabled by the default for all properties.
     void EnableCommonValue( bool enable = true )
     {
-        ChangeFlag(wxPGPropertyFlags::UsesCommonValue, enable);
+        ChangeFlag(wxPGFlags::UsesCommonValue, enable);
     }
 
     // Composes text from values of child properties.
@@ -1491,35 +1492,35 @@ public:
 
 #if WXWIN_COMPATIBILITY_3_0
     // Returns non-zero if property has given flag set.
-    wxDEPRECATED_MSG("use HasFlag() with 'flag' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use HasFlag() with 'flag' argument as wxPGFlags")
     FlagType HasFlag( FlagType flag ) const
     {
         return ( static_cast<FlagType>(m_flags) & flag );
     }
 #endif
     // Returns true if property has given flag set.
-    bool HasFlag(wxPGPropertyFlags flag) const
+    bool HasFlag(wxPGFlags flag) const
     {
         return !!(m_flags & flag);
     }
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use HasFlag() with 'flag' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use HasFlag() with 'flag' argument as wxPGFlags")
     // Returns true if property has given flag set.
     bool HasFlag(int flag) const
     {
-        return HasFlag(static_cast<wxPGPropertyFlags>(flag));
+        return HasFlag(static_cast<wxPGFlags>(flag));
     }
 #endif // WXWIN_COMPATIBILITY_3_2
 
     // Returns true if property has all given flags set.
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use HasFlagExact() with 'flags' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use HasFlagExact() with 'flags' argument as wxPGFlags")
     bool HasFlagsExact(int flags) const
     {
-        return HasFlagsExact(static_cast<wxPGPropertyFlags>(flags));
+        return HasFlagsExact(static_cast<wxPGFlags>(flags));
     }
 #endif // WXWIN_COMPATIBILITY_3_2
-    bool HasFlagsExact(wxPGPropertyFlags flags) const
+    bool HasFlagsExact(wxPGFlags flags) const
     {
         return (m_flags & flags) == flags;
     }
@@ -1578,7 +1579,7 @@ public:
     int InsertChoice( const wxString& label, int index, int value = wxPG_INVALID_VALUE );
 
     // Returns true if this property is actually a wxPropertyCategory.
-    bool IsCategory() const { return !!(m_flags & wxPGPropertyFlags::Category); }
+    bool IsCategory() const { return !!(m_flags & wxPGFlags::Category); }
 
     // Returns true if this property is actually a wxRootProperty.
     bool IsRoot() const { return (m_parent == nullptr); }
@@ -1620,7 +1621,7 @@ public:
     // Returns true if containing grid uses wxPG_EX_AUTO_UNSPECIFIED_VALUES.
     bool UsesAutoUnspecified() const
     {
-        return !!(m_flags & wxPGPropertyFlags::AutoUnspecified);
+        return !!(m_flags & wxPGFlags::AutoUnspecified);
     }
 
     // Returns bitmap that appears next to value text. Only returns non-null
@@ -1645,16 +1646,16 @@ public:
     unsigned int GetDepth() const { return (unsigned int)m_depth; }
 
     // Gets flags as a'|' delimited string. Note that flag names are not
-    // prepended with 'wxPGPropertyFlags'.
+    // prepended with 'wxPGFlags'.
     // flagmask - String will only be made to include flags combined by this parameter.
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use GetFlagsAsString() with 'flags' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use GetFlagsAsString() with 'flags' argument as wxPGFlags")
     wxString GetFlagsAsString( int flagsMask ) const
     {
-        return GetFlagsAsString(static_cast<wxPGPropertyFlags>(flagsMask));
+        return GetFlagsAsString(static_cast<wxPGFlags>(flagsMask));
     }
 #endif // WXWIN_COMPATIBILITY_3_2
-    wxString GetFlagsAsString(wxPGPropertyFlags flagsMask) const;
+    wxString GetFlagsAsString(wxPGFlags flagsMask) const;
 
     // Returns position in parent's array.
     unsigned int GetIndexInParent() const
@@ -1677,13 +1678,13 @@ public:
 
     // Returns true if property has visible children.
     bool IsExpanded() const
-        { return (!(m_flags & wxPGPropertyFlags::Collapsed) && HasAnyChild()); }
+        { return (!(m_flags & wxPGFlags::Collapsed) && HasAnyChild()); }
 
     // Returns true if all parents expanded.
     bool IsVisible() const;
 
     // Returns true if property is enabled.
-    bool IsEnabled() const { return !(m_flags & wxPGPropertyFlags::Disabled); }
+    bool IsEnabled() const { return !(m_flags & wxPGFlags::Disabled); }
 
     // If property's editor is created this forces its recreation.
     // Useful in SetAttribute etc. Returns true if actually did anything.
@@ -1709,7 +1710,7 @@ public:
     // by default).
     void SetAutoUnspecified( bool enable = true )
     {
-        ChangeFlag(wxPGPropertyFlags::AutoUnspecified, enable);
+        ChangeFlag(wxPGFlags::AutoUnspecified, enable);
     }
 
     // Sets property's background colour.
@@ -1784,13 +1785,13 @@ public:
     }
 
     // Sets flags from a '|' delimited string. Note that flag names are not
-    // prepended with 'wxPGPropertyFlags'.
+    // prepended with 'wxPGFlags'.
     void SetFlagsFromString( const wxString& str );
 
     // Sets property's "is it modified?" flag. Affects children recursively.
     void SetModifiedStatus( bool modified )
     {
-        SetFlagRecursively(wxPGPropertyFlags::Modified, modified);
+        SetFlagRecursively(wxPGFlags::Modified, modified);
     }
 
     // Call in OnEvent(), OnButtonClick() etc. to change the property value
@@ -1831,15 +1832,15 @@ public:
 
     void SetExpanded( bool expanded )
     {
-        ChangeFlag(wxPGPropertyFlags::Collapsed, !expanded);
+        ChangeFlag(wxPGFlags::Collapsed, !expanded);
     }
 
     // Sets or clears given property flag. Mainly for internal use.
     // Setting a property flag never has any side-effect, and is
     // intended almost exclusively for internal use. So, for
     // example, if you want to disable a property, call
-    // Enable(false) instead of setting wxPGPropertyFlags::Disabled flag.
-    void ChangeFlag( wxPGPropertyFlags flag, bool set )
+    // Enable(false) instead of setting wxPGFlags::Disabled flag.
+    void ChangeFlag( wxPGFlags flag, bool set )
     {
         if ( set )
             m_flags |= flag;
@@ -1849,7 +1850,7 @@ public:
 
     // Sets or clears given property flag, recursively. This function is
     // primarily intended for internal use.
-    void SetFlagRecursively( wxPGPropertyFlags flag, bool set );
+    void SetFlagRecursively( wxPGFlags flag, bool set );
 
     // Sets property's help string, which is shown, for example, in
     // wxPropertyGridManager's description text box.
@@ -1867,21 +1868,21 @@ public:
     void SetName( const wxString& newName );
 
     // Changes what sort of parent this property is for its children.
-    // flag - Use one of the following values: wxPGPropertyFlags::MiscParent (for
-    //   generic parents), wxPGPropertyFlags::Category (for categories), or
-    //   wxPGPropertyFlags::Aggregate (for derived property classes with private
+    // flag - Use one of the following values: wxPGFlags::MiscParent (for
+    //   generic parents), wxPGFlags::Category (for categories), or
+    //   wxPGFlags::Aggregate (for derived property classes with private
     //   children).
     // You generally do not need to call this function.
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use SetParentalType() with 'flag' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use SetParentalType() with 'flag' argument as wxPGFlags")
     void SetParentalType(int flag)
     {
-        SetParentalType(static_cast<wxPGPropertyFlags>(flag));
+        SetParentalType(static_cast<wxPGFlags>(flag));
     }
 #endif // WXWIN_COMPATIBILITY_3_2
-    void SetParentalType(wxPGPropertyFlags flag)
+    void SetParentalType(wxPGFlags flag)
     {
-        m_flags &= ~(wxPGPropertyFlags::Property | wxPGPropertyFlags::ParentalFlags);
+        m_flags &= ~(wxPGFlags::Property | wxPGFlags::ParentalFlags);
         m_flags |= flag;
     }
 
@@ -1948,7 +1949,7 @@ public:
     // (i.e. cancel 'true' returned by StringToValue() or IntToValue()).
     void SetWasModified( bool set = true )
     {
-        ChangeFlag(wxPGPropertyFlags::WasModified, set);
+        ChangeFlag(wxPGFlags::WasModified, set);
     }
 
     // Returns property's help or description text.
@@ -1968,7 +1969,7 @@ public:
     // Adds a private child property. If you use this instead of
     // wxPropertyGridInterface::Insert() or
     // wxPropertyGridInterface::AppendIn(), then property's parental
-    // type will automatically be set up to wxPGPropertyFlags::Aggregate. In other
+    // type will automatically be set up to wxPGFlags::Aggregate. In other
     // words, all properties of this property will become private.
     void AddPrivateChild( wxPGProperty* prop );
 
@@ -2078,7 +2079,7 @@ protected:
     // ignoreWithFlags - Properties with any one of these flags are skipped.
     // recursively - If true, apply this operation recursively in child properties.
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use AdaptiveSetCell() with 'ignoreWithFlags' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use AdaptiveSetCell() with 'ignoreWithFlags' argument as wxPGFlags")
     void AdaptiveSetCell( unsigned int firstCol,
                           unsigned int lastCol,
                           const wxPGCell& preparedCell,
@@ -2088,7 +2089,7 @@ protected:
                           bool recursively )
     {
         AdaptiveSetCell(firstCol, lastCol, preparedCell, srcData, unmodCellData,
-                        static_cast<wxPGPropertyFlags>(ignoreWithFlags), recursively);
+                        static_cast<wxPGFlags>(ignoreWithFlags), recursively);
     }
 #endif // WXWIN_COMPATIBILITY_3_2
     void AdaptiveSetCell(unsigned int firstCol,
@@ -2096,19 +2097,19 @@ protected:
                          const wxPGCell& preparedCell,
                          const wxPGCell& srcData,
                          wxPGCellData* unmodCellData,
-                         wxPGPropertyFlags ignoreWithFlags,
+                         wxPGFlags ignoreWithFlags,
                          bool recursively);
 
     // Clear cells associated with property.
     // recursively - If true, apply this operation recursively in child properties.
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use ClearCells() with 'ignoreWithFlags' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use ClearCells() with 'ignoreWithFlags' argument as wxPGFlags")
     void ClearCells(int ignoreWithFlags, bool recursively)
     {
-        ClearCells(static_cast<wxPGPropertyFlags>(ignoreWithFlags), recursively);
+        ClearCells(static_cast<wxPGFlags>(ignoreWithFlags), recursively);
     }
 #endif // WXWIN_COMPATIBILITY_3_2
-    void ClearCells(wxPGPropertyFlags ignoreWithFlags, bool recursively);
+    void ClearCells(wxPGFlags ignoreWithFlags, bool recursively);
 
     // Makes sure m_cells has size of column+1 (or more).
     void EnsureCells( unsigned int column );
@@ -2178,23 +2179,23 @@ protected:
     void SetParentState( wxPropertyGridPageState* pstate )
         { m_parentState = pstate; }
 
-    void SetFlag( wxPGPropertyFlags flag )
+    void SetFlag( wxPGFlags flag )
     {
         //
-        // NB: While using wxPGPropertyFlags here makes it difficult to
+        // NB: While using wxPGFlags here makes it difficult to
         //     combine different flags, it usefully prevents user from
         //     using incorrect flags (say, wxWindow styles).
         m_flags |= flag;
     }
 
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use ClearFlag() with 'flag' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use ClearFlag() with 'flag' argument as wxPGFlags")
     void ClearFlag( int flag )
     {
-        ClearFlag(static_cast<wxPGPropertyFlags>(flag));
+        ClearFlag(static_cast<wxPGFlags>(flag));
     }
 #endif // WXWIN_COMPATIBILITY_3_2
-    void ClearFlag(wxPGPropertyFlags flag)
+    void ClearFlag(wxPGFlags flag)
     {
         m_flags &= ~(flag);
     }
@@ -2249,7 +2250,7 @@ protected:
     // If not -1, then overrides m_value
     int                         m_commonValue;
 
-    wxPGPropertyFlags           m_flags;
+    wxPGFlags                   m_flags;
 
     // Maximum length (for string properties). Could be in some sort of
     // wxBaseStringProperty, but currently, for maximum flexibility and

--- a/include/wx/propgrid/property.h
+++ b/include/wx/propgrid/property.h
@@ -475,56 +475,36 @@ constexpr int operator&(int a, wxPGPropertyFlags b)
 // =====
 
 #if WXWIN_COMPATIBILITY_3_2
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Modified instead")
-constexpr wxPGPropertyFlags wxPG_PROP_MODIFIED = wxPGPropertyFlags::Modified;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Disabled instead")
-constexpr wxPGPropertyFlags wxPG_PROP_DISABLED = wxPGPropertyFlags::Disabled;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Hidden instead")
-constexpr wxPGPropertyFlags wxPG_PROP_HIDDEN = wxPGPropertyFlags::Hidden;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::CustomImage instead")
-constexpr wxPGPropertyFlags wxPG_PROP_CUSTOMIMAGE = wxPGPropertyFlags::CustomImage;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::NoEditor instead")
-constexpr wxPGPropertyFlags wxPG_PROP_NOEDITOR = wxPGPropertyFlags::NoEditor;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Collapsed instead")
-constexpr wxPGPropertyFlags wxPG_PROP_COLLAPSED = wxPGPropertyFlags::Collapsed;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::InvalidValue instead")
-constexpr wxPGPropertyFlags wxPG_PROP_INVALID_VALUE = wxPGPropertyFlags::InvalidValue;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::WasModified instead")
-constexpr wxPGPropertyFlags wxPG_PROP_WAS_MODIFIED = wxPGPropertyFlags::WasModified;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Aggregate instead")
-constexpr wxPGPropertyFlags wxPG_PROP_AGGREGATE = wxPGPropertyFlags::Aggregate;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::ChildrenAreCopies instead")
-constexpr wxPGPropertyFlags wxPG_PROP_CHILDREN_ARE_COPIES = wxPGPropertyFlags::ChildrenAreCopies;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Property instead")
-constexpr wxPGPropertyFlags wxPG_PROP_PROPERTY = wxPGPropertyFlags::Property;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Category instead")
-constexpr wxPGPropertyFlags wxPG_PROP_CATEGORY = wxPGPropertyFlags::Category;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::MiscParent instead")
-constexpr wxPGPropertyFlags wxPG_PROP_MISC_PARENT = wxPGPropertyFlags::MiscParent;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::ReadOnly instead")
-constexpr wxPGPropertyFlags wxPG_PROP_READONLY = wxPGPropertyFlags::ReadOnly;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::ComposedValue instead")
-constexpr wxPGPropertyFlags wxPG_PROP_COMPOSED_VALUE = wxPGPropertyFlags::ComposedValue;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::UsesCommonValue instead")
-constexpr wxPGPropertyFlags wxPG_PROP_USES_COMMON_VALUE = wxPGPropertyFlags::UsesCommonValue;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::AutoUnspecified instead")
-constexpr wxPGPropertyFlags wxPG_PROP_AUTO_UNSPECIFIED = wxPGPropertyFlags::AutoUnspecified;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::BeingDeleted instead")
-constexpr wxPGPropertyFlags wxPG_PROP_BEING_DELETED = wxPGPropertyFlags::BeingDeleted;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::ParentalFlags instead")
-constexpr wxPGPropertyFlags wxPG_PROP_PARENTAL_FLAGS = wxPGPropertyFlags::ParentalFlags;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::StringStoredFlags instead")
-constexpr wxPGPropertyFlags wxPG_STRING_STORED_FLAGS = wxPGPropertyFlags::StringStoredFlags;
-wxDEPRECATED_MSG("use wxPGPropertyFlags::Max instead")
-constexpr wxPGPropertyFlags wxPG_PROP_MAX = wxPGPropertyFlags::Max;
+// These constants themselves intentionally don't use wxDEPRECATED_MSG()
+// because one will be given whenever they are used with any function now
+// taking wxPGPropertyFlags anyhow and giving multiple deprecation warnings for
+// the same line of code is more annoying than helpful.
+constexpr int wxPG_PROP_MODIFIED = static_cast<int>(wxPGPropertyFlags::Modified);
+constexpr int wxPG_PROP_DISABLED = static_cast<int>(wxPGPropertyFlags::Disabled);
+constexpr int wxPG_PROP_HIDDEN = static_cast<int>(wxPGPropertyFlags::Hidden);
+constexpr int wxPG_PROP_CUSTOMIMAGE = static_cast<int>(wxPGPropertyFlags::CustomImage);
+constexpr int wxPG_PROP_NOEDITOR = static_cast<int>(wxPGPropertyFlags::NoEditor);
+constexpr int wxPG_PROP_COLLAPSED = static_cast<int>(wxPGPropertyFlags::Collapsed);
+constexpr int wxPG_PROP_INVALID_VALUE = static_cast<int>(wxPGPropertyFlags::InvalidValue);
+constexpr int wxPG_PROP_WAS_MODIFIED = static_cast<int>(wxPGPropertyFlags::WasModified);
+constexpr int wxPG_PROP_AGGREGATE = static_cast<int>(wxPGPropertyFlags::Aggregate);
+constexpr int wxPG_PROP_CHILDREN_ARE_COPIES = static_cast<int>(wxPGPropertyFlags::ChildrenAreCopies);
+constexpr int wxPG_PROP_PROPERTY = static_cast<int>(wxPGPropertyFlags::Property);
+constexpr int wxPG_PROP_CATEGORY = static_cast<int>(wxPGPropertyFlags::Category);
+constexpr int wxPG_PROP_MISC_PARENT = static_cast<int>(wxPGPropertyFlags::MiscParent);
+constexpr int wxPG_PROP_READONLY = static_cast<int>(wxPGPropertyFlags::ReadOnly);
+constexpr int wxPG_PROP_COMPOSED_VALUE = static_cast<int>(wxPGPropertyFlags::ComposedValue);
+constexpr int wxPG_PROP_USES_COMMON_VALUE = static_cast<int>(wxPGPropertyFlags::UsesCommonValue);
+constexpr int wxPG_PROP_AUTO_UNSPECIFIED = static_cast<int>(wxPGPropertyFlags::AutoUnspecified);
+constexpr int wxPG_PROP_BEING_DELETED = static_cast<int>(wxPGPropertyFlags::BeingDeleted);
+constexpr int wxPG_PROP_PARENTAL_FLAGS = static_cast<int>(wxPGPropertyFlags::ParentalFlags);
+constexpr int wxPG_STRING_STORED_FLAGS = static_cast<int>(wxPGPropertyFlags::StringStoredFlags);
+constexpr int wxPG_PROP_MAX = static_cast<int>(wxPGPropertyFlags::Max);
 
 // Indicates bits usable by derived properties.
-wxDEPRECATED_BUT_USED_INTERNALLY_MSG("wxPG_PROP_CLASS_SPECIFIC_1 in intended for internal use only.")
-constexpr wxPGPropertyFlags wxPG_PROP_CLASS_SPECIFIC_1 = wxPGPropertyFlags::Reserved_1;
-wxDEPRECATED_BUT_USED_INTERNALLY_MSG("wxPG_PROP_CLASS_SPECIFIC_2 in intended for internal use only.")
-constexpr wxPGPropertyFlags wxPG_PROP_CLASS_SPECIFIC_2 = wxPGPropertyFlags::Reserved_2;
-wxDEPRECATED_BUT_USED_INTERNALLY_MSG("wxPG_PROP_CLASS_SPECIFIC_3 in intended for internal use only.")
-constexpr wxPGPropertyFlags wxPG_PROP_CLASS_SPECIFIC_3 = wxPGPropertyFlags::Reserved_3;
+constexpr int wxPG_PROP_CLASS_SPECIFIC_1 = static_cast<int>(wxPGPropertyFlags::Reserved_1);
+constexpr int wxPG_PROP_CLASS_SPECIFIC_2 = static_cast<int>(wxPGPropertyFlags::Reserved_2);
+constexpr int wxPG_PROP_CLASS_SPECIFIC_3 = static_cast<int>(wxPGPropertyFlags::Reserved_3);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------

--- a/include/wx/propgrid/property.h
+++ b/include/wx/propgrid/property.h
@@ -1858,6 +1858,13 @@ public:
     // Sets or clears given property flag, recursively. This function is
     // primarily intended for internal use.
     void SetFlagRecursively( wxPGFlags flag, bool set );
+#if WXWIN_COMPATIBILITY_3_2
+    wxDEPRECATED_MSG("use SetFlagRecursively with flags argument as wxPGFlags")
+    void SetFlagRecursively(wxPGPropertyFlags flags, bool set)
+    {
+        ChangeFlag(static_cast<wxPGFlags>(flags), set);
+    }
+#endif // WXWIN_COMPATIBILITY_3_2
 
     // Sets property's help string, which is shown, for example, in
     // wxPropertyGridManager's description text box.
@@ -2194,10 +2201,17 @@ protected:
         //     using incorrect flags (say, wxWindow styles).
         m_flags |= flag;
     }
+#if WXWIN_COMPATIBILITY_3_2
+    wxDEPRECATED_MSG("use SetFlag() with 'flag' argument as wxPGFlags")
+    void SetFlag( wxPGPropertyFlags flag )
+    {
+        SetFlag(static_cast<wxPGFlags>(flag));
+    }
+#endif // WXWIN_COMPATIBILITY_3_2
 
 #if WXWIN_COMPATIBILITY_3_2
     wxDEPRECATED_MSG("use ClearFlag() with 'flag' argument as wxPGFlags")
-    void ClearFlag( int flag )
+    void ClearFlag(wxPGPropertyFlags flag)
     {
         ClearFlag(static_cast<wxPGFlags>(flag));
     }

--- a/include/wx/propgrid/property.h
+++ b/include/wx/propgrid/property.h
@@ -1847,6 +1847,13 @@ public:
         else
             m_flags &= ~flag;
     }
+#if WXWIN_COMPATIBILITY_3_2
+    wxDEPRECATED_MSG("use ChangeFlag with flags argument as wxPGFlags")
+    void ChangeFlag(wxPGPropertyFlags flags, bool set)
+    {
+        ChangeFlag(static_cast<wxPGFlags>(flags), set);
+    }
+#endif // WXWIN_COMPATIBILITY_3_2
 
     // Sets or clears given property flag, recursively. This function is
     // primarily intended for internal use.

--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -592,7 +592,7 @@ public:
     //   trigger the action.
 #if WXWIN_COMPATIBILITY_3_2
     wxDEPRECATED_MSG("use AddActionTrigger with 'action' argument as wxPGKeyboardAction")
-    void AddActionTrigger(int action, int keycode, int modifiers)
+    void AddActionTrigger(int action, int keycode, int modifiers = 0)
     {
         AddActionTrigger(static_cast<wxPGKeyboardAction>(action), keycode, modifiers);
     }

--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -250,8 +250,8 @@ wxPG_EX_HELP_AS_TOOLTIPS            = 0x00010000,
 wxPG_EX_NATIVE_DOUBLE_BUFFERING         = 0x00080000,
 
 // Set this style to let user have ability to set values of properties to
-// unspecified state. Same as setting wxPGPropertyFlags::AutoUnspecified for
-// all properties.
+// unspecified state. Same as setting wxPGFlags::AutoUnspecified for all
+// properties.
 wxPG_EX_AUTO_UNSPECIFIED_VALUES         = 0x00200000,
 
 // If this style is used, built-in attributes (such as wxPG_FLOAT_PRECISION
@@ -1306,10 +1306,10 @@ public:
     // Called to indicate property and editor has valid value now.
     void OnValidationFailureReset( wxPGProperty* property )
     {
-        if ( property && property->HasFlag(wxPGPropertyFlags::InvalidValue) )
+        if ( property && property->HasFlag(wxPGFlags::InvalidValue) )
         {
             DoOnValidationFailureReset(property);
-            property->ClearFlag(wxPGPropertyFlags::InvalidValue);
+            property->ClearFlag(wxPGFlags::InvalidValue);
         }
         m_validationInfo.ClearFailureMessage();
     }
@@ -1343,7 +1343,7 @@ public:
                                         wxVariant& invalidValue );
 
     // Override to customize resetting of property validation failure status.
-    // Property is guaranteed to have flag wxPGPropertyFlags::InvalidValue set.
+    // Property is guaranteed to have flag wxPGFlags::InvalidValue set.
     virtual void DoOnValidationFailureReset( wxPGProperty* property );
 
     int GetSpacingY() const { return m_spacingy; }

--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -474,22 +474,18 @@ enum class wxPGKeyboardAction
 wxDEPRECATED_MSG("use wxPGKeyboardAction type instead")
 typedef wxPGKeyboardAction wxPGKeyboardActions;
 
-wxDEPRECATED_MSG("use wxPGKeyboardAction::Invalid instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_INVALID { wxPGKeyboardAction::Invalid };
-wxDEPRECATED_MSG("use wxPGKeyboardAction::NextProperty instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_NEXT_PROPERTY { wxPGKeyboardAction::NextProperty };
-wxDEPRECATED_MSG("use wxPGKeyboardAction::PrevProperty instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_PREV_PROPERTY { wxPGKeyboardAction::PrevProperty };
-wxDEPRECATED_MSG("use wxPGKeyboardAction::ExpandProperty instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_EXPAND_PROPERTY { wxPGKeyboardAction::ExpandProperty };
-wxDEPRECATED_MSG("use wxPGKeyboardAction::CollapseProperty instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_COLLAPSE_PROPERTY { wxPGKeyboardAction::CollapseProperty };
-wxDEPRECATED_MSG("use wxPGKeyboardAction::CancelEdit instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_CANCEL_EDIT { wxPGKeyboardAction::CancelEdit };
-wxDEPRECATED_MSG("use wxPGKeyboardAction::Edit instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_EDIT { wxPGKeyboardAction::Edit };
-wxDEPRECATED_MSG("use wxPGKeyboardAction::PressButton instead")
-constexpr wxPGKeyboardAction wxPG_ACTION_PRESS_BUTTON { wxPGKeyboardAction::PressButton };
+// These constants themselves intentionally don't use wxDEPRECATED_MSG()
+// because one will be given whenever they are used with any function now
+// taking wxPGKeyboardAction anyhow and giving multiple deprecation warnings
+// for the same line of code is more annoying than helpful.
+constexpr int wxPG_ACTION_INVALID  = static_cast<int>(wxPGKeyboardAction::Invalid);
+constexpr int wxPG_ACTION_NEXT_PROPERTY  = static_cast<int>(wxPGKeyboardAction::NextProperty);
+constexpr int wxPG_ACTION_PREV_PROPERTY  = static_cast<int>(wxPGKeyboardAction::PrevProperty);
+constexpr int wxPG_ACTION_EXPAND_PROPERTY  = static_cast<int>(wxPGKeyboardAction::ExpandProperty);
+constexpr int wxPG_ACTION_COLLAPSE_PROPERTY  = static_cast<int>(wxPGKeyboardAction::CollapseProperty);
+constexpr int wxPG_ACTION_CANCEL_EDIT  = static_cast<int>(wxPGKeyboardAction::CancelEdit);
+constexpr int wxPG_ACTION_EDIT  = static_cast<int>(wxPGKeyboardAction::Edit);
+constexpr int wxPG_ACTION_PRESS_BUTTON  = static_cast<int>(wxPGKeyboardAction::PressButton);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------

--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -478,14 +478,18 @@ typedef wxPGKeyboardAction wxPGKeyboardActions;
 // because one will be given whenever they are used with any function now
 // taking wxPGKeyboardAction anyhow and giving multiple deprecation warnings
 // for the same line of code is more annoying than helpful.
-constexpr int wxPG_ACTION_INVALID  = static_cast<int>(wxPGKeyboardAction::Invalid);
-constexpr int wxPG_ACTION_NEXT_PROPERTY  = static_cast<int>(wxPGKeyboardAction::NextProperty);
-constexpr int wxPG_ACTION_PREV_PROPERTY  = static_cast<int>(wxPGKeyboardAction::PrevProperty);
-constexpr int wxPG_ACTION_EXPAND_PROPERTY  = static_cast<int>(wxPGKeyboardAction::ExpandProperty);
-constexpr int wxPG_ACTION_COLLAPSE_PROPERTY  = static_cast<int>(wxPGKeyboardAction::CollapseProperty);
-constexpr int wxPG_ACTION_CANCEL_EDIT  = static_cast<int>(wxPGKeyboardAction::CancelEdit);
-constexpr int wxPG_ACTION_EDIT  = static_cast<int>(wxPGKeyboardAction::Edit);
-constexpr int wxPG_ACTION_PRESS_BUTTON  = static_cast<int>(wxPGKeyboardAction::PressButton);
+enum wxPG_KEYBOARD_ACTIONS
+{
+    wxPG_ACTION_INVALID = static_cast<int>(wxPGKeyboardAction::Invalid),
+    wxPG_ACTION_NEXT_PROPERTY = static_cast<int>(wxPGKeyboardAction::NextProperty),
+    wxPG_ACTION_PREV_PROPERTY = static_cast<int>(wxPGKeyboardAction::PrevProperty),
+    wxPG_ACTION_EXPAND_PROPERTY = static_cast<int>(wxPGKeyboardAction::ExpandProperty),
+    wxPG_ACTION_COLLAPSE_PROPERTY = static_cast<int>(wxPGKeyboardAction::CollapseProperty),
+    wxPG_ACTION_CANCEL_EDIT = static_cast<int>(wxPGKeyboardAction::CancelEdit),
+    wxPG_ACTION_EDIT = static_cast<int>(wxPGKeyboardAction::Edit),
+    wxPG_ACTION_PRESS_BUTTON = static_cast<int>(wxPGKeyboardAction::PressButton),
+    wxPG_ACTION_MAX
+};
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------

--- a/include/wx/propgrid/propgriddefs.h
+++ b/include/wx/propgrid/propgriddefs.h
@@ -182,20 +182,17 @@ constexpr bool operator!(wxPGPropertyValuesFlags a)
 }
 
 #if WXWIN_COMPATIBILITY_3_2
-wxDEPRECATED_MSG("use wxPGPropertyValuesFlags::DontRecurse instead")
-constexpr wxPGPropertyValuesFlags wxPG_DONT_RECURSE { wxPGPropertyValuesFlags::DontRecurse };
-wxDEPRECATED_MSG("use wxPGPropertyValuesFlags::KeepStructure instead")
-constexpr wxPGPropertyValuesFlags wxPG_KEEP_STRUCTURE { wxPGPropertyValuesFlags::KeepStructure };
-wxDEPRECATED_MSG("use wxPGPropertyValuesFlags::Recurse instead")
-constexpr wxPGPropertyValuesFlags wxPG_RECURSE { wxPGPropertyValuesFlags::Recurse };
-wxDEPRECATED_MSG("use wxPGPropertyValuesFlags::IncAttributes instead")
-constexpr wxPGPropertyValuesFlags wxPG_INC_ATTRIBUTES { wxPGPropertyValuesFlags::IncAttributes };
-wxDEPRECATED_MSG("use wxPGPropertyValuesFlags::RecurseStarts instead")
-constexpr wxPGPropertyValuesFlags wxPG_RECURSE_STARTS { wxPGPropertyValuesFlags::RecurseStarts };
-wxDEPRECATED_MSG("use wxPGPropertyValuesFlags::Force instead")
-constexpr wxPGPropertyValuesFlags wxPG_FORCE { wxPGPropertyValuesFlags::Force };
-wxDEPRECATED_MSG("use wxPGPropertyValuesFlags::SortTopLevelOnly instead")
-constexpr wxPGPropertyValuesFlags wxPG_SORT_TOP_LEVEL_ONLY { wxPGPropertyValuesFlags::SortTopLevelOnly };
+// These constants themselves intentionally don't use wxDEPRECATED_MSG()
+// because one will be given whenever they are used with any function now
+// taking wxPGPropertyValuesFlags anyhow and giving multiple deprecation
+// warnings for the same line of code is more annoying than helpful.
+constexpr int wxPG_DONT_RECURSE  = static_cast<int>(wxPGPropertyValuesFlags::DontRecurse);
+constexpr int wxPG_KEEP_STRUCTURE  = static_cast<int>(wxPGPropertyValuesFlags::KeepStructure);
+constexpr int wxPG_RECURSE  = static_cast<int>(wxPGPropertyValuesFlags::Recurse);
+constexpr int wxPG_INC_ATTRIBUTES  = static_cast<int>(wxPGPropertyValuesFlags::IncAttributes);
+constexpr int wxPG_RECURSE_STARTS  = static_cast<int>(wxPGPropertyValuesFlags::RecurseStarts);
+constexpr int wxPG_FORCE  = static_cast<int>(wxPGPropertyValuesFlags::Force);
+constexpr int wxPG_SORT_TOP_LEVEL_ONLY  = static_cast<int>(wxPGPropertyValuesFlags::SortTopLevelOnly);
 
 wxDEPRECATED_MSG("use wxPGPropertyValuesFlags instead")
 constexpr bool operator==(wxPGPropertyValuesFlags a, int b)
@@ -281,22 +278,15 @@ inline int operator|=(int& a, wxPGPropValFormatFlags b)
     return a = a | static_cast<int>(b);
 }
 
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::FullValue instead")
-constexpr wxPGPropValFormatFlags wxPG_FULL_VALUE { wxPGPropValFormatFlags::FullValue };
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::ReportError instead")
-constexpr wxPGPropValFormatFlags wxPG_REPORT_ERROR { wxPGPropValFormatFlags::ReportError };
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::PropertySpecific instead")
-constexpr wxPGPropValFormatFlags wxPG_PROPERTY_SPECIFIC { wxPGPropValFormatFlags::PropertySpecific };
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::EditableValue instead")
-constexpr wxPGPropValFormatFlags wxPG_EDITABLE_VALUE { wxPGPropValFormatFlags::EditableValue };
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::CompositeFragment instead")
-constexpr wxPGPropValFormatFlags wxPG_COMPOSITE_FRAGMENT { wxPGPropValFormatFlags::CompositeFragment };
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::UneditableCompositeFragment instead")
-constexpr wxPGPropValFormatFlags wxPG_UNEDITABLE_COMPOSITE_FRAGMENT { wxPGPropValFormatFlags::UneditableCompositeFragment };
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::ValueIsCurrent instead")
-constexpr wxPGPropValFormatFlags wxPG_VALUE_IS_CURRENT { wxPGPropValFormatFlags::ValueIsCurrent };
-wxDEPRECATED_MSG("use wxPGPropValFormatFlags::ProgrammaticValue instead")
-constexpr wxPGPropValFormatFlags wxPG_PROGRAMMATIC_VALUE { wxPGPropValFormatFlags::ProgrammaticValue };
+// See comment before wxPG_RECURSE above.
+constexpr int wxPG_FULL_VALUE  = static_cast<int>(wxPGPropValFormatFlags::FullValue);
+constexpr int wxPG_REPORT_ERROR  = static_cast<int>(wxPGPropValFormatFlags::ReportError);
+constexpr int wxPG_PROPERTY_SPECIFIC  = static_cast<int>(wxPGPropValFormatFlags::PropertySpecific);
+constexpr int wxPG_EDITABLE_VALUE  = static_cast<int>(wxPGPropValFormatFlags::EditableValue);
+constexpr int wxPG_COMPOSITE_FRAGMENT  = static_cast<int>(wxPGPropValFormatFlags::CompositeFragment);
+constexpr int wxPG_UNEDITABLE_COMPOSITE_FRAGMENT  = static_cast<int>(wxPGPropValFormatFlags::UneditableCompositeFragment);
+constexpr int wxPG_VALUE_IS_CURRENT  = static_cast<int>(wxPGPropValFormatFlags::ValueIsCurrent);
+constexpr int wxPG_PROGRAMMATIC_VALUE  = static_cast<int>(wxPGPropValFormatFlags::ProgrammaticValue);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------
@@ -331,14 +321,10 @@ constexpr bool operator!(wxPGSetValueFlags a)
 }
 
 #if WXWIN_COMPATIBILITY_3_2
-wxDEPRECATED_MSG("use wxPGSetValueFlags::RefreshEditor instead")
-constexpr wxPGSetValueFlags wxPG_SETVAL_REFRESH_EDITOR { wxPGSetValueFlags::RefreshEditor };
-wxDEPRECATED_MSG("use wxPGSetValueFlags::Aggregated instead")
-constexpr wxPGSetValueFlags wxPG_SETVAL_AGGREGATED { wxPGSetValueFlags::Aggregated };
-wxDEPRECATED_MSG("use wxPGSetValueFlags::FromParent instead")
-constexpr wxPGSetValueFlags wxPG_SETVAL_FROM_PARENT { wxPGSetValueFlags::FromParent };
-wxDEPRECATED_MSG("use wxPGSetValueFlags::ByUser instead")
-constexpr wxPGSetValueFlags wxPG_SETVAL_BY_USER { wxPGSetValueFlags::ByUser };
+constexpr int wxPG_SETVAL_REFRESH_EDITOR  = static_cast<int>(wxPGSetValueFlags::RefreshEditor);
+constexpr int wxPG_SETVAL_AGGREGATED  = static_cast<int>(wxPGSetValueFlags::Aggregated);
+constexpr int wxPG_SETVAL_FROM_PARENT  = static_cast<int>(wxPGSetValueFlags::FromParent);
+constexpr int wxPG_SETVAL_BY_USER  = static_cast<int>(wxPGSetValueFlags::ByUser);
 
 wxDEPRECATED_MSG("use wxPGSetValueFlags instead")
 constexpr bool operator==(wxPGSetValueFlags a, int b)

--- a/include/wx/propgrid/propgriddefs.h
+++ b/include/wx/propgrid/propgriddefs.h
@@ -182,17 +182,20 @@ constexpr bool operator!(wxPGPropertyValuesFlags a)
 }
 
 #if WXWIN_COMPATIBILITY_3_2
-// These constants themselves intentionally don't use wxDEPRECATED_MSG()
+// These constants are deprecated but intentionally don't use wxDEPRECATED_MSG()
 // because one will be given whenever they are used with any function now
 // taking wxPGPropertyValuesFlags anyhow and giving multiple deprecation
 // warnings for the same line of code is more annoying than helpful.
-constexpr int wxPG_DONT_RECURSE  = static_cast<int>(wxPGPropertyValuesFlags::DontRecurse);
-constexpr int wxPG_KEEP_STRUCTURE  = static_cast<int>(wxPGPropertyValuesFlags::KeepStructure);
-constexpr int wxPG_RECURSE  = static_cast<int>(wxPGPropertyValuesFlags::Recurse);
-constexpr int wxPG_INC_ATTRIBUTES  = static_cast<int>(wxPGPropertyValuesFlags::IncAttributes);
-constexpr int wxPG_RECURSE_STARTS  = static_cast<int>(wxPGPropertyValuesFlags::RecurseStarts);
-constexpr int wxPG_FORCE  = static_cast<int>(wxPGPropertyValuesFlags::Force);
-constexpr int wxPG_SORT_TOP_LEVEL_ONLY  = static_cast<int>(wxPGPropertyValuesFlags::SortTopLevelOnly);
+enum wxPG_PROPERTYVALUES_FLAGS
+{
+    wxPG_DONT_RECURSE = static_cast<int>(wxPGPropertyValuesFlags::DontRecurse),
+    wxPG_KEEP_STRUCTURE = static_cast<int>(wxPGPropertyValuesFlags::KeepStructure),
+    wxPG_RECURSE = static_cast<int>(wxPGPropertyValuesFlags::Recurse),
+    wxPG_INC_ATTRIBUTES = static_cast<int>(wxPGPropertyValuesFlags::IncAttributes),
+    wxPG_RECURSE_STARTS = static_cast<int>(wxPGPropertyValuesFlags::RecurseStarts),
+    wxPG_FORCE = static_cast<int>(wxPGPropertyValuesFlags::Force),
+    wxPG_SORT_TOP_LEVEL_ONLY = static_cast<int>(wxPGPropertyValuesFlags::SortTopLevelOnly),
+};
 
 wxDEPRECATED_MSG("use wxPGPropertyValuesFlags instead")
 constexpr bool operator==(wxPGPropertyValuesFlags a, int b)
@@ -279,14 +282,17 @@ inline int operator|=(int& a, wxPGPropValFormatFlags b)
 }
 
 // See comment before wxPG_RECURSE above.
-constexpr int wxPG_FULL_VALUE  = static_cast<int>(wxPGPropValFormatFlags::FullValue);
-constexpr int wxPG_REPORT_ERROR  = static_cast<int>(wxPGPropValFormatFlags::ReportError);
-constexpr int wxPG_PROPERTY_SPECIFIC  = static_cast<int>(wxPGPropValFormatFlags::PropertySpecific);
-constexpr int wxPG_EDITABLE_VALUE  = static_cast<int>(wxPGPropValFormatFlags::EditableValue);
-constexpr int wxPG_COMPOSITE_FRAGMENT  = static_cast<int>(wxPGPropValFormatFlags::CompositeFragment);
-constexpr int wxPG_UNEDITABLE_COMPOSITE_FRAGMENT  = static_cast<int>(wxPGPropValFormatFlags::UneditableCompositeFragment);
-constexpr int wxPG_VALUE_IS_CURRENT  = static_cast<int>(wxPGPropValFormatFlags::ValueIsCurrent);
-constexpr int wxPG_PROGRAMMATIC_VALUE  = static_cast<int>(wxPGPropValFormatFlags::ProgrammaticValue);
+enum wxPG_MISC_ARG_FLAGS
+{
+    wxPG_FULL_VALUE = static_cast<int>(wxPGPropValFormatFlags::FullValue),
+    wxPG_REPORT_ERROR = static_cast<int>(wxPGPropValFormatFlags::ReportError),
+    wxPG_PROPERTY_SPECIFIC = static_cast<int>(wxPGPropValFormatFlags::PropertySpecific),
+    wxPG_EDITABLE_VALUE = static_cast<int>(wxPGPropValFormatFlags::EditableValue),
+    wxPG_COMPOSITE_FRAGMENT = static_cast<int>(wxPGPropValFormatFlags::CompositeFragment),
+    wxPG_UNEDITABLE_COMPOSITE_FRAGMENT = static_cast<int>(wxPGPropValFormatFlags::UneditableCompositeFragment),
+    wxPG_VALUE_IS_CURRENT = static_cast<int>(wxPGPropValFormatFlags::ValueIsCurrent),
+    wxPG_PROGRAMMATIC_VALUE = static_cast<int>(wxPGPropValFormatFlags::ProgrammaticValue),
+};
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------
@@ -321,10 +327,13 @@ constexpr bool operator!(wxPGSetValueFlags a)
 }
 
 #if WXWIN_COMPATIBILITY_3_2
-constexpr int wxPG_SETVAL_REFRESH_EDITOR  = static_cast<int>(wxPGSetValueFlags::RefreshEditor);
-constexpr int wxPG_SETVAL_AGGREGATED  = static_cast<int>(wxPGSetValueFlags::Aggregated);
-constexpr int wxPG_SETVAL_FROM_PARENT  = static_cast<int>(wxPGSetValueFlags::FromParent);
-constexpr int wxPG_SETVAL_BY_USER  = static_cast<int>(wxPGSetValueFlags::ByUser);
+enum wxPG_SETVALUE_FLAGS
+{
+    wxPG_SETVAL_REFRESH_EDITOR = static_cast<int>(wxPGSetValueFlags::RefreshEditor),
+    wxPG_SETVAL_AGGREGATED = static_cast<int>(wxPGSetValueFlags::Aggregated),
+    wxPG_SETVAL_FROM_PARENT = static_cast<int>(wxPGSetValueFlags::FromParent),
+    wxPG_SETVAL_BY_USER = static_cast<int>(wxPGSetValueFlags::ByUser),
+};
 
 wxDEPRECATED_MSG("use wxPGSetValueFlags instead")
 constexpr bool operator==(wxPGSetValueFlags a, int b)

--- a/include/wx/propgrid/propgridiface.h
+++ b/include/wx/propgrid/propgridiface.h
@@ -76,15 +76,18 @@ constexpr bool operator!(wxPGVFBFlags a)
 // because one will be given whenever they are used with any function now
 // taking wxPGVFBFlags anyhow and giving multiple deprecation warnings for the
 // same line of code is more annoying than helpful.
-constexpr int wxPG_VFB_NULL = static_cast<int>(wxPGVFBFlags::Null);
-constexpr int wxPG_VFB_STAY_IN_PROPERTY = static_cast<int>(wxPGVFBFlags::StayInProperty);
-constexpr int wxPG_VFB_BEEP = static_cast<int>(wxPGVFBFlags::Beep);
-constexpr int wxPG_VFB_MARK_CELL = static_cast<int>(wxPGVFBFlags::MarkCell);
-constexpr int wxPG_VFB_SHOW_MESSAGE = static_cast<int>(wxPGVFBFlags::ShowMessage);
-constexpr int wxPG_VFB_SHOW_MESSAGEBOX = static_cast<int>(wxPGVFBFlags::ShowMessageBox);
-constexpr int wxPG_VFB_SHOW_MESSAGE_ON_STATUSBAR = static_cast<int>(wxPGVFBFlags::ShowMessageOnStatusBar);
-constexpr int wxPG_VFB_DEFAULT = static_cast<int>(wxPGVFBFlags::Default);
-constexpr int wxPG_VFB_UNDEFINED = static_cast<int>(wxPGVFBFlags::Undefined);
+enum wxPG_VALIDATION_FAILURE_BEHAVIOR_FLAGS
+{
+    wxPG_VFB_NULL = static_cast<int>(wxPGVFBFlags::Null),
+    wxPG_VFB_STAY_IN_PROPERTY = static_cast<int>(wxPGVFBFlags::StayInProperty),
+    wxPG_VFB_BEEP = static_cast<int>(wxPGVFBFlags::Beep),
+    wxPG_VFB_MARK_CELL = static_cast<int>(wxPGVFBFlags::MarkCell),
+    wxPG_VFB_SHOW_MESSAGE = static_cast<int>(wxPGVFBFlags::ShowMessage),
+    wxPG_VFB_SHOW_MESSAGEBOX = static_cast<int>(wxPGVFBFlags::ShowMessageBox),
+    wxPG_VFB_SHOW_MESSAGE_ON_STATUSBAR = static_cast<int>(wxPGVFBFlags::ShowMessageOnStatusBar),
+    wxPG_VFB_DEFAULT = static_cast<int>(wxPGVFBFlags::Default),
+    wxPG_VFB_UNDEFINED = static_cast<int>(wxPGVFBFlags::Undefined),
+};
 
 wxDEPRECATED_MSG("use wxPGVFBFlags instead")
 constexpr bool operator==(wxPGVFBFlags a, int b)

--- a/include/wx/propgrid/propgridiface.h
+++ b/include/wx/propgrid/propgridiface.h
@@ -326,7 +326,7 @@ public:
     {
         wxPG_PROP_ARG_CALL_PROLOG_RETVAL(wxNullProperty)
 
-        if ( !p->HasAnyChild() || p->HasFlag(wxPGPropertyFlags::Aggregate) )
+        if ( !p->HasAnyChild() || p->HasFlag(wxPGFlags::Aggregate) )
             return wxNullProperty;
 
         return p->Item(0);
@@ -406,7 +406,7 @@ public:
     // flags - Property flags to use.
     // iterFlags - Iterator flags to use. Default is everything expect private children.
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use GetPropertiesWithFlag() with 'flags' argument as wxPGPropertyFlags")
+    wxDEPRECATED_MSG("use GetPropertiesWithFlag() with 'flags' argument as wxPGFlags")
     void GetPropertiesWithFlag( wxArrayPGProperty* targetArr,
                                 int flags,
                                 bool inverse = false,
@@ -414,11 +414,11 @@ public:
                                                 wxPG_ITERATE_HIDDEN |
                                                 wxPG_ITERATE_CATEGORIES) const
     {
-        GetPropertiesWithFlag(targetArr, static_cast<wxPGPropertyFlags>(flags), inverse, iterFlags);
+        GetPropertiesWithFlag(targetArr, static_cast<wxPGFlags>(flags), inverse, iterFlags);
     }
 #endif // WXWIN_COMPATIBILITY_3_2
     void GetPropertiesWithFlag(wxArrayPGProperty* targetArr,
-                               wxPGPropertyFlags flags,
+                               wxPGFlags flags,
                                bool inverse = false,
                                int iterFlags = wxPG_ITERATE_PROPERTIES |
                                                wxPG_ITERATE_HIDDEN |
@@ -657,7 +657,7 @@ public:
     bool IsPropertyEnabled( wxPGPropArg id ) const
     {
         wxPG_PROP_ARG_CALL_PROLOG_RETVAL(false)
-        return !p->HasFlag(wxPGPropertyFlags::Disabled);
+        return !p->HasFlag(wxPGFlags::Disabled);
     }
 
     // Returns true if given property is expanded.
@@ -669,7 +669,7 @@ public:
     bool IsPropertyModified( wxPGPropArg id ) const
     {
         wxPG_PROP_ARG_CALL_PROLOG_RETVAL(false)
-        return p->HasFlag(wxPGPropertyFlags::Modified);
+        return p->HasFlag(wxPGFlags::Modified);
     }
 
     // Returns true if property is selected.
@@ -684,7 +684,7 @@ public:
     bool IsPropertyShown( wxPGPropArg id ) const
     {
         wxPG_PROP_ARG_CALL_PROLOG_RETVAL(false)
-        return !p->HasFlag(wxPGPropertyFlags::Hidden);
+        return !p->HasFlag(wxPGFlags::Hidden);
     }
 
     // Returns true if property value is set to unspecified.

--- a/include/wx/propgrid/propgridiface.h
+++ b/include/wx/propgrid/propgridiface.h
@@ -72,24 +72,19 @@ constexpr bool operator!(wxPGVFBFlags a)
 }
 
 #if WXWIN_COMPATIBILITY_3_2
-wxDEPRECATED_MSG("use wxPGVFBFlags::Null instead")
-constexpr wxPGVFBFlags wxPG_VFB_NULL{ wxPGVFBFlags::Null };
-wxDEPRECATED_MSG("use wxPGVFBFlags::StayInProperty instead")
-constexpr wxPGVFBFlags wxPG_VFB_STAY_IN_PROPERTY{ wxPGVFBFlags::StayInProperty };
-wxDEPRECATED_MSG("use wxPGVFBFlags::Beep instead")
-constexpr wxPGVFBFlags wxPG_VFB_BEEP{ wxPGVFBFlags::Beep };
-wxDEPRECATED_MSG("use wxPGVFBFlags::MarkCell instead")
-constexpr wxPGVFBFlags wxPG_VFB_MARK_CELL{ wxPGVFBFlags::MarkCell };
-wxDEPRECATED_MSG("use wxPGVFBFlags::ShowMessage instead")
-constexpr wxPGVFBFlags wxPG_VFB_SHOW_MESSAGE{ wxPGVFBFlags::ShowMessage };
-wxDEPRECATED_MSG("use wxPGVFBFlags::ShowMessageBox instead")
-constexpr wxPGVFBFlags wxPG_VFB_SHOW_MESSAGEBOX{ wxPGVFBFlags::ShowMessageBox };
-wxDEPRECATED_MSG("use wxPGVFBFlags::ShowMessageOnStatusBar instead")
-constexpr wxPGVFBFlags wxPG_VFB_SHOW_MESSAGE_ON_STATUSBAR{ wxPGVFBFlags::ShowMessageOnStatusBar };
-wxDEPRECATED_MSG("use wxPGVFBFlags::Default instead")
-constexpr wxPGVFBFlags wxPG_VFB_DEFAULT{ wxPGVFBFlags::Default };
-wxDEPRECATED_MSG("use wxPGVFBFlags::Undefined instead")
-constexpr wxPGVFBFlags wxPG_VFB_UNDEFINED{ wxPGVFBFlags::Undefined };
+// These constants themselves intentionally don't use wxDEPRECATED_MSG()
+// because one will be given whenever they are used with any function now
+// taking wxPGVFBFlags anyhow and giving multiple deprecation warnings for the
+// same line of code is more annoying than helpful.
+constexpr int wxPG_VFB_NULL = static_cast<int>(wxPGVFBFlags::Null);
+constexpr int wxPG_VFB_STAY_IN_PROPERTY = static_cast<int>(wxPGVFBFlags::StayInProperty);
+constexpr int wxPG_VFB_BEEP = static_cast<int>(wxPGVFBFlags::Beep);
+constexpr int wxPG_VFB_MARK_CELL = static_cast<int>(wxPGVFBFlags::MarkCell);
+constexpr int wxPG_VFB_SHOW_MESSAGE = static_cast<int>(wxPGVFBFlags::ShowMessage);
+constexpr int wxPG_VFB_SHOW_MESSAGEBOX = static_cast<int>(wxPGVFBFlags::ShowMessageBox);
+constexpr int wxPG_VFB_SHOW_MESSAGE_ON_STATUSBAR = static_cast<int>(wxPGVFBFlags::ShowMessageOnStatusBar);
+constexpr int wxPG_VFB_DEFAULT = static_cast<int>(wxPGVFBFlags::Default);
+constexpr int wxPG_VFB_UNDEFINED = static_cast<int>(wxPGVFBFlags::Undefined);
 
 wxDEPRECATED_MSG("use wxPGVFBFlags instead")
 constexpr bool operator==(wxPGVFBFlags a, int b)

--- a/include/wx/propgrid/propgridpagestate.h
+++ b/include/wx/propgrid/propgridpagestate.h
@@ -51,16 +51,19 @@ enum class wxPGSelectPropertyFlags : int
 // because one will be given whenever they are used with any function now
 // taking wxPGSelectPropertyFlags anyhow and giving multiple deprecation
 // warnings for the same line of code is more annoying than helpful.
-constexpr int wxPG_SEL_NONE = static_cast<int>(wxPGSelectPropertyFlags::Null);
-constexpr int wxPG_SEL_FOCUS = static_cast<int>(wxPGSelectPropertyFlags::Focus);
-constexpr int wxPG_SEL_FORCE = static_cast<int>(wxPGSelectPropertyFlags::Force);
-constexpr int wxPG_SEL_NONVISIBLE = static_cast<int>(wxPGSelectPropertyFlags::Nonvisible);
-constexpr int wxPG_SEL_NOVALIDATE = static_cast<int>(wxPGSelectPropertyFlags::NoValidate);
-constexpr int wxPG_SEL_DELETING = static_cast<int>(wxPGSelectPropertyFlags::Deleting);
-constexpr int wxPG_SEL_SETUNSPEC = static_cast<int>(wxPGSelectPropertyFlags::SetUnspec);
-constexpr int wxPG_SEL_DIALOGVAL = static_cast<int>(wxPGSelectPropertyFlags::DialogVal);
-constexpr int wxPG_SEL_DONT_SEND_EVENT = static_cast<int>(wxPGSelectPropertyFlags::DontSendEvent);
-constexpr int wxPG_SEL_NO_REFRESH = static_cast<int>(wxPGSelectPropertyFlags::NoRefresh);
+enum wxPG_SELECT_PROPERTY_FLAGS
+{
+    wxPG_SEL_NONE = static_cast<int>(wxPGSelectPropertyFlags::Null),
+    wxPG_SEL_FOCUS = static_cast<int>(wxPGSelectPropertyFlags::Focus),
+    wxPG_SEL_FORCE = static_cast<int>(wxPGSelectPropertyFlags::Force),
+    wxPG_SEL_NONVISIBLE = static_cast<int>(wxPGSelectPropertyFlags::Nonvisible),
+    wxPG_SEL_NOVALIDATE = static_cast<int>(wxPGSelectPropertyFlags::NoValidate),
+    wxPG_SEL_DELETING = static_cast<int>(wxPGSelectPropertyFlags::Deleting),
+    wxPG_SEL_SETUNSPEC = static_cast<int>(wxPGSelectPropertyFlags::SetUnspec),
+    wxPG_SEL_DIALOGVAL = static_cast<int>(wxPGSelectPropertyFlags::DialogVal),
+    wxPG_SEL_DONT_SEND_EVENT = static_cast<int>(wxPGSelectPropertyFlags::DontSendEvent),
+    wxPG_SEL_NO_REFRESH = static_cast<int>(wxPGSelectPropertyFlags::NoRefresh),
+};
 
 wxDEPRECATED_MSG("use wxPGSelectPropertyFlags instead")
 constexpr bool operator==(wxPGSelectPropertyFlags a, int b)
@@ -125,10 +128,13 @@ constexpr bool operator!(wxPGSplitterPositionFlags a)
 
 #if WXWIN_COMPATIBILITY_3_2
 // See comment before wxPG_SEL_NONE above.
-constexpr int wxPG_SPLITTER_REFRESH  = static_cast<int>(wxPGSplitterPositionFlags::Refresh);
-constexpr int wxPG_SPLITTER_ALL_PAGES  = static_cast<int>(wxPGSplitterPositionFlags::AllPages);
-constexpr int wxPG_SPLITTER_FROM_EVENT  = static_cast<int>(wxPGSplitterPositionFlags::FromEvent);
-constexpr int wxPG_SPLITTER_FROM_AUTO_CENTER  = static_cast<int>(wxPGSplitterPositionFlags::FromAutoCenter);
+enum wxPG_SET_SPLITTER_POSITION_SPLITTER_FLAGS
+{
+    wxPG_SPLITTER_REFRESH = static_cast<int>(wxPGSplitterPositionFlags::Refresh),
+    wxPG_SPLITTER_ALL_PAGES = static_cast<int>(wxPGSplitterPositionFlags::AllPages),
+    wxPG_SPLITTER_FROM_EVENT = static_cast<int>(wxPGSplitterPositionFlags::FromEvent),
+    wxPG_SPLITTER_FROM_AUTO_CENTER = static_cast<int>(wxPGSplitterPositionFlags::FromAutoCenter),
+};
 
 wxDEPRECATED_MSG("use wxPGSplitterPositionFlags instead")
 constexpr bool operator==(wxPGSplitterPositionFlags a, int b)

--- a/include/wx/propgrid/propgridpagestate.h
+++ b/include/wx/propgrid/propgridpagestate.h
@@ -47,26 +47,20 @@ enum class wxPGSelectPropertyFlags : int
 };
 
 #if WXWIN_COMPATIBILITY_3_2
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::Null instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_NONE{ wxPGSelectPropertyFlags::Null };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::Focus instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_FOCUS{wxPGSelectPropertyFlags::Focus };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::Force instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_FORCE{ wxPGSelectPropertyFlags::Force };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::Nonvisible instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_NONVISIBLE{ wxPGSelectPropertyFlags::Nonvisible };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::NoValidate instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_NOVALIDATE{ wxPGSelectPropertyFlags::NoValidate };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::Deleting instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_DELETING{wxPGSelectPropertyFlags::Deleting };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::SetUnspec instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_SETUNSPEC{ wxPGSelectPropertyFlags::SetUnspec };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::DialogVal instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_DIALOGVAL{ wxPGSelectPropertyFlags::DialogVal };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::DontSendEvent instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_DONT_SEND_EVENT{ wxPGSelectPropertyFlags::DontSendEvent };
-wxDEPRECATED_MSG("use wxPGSelectPropertyFlags::NoRefresh instead")
-constexpr wxPGSelectPropertyFlags wxPG_SEL_NO_REFRESH{ wxPGSelectPropertyFlags::NoRefresh };
+// These constants themselves intentionally don't use wxDEPRECATED_MSG()
+// because one will be given whenever they are used with any function now
+// taking wxPGSelectPropertyFlags anyhow and giving multiple deprecation
+// warnings for the same line of code is more annoying than helpful.
+constexpr int wxPG_SEL_NONE = static_cast<int>(wxPGSelectPropertyFlags::Null);
+constexpr int wxPG_SEL_FOCUS = static_cast<int>(wxPGSelectPropertyFlags::Focus);
+constexpr int wxPG_SEL_FORCE = static_cast<int>(wxPGSelectPropertyFlags::Force);
+constexpr int wxPG_SEL_NONVISIBLE = static_cast<int>(wxPGSelectPropertyFlags::Nonvisible);
+constexpr int wxPG_SEL_NOVALIDATE = static_cast<int>(wxPGSelectPropertyFlags::NoValidate);
+constexpr int wxPG_SEL_DELETING = static_cast<int>(wxPGSelectPropertyFlags::Deleting);
+constexpr int wxPG_SEL_SETUNSPEC = static_cast<int>(wxPGSelectPropertyFlags::SetUnspec);
+constexpr int wxPG_SEL_DIALOGVAL = static_cast<int>(wxPGSelectPropertyFlags::DialogVal);
+constexpr int wxPG_SEL_DONT_SEND_EVENT = static_cast<int>(wxPGSelectPropertyFlags::DontSendEvent);
+constexpr int wxPG_SEL_NO_REFRESH = static_cast<int>(wxPGSelectPropertyFlags::NoRefresh);
 
 wxDEPRECATED_MSG("use wxPGSelectPropertyFlags instead")
 constexpr bool operator==(wxPGSelectPropertyFlags a, int b)
@@ -130,14 +124,11 @@ constexpr bool operator!(wxPGSplitterPositionFlags a)
 }
 
 #if WXWIN_COMPATIBILITY_3_2
-wxDEPRECATED_MSG("use wxPGSplitterPositionFlags::Refresh instead")
-constexpr wxPGSplitterPositionFlags wxPG_SPLITTER_REFRESH { wxPGSplitterPositionFlags::Refresh };
-wxDEPRECATED_MSG("use wxPGSplitterPositionFlags::AllPages instead")
-constexpr wxPGSplitterPositionFlags wxPG_SPLITTER_ALL_PAGES { wxPGSplitterPositionFlags::AllPages };
-wxDEPRECATED_MSG("use wxPGSplitterPositionFlags::FromEvent instead")
-constexpr wxPGSplitterPositionFlags wxPG_SPLITTER_FROM_EVENT { wxPGSplitterPositionFlags::FromEvent };
-wxDEPRECATED_MSG("use wxPGSplitterPositionFlags::FromAutoCenter instead")
-constexpr wxPGSplitterPositionFlags wxPG_SPLITTER_FROM_AUTO_CENTER { wxPGSplitterPositionFlags::FromAutoCenter };
+// See comment before wxPG_SEL_NONE above.
+constexpr int wxPG_SPLITTER_REFRESH  = static_cast<int>(wxPGSplitterPositionFlags::Refresh);
+constexpr int wxPG_SPLITTER_ALL_PAGES  = static_cast<int>(wxPGSplitterPositionFlags::AllPages);
+constexpr int wxPG_SPLITTER_FROM_EVENT  = static_cast<int>(wxPGSplitterPositionFlags::FromEvent);
+constexpr int wxPG_SPLITTER_FROM_AUTO_CENTER  = static_cast<int>(wxPGSplitterPositionFlags::FromAutoCenter);
 
 wxDEPRECATED_MSG("use wxPGSplitterPositionFlags instead")
 constexpr bool operator==(wxPGSplitterPositionFlags a, int b)

--- a/include/wx/propgrid/propgridpagestate.h
+++ b/include/wx/propgrid/propgridpagestate.h
@@ -204,54 +204,54 @@ enum wxPG_ITERATOR_FLAGS
 
 // Iterate through 'normal' property items (does not include children of
 // aggregate or hidden items by default).
-wxPG_ITERATE_PROPERTIES = wxPGPropertyFlags::Property |
-                          wxPGPropertyFlags::MiscParent |
-                          wxPGPropertyFlags::Aggregate |
-                          wxPGPropertyFlags::Collapsed |
-                          wxPG_IT_CHILDREN(wxPGPropertyFlags::MiscParent) |
-                          wxPG_IT_CHILDREN(wxPGPropertyFlags::Category),
+wxPG_ITERATE_PROPERTIES = wxPGFlags::Property |
+                          wxPGFlags::MiscParent |
+                          wxPGFlags::Aggregate |
+                          wxPGFlags::Collapsed |
+                          wxPG_IT_CHILDREN(wxPGFlags::MiscParent) |
+                          wxPG_IT_CHILDREN(wxPGFlags::Category),
 
 // Iterate children of collapsed parents, and individual items that are hidden.
-wxPG_ITERATE_HIDDEN = wxPGPropertyFlags::Hidden |
-                      wxPG_IT_CHILDREN(wxPGPropertyFlags::Collapsed),
+wxPG_ITERATE_HIDDEN = wxPGFlags::Hidden |
+                      wxPG_IT_CHILDREN(wxPGFlags::Collapsed),
 
 // Iterate children of parent that is an aggregate property (ie has fixed
 // children).
-wxPG_ITERATE_FIXED_CHILDREN = wxPG_IT_CHILDREN(wxPGPropertyFlags::Aggregate) |
+wxPG_ITERATE_FIXED_CHILDREN = wxPG_IT_CHILDREN(wxPGFlags::Aggregate) |
                               wxPG_ITERATE_PROPERTIES,
 
 // Iterate categories.
 // Note that even without this flag, children of categories are still iterated
 // through.
-wxPG_ITERATE_CATEGORIES = wxPGPropertyFlags::Category |
-                          wxPG_IT_CHILDREN(wxPGPropertyFlags::Category) |
-                          wxPGPropertyFlags::Collapsed,
+wxPG_ITERATE_CATEGORIES = wxPGFlags::Category |
+                          wxPG_IT_CHILDREN(wxPGFlags::Category) |
+                          wxPGFlags::Collapsed,
 
-wxPG_ITERATE_ALL_PARENTS = static_cast<int>(wxPGPropertyFlags::MiscParent |
-                           wxPGPropertyFlags::Aggregate |
-                           wxPGPropertyFlags::Category),
+wxPG_ITERATE_ALL_PARENTS = static_cast<int>(wxPGFlags::MiscParent |
+                           wxPGFlags::Aggregate |
+                           wxPGFlags::Category),
 
 wxPG_ITERATE_ALL_PARENTS_RECURSIVELY = wxPG_ITERATE_ALL_PARENTS |
                                        wxPG_IT_CHILDREN(
                                                 wxPG_ITERATE_ALL_PARENTS),
 
-wxPG_ITERATOR_FLAGS_ALL = static_cast<int>(wxPGPropertyFlags::Property |
-                          wxPGPropertyFlags::MiscParent |
-                          wxPGPropertyFlags::Aggregate |
-                          wxPGPropertyFlags::Hidden |
-                          wxPGPropertyFlags::Category |
-                          wxPGPropertyFlags::Collapsed),
+wxPG_ITERATOR_FLAGS_ALL = static_cast<int>(wxPGFlags::Property |
+                          wxPGFlags::MiscParent |
+                          wxPGFlags::Aggregate |
+                          wxPGFlags::Hidden |
+                          wxPGFlags::Category |
+                          wxPGFlags::Collapsed),
 
 wxPG_ITERATOR_MASK_OP_ITEM = wxPG_ITERATOR_FLAGS_ALL,
 
-// (wxPGPropertyFlags::MiscParent|wxPGPropertyFlags::Aggregate|wxPGPropertyFlags::Category)
+// (wxPGFlags::MiscParent|wxPGFlags::Aggregate|wxPGFlags::Category)
 wxPG_ITERATOR_MASK_OP_PARENT = wxPG_ITERATOR_FLAGS_ALL,
 
 // Combines all flags needed to iterate through visible properties
 // (ie. hidden properties and children of collapsed parents are skipped).
 wxPG_ITERATE_VISIBLE = wxPG_ITERATE_PROPERTIES |
-                       wxPGPropertyFlags::Category |
-                       wxPG_IT_CHILDREN(wxPGPropertyFlags::Aggregate),
+                       wxPGFlags::Category |
+                       wxPG_IT_CHILDREN(wxPGFlags::Aggregate),
 
 // Iterate all items.
 wxPG_ITERATE_ALL = wxPG_ITERATE_VISIBLE |
@@ -267,11 +267,11 @@ wxPG_ITERATE_DEFAULT = wxPG_ITERATE_NORMAL
 
 };
 
-inline void wxPGCreateIteratorMasks(int flags, wxPGPropertyFlags& itemExMask, wxPGPropertyFlags& parentExMask)
+inline void wxPGCreateIteratorMasks(int flags, wxPGFlags& itemExMask, wxPGFlags& parentExMask)
 {
-    itemExMask = static_cast<wxPGPropertyFlags>((flags ^ wxPG_ITERATOR_MASK_OP_ITEM) &
+    itemExMask = static_cast<wxPGFlags>((flags ^ wxPG_ITERATOR_MASK_OP_ITEM) &
         wxPG_ITERATOR_MASK_OP_ITEM & 0xFFFF);
-    parentExMask = static_cast<wxPGPropertyFlags>(((flags >> 16) ^ wxPG_ITERATOR_MASK_OP_PARENT) &
+    parentExMask = static_cast<wxPGFlags>(((flags >> 16) ^ wxPG_ITERATOR_MASK_OP_PARENT) &
         wxPG_ITERATOR_MASK_OP_PARENT & 0xFFFF);
 }
 
@@ -328,8 +328,8 @@ private:
     wxPGProperty*               m_baseParent;
 
     // Masks are used to quickly exclude items
-    wxPGPropertyFlags           m_itemExMask;
-    wxPGPropertyFlags           m_parentExMask;
+    wxPGFlags           m_itemExMask;
+    wxPGFlags           m_parentExMask;
 };
 
 template <typename PROPERTY, typename STATE>
@@ -632,7 +632,7 @@ protected:
 
     void DoLimitPropertyEditing(wxPGProperty* p, bool limit = true)
     {
-        p->SetFlagRecursively(wxPGPropertyFlags::NoEditor, limit);
+        p->SetFlagRecursively(wxPGFlags::NoEditor, limit);
     }
 
     bool DoSelectProperty(wxPGProperty* p, wxPGSelectPropertyFlags flags = wxPGSelectPropertyFlags::Null);

--- a/include/wx/propgrid/props.h
+++ b/include/wx/propgrid/props.h
@@ -146,12 +146,13 @@ enum class wxPGNumericValidationMode
 };
 
 #if WXWIN_COMPATIBILITY_3_2
-wxDEPRECATED_MSG("use wxPGNumericValidationMode::ErrorMessage instead")
-constexpr wxPGNumericValidationMode wxPG_PROPERTY_VALIDATION_ERROR_MESSAGE { wxPGNumericValidationMode::ErrorMessage };
-wxDEPRECATED_MSG("use wxPGNumericValidationMode::Saturate instead")
-constexpr wxPGNumericValidationMode wxPG_PROPERTY_VALIDATION_SATURATE { wxPGNumericValidationMode::Saturate };
-wxDEPRECATED_MSG("use wxPGNumericValidationMode::Wrap instead")
-constexpr wxPGNumericValidationMode wxPG_PROPERTY_VALIDATION_WRAP { wxPGNumericValidationMode::Wrap };
+// These constants themselves intentionally don't use wxDEPRECATED_MSG()
+// because one will be given whenever they are used with any function now
+// taking wxPGNumericValidationMode anyhow and giving multiple deprecation
+// warnings for the same line of code is more annoying than helpful.
+constexpr int wxPG_PROPERTY_VALIDATION_ERROR_MESSAGE  = static_cast<int>(wxPGNumericValidationMode::ErrorMessage);
+constexpr int wxPG_PROPERTY_VALIDATION_SATURATE  = static_cast<int>(wxPGNumericValidationMode::Saturate);
+constexpr int wxPG_PROPERTY_VALIDATION_WRAP  = static_cast<int>(wxPGNumericValidationMode::Wrap);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------
@@ -170,12 +171,10 @@ public:
     };
 
 #if WXWIN_COMPATIBILITY_3_2
-    wxDEPRECATED_MSG("use NumericType::Signed instead")
-    static const NumericType Signed = NumericType::Signed;
-    wxDEPRECATED_MSG("use NumericType::Unsigned instead")
-    static const NumericType Unsigned = NumericType::Unsigned;
-    wxDEPRECATED_MSG("use NumericType::Float instead")
-    static const NumericType Float = NumericType::Float;
+    // See comments above.
+    static const int Signed = static_cast<int>(NumericType::Signed);
+    static const int Unsigned = static_cast<int>(NumericType::Unsigned);
+    static const int Float = static_cast<int>(NumericType::Float);
 #endif // WXWIN_COMPATIBILITY_3_2
 
     wxNumericPropertyValidator( NumericType numericType, int base = 10 );
@@ -459,8 +458,7 @@ public:
 #if WXWIN_COMPATIBILITY_3_2
 // If set, then selection of choices is static and should not be
 // changed (i.e. returns nullptr in GetPropertyChoices).
-wxDEPRECATED_MSG("wxPG_PROP_STATIC_CHOICES is intended for internal use.")
-constexpr wxPGPropertyFlags wxPG_PROP_STATIC_CHOICES = wxPGPropertyFlags::Reserved_1;
+constexpr int wxPG_PROP_STATIC_CHOICES = static_cast<int>(wxPGPropertyFlags::Reserved_1);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Represents a single selection from a list of choices
@@ -765,9 +763,7 @@ protected:
 // -----------------------------------------------------------------------
 
 #if WXWIN_COMPATIBILITY_3_2
-// Indicates first bit usable by derived properties.
-wxDEPRECATED_MSG("wxPG_PROP_SHOW_FULL_FILENAME is intended for internal use.")
-constexpr wxPGPropertyFlags wxPG_PROP_SHOW_FULL_FILENAME = wxPGPropertyFlags::Reserved_1;
+constexpr int wxPG_PROP_SHOW_FULL_FILENAME = static_cast<int>(wxPGPropertyFlags::Reserved_1);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Like wxLongStringProperty, but the button triggers file selector instead.
@@ -824,8 +820,7 @@ protected:
 #if WXWIN_COMPATIBILITY_3_2
 // Flag used in wxLongStringProperty to mark that edit button
 // should be enabled even in the read-only mode.
-wxDEPRECATED_MSG("wxPG_PROP_ACTIVE_BTN is intended for internal use.")
-constexpr wxPGPropertyFlags wxPG_PROP_ACTIVE_BTN = wxPGPropertyFlags::Reserved_3;
+constexpr int wxPG_PROP_ACTIVE_BTN = static_cast<int>(wxPGPropertyFlags::Reserved_3);
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Like wxStringProperty, but has a button that triggers a small text

--- a/include/wx/propgrid/props.h
+++ b/include/wx/propgrid/props.h
@@ -163,19 +163,12 @@ constexpr int wxPG_PROPERTY_VALIDATION_WRAP  = static_cast<int>(wxPGNumericValid
 class WXDLLIMPEXP_PROPGRID wxNumericPropertyValidator : public wxTextValidator
 {
 public:
-    enum class NumericType
+    enum NumericType
     {
-        Signed,
+        Signed = 0,
         Unsigned,
         Float
     };
-
-#if WXWIN_COMPATIBILITY_3_2
-    // See comments above.
-    static const int Signed = static_cast<int>(NumericType::Signed);
-    static const int Unsigned = static_cast<int>(NumericType::Unsigned);
-    static const int Float = static_cast<int>(NumericType::Float);
-#endif // WXWIN_COMPATIBILITY_3_2
 
     wxNumericPropertyValidator( NumericType numericType, int base = 10 );
     virtual ~wxNumericPropertyValidator() = default;

--- a/include/wx/propgrid/props.h
+++ b/include/wx/propgrid/props.h
@@ -458,7 +458,7 @@ public:
 #if WXWIN_COMPATIBILITY_3_2
 // If set, then selection of choices is static and should not be
 // changed (i.e. returns nullptr in GetPropertyChoices).
-constexpr int wxPG_PROP_STATIC_CHOICES = static_cast<int>(wxPGPropertyFlags::Reserved_1);
+constexpr int wxPG_PROP_STATIC_CHOICES = wxPG_PROP_CLASS_SPECIFIC_1;
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Represents a single selection from a list of choices
@@ -763,7 +763,7 @@ protected:
 // -----------------------------------------------------------------------
 
 #if WXWIN_COMPATIBILITY_3_2
-constexpr int wxPG_PROP_SHOW_FULL_FILENAME = static_cast<int>(wxPGPropertyFlags::Reserved_1);
+constexpr int wxPG_PROP_SHOW_FULL_FILENAME = wxPG_PROP_CLASS_SPECIFIC_1;
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Like wxLongStringProperty, but the button triggers file selector instead.
@@ -820,7 +820,7 @@ protected:
 #if WXWIN_COMPATIBILITY_3_2
 // Flag used in wxLongStringProperty to mark that edit button
 // should be enabled even in the read-only mode.
-constexpr int wxPG_PROP_ACTIVE_BTN = static_cast<int>(wxPGPropertyFlags::Reserved_3);
+constexpr int wxPG_PROP_ACTIVE_BTN = wxPG_PROP_CLASS_SPECIFIC_3;
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // Like wxStringProperty, but has a button that triggers a small text

--- a/include/wx/propgrid/props.h
+++ b/include/wx/propgrid/props.h
@@ -150,9 +150,12 @@ enum class wxPGNumericValidationMode
 // because one will be given whenever they are used with any function now
 // taking wxPGNumericValidationMode anyhow and giving multiple deprecation
 // warnings for the same line of code is more annoying than helpful.
-constexpr int wxPG_PROPERTY_VALIDATION_ERROR_MESSAGE  = static_cast<int>(wxPGNumericValidationMode::ErrorMessage);
-constexpr int wxPG_PROPERTY_VALIDATION_SATURATE  = static_cast<int>(wxPGNumericValidationMode::Saturate);
-constexpr int wxPG_PROPERTY_VALIDATION_WRAP  = static_cast<int>(wxPGNumericValidationMode::Wrap);
+enum wxPGNumericValidationConstants
+{
+    wxPG_PROPERTY_VALIDATION_ERROR_MESSAGE = static_cast<int>(wxPGNumericValidationMode::ErrorMessage),
+    wxPG_PROPERTY_VALIDATION_SATURATE = static_cast<int>(wxPGNumericValidationMode::Saturate),
+    wxPG_PROPERTY_VALIDATION_WRAP = static_cast<int>(wxPGNumericValidationMode::Wrap),
+};
 #endif // WXWIN_COMPATIBILITY_3_2
 
 // -----------------------------------------------------------------------

--- a/interface/wx/propgrid/property.h
+++ b/interface/wx/propgrid/property.h
@@ -235,7 +235,16 @@ struct wxPGPaintData
     @{
 */
 
-enum class wxPGPropertyFlags : int
+/**
+    Strongly typed enums containing properties flags.
+
+    Note that this replaces wxPGPropertyFlags enum used in previous wxWidgets
+    versions which defined the same flags using `wxPG_PROP_XXX` naming
+    convention.
+
+    @since 3.3.1
+ */
+enum class wxPGFlags : int
 {
     /** No flags.
         @hideinitializer
@@ -1286,7 +1295,7 @@ public:
         Adds a private child property. If you use this instead of
         wxPropertyGridInterface::Insert() or
         wxPropertyGridInterface::AppendIn(), then property's parental
-        type will automatically be set up to wxPGPropertyFlags::Aggregate.
+        type will automatically be set up to wxPGFlags::Aggregate.
         In other words, all properties of this property will become private.
     */
     void AddPrivateChild( wxPGProperty* prop );
@@ -1332,11 +1341,11 @@ public:
                  intended almost exclusively for internal use. So, for
                  example, if you want to disable a property, call
                  @code Enable(false) @endcode instead of setting
-                 wxPGPropertyFlags::Disabled flag.
+                 wxPGFlags::Disabled flag.
 
         @see HasFlag(), GetFlags()
     */
-    void ChangeFlag( wxPGPropertyFlags flag, bool set );
+    void ChangeFlag( wxPGFlags flag, bool set );
 
     /**
         Deletes children of the property.
@@ -1550,12 +1559,12 @@ public:
     const wxString& GetHelpString() const;
 
     /** Gets flags as a'|' delimited string. Note that flag names are not
-        prepended with 'wxPGPropertyFlags'.
+        prepended with 'wxPGFlags'.
 
         @param flagsMask
         String will only be made to include flags combined by this parameter.
     */
-    wxString GetFlagsAsString(wxPGPropertyFlags flagsMask) const;
+    wxString GetFlagsAsString(wxPGFlags flagsMask) const;
 
     /**
         Returns position in parent's array.
@@ -1658,12 +1667,12 @@ public:
 
         @see propgrid_propflags
     */
-    bool HasFlag(wxPGPropertyFlags flag) const;
+    bool HasFlag(wxPGFlags flag) const;
 
     /**
         Returns @true if property has all given flags set.
     */
-    bool HasFlagsExact(wxPGPropertyFlags flags) const;
+    bool HasFlagsExact(wxPGFlags flags) const;
 
     /**
         Returns @true if property has even one visible child.
@@ -1903,7 +1912,7 @@ public:
     void SetExpanded( bool expanded );
 
     /** Sets flags from a '|' delimited string. Note that flag names are not
-        prepended with 'wxPGPropertyFlags'.
+        prepended with 'wxPGFlags'.
     */
     void SetFlagsFromString( const wxString& str );
 
@@ -1913,7 +1922,7 @@ public:
 
         @see ChangeFlag()
     */
-    void SetFlagRecursively( wxPGPropertyFlags flag, bool set );
+    void SetFlagRecursively( wxPGFlags flag, bool set );
 
     /**
         Sets property's help string, which is shown, for example, in
@@ -1962,14 +1971,14 @@ public:
         Changes what sort of parent this property is for its children.
 
         @param flag
-            Use one of the following values: wxPGPropertyFlags::MiscParent (for
-            generic parents), wxPGPropertyFlags::Category (for categories), or
-            wxPGPropertyFlags::Aggregate (for derived property classes with
+            Use one of the following values: wxPGFlags::MiscParent (for
+            generic parents), wxPGFlags::Category (for categories), or
+            wxPGFlags::Aggregate (for derived property classes with
             private children).
 
         @remarks You generally do not need to call this function.
     */
-    void SetParentalType(wxPGPropertyFlags flag);
+    void SetParentalType(wxPGFlags flag);
 
     /**
         Sets property's text colour.
@@ -2148,7 +2157,7 @@ protected:
                           const wxPGCell& preparedCell,
                           const wxPGCell& srcData,
                           wxPGCellData* unmodCellData,
-                          wxPGPropertyFlags ignoreWithFlags,
+                          wxPGFlags ignoreWithFlags,
                           bool recursively );
 
     /**
@@ -2162,7 +2171,7 @@ protected:
 
         @since 3.1.0
     */
-    void ClearCells(wxPGPropertyFlags ignoreWithFlags, bool recursively);
+    void ClearCells(wxPGFlags ignoreWithFlags, bool recursively);
 
     /**
         Makes sure m_cells has size of column+1 (or more).

--- a/interface/wx/propgrid/propgrid.h
+++ b/interface/wx/propgrid/propgrid.h
@@ -166,8 +166,8 @@ wxPG_EX_NATIVE_DOUBLE_BUFFERING         = 0x00080000,
 
 /**
     Set this style to let user have ability to set values of properties to
-    unspecified state. Same as setting wxPGPropertyFlags::AutoUnspecified
-    for all properties.
+    unspecified state. Same as setting wxPGFlags::AutoUnspecified for all
+    properties.
     @hideinitializer
 */
 wxPG_EX_AUTO_UNSPECIFIED_VALUES         = 0x00200000,
@@ -899,7 +899,7 @@ public:
         Note that @a column must not be equal to 1, as the second column is
         always editable and can be made read-only only on cell-by-cell basis
         using
-        @code wxPGProperty::ChangeFlag(wxPGPropertyFlags::ReadOnly, true) @endcode
+        @code wxPGProperty::ChangeFlag(wxPGFlags::ReadOnly, true) @endcode
 
         @see BeginLabelEdit(), EndLabelEdit()
     */
@@ -1206,7 +1206,7 @@ public:
 
     /** Override to customize resetting of property validation failure status.
         @remarks
-        Property is guaranteed to have flag wxPGPropertyFlags::InvalidValue set.
+        Property is guaranteed to have flag wxPGFlags::InvalidValue set.
     */
     virtual void DoOnValidationFailureReset( wxPGProperty* property );
 

--- a/interface/wx/propgrid/propgridiface.h
+++ b/interface/wx/propgrid/propgridiface.h
@@ -368,7 +368,7 @@ public:
             See @ref propgrid_iterator_flags.
     */
     void GetPropertiesWithFlag( wxArrayPGProperty* targetArr,
-                                wxPGPropertyFlags flags,
+                                wxPGFlags flags,
                                 bool inverse = false,
                                 int iterFlags = (wxPG_ITERATE_PROPERTIES|wxPG_ITERATE_HIDDEN|wxPG_ITERATE_CATEGORIES) ) const;
 

--- a/interface/wx/propgrid/propgridpagestate.h
+++ b/interface/wx/propgrid/propgridpagestate.h
@@ -146,26 +146,26 @@ enum wxPG_ITERATOR_FLAGS
     aggregate or hidden items by default).
     @hideinitializer
 */
-wxPG_ITERATE_PROPERTIES = wxPGPropertyFlags::Property |
-                          wxPGPropertyFlags::MiscParent |
-                          wxPGPropertyFlags::Aggregate |
-                          wxPGPropertyFlags::Collapsed |
-                          wxPG_IT_CHILDREN(wxPGPropertyFlags::MiscParent) |
-                          wxPG_IT_CHILDREN(wxPGPropertyFlags::Category),
+wxPG_ITERATE_PROPERTIES = wxPGFlags::Property |
+                          wxPGFlags::MiscParent |
+                          wxPGFlags::Aggregate |
+                          wxPGFlags::Collapsed |
+                          wxPG_IT_CHILDREN(wxPGFlags::MiscParent) |
+                          wxPG_IT_CHILDREN(wxPGFlags::Category),
 
 /**
     Iterate children of collapsed parents, and individual items that are hidden.
     @hideinitializer
 */
-wxPG_ITERATE_HIDDEN = wxPGPropertyFlags::Hidden |
-                      wxPG_IT_CHILDREN(wxPGPropertyFlags::Collapsed),
+wxPG_ITERATE_HIDDEN = wxPGFlags::Hidden |
+                      wxPG_IT_CHILDREN(wxPGFlags::Collapsed),
 
 /**
     Iterate children of parent that is an aggregate property (ie has fixed
     children).
     @hideinitializer
 */
-wxPG_ITERATE_FIXED_CHILDREN = wxPG_IT_CHILDREN(wxPGPropertyFlags::Aggregate) |
+wxPG_ITERATE_FIXED_CHILDREN = wxPG_IT_CHILDREN(wxPGFlags::Aggregate) |
                               wxPG_ITERATE_PROPERTIES,
 
 /** Iterate categories.
@@ -173,16 +173,16 @@ wxPG_ITERATE_FIXED_CHILDREN = wxPG_IT_CHILDREN(wxPGPropertyFlags::Aggregate) |
     through.
     @hideinitializer
 */
-wxPG_ITERATE_CATEGORIES = wxPGPropertyFlags::Category |
-                          wxPG_IT_CHILDREN(wxPGPropertyFlags::Category) |
-                          wxPGPropertyFlags::Collapsed,
+wxPG_ITERATE_CATEGORIES = wxPGFlags::Category |
+                          wxPG_IT_CHILDREN(wxPGFlags::Category) |
+                          wxPGFlags::Collapsed,
 
 /**
     @hideinitializer
 */
-wxPG_ITERATE_ALL_PARENTS = wxPGPropertyFlags::MiscParent |
-                           wxPGPropertyFlags::Aggregate |
-                           wxPGPropertyFlags::Category,
+wxPG_ITERATE_ALL_PARENTS = wxPGFlags::MiscParent |
+                           wxPGFlags::Aggregate |
+                           wxPGFlags::Category,
 
 /**
     @hideinitializer
@@ -194,12 +194,12 @@ wxPG_ITERATE_ALL_PARENTS_RECURSIVELY = wxPG_ITERATE_ALL_PARENTS |
 /**
     @hideinitializer
 */
-wxPG_ITERATOR_FLAGS_ALL = wxPGPropertyFlags::Property |
-                          wxPGPropertyFlags::MiscParent |
-                          wxPGPropertyFlags::Aggregate |
-                          wxPGPropertyFlags::Hidden |
-                          wxPGPropertyFlags::Category |
-                          wxPGPropertyFlags::Collapsed,
+wxPG_ITERATOR_FLAGS_ALL = wxPGFlags::Property |
+                          wxPGFlags::MiscParent |
+                          wxPGFlags::Aggregate |
+                          wxPGFlags::Hidden |
+                          wxPGFlags::Category |
+                          wxPGFlags::Collapsed,
 
 /**
     @hideinitializer
@@ -217,8 +217,8 @@ wxPG_ITERATOR_MASK_OP_PARENT = wxPG_ITERATOR_FLAGS_ALL,
     @hideinitializer
 */
 wxPG_ITERATE_VISIBLE = wxPG_ITERATE_PROPERTIES |
-                       wxPGPropertyFlags::Category |
-                       wxPG_IT_CHILDREN(wxPGPropertyFlags::Aggregate),
+                       wxPGFlags::Category |
+                       wxPG_IT_CHILDREN(wxPGFlags::Aggregate),
 
 /**
     Iterate all items.

--- a/interface/wx/propgrid/props.h
+++ b/interface/wx/propgrid/props.h
@@ -86,9 +86,9 @@ enum class wxPGNumericValidationMode
 class wxNumericPropertyValidator : public wxTextValidator
 {
 public:
-    enum class NumericType
+    enum NumericType
     {
-        Signed,
+        Signed = 0,
         Unsigned,
         Float
     };

--- a/samples/propgrid/sampleprops.cpp
+++ b/samples/propgrid/sampleprops.cpp
@@ -632,7 +632,7 @@ wxValidator* wxArrayDoubleProperty::DoGetValidator() const
     WX_PG_DOGETVALIDATOR_ENTRY()
 
     wxTextValidator* validator =
-        new wxNumericPropertyValidator(wxNumericPropertyValidator::NumericType::Float);
+        new wxNumericPropertyValidator(wxNumericPropertyValidator::Float);
 
     // Accept also a delimiter and space character
     validator->AddCharIncludes(m_delimiter);

--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -197,7 +197,7 @@ void wxPGEditor::SetControlAppearance( wxPropertyGrid* pg,
 #else
             tcText = property->GetValueAsString(
 #endif // WXWIN_COMPATIBILITY_3_2 | !WXWIN_COMPATIBILITY_3_2
-                property->HasFlag(wxPGPropertyFlags::ReadOnly)?wxPGPropValFormatFlags::Null:wxPGPropValFormatFlags::EditableValue);
+                property->HasFlag(wxPGFlags::ReadOnly)?wxPGPropValFormatFlags::Null:wxPGPropValFormatFlags::EditableValue);
             changeText = true;
         }
 
@@ -285,12 +285,12 @@ wxPGWindowList wxPGTextCtrlEditor::CreateControls( wxPropertyGrid* propGrid,
 
     //
     // If has children, and limited editing is specified, then don't create.
-    if ( property->HasFlag(wxPGPropertyFlags::NoEditor) &&
+    if ( property->HasFlag(wxPGFlags::NoEditor) &&
          property->HasAnyChild() )
         return nullptr;
 
     wxPGPropValFormatFlags fmtFlags = wxPGPropValFormatFlags::Null;
-    if ( !property->HasFlag(wxPGPropertyFlags::ReadOnly) &&
+    if ( !property->HasFlag(wxPGFlags::ReadOnly) &&
          !property->IsValueUnspecified() )
         fmtFlags |= wxPGPropValFormatFlags::EditableValue;
 #if WXWIN_COMPATIBILITY_3_2
@@ -455,7 +455,7 @@ void wxPGTextCtrlEditor_OnFocus( wxPGProperty* property,
 {
     // Make sure there is correct text (instead of unspecified value
     // indicator or hint text)
-    wxPGPropValFormatFlags fmtFlags = property->HasFlag(wxPGPropertyFlags::ReadOnly) ?
+    wxPGPropValFormatFlags fmtFlags = property->HasFlag(wxPGFlags::ReadOnly) ?
         wxPGPropValFormatFlags::Null : wxPGPropValFormatFlags::EditableValue;
 #if WXWIN_COMPATIBILITY_3_2
     // Special implementation with check if user-overriden obsolete function is still in use
@@ -829,11 +829,11 @@ void wxPropertyGrid::OnComboItemPaint( const wxPGComboBox* pCb,
     {
         renderFlags |= wxPGCellRenderer::Control;
 
-        // If wxPGPropertyFlags::CustomImage was set, then that means any custom
+        // If wxPGFlags::CustomImage was set, then that means any custom
         // image will not appear on the control row (it may be too
         // large to fit, for instance). Also do not draw custom image
         // if no choice was selected.
-        if ( !p->HasFlag(wxPGPropertyFlags::CustomImage) )
+        if ( !p->HasFlag(wxPGFlags::CustomImage) )
             useCustomPaintProcedure = false;
     }
     else
@@ -971,7 +971,7 @@ wxWindow* wxPGChoiceEditor::CreateControlsBase( wxPropertyGrid* propGrid,
     // Since it is not possible (yet) to create a read-only combo box in
     // the same sense that wxTextCtrl is read-only, simply do not create
     // the control in this case.
-    if ( property->HasFlag(wxPGPropertyFlags::ReadOnly) )
+    if ( property->HasFlag(wxPGFlags::ReadOnly) )
         return nullptr;
 
     const wxPGChoices& choices = property->GetChoices();
@@ -979,7 +979,7 @@ wxWindow* wxPGChoiceEditor::CreateControlsBase( wxPropertyGrid* propGrid,
     int index = property->GetChoiceSelection();
 
     wxPGPropValFormatFlags fmtFlags = wxPGPropValFormatFlags::Null;
-    if ( !property->HasFlag(wxPGPropertyFlags::ReadOnly) &&
+    if ( !property->HasFlag(wxPGFlags::ReadOnly) &&
          !property->IsValueUnspecified() )
         fmtFlags |= wxPGPropValFormatFlags::EditableValue;
 #if WXWIN_COMPATIBILITY_3_2
@@ -1392,7 +1392,7 @@ wxPGWindowList wxPGTextCtrlAndButtonEditor::CreateControls( wxPropertyGrid* prop
 {
     wxWindow* wnd2;
     wxWindow* wnd = propGrid->GenerateEditorTextCtrlAndButton( pos, sz, &wnd2,
-        property->HasFlag(wxPGPropertyFlags::NoEditor), property);
+        property->HasFlag(wxPGFlags::NoEditor), property);
 
     return wxPGWindowList(wnd, wnd2);
 }
@@ -1678,7 +1678,7 @@ wxPGWindowList wxPGCheckBoxEditor::CreateControls( wxPropertyGrid* propGrid,
                                                    const wxPoint& pos,
                                                    const wxSize& size ) const
 {
-    if ( property->HasFlag(wxPGPropertyFlags::ReadOnly) )
+    if ( property->HasFlag(wxPGFlags::ReadOnly) )
         return nullptr;
 
     wxPoint pt = pos;
@@ -1955,7 +1955,7 @@ wxWindow* wxPropertyGrid::GenerateEditorTextCtrl( const wxPoint& pos,
 
     int tcFlags = wxTE_PROCESS_ENTER | extraStyle;
 
-    if ( prop->HasFlag(wxPGPropertyFlags::ReadOnly) && forColumn == 1 )
+    if ( prop->HasFlag(wxPGFlags::ReadOnly) && forColumn == 1 )
         tcFlags |= wxTE_READONLY;
 
     wxPoint p(pos);
@@ -2008,7 +2008,7 @@ wxWindow* wxPropertyGrid::GenerateEditorTextCtrl( const wxPoint& pos,
     // This code is repeated from DoSelectProperty(). However, font boldness
     // must be set before margin is set up below in FixPosForTextCtrl().
     if ( forColumn == 1 &&
-         prop->HasFlag(wxPGPropertyFlags::Modified) &&
+         prop->HasFlag(wxPGFlags::Modified) &&
          HasFlag(wxPG_BOLD_MODIFIED) )
          tc->SetFont( m_captionFont );
 
@@ -2075,7 +2075,7 @@ wxWindow* wxPropertyGrid::GenerateEditorButton( const wxPoint& pos, const wxSize
     p.x = pos.x + sz.x - s.x;
     but->Move(p);
 
-    if ( selected->HasFlag(wxPGPropertyFlags::ReadOnly) && !selected->HasFlag(wxPGPropertyFlags_ActiveButton) )
+    if ( selected->HasFlag(wxPGFlags::ReadOnly) && !selected->HasFlag(wxPGPropertyFlags_ActiveButton) )
         but->Disable();
 
     return but;
@@ -2106,9 +2106,9 @@ wxWindow* wxPropertyGrid::GenerateEditorTextCtrlAndButton( const wxPoint& pos,
     if ( !property->IsValueUnspecified() )
 #if WXWIN_COMPATIBILITY_3_2
         // Special implementation with check if user-overriden obsolete function is still in use
-        text = property->GetValueAsStringWithCheck(property->HasFlag(wxPGPropertyFlags::ReadOnly)?wxPGPropValFormatFlags::Null : wxPGPropValFormatFlags::EditableValue);
+        text = property->GetValueAsStringWithCheck(property->HasFlag(wxPGFlags::ReadOnly)?wxPGPropValFormatFlags::Null : wxPGPropValFormatFlags::EditableValue);
 #else
-        text = property->GetValueAsString(property->HasFlag(wxPGPropertyFlags::ReadOnly) ? wxPGPropValFormatFlags::Null : wxPGPropValFormatFlags::EditableValue);
+        text = property->GetValueAsString(property->HasFlag(wxPGFlags::ReadOnly) ? wxPGPropValFormatFlags::Null : wxPGPropValFormatFlags::EditableValue);
 #endif // WXWIN_COMPATIBILITY_3_2 | !WXWIN_COMPATIBILITY_3_2
 
     return GenerateEditorTextCtrl(pos, sz, text, but, 0, property->GetMaxLength());

--- a/src/propgrid/property.cpp
+++ b/src/propgrid/property.cpp
@@ -587,7 +587,7 @@ void wxPGProperty::Init()
 
     m_maxLen = 0; // infinite maximum length
 
-    m_flags = wxPGPropertyFlags::Property;
+    m_flags = wxPGFlags::Property;
 
     m_depth = 1;
 
@@ -639,24 +639,24 @@ void wxPGProperty::InitAfterAdded( wxPropertyGridPageState* pageState,
     // If in hideable adding mode, or if assigned parent is hideable, then
     // make this one hideable.
     if (
-         ( !parentIsRoot && parent->HasFlag(wxPGPropertyFlags::Hidden) ) ||
+         ( !parentIsRoot && parent->HasFlag(wxPGFlags::Hidden) ) ||
          ( propgrid && (propgrid->HasInternalFlag(wxPropertyGrid::wxPG_FL_ADDING_HIDEABLES)) )
        )
-        SetFlag(wxPGPropertyFlags::Hidden);
+        SetFlag(wxPGFlags::Hidden);
 
     // Set custom image flag.
     int custImgHeight = OnMeasureImage().y;
     if ( custImgHeight == wxDefaultCoord )
     {
-        SetFlag(wxPGPropertyFlags::CustomImage);
+        SetFlag(wxPGFlags::CustomImage);
     }
 
     if ( propgrid && (propgrid->HasFlag(wxPG_LIMITED_EDITING)) )
-        SetFlag(wxPGPropertyFlags::NoEditor);
+        SetFlag(wxPGFlags::NoEditor);
 
     // Make sure parent has some parental flags
-    if ( !parent->HasFlag(wxPGPropertyFlags::ParentalFlags) )
-        parent->SetParentalType(wxPGPropertyFlags::MiscParent);
+    if ( !parent->HasFlag(wxPGFlags::ParentalFlags) )
+        parent->SetParentalType(wxPGFlags::MiscParent);
 
     if ( !IsCategory() )
     {
@@ -712,14 +712,14 @@ void wxPGProperty::InitAfterAdded( wxPropertyGridPageState* pageState,
     if ( HasAnyChild() )
     {
         // Check parental flags
-        wxASSERT_MSG( ((m_flags & wxPGPropertyFlags::ParentalFlags) ==
-                            wxPGPropertyFlags::Aggregate) ||
-                      ((m_flags & wxPGPropertyFlags::ParentalFlags) ==
-                            wxPGPropertyFlags::MiscParent),
+        wxASSERT_MSG( ((m_flags & wxPGFlags::ParentalFlags) ==
+                            wxPGFlags::Aggregate) ||
+                      ((m_flags & wxPGFlags::ParentalFlags) ==
+                            wxPGFlags::MiscParent),
                       wxS("wxPGProperty parental flags set incorrectly at ")
                       wxS("this time") );
 
-        if ( HasFlag(wxPGPropertyFlags::Aggregate) )
+        if ( HasFlag(wxPGFlags::Aggregate) )
         {
             // Properties with private children are not expanded by default.
             SetExpanded(false);
@@ -739,7 +739,7 @@ void wxPGProperty::InitAfterAdded( wxPropertyGridPageState* pageState,
         }
 
         if ( propgrid && propgrid->HasExtraStyle(wxPG_EX_AUTO_UNSPECIFIED_VALUES) )
-            SetFlagRecursively(wxPGPropertyFlags::AutoUnspecified, true);
+            SetFlagRecursively(wxPGFlags::AutoUnspecified, true);
     }
 }
 
@@ -1047,7 +1047,7 @@ void wxPGProperty::DoGenerateComposedValue( wxString& text,
         if ( !childValue.IsNull() )
         {
             if ( overridesLeft &&
-                 curChild->HasFlag(wxPGPropertyFlags::ComposedValue) &&
+                 curChild->HasFlag(wxPGFlags::ComposedValue) &&
                  childValue.IsType(wxPG_VARIANT_TYPE_LIST) )
             {
                 wxVariantList& childList = childValue.GetList();
@@ -1309,8 +1309,8 @@ bool wxPGProperty::StringToValue( wxVariant& v, const wxString& text, wxPGPropVa
 
                     // Add only if editable or setting programmatically
                     if ( !!(flags & wxPGPropValFormatFlags::ProgrammaticValue) ||
-                         (!child->HasFlag(wxPGPropertyFlags::Disabled) &&
-                          !child->HasFlag(wxPGPropertyFlags::ReadOnly)) )
+                         (!child->HasFlag(wxPGFlags::Disabled) &&
+                          !child->HasFlag(wxPGFlags::ReadOnly)) )
                     {
                         if ( len > 0 )
                         {
@@ -1394,8 +1394,8 @@ bool wxPGProperty::StringToValue( wxVariant& v, const wxString& text, wxPGPropVa
                     wxVariant variant(oldChildValue);
 
                     if ( !!(flags & wxPGPropValFormatFlags::ProgrammaticValue) ||
-                         (!child->HasFlag(wxPGPropertyFlags::Disabled) &&
-                          !child->HasFlag(wxPGPropertyFlags::ReadOnly)) )
+                         (!child->HasFlag(wxPGFlags::Disabled) &&
+                          !child->HasFlag(wxPGFlags::ReadOnly)) )
                     {
                         wxString childName = child->GetBaseName();
 
@@ -1578,7 +1578,7 @@ void wxPGProperty::SetValue( wxVariant value, wxVariant* pList, wxPGSetValueFlag
         {
             //
             // However, situation is different for composed string properties
-            if ( HasFlag(wxPGPropertyFlags::ComposedValue) )
+            if ( HasFlag(wxPGFlags::ComposedValue) )
             {
                 tempListVariant = value;
                 pList = &tempListVariant;
@@ -1590,7 +1590,7 @@ void wxPGProperty::SetValue( wxVariant value, wxVariant* pList, wxPGSetValueFlag
             //wxLogDebug(wxS(">> %s.SetValue() adapted list value to type '%s'"),GetName(),value.GetType());
         }
 
-        if ( HasFlag(wxPGPropertyFlags::Aggregate) )
+        if ( HasFlag(wxPGFlags::Aggregate) )
             flags |= wxPGSetValueFlags::Aggregated;
 
         if ( pList && !pList->IsNull() )
@@ -1615,7 +1615,7 @@ void wxPGProperty::SetValue( wxVariant value, wxVariant* pList, wxPGSetValueFlag
                     //wxLogDebug(wxS("%i: child = %s, childValue.GetType()=%s"),i,child->GetBaseName(),childValue.GetType());
                     if ( childValue.IsType(wxPG_VARIANT_TYPE_LIST) )
                     {
-                        if ( child->HasFlag(wxPGPropertyFlags::Aggregate) && !(flags & wxPGSetValueFlags::Aggregated) )
+                        if ( child->HasFlag(wxPGFlags::Aggregate) && !(flags & wxPGSetValueFlags::Aggregated) )
                         {
                             wxVariant listRefCopy = childValue;
                             child->SetValue(childValue, &listRefCopy, flags| wxPGSetValueFlags::FromParent);
@@ -1630,10 +1630,10 @@ void wxPGProperty::SetValue( wxVariant value, wxVariant* pList, wxPGSetValueFlag
                     {
                         // For aggregate properties, we will trust RefreshChildren()
                         // to update child values.
-                        if ( !HasFlag(wxPGPropertyFlags::Aggregate) )
+                        if ( !HasFlag(wxPGFlags::Aggregate) )
                             child->SetValue(childValue, nullptr, flags| wxPGSetValueFlags::FromParent);
                         if ( !!(flags & wxPGSetValueFlags::ByUser) )
-                            child->SetFlag(wxPGPropertyFlags::Modified);
+                            child->SetFlag(wxPGFlags::Modified);
                     }
                 }
                 i++;
@@ -1653,9 +1653,9 @@ void wxPGProperty::SetValue( wxVariant value, wxVariant* pList, wxPGSetValueFlag
         }
 
         if ( !!(flags & wxPGSetValueFlags::ByUser) )
-            SetFlag(wxPGPropertyFlags::Modified);
+            SetFlag(wxPGFlags::Modified);
 
-        if ( HasFlag(wxPGPropertyFlags::Aggregate) )
+        if ( HasFlag(wxPGFlags::Aggregate) )
             RefreshChildren();
     }
     else
@@ -1710,7 +1710,7 @@ void wxPGProperty::SetValueInEvent( const wxVariant& value ) const
     GetGrid()->ValueChangeInEvent(value);
 }
 
-void wxPGProperty::SetFlagRecursively( wxPGPropertyFlags flag, bool set )
+void wxPGProperty::SetFlagRecursively( wxPGFlags flag, bool set )
 {
     ChangeFlag(flag, set);
 
@@ -1785,7 +1785,7 @@ void wxPGProperty::Enable( bool enable )
 
 void wxPGProperty::DoEnable( bool enable )
 {
-    ChangeFlag(wxPGPropertyFlags::Disabled, !enable);
+    ChangeFlag(wxPGFlags::Disabled, !enable);
 
     // Apply same to sub-properties as well
     for ( wxPGProperty* child : m_children )
@@ -1824,7 +1824,7 @@ void wxPGProperty::AdaptiveSetCell( unsigned int firstCol,
                                     const wxPGCell& cell,
                                     const wxPGCell& srcData,
                                     wxPGCellData* unmodCellData,
-                                    wxPGPropertyFlags ignoreWithFlags,
+                                    wxPGFlags ignoreWithFlags,
                                     bool recursively )
 {
     //
@@ -1866,7 +1866,7 @@ void wxPGProperty::AdaptiveSetCell( unsigned int firstCol,
     }
 }
 
-void wxPGProperty::ClearCells(wxPGPropertyFlags ignoreWithFlags, bool recursively)
+void wxPGProperty::ClearCells(wxPGFlags ignoreWithFlags, bool recursively)
 {
     if ( !(m_flags & ignoreWithFlags) && !IsRoot() )
     {
@@ -1937,7 +1937,7 @@ void wxPGProperty::SetBackgroundColour(const wxColour& colour, wxPGPropertyValue
                      newCell,
                      srcCell,
                      firstCellData,
-                     recursively ? wxPGPropertyFlags::Category : wxPGPropertyFlags::Null,
+                     recursively ? wxPGFlags::Category : wxPGFlags::Null,
                      recursively );
 }
 
@@ -1972,7 +1972,7 @@ void wxPGProperty::SetTextColour(const wxColour& colour, wxPGPropertyValuesFlags
                      newCell,
                      srcCell,
                      firstCellData,
-                     recursively ? wxPGPropertyFlags::Category : wxPGPropertyFlags::Null,
+                     recursively ? wxPGFlags::Category : wxPGFlags::Null,
                      recursively );
 }
 
@@ -1993,7 +1993,7 @@ void wxPGProperty::SetDefaultColours(wxPGPropertyValuesFlags flags)
         }
     }
 
-    ClearCells(recursively ? wxPGPropertyFlags::Category : wxPGPropertyFlags::Null,
+    ClearCells(recursively ? wxPGFlags::Category : wxPGFlags::Null,
                recursively);
 }
 
@@ -2082,18 +2082,18 @@ wxVariant wxPGProperty::GetAttributesAsList() const
 
 // Utility flags are excluded.
 // Store the literals in the internal representation for better performance.
-static const std::array<std::pair<wxPGPropertyFlags, const wxStringCharType*>, 4> gs_propFlagToString
+static const std::array<std::pair<wxPGFlags, const wxStringCharType*>, 4> gs_propFlagToString
 { {
-  { wxPGPropertyFlags::Disabled,  wxS("DISABLED")  },
-  { wxPGPropertyFlags::Hidden,    wxS("HIDDEN")    },
-  { wxPGPropertyFlags::NoEditor,  wxS("NOEDITOR")  },
-  { wxPGPropertyFlags::Collapsed, wxS("COLLAPSED") }
+  { wxPGFlags::Disabled,  wxS("DISABLED")  },
+  { wxPGFlags::Hidden,    wxS("HIDDEN")    },
+  { wxPGFlags::NoEditor,  wxS("NOEDITOR")  },
+  { wxPGFlags::Collapsed, wxS("COLLAPSED") }
 } };
 
-wxString wxPGProperty::GetFlagsAsString(wxPGPropertyFlags flagsMask) const
+wxString wxPGProperty::GetFlagsAsString(wxPGFlags flagsMask) const
 {
     wxString s;
-    const wxPGPropertyFlags relevantFlags = m_flags & flagsMask & wxPGPropertyFlags::StringStoredFlags;
+    const wxPGFlags relevantFlags = m_flags & flagsMask & wxPGFlags::StringStoredFlags;
 
     for ( auto& item : gs_propFlagToString )
     {
@@ -2112,7 +2112,7 @@ wxString wxPGProperty::GetFlagsAsString(wxPGPropertyFlags flagsMask) const
 
 void wxPGProperty::SetFlagsFromString( const wxString& str )
 {
-    wxPGPropertyFlags flags = wxPGPropertyFlags::Null;
+    wxPGFlags flags = wxPGFlags::Null;
 
     WX_PG_TOKENIZER1_BEGIN(str, wxS('|'))
         for ( auto& item : gs_propFlagToString )
@@ -2125,7 +2125,7 @@ void wxPGProperty::SetFlagsFromString( const wxString& str )
         }
     WX_PG_TOKENIZER1_END()
 
-    m_flags = (m_flags & ~wxPGPropertyFlags::StringStoredFlags) | flags;
+    m_flags = (m_flags & ~wxPGFlags::StringStoredFlags) | flags;
 }
 
 wxValidator* wxPGProperty::DoGetValidator() const
@@ -2306,7 +2306,7 @@ bool wxPGProperty::Hide( bool hide, wxPGPropertyValuesFlags flags )
 
 bool wxPGProperty::DoHide( bool hide, wxPGPropertyValuesFlags flags )
 {
-    ChangeFlag(wxPGPropertyFlags::Hidden, hide);
+    ChangeFlag(wxPGFlags::Hidden, hide);
 
     if ( !!(flags & wxPGPropertyValuesFlags::Recurse) )
     {
@@ -2321,7 +2321,7 @@ bool wxPGProperty::HasVisibleChildren() const
 {
     for ( wxPGProperty* child : m_children )
     {
-        if ( !child->HasFlag(wxPGPropertyFlags::Hidden) )
+        if ( !child->HasFlag(wxPGFlags::Hidden) )
             return true;
     }
 
@@ -2351,12 +2351,12 @@ void wxPGProperty::SetValueImage( const wxBitmapBundle& bmp )
     if ( bmp.IsOk() )
     {
         m_valueBitmapBundle = bmp;
-        m_flags |= wxPGPropertyFlags::CustomImage;
+        m_flags |= wxPGFlags::CustomImage;
     }
     else
     {
         m_valueBitmapBundle = wxBitmapBundle();
-        m_flags &= ~(wxPGPropertyFlags::CustomImage);
+        m_flags &= ~(wxPGFlags::CustomImage);
     }
 }
 
@@ -2389,12 +2389,12 @@ const wxPGProperty* wxPGProperty::GetLastVisibleSubItem() const
 
 bool wxPGProperty::IsVisible() const
 {
-    if ( HasFlag(wxPGPropertyFlags::Hidden) )
+    if ( HasFlag(wxPGFlags::Hidden) )
         return false;
 
     for (const wxPGProperty* parent = GetParent(); parent != nullptr; parent = parent->GetParent() )
     {
-        if ( !parent->IsExpanded() || parent->HasFlag(wxPGPropertyFlags::Hidden) )
+        if ( !parent->IsExpanded() || parent->HasFlag(wxPGFlags::Hidden) )
             return false;
     }
 
@@ -2470,17 +2470,17 @@ void wxPGProperty::DoPreAddChild( int index, wxPGProperty* prop )
 
     int custImgHeight = prop->OnMeasureImage().y;
     if ( custImgHeight == wxDefaultCoord /*|| custImgHeight > 1*/ )
-        prop->m_flags |= wxPGPropertyFlags::CustomImage;
+        prop->m_flags |= wxPGFlags::CustomImage;
 
     prop->m_parent = this;
 }
 
 void wxPGProperty::AddPrivateChild( wxPGProperty* prop )
 {
-    if ( !(m_flags & wxPGPropertyFlags::ParentalFlags) )
-        SetParentalType(wxPGPropertyFlags::Aggregate);
+    if ( !(m_flags & wxPGFlags::ParentalFlags) )
+        SetParentalType(wxPGFlags::Aggregate);
 
-    wxASSERT_MSG( (m_flags & wxPGPropertyFlags::ParentalFlags) == wxPGPropertyFlags::Aggregate,
+    wxASSERT_MSG( (m_flags & wxPGFlags::ParentalFlags) == wxPGFlags::Aggregate,
                   wxS("Do not mix up AddPrivateChild() calls with other ")
                   wxS("property adders.") );
 
@@ -2499,10 +2499,10 @@ wxPGProperty* wxPGProperty::InsertChild( int index,
     }
     else
     {
-        if ( !(m_flags & wxPGPropertyFlags::ParentalFlags) )
-            SetParentalType(wxPGPropertyFlags::MiscParent);
+        if ( !(m_flags & wxPGFlags::ParentalFlags) )
+            SetParentalType(wxPGFlags::MiscParent);
 
-        wxASSERT_MSG( (m_flags & wxPGPropertyFlags::ParentalFlags) == wxPGPropertyFlags::MiscParent,
+        wxASSERT_MSG( (m_flags & wxPGFlags::ParentalFlags) == wxPGFlags::MiscParent,
                       wxS("Do not mix up AddPrivateChild() calls with other ")
                       wxS("property adders.") );
 
@@ -2555,7 +2555,7 @@ void wxPGProperty::AdaptListToValue( wxVariant& list, wxVariant* value ) const
 
     // Don't fully update aggregate properties unless all children have
     // specified value
-    if ( HasFlag(wxPGPropertyFlags::Aggregate) )
+    if ( HasFlag(wxPGFlags::Aggregate) )
         allChildrenSpecified = AreAllChildrenSpecified(&list);
     else
         allChildrenSpecified = true;
@@ -2666,7 +2666,7 @@ int wxPGProperty::GetChildrenHeight( int lh, int iMax ) const
     {
         wxPGProperty* pwc = Item(i);
 
-        if ( !pwc->HasFlag(wxPGPropertyFlags::Hidden) )
+        if ( !pwc->HasFlag(wxPGFlags::Hidden) )
         {
             if ( !pwc->IsExpanded() ||
                  !pwc->HasAnyChild() )
@@ -2694,7 +2694,7 @@ wxPGProperty* wxPGProperty::GetItemAtY( unsigned int y,
 
     for ( wxPGProperty* pwc : m_children )
     {
-        if ( !pwc->HasFlag(wxPGPropertyFlags::Hidden) )
+        if ( !pwc->HasFlag(wxPGFlags::Hidden) )
         {
             // Found?
             if ( y < iy )
@@ -2739,7 +2739,7 @@ wxPGProperty* wxPGProperty::GetItemAtY( unsigned int y,
 
 void wxPGProperty::Empty()
 {
-    if ( !HasFlag(wxPGPropertyFlags::ChildrenAreCopies) )
+    if ( !HasFlag(wxPGFlags::ChildrenAreCopies) )
     {
         for ( wxPGProperty* child : m_children )
         {
@@ -2857,7 +2857,7 @@ bool wxPGProperty::AreAllChildrenSpecified( const wxVariant* pendingList ) const
 wxPGProperty* wxPGProperty::UpdateParentValues()
 {
     wxPGProperty* parent = m_parent;
-    if ( parent && parent->HasFlag(wxPGPropertyFlags::ComposedValue) &&
+    if ( parent && parent->HasFlag(wxPGFlags::ComposedValue) &&
          !parent->IsCategory() && !parent->IsRoot() )
     {
         wxString s;
@@ -2870,10 +2870,10 @@ wxPGProperty* wxPGProperty::UpdateParentValues()
 
 bool wxPGProperty::IsTextEditable() const
 {
-    if ( HasFlag(wxPGPropertyFlags::ReadOnly) )
+    if ( HasFlag(wxPGFlags::ReadOnly) )
         return false;
 
-    if ( HasFlag(wxPGPropertyFlags::NoEditor) &&
+    if ( HasFlag(wxPGFlags::NoEditor) &&
          (HasAnyChild() ||
           wxString(GetEditorClass()->GetClassInfo()->GetClassName()).EndsWith(wxS("Button")))
        )
@@ -2925,7 +2925,7 @@ wxString wxPGProperty::GetHintText() const
 
 int wxPGProperty::GetDisplayedCommonValueCount() const
 {
-    if ( HasFlag(wxPGPropertyFlags::UsesCommonValue) )
+    if ( HasFlag(wxPGFlags::UsesCommonValue) )
     {
         wxPropertyGrid* pg = GetGrid();
         if ( pg )
@@ -2980,7 +2980,7 @@ wxPGRootProperty::wxPGRootProperty( const wxString& name )
 {
     m_name = name;
     m_label = m_name;
-    SetParentalType(wxPGPropertyFlags::Null);
+    SetParentalType(wxPGFlags::Null);
     m_depth = 0;
 }
 
@@ -2993,7 +2993,7 @@ wxPG_IMPLEMENT_PROPERTY_CLASS(wxPropertyCategory, wxPGProperty, TextCtrl)
 void wxPropertyCategory::Init()
 {
     // don't set colour - prepareadditem method should do this
-    SetParentalType(wxPGPropertyFlags::Category);
+    SetParentalType(wxPGFlags::Category);
     m_capFgColIndex = 1;
     m_textExtent = -1;
 }

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -957,11 +957,11 @@ void wxPropertyGrid::MakeColumnEditable( unsigned int column,
                                          bool editable )
 {
     // The second column is always editable. To make it read-only is a property
-    // by property decision by setting its wxPGPropertyFlags::ReadOnly flag.
+    // by property decision by setting its wxPGFlags::ReadOnly flag.
     wxASSERT_MSG
     (
          column != 1,
-         wxS("Set wxPGPropertyFlags::ReadOnly property flag instead")
+         wxS("Set wxPGFlags::ReadOnly property flag instead")
     );
 
     if ( editable )
@@ -2140,7 +2140,7 @@ int wxPropertyGrid::DoDrawItems( wxDC& dc,
     {
         const wxPGProperty* p = *it;
 
-        if ( !p->HasFlag(wxPGPropertyFlags::Hidden) )
+        if ( !p->HasFlag(wxPGFlags::Hidden) )
         {
             visPropArray.push_back(const_cast<wxPGProperty*>(p));
 
@@ -2347,7 +2347,7 @@ int wxPropertyGrid::DoDrawItems( wxDC& dc,
             if ( butRect.x > 0 )
                 butRect.x += IN_CELL_EXPANDER_BUTTON_X_ADJUST;
 
-            if ( p->HasFlag(wxPGPropertyFlags::Modified) &&
+            if ( p->HasFlag(wxPGFlags::Modified) &&
                  (windowStyle & wxPG_BOLD_MODIFIED) )
             {
                 dc.SetFont(m_captionFont);
@@ -2986,7 +2986,7 @@ bool wxPropertyGrid::PerformValidation( wxPGProperty* p, wxVariant& pendingValue
     wxVariant* pPendingValue = &pendingValue;
     wxVariant* pList = nullptr;
 
-    // If parent has wxPGPropertyFlags::Aggregate flag, or uses composite
+    // If parent has wxPGFlags::Aggregate flag, or uses composite
     // string value, then we need treat as it was changed instead
     // (or, in addition, as is the case with composite string parent).
     // This includes creating list variant for child values.
@@ -3000,7 +3000,7 @@ bool wxPropertyGrid::PerformValidation( wxPGProperty* p, wxVariant& pendingValue
     listValue.SetName(p->GetBaseName());
 
     while ( pwc &&
-            (pwc->HasFlag(wxPGPropertyFlags::Aggregate) || pwc->HasFlag(wxPGPropertyFlags::ComposedValue)) )
+            (pwc->HasFlag(wxPGFlags::Aggregate) || pwc->HasFlag(wxPGFlags::ComposedValue)) )
     {
         wxVariantList tempList;
         wxVariant lv(tempList, pwc->GetBaseName());
@@ -3008,7 +3008,7 @@ bool wxPropertyGrid::PerformValidation( wxPGProperty* p, wxVariant& pendingValue
         listValue = lv;
         pPendingValue = &listValue;
 
-        if ( pwc->HasFlag(wxPGPropertyFlags::Aggregate) )
+        if ( pwc->HasFlag(wxPGFlags::Aggregate) )
         {
             baseChangedProperty = pwc;
             bcpPendingList = lv;
@@ -3038,9 +3038,9 @@ bool wxPropertyGrid::PerformValidation( wxPGProperty* p, wxVariant& pendingValue
     {
         // FIXME: After proper ValueToString()s added, remove
         // this. It is just a temporary fix, as evt_changing
-        // will simply not work for wxPGPropertyFlags::ComposedValue
+        // will simply not work for wxPGFlags::ComposedValue
         // (unless it is selected, and textctrl editor is open).
-        if ( changedProperty->HasFlag(wxPGPropertyFlags::ComposedValue) )
+        if ( changedProperty->HasFlag(wxPGFlags::ComposedValue) )
         {
             evtChangingProperty = baseChangedProperty;
             if ( evtChangingProperty != p )
@@ -3053,7 +3053,7 @@ bool wxPropertyGrid::PerformValidation( wxPGProperty* p, wxVariant& pendingValue
             }
         }
 
-        if ( evtChangingProperty->HasFlag(wxPGPropertyFlags::ComposedValue) )
+        if ( evtChangingProperty->HasFlag(wxPGFlags::ComposedValue) )
         {
             if ( changedProperty == GetSelection() )
             {
@@ -3180,7 +3180,7 @@ bool wxPropertyGrid::OnValidationFailure( wxPGProperty* property,
     {
         // When property selection is being changed, do not display any
         // messages, if some were already shown for this property.
-        if ( property->HasFlag(wxPGPropertyFlags::InvalidValue) )
+        if ( property->HasFlag(wxPGFlags::InvalidValue) )
         {
             m_validationInfo.SetFailureBehavior(
                 vfb & (~(wxPGVFBFlags::ShowMessage |
@@ -3202,7 +3202,7 @@ bool wxPropertyGrid::OnValidationFailure( wxPGProperty* property,
         property->GetEditorClass()->UpdateControl(property, editor);
     }
 
-    property->SetFlag(wxPGPropertyFlags::InvalidValue);
+    property->SetFlag(wxPGFlags::InvalidValue);
 
     return res;
 }
@@ -3215,7 +3215,7 @@ bool wxPropertyGrid::DoOnValidationFailure( wxPGProperty* property, wxVariant& W
         ::wxBell();
 
     if ( !!(vfb & wxPGVFBFlags::MarkCell) &&
-         !property->HasFlag(wxPGPropertyFlags::InvalidValue) )
+         !property->HasFlag(wxPGFlags::InvalidValue) )
     {
         unsigned int colCount = m_pState->GetColumnCount();
 
@@ -3367,9 +3367,9 @@ bool wxPropertyGrid::DoPropertyChanged( wxPGProperty* p, wxPGSelectPropertyFlags
     wxWindow* editor = GetEditorControl();
 
     // Set as Modified (not if dragging just began)
-    if ( !p->HasFlag(wxPGPropertyFlags::Modified) )
+    if ( !p->HasFlag(wxPGFlags::Modified) )
     {
-        p->SetFlag(wxPGPropertyFlags::Modified);
+        p->SetFlag(wxPGFlags::Modified);
         if ( p == selected && (m_windowStyle & wxPG_BOLD_MODIFIED) )
         {
             if ( editor )
@@ -3384,7 +3384,7 @@ bool wxPropertyGrid::DoPropertyChanged( wxPGProperty* p, wxPGSelectPropertyFlags
 
     while ( prevPwc != topPaintedProperty )
     {
-        pwc->SetFlag(wxPGPropertyFlags::Modified);
+        pwc->SetFlag(wxPGFlags::Modified);
 
         if ( pwc == selected && (m_windowStyle & wxPG_BOLD_MODIFIED) )
         {
@@ -3415,11 +3415,11 @@ bool wxPropertyGrid::DoPropertyChanged( wxPGProperty* p, wxPGSelectPropertyFlags
     }
 
     // Sanity check
-    wxASSERT( !changedProperty->GetParent()->HasFlag(wxPGPropertyFlags::Aggregate) );
+    wxASSERT( !changedProperty->GetParent()->HasFlag(wxPGFlags::Aggregate) );
 
     // If top parent has composite string value, then send to child parents,
     // starting from baseChangedProperty.
-    if ( changedProperty->HasFlag(wxPGPropertyFlags::ComposedValue) )
+    if ( changedProperty->HasFlag(wxPGFlags::ComposedValue) )
     {
         pwc = m_chgInfo_baseChangedProperty;
 
@@ -3547,7 +3547,7 @@ bool wxPropertyGrid::HandleCustomEditorEvent( wxEvent &event )
     // Somehow, event is handled after property has been deselected.
     // Possibly, but very rare.
     if ( !selected ||
-          selected->HasFlag(wxPGPropertyFlags::BeingDeleted) ||
+          selected->HasFlag(wxPGFlags::BeingDeleted) ||
           m_inOnValidationFailure ||
           // Also don't handle editor event if wxEVT_PG_CHANGED or
           // similar is currently doing something (showing a
@@ -4027,7 +4027,7 @@ bool wxPropertyGrid::DoSelectProperty( wxPGProperty* p, wxPGSelectPropertyFlags 
 
     prevFirstSel = prevSelection.empty()? nullptr: prevSelection[0];
 
-    if ( prevFirstSel && prevFirstSel->HasFlag(wxPGPropertyFlags::BeingDeleted) )
+    if ( prevFirstSel && prevFirstSel->HasFlag(wxPGFlags::BeingDeleted) )
         prevFirstSel = nullptr;
 
     // Always send event, as this is indirect call
@@ -4141,7 +4141,7 @@ bool wxPropertyGrid::DoSelectProperty( wxPGProperty* p, wxPGSelectPropertyFlags 
 
             //
             // Only create editor for non-disabled non-caption
-            if ( !p->IsCategory() && !p->HasFlag(wxPGPropertyFlags::Disabled) )
+            if ( !p->IsCategory() && !p->HasFlag(wxPGFlags::Disabled) )
             {
             // do this for non-caption items
 
@@ -4149,7 +4149,7 @@ bool wxPropertyGrid::DoSelectProperty( wxPGProperty* p, wxPGSelectPropertyFlags 
 
                 // Do we need to paint the custom image, if any?
                 m_iFlags &= ~(wxPG_FL_CUR_USES_CUSTOM_IMAGE);
-                if ( p->HasFlag(wxPGPropertyFlags::CustomImage) &&
+                if ( p->HasFlag(wxPGFlags::CustomImage) &&
                      !p->GetEditorClass()->CanContainCustomImage()
                    )
                     m_iFlags |= wxPG_FL_CUR_USES_CUSTOM_IMAGE;
@@ -4215,7 +4215,7 @@ bool wxPropertyGrid::DoSelectProperty( wxPGProperty* p, wxPGSelectPropertyFlags 
 
                     // If it has modified status, use bold font
                     // (must be done before capturing m_ctrlXAdjust)
-                    if ( p->HasFlag(wxPGPropertyFlags::Modified) &&
+                    if ( p->HasFlag(wxPGFlags::Modified) &&
                          (m_windowStyle & wxPG_BOLD_MODIFIED) )
                         SetCurControlBoldFont();
                     // Store x relative to splitter (we'll need it).
@@ -4406,7 +4406,7 @@ void wxPropertyGrid::RefreshEditor()
     // calling UpdateControl().
     if ( HasFlag(wxPG_BOLD_MODIFIED) )
     {
-        if ( p->HasFlag(wxPGPropertyFlags::Modified) )
+        if ( p->HasFlag(wxPGFlags::Modified) )
             wnd->SetFont(GetCaptionFont());
         else
             wnd->SetFont(GetFont());
@@ -5109,7 +5109,7 @@ bool wxPropertyGrid::HandleMouseMove( int x, unsigned int y,
                         space -= (wxPG_XBEFORETEXT + 1);
                         int tw, th;
                         const wxFont* font = nullptr;
-                        if ( (m_windowStyle & wxPG_BOLD_MODIFIED) && m_propHover->HasFlag(wxPGPropertyFlags::Modified) )
+                        if ( (m_windowStyle & wxPG_BOLD_MODIFIED) && m_propHover->HasFlag(wxPGFlags::Modified) )
                             font = &m_captionFont;
                         if ( cell.GetFont().IsOk() )
                             font = &cell.GetFont();
@@ -5181,7 +5181,7 @@ bool wxPropertyGrid::HandleMouseMove( int x, unsigned int y,
 
             // Since categories cannot be selected along with 'other'
             // properties, exclude them from iterator flags.
-            int iterFlags = wxPG_ITERATE_VISIBLE & (~wxPGPropertyFlags::Category);
+            int iterFlags = wxPG_ITERATE_VISIBLE & (~wxPGFlags::Category);
 
             for ( int i=(selection.size()-1); i>=0; i-- )
             {
@@ -5728,7 +5728,7 @@ void wxPropertyGrid::HandleKeyEvent( wxKeyEvent &event, bool fromChild )
         if ( action == wxPGKeyboardAction::Edit && !editorFocused )
         {
             // Mark as handled only for editable property
-            if ( !p->IsCategory() && p->IsEnabled() && !p->HasFlag(wxPGPropertyFlags::ReadOnly) )
+            if ( !p->IsCategory() && p->IsEnabled() && !p->HasFlag(wxPGFlags::ReadOnly) )
             {
                 DoSelectProperty( p, wxPGSelectPropertyFlags::Focus );
                 wasHandled = true;
@@ -6371,7 +6371,7 @@ wxPGProperty* wxPropertyGridPopulator::Add( const wxString& propClass,
     wxClassInfo* classInfo = wxClassInfo::FindClass(propClass);
     wxPGProperty* parent = GetCurParent();
 
-    if ( parent->HasFlag(wxPGPropertyFlags::Aggregate) )
+    if ( parent->HasFlag(wxPGFlags::Aggregate) )
     {
         ProcessError(wxString::Format(wxS("new children cannot be added to '%s'"),parent->GetName()));
         return nullptr;

--- a/src/propgrid/propgridiface.cpp
+++ b/src/propgrid/propgridiface.cpp
@@ -125,7 +125,7 @@ wxPGProperty* wxPropertyGridInterface::RemoveProperty( wxPGPropArg id )
 {
     wxPG_PROP_ARG_CALL_PROLOG_RETVAL(wxNullProperty)
 
-    wxCHECK( !p->HasAnyChild() || p->HasFlag(wxPGPropertyFlags::Aggregate),
+    wxCHECK( !p->HasAnyChild() || p->HasFlag(wxPGFlags::Aggregate),
              wxNullProperty);
 
     wxPropertyGridPageState* state = p->GetParentState();
@@ -228,7 +228,7 @@ bool wxPropertyGridInterface::EnableProperty( wxPGPropArg id, bool enable )
 
     if ( enable )
     {
-        if ( !p->HasFlag(wxPGPropertyFlags::Disabled) )
+        if ( !p->HasFlag(wxPGFlags::Disabled) )
             return false;
 
         // If active, Set active Editor.
@@ -237,7 +237,7 @@ bool wxPropertyGridInterface::EnableProperty( wxPGPropArg id, bool enable )
     }
     else
     {
-        if ( p->HasFlag(wxPGPropertyFlags::Disabled) )
+        if ( p->HasFlag(wxPGFlags::Disabled) )
             return false;
 
         // If active, Disable as active Editor.
@@ -258,17 +258,17 @@ void wxPropertyGridInterface::SetPropertyReadOnly( wxPGPropArg id, bool set, wxP
 
     if ( !!(flags & wxPGPropertyValuesFlags::Recurse) )
     {
-        p->SetFlagRecursively(wxPGPropertyFlags::ReadOnly, set);
+        p->SetFlagRecursively(wxPGFlags::ReadOnly, set);
     }
     else
     {
         // Do nothing if flag is already set as required.
-        if ( set && p->HasFlag(wxPGPropertyFlags::ReadOnly) )
+        if ( set && p->HasFlag(wxPGFlags::ReadOnly) )
             return;
-        if ( !set && !p->HasFlag(wxPGPropertyFlags::ReadOnly) )
+        if ( !set && !p->HasFlag(wxPGFlags::ReadOnly) )
             return;
 
-        p->ChangeFlag(wxPGPropertyFlags::ReadOnly, set);
+        p->ChangeFlag(wxPGFlags::ReadOnly, set);
     }
 
     wxPropertyGridPageState* state = p->GetParentState();
@@ -337,7 +337,7 @@ void wxPropertyGridInterface::ClearModifiedStatus()
     wxPropertyGridPageState* page;
     while ( (page = GetPageState(pageIndex)) != nullptr )
     {
-        page->DoGetRoot()->SetFlagRecursively(wxPGPropertyFlags::Modified, false);
+        page->DoGetRoot()->SetFlagRecursively(wxPGFlags::Modified, false);
         page->m_anyModified = false;
 
         pageIndex++;
@@ -456,7 +456,7 @@ void wxPropertyGridInterface::SetPropertyAttributeAll( const wxString& attrName,
 // -----------------------------------------------------------------------
 
 void wxPropertyGridInterface::GetPropertiesWithFlag( wxArrayPGProperty* targetArr,
-                                                     wxPGPropertyFlags flags,
+                                                     wxPGFlags flags,
                                                      bool inverse,
                                                      int iterFlags ) const
 {
@@ -538,9 +538,9 @@ bool wxPropertyGridInterface::HideProperty(wxPGPropArg id, bool hide, wxPGProper
     // Do nothing if single property is already hidden/visible as requested.
     if ( !(flags & wxPGPropertyValuesFlags::Recurse) )
     {
-        if ( hide && p->HasFlag(wxPGPropertyFlags::Hidden) )
+        if ( hide && p->HasFlag(wxPGFlags::Hidden) )
             return false;
-        if ( !hide && !p->HasFlag(wxPGPropertyFlags::Hidden) )
+        if ( !hide && !p->HasFlag(wxPGFlags::Hidden) )
             return false;
     }
 
@@ -847,9 +847,9 @@ bool wxPropertyGridInterface::ChangePropertyValue( wxPGPropArg id, wxVariant new
 void wxPropertyGridInterface::BeginAddChildren( wxPGPropArg id )
 {
     wxPG_PROP_ARG_CALL_PROLOG()
-    wxCHECK_RET( p->HasFlag(wxPGPropertyFlags::Aggregate), wxS("only call on properties with fixed children") );
-    p->ClearFlag(wxPGPropertyFlags::Aggregate);
-    p->SetFlag(wxPGPropertyFlags::MiscParent);
+    wxCHECK_RET( p->HasFlag(wxPGFlags::Aggregate), wxS("only call on properties with fixed children") );
+    p->ClearFlag(wxPGFlags::Aggregate);
+    p->SetFlag(wxPGFlags::MiscParent);
 }
 
 // -----------------------------------------------------------------------
@@ -864,9 +864,9 @@ bool wxPropertyGridInterface::EditorValidate()
 void wxPropertyGridInterface::EndAddChildren( wxPGPropArg id )
 {
     wxPG_PROP_ARG_CALL_PROLOG()
-    wxCHECK_RET( p->HasFlag(wxPGPropertyFlags::MiscParent), wxS("only call on properties for which BeginAddChildren was called prior") );
-    p->ClearFlag(wxPGPropertyFlags::MiscParent);
-    p->SetFlag(wxPGPropertyFlags::Aggregate);
+    wxCHECK_RET( p->HasFlag(wxPGFlags::MiscParent), wxS("only call on properties for which BeginAddChildren was called prior") );
+    p->ClearFlag(wxPGFlags::MiscParent);
+    p->SetFlag(wxPGFlags::Aggregate);
 }
 
 // -----------------------------------------------------------------------
@@ -955,7 +955,7 @@ wxString wxPropertyGridInterface::SaveEditableState( int includedStates ) const
             {
                 const wxPGProperty* p = it.GetProperty();
 
-                if ( !p->HasFlag(wxPGPropertyFlags::Collapsed) )
+                if ( !p->HasFlag(wxPGFlags::Collapsed) )
                     result += EscapeDelimiters(p->GetName());
                 result += wxS(",");
 

--- a/src/propgrid/propgridpagestate.cpp
+++ b/src/propgrid/propgridpagestate.cpp
@@ -225,7 +225,7 @@ void wxPropertyGridPageState::InitNonCatMode()
 
     m_abcArray = new wxPGRootProperty(wxS("<Root_NonCat>"));
     m_abcArray->SetParentState(this);
-    m_abcArray->SetFlag(wxPGPropertyFlags::ChildrenAreCopies);
+    m_abcArray->SetFlag(wxPGFlags::ChildrenAreCopies);
 
     // Must be called when state::m_properties still points to regularArray.
     wxPGProperty* oldProperties = m_properties;
@@ -395,8 +395,8 @@ wxPGProperty* wxPropertyGridPageState::GetLastItem( int flags )
     if ( !m_properties->HasAnyChild() )
         return nullptr;
 
-    wxPGPropertyFlags itemExMask;
-    wxPGPropertyFlags parentExMask;
+    wxPGFlags itemExMask;
+    wxPGFlags parentExMask;
     wxPGCreateIteratorMasks(flags, itemExMask, parentExMask);
 
     // First, get last child of last parent if children of 'pwc' should be iterated through
@@ -603,7 +603,7 @@ void wxPropertyGridPageState::DoSortChildren(wxPGProperty* p, wxPGPropertyValues
         return;
 
     // Never sort children of aggregate properties
-    if ( p->HasFlag(wxPGPropertyFlags::Aggregate) )
+    if ( p->HasFlag(wxPGFlags::Aggregate) )
         return;
 
     if ( !!(flags & wxPGPropertyValuesFlags::SortTopLevelOnly)
@@ -1383,12 +1383,12 @@ wxVariant wxPropertyGridPageState::DoGetPropertyValues(const wxString& listname,
     {
         if ( !!(flags & wxPGPropertyValuesFlags::KeepStructure) )
         {
-            wxASSERT( !pwc->HasFlag(wxPGPropertyFlags::Aggregate) );
+            wxASSERT( !pwc->HasFlag(wxPGFlags::Aggregate) );
 
             for ( unsigned int i = 0; i < pwc->GetChildCount(); i++ )
             {
                 wxPGProperty* p = pwc->Item(i);
-                if ( !p->HasAnyChild() || p->HasFlag(wxPGPropertyFlags::Aggregate) )
+                if ( !p->HasAnyChild() || p->HasFlag(wxPGFlags::Aggregate) )
                 {
                     wxVariant variant = p->GetValue();
                     variant.SetName( p->GetBaseName() );
@@ -1412,7 +1412,7 @@ wxVariant wxPropertyGridPageState::DoGetPropertyValues(const wxString& listname,
                 const wxPGProperty* p = it.GetProperty();
 
                 // Use a trick to ignore wxParentProperty itself, but not its sub-properties.
-                if ( !p->HasAnyChild() || p->HasFlag(wxPGPropertyFlags::Aggregate) )
+                if ( !p->HasAnyChild() || p->HasFlag(wxPGFlags::Aggregate) )
                 {
                     wxVariant variant = p->GetValue();
                     variant.SetName( p->GetName() );
@@ -1672,7 +1672,7 @@ wxPGProperty* wxPropertyGridPageState::DoInsert( wxPGProperty* parent, int index
     if ( !parent )
         parent = m_properties;
 
-    wxCHECK_MSG( !parent->HasFlag(wxPGPropertyFlags::Aggregate),
+    wxCHECK_MSG( !parent->HasFlag(wxPGFlags::Aggregate),
                  wxNullProperty,
                  wxS("when adding properties to fixed parents, use BeginAddChildren and EndAddChildren.") );
 
@@ -1742,7 +1742,7 @@ wxPGProperty* wxPropertyGridPageState::DoInsert( wxPGProperty* parent, int index
 
     // Update editor controls of all parents if they are containers of composed values.
     for( wxPGProperty *p = property->GetParent();
-         p && !p->IsRoot() && !p->IsCategory() && p->HasFlag(wxPGPropertyFlags::ComposedValue);
+         p && !p->IsRoot() && !p->IsCategory() && p->HasFlag(wxPGFlags::ComposedValue);
          p = p->GetParent() )
     {
         p->RefreshEditor();
@@ -1790,7 +1790,7 @@ void wxPropertyGridPageState::DoMarkChildrenAsDeleted(wxPGProperty* p,
     {
         wxPGProperty* child = p->Item(i);
 
-        child->SetFlag(wxPGPropertyFlags::BeingDeleted);
+        child->SetFlag(wxPGFlags::BeingDeleted);
 
         if ( recursive )
         {
@@ -1893,7 +1893,7 @@ void wxPropertyGridPageState::DoDelete( wxPGProperty* item, bool doDelete )
 
     wxPGProperty* parent = item->GetParent();
 
-    wxCHECK_RET( !parent->HasFlag(wxPGPropertyFlags::Aggregate),
+    wxCHECK_RET( !parent->HasFlag(wxPGFlags::Aggregate),
         wxS("wxPropertyGrid: Do not attempt to remove sub-properties.") );
 
     wxASSERT( item->GetParentState() == this );
@@ -1960,13 +1960,13 @@ void wxPropertyGridPageState::DoDelete( wxPGProperty* item, bool doDelete )
                   wxS("Current category cannot be deleted") );
 
     // Prevent property and its children from being re-selected
-    item->SetFlag(wxPGPropertyFlags::BeingDeleted);
+    item->SetFlag(wxPGFlags::BeingDeleted);
     DoMarkChildrenAsDeleted(item, true);
 
     unsigned int indinparent = item->GetIndexInParent();
 
     // Delete children
-    if ( item->HasAnyChild() && !item->HasFlag(wxPGPropertyFlags::Aggregate) )
+    if ( item->HasAnyChild() && !item->HasFlag(wxPGFlags::Aggregate) )
     {
         // deleting a category
         item->DeleteChildren();

--- a/src/propgrid/props.cpp
+++ b/src/propgrid/props.cpp
@@ -60,9 +60,9 @@ wxStringProperty::wxStringProperty( const wxString& label,
 void wxStringProperty::OnSetValue()
 {
     if ( !m_value.IsNull() && m_value.GetString() == wxS("<composed>") )
-        SetFlag(wxPGPropertyFlags::ComposedValue);
+        SetFlag(wxPGFlags::ComposedValue);
 
-    if ( HasFlag(wxPGPropertyFlags::ComposedValue) )
+    if ( HasFlag(wxPGFlags::ComposedValue) )
     {
         wxString s;
         DoGenerateComposedValue(s);
@@ -75,7 +75,7 @@ wxString wxStringProperty::ValueToString( wxVariant& value,
 {
     wxString s = value.GetString();
 
-    if ( HasAnyChild() && HasFlag(wxPGPropertyFlags::ComposedValue) )
+    if ( HasAnyChild() && HasFlag(wxPGFlags::ComposedValue) )
     {
         // Value stored in m_value is non-editable, non-full value
         if ( !!(flags & wxPGPropValFormatFlags::FullValue) ||
@@ -103,7 +103,7 @@ wxString wxStringProperty::ValueToString( wxVariant& value,
 
 bool wxStringProperty::StringToValue( wxVariant& variant, const wxString& text, wxPGPropValFormatFlags flags ) const
 {
-    if ( HasAnyChild() && HasFlag(wxPGPropertyFlags::ComposedValue) )
+    if ( HasAnyChild() && HasFlag(wxPGFlags::ComposedValue) )
         return wxPGProperty::StringToValue(variant, text, flags);
 
     if ( variant != text )
@@ -1566,7 +1566,7 @@ void wxFlagsProperty::OnSetValue()
             long flag = m_choices.GetValue(i);
 
             if ( (newFlags & flag) != (m_oldValue & flag) )
-                Item(i)->ChangeFlag(wxPGPropertyFlags::Modified, true );
+                Item(i)->ChangeFlag(wxPGFlags::Modified, true );
         }
 
         m_oldValue = newFlags;
@@ -1667,7 +1667,7 @@ void wxFlagsProperty::RefreshChildren()
         wxPGProperty* p = Item(i);
 
         if ( subVal != (m_oldValue & flag) )
-            p->ChangeFlag(wxPGPropertyFlags::Modified, true );
+            p->ChangeFlag(wxPGFlags::Modified, true );
 
         p->SetValue( subVal == flag?true:false );
     }
@@ -1960,7 +1960,7 @@ wxString wxFileProperty::ValueToString( wxVariant& value,
     {
         return filename.GetFullPath();
     }
-    else if ( !!(m_flags & wxPGPropertyFlags::ShowFullFileName) )
+    else if ( !!(m_flags & wxPGFlags::ShowFullFileName) )
     {
         if ( !m_basePath.empty() )
         {
@@ -1978,7 +1978,7 @@ bool wxFileProperty::StringToValue( wxVariant& variant, const wxString& text, wx
 {
     wxFileName filename = variant.GetString();
 
-    if ( !!(m_flags & wxPGPropertyFlags::ShowFullFileName) || !!(flags & wxPGPropValFormatFlags::FullValue) )
+    if ( !!(m_flags & wxPGFlags::ShowFullFileName) || !!(flags & wxPGPropValFormatFlags::FullValue) )
     {
         if ( filename != text )
         {
@@ -2108,7 +2108,7 @@ bool wxLongStringProperty::DisplayEditorDialog(wxPropertyGrid* pg, wxVariant& va
     wxBoxSizer* topsizer = new wxBoxSizer( wxVERTICAL );
     wxBoxSizer* rowsizer = new wxBoxSizer( wxHORIZONTAL );
     long edStyle = wxTE_MULTILINE;
-    if ( HasFlag(wxPGPropertyFlags::ReadOnly) )
+    if ( HasFlag(wxPGFlags::ReadOnly) )
         edStyle |= wxTE_READONLY;
     wxString strVal;
     wxPropertyGrid::ExpandEscapeSequences(strVal, value.GetString());
@@ -2121,7 +2121,7 @@ bool wxLongStringProperty::DisplayEditorDialog(wxPropertyGrid* pg, wxVariant& va
     topsizer->Add(rowsizer, wxSizerFlags(1).Expand());
 
     long btnSizerFlags = wxCANCEL;
-    if ( !HasFlag(wxPGPropertyFlags::ReadOnly) )
+    if ( !HasFlag(wxPGFlags::ReadOnly) )
         btnSizerFlags |= wxOK;
     wxStdDialogButtonSizer* buttonSizer = dlg->CreateStdDialogButtonSizer(btnSizerFlags);
     topsizer->Add(buttonSizer, wxSizerFlags(0).Right().Border(wxBOTTOM|wxRIGHT, spacing));

--- a/src/propgrid/props.cpp
+++ b/src/propgrid/props.cpp
@@ -160,11 +160,11 @@ wxNumericPropertyValidator::
             style |= wxFILTER_DIGITS;
     }
 
-    if ( numericType == NumericType::Signed )
+    if ( numericType == Signed )
     {
         allowedChars += wxS("-+");
     }
-    else if ( numericType == NumericType::Float )
+    else if ( numericType == Float )
     {
         allowedChars += wxS("-+eE");
 
@@ -504,7 +504,7 @@ wxValidator* wxIntProperty::GetClassValidator()
     WX_PG_DOGETVALIDATOR_ENTRY()
 
     wxValidator* validator = new wxNumericPropertyValidator(
-                                    wxNumericPropertyValidator::NumericType::Signed);
+                                    wxNumericPropertyValidator::Signed);
 
     WX_PG_DOGETVALIDATOR_EXIT(validator)
 #else
@@ -749,7 +749,7 @@ wxValidator* wxUIntProperty::DoGetValidator() const
     WX_PG_DOGETVALIDATOR_ENTRY()
 
     wxValidator* validator = new wxNumericPropertyValidator(
-                                    wxNumericPropertyValidator::NumericType::Unsigned,
+                                    wxNumericPropertyValidator::Unsigned,
                                     m_realBase);
 
     WX_PG_DOGETVALIDATOR_EXIT(validator)
@@ -977,7 +977,7 @@ wxFloatProperty::GetClassValidator()
     WX_PG_DOGETVALIDATOR_ENTRY()
 
     wxValidator* validator = new wxNumericPropertyValidator(
-                                    wxNumericPropertyValidator::NumericType::Float);
+                                    wxNumericPropertyValidator::Float);
 
     WX_PG_DOGETVALIDATOR_EXIT(validator)
 #else

--- a/tests/controls/propgridtest.cpp
+++ b/tests/controls/propgridtest.cpp
@@ -503,7 +503,7 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
             wxPGProperty* p = it.GetProperty();
             if ( p->IsCategory() )
                 FAIL_CHECK(wxString::Format("'%s' is a category (non-private child property expected)", p->GetLabel()).c_str());
-            else if ( p->GetParent()->HasFlag(wxPGPropertyFlags::Aggregate) )
+            else if ( p->GetParent()->HasFlag(wxPGFlags::Aggregate) )
                 FAIL_CHECK(wxString::Format("'%s' is a private child (non-private child property expected)", p->GetLabel()).c_str());
             count++;
         }
@@ -523,7 +523,7 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
         for ( auto it = pgManager->GetVIterator(wxPG_ITERATE_PROPERTIES | wxPG_ITERATE_CATEGORIES); !it.AtEnd(); it.Next() )
         {
             wxPGProperty* p = it.GetProperty();
-            if ( p->GetParent()->HasFlag(wxPGPropertyFlags::Aggregate) )
+            if ( p->GetParent()->HasFlag(wxPGFlags::Aggregate) )
                 FAIL_CHECK(wxString::Format("'%s' is a private child (non-private child property or category expected)", p->GetLabel()).c_str());
             count++;
         }
@@ -535,7 +535,7 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
             wxPGProperty* p = it.GetProperty();
             if ( (p->GetParent() != p->GetGrid()->GetRoot() && !p->GetParent()->IsExpanded()) )
                 FAIL_CHECK(wxString::Format("'%s' had collapsed parent (only visible properties expected)", p->GetLabel()).c_str());
-            else if ( p->HasFlag(wxPGPropertyFlags::Hidden) )
+            else if ( p->HasFlag(wxPGFlags::Hidden) )
                 FAIL_CHECK(wxString::Format("'%s' was hidden (only visible properties expected)", p->GetLabel()).c_str());
             count++;
         }
@@ -693,7 +693,7 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
         // Delete everything in reverse order
 
         std::vector<wxPGProperty*> array;
-        for ( auto it = pgManager->GetVIterator(wxPG_ITERATE_ALL & ~(wxPG_IT_CHILDREN(wxPGPropertyFlags::Aggregate))); !it.AtEnd(); it.Next() )
+        for ( auto it = pgManager->GetVIterator(wxPG_ITERATE_ALL & ~(wxPG_IT_CHILDREN(wxPGFlags::Aggregate))); !it.AtEnd(); it.Next() )
         {
             array.push_back(it.GetProperty());
         }
@@ -706,7 +706,7 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
         }
 
         // Check if grid is empty.
-        auto it = pgManager->GetVIterator(wxPG_ITERATE_ALL & ~(wxPG_IT_CHILDREN(wxPGPropertyFlags::Aggregate)));
+        auto it = pgManager->GetVIterator(wxPG_ITERATE_ALL & ~(wxPG_IT_CHILDREN(wxPGFlags::Aggregate)));
         if ( !it.AtEnd() )
         {
             FAIL_CHECK("Not all properties are deleted");
@@ -1580,22 +1580,22 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 wxPGProperty* p = *it;
 
                 // Save initial flags
-                wxPGPropertyFlags oldFlags = wxPGPropertyFlags::Null;
-                if ( p->HasFlag(wxPGPropertyFlags::Collapsed) )
+                wxPGFlags oldFlags = wxPGFlags::Null;
+                if ( p->HasFlag(wxPGFlags::Collapsed) )
                 {
-                    oldFlags |= wxPGPropertyFlags::Collapsed;
+                    oldFlags |= wxPGFlags::Collapsed;
                 }
-                if ( p->HasFlag(wxPGPropertyFlags::Disabled) )
+                if ( p->HasFlag(wxPGFlags::Disabled) )
                 {
-                    oldFlags |= wxPGPropertyFlags::Disabled;
+                    oldFlags |= wxPGFlags::Disabled;
                 }
-                if ( p->HasFlag(wxPGPropertyFlags::Hidden) )
+                if ( p->HasFlag(wxPGFlags::Hidden) )
                 {
-                    oldFlags |= wxPGPropertyFlags::Hidden;
+                    oldFlags |= wxPGFlags::Hidden;
                 }
-                if ( p->HasFlag(wxPGPropertyFlags::NoEditor) )
+                if ( p->HasFlag(wxPGFlags::NoEditor) )
                 {
-                    oldFlags |= wxPGPropertyFlags::NoEditor;
+                    oldFlags |= wxPGFlags::NoEditor;
                 }
 
                 wxString flags;
@@ -1635,37 +1635,37 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
 
                 // Verify if flags have been properly set
                 if ( flags.Find("COLLAPSED") != wxNOT_FOUND &&
-                    !p->HasFlag(wxPGPropertyFlags::Collapsed) )
+                    !p->HasFlag(wxPGFlags::Collapsed) )
                 {
                     FAIL_CHECK(wxString::Format("Error setting flag from string 'COLLAPSED' for property '%s'",
                         p->GetName()).c_str());
                 }
                 if ( flags.Find("COLLAPSED") == wxNOT_FOUND &&
-                    p->HasFlag(wxPGPropertyFlags::Collapsed) )
+                    p->HasFlag(wxPGFlags::Collapsed) )
                 {
                     FAIL_CHECK(wxString::Format("Error resetting flag from string 'COLLAPSED'for property '%s'",
                         p->GetName()).c_str());
                 }
                 if ( flags.Find("DISABLED") != wxNOT_FOUND &&
-                    !p->HasFlag(wxPGPropertyFlags::Disabled) )
+                    !p->HasFlag(wxPGFlags::Disabled) )
                 {
                     FAIL_CHECK(wxString::Format("Error setting flag from string 'DISABLED' for property '%s'",
                         p->GetName()).c_str());
                 }
                 if ( flags.Find("DISABLED") == wxNOT_FOUND &&
-                    p->HasFlag(wxPGPropertyFlags::Disabled) )
+                    p->HasFlag(wxPGFlags::Disabled) )
                 {
                     FAIL_CHECK(wxString::Format("Error resetting flag from string 'DISABLED' for property '%s'",
                         p->GetName()).c_str());
                 }
                 if ( flags.Find("HIDDEN") != wxNOT_FOUND &&
-                    !p->HasFlag(wxPGPropertyFlags::Hidden) )
+                    !p->HasFlag(wxPGFlags::Hidden) )
                 {
                     FAIL_CHECK(wxString::Format("Error setting flag from string 'HIDDEN' for property '%s'",
                         p->GetName()).c_str());
                 }
                 if ( flags.Find("HIDDEN") == wxNOT_FOUND &&
-                    p->HasFlag(wxPGPropertyFlags::Hidden) )
+                    p->HasFlag(wxPGFlags::Hidden) )
                 {
                     FAIL_CHECK(wxString::Format("Error resetting flag from string 'HIDDEN' for property '%s'",
                         p->GetName()).c_str());
@@ -1674,8 +1674,8 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 // Get individual flags
                 bool ok;
 
-                flags = p->GetFlagsAsString(wxPGPropertyFlags::Collapsed);
-                if ( p->HasFlag(wxPGPropertyFlags::Collapsed) )
+                flags = p->GetFlagsAsString(wxPGFlags::Collapsed);
+                if ( p->HasFlag(wxPGFlags::Collapsed) )
                 {
                     ok = (flags == "COLLAPSED");
                 }
@@ -1685,12 +1685,12 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::Collapsed flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::Collapsed flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
-                flags = p->GetFlagsAsString(wxPGPropertyFlags::Disabled);
-                if ( p->HasFlag(wxPGPropertyFlags::Disabled) )
+                flags = p->GetFlagsAsString(wxPGFlags::Disabled);
+                if ( p->HasFlag(wxPGFlags::Disabled) )
                 {
                     ok = (flags == "DISABLED");
                 }
@@ -1700,12 +1700,12 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::Disabled flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::Disabled flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
-                flags = p->GetFlagsAsString(wxPGPropertyFlags::Hidden);
-                if ( p->HasFlag(wxPGPropertyFlags::Hidden) )
+                flags = p->GetFlagsAsString(wxPGFlags::Hidden);
+                if ( p->HasFlag(wxPGFlags::Hidden) )
                 {
                     ok = (flags == "HIDDEN");
                 }
@@ -1715,12 +1715,12 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::Hidden flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::Hidden flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
-                flags = p->GetFlagsAsString(wxPGPropertyFlags::NoEditor);
-                if ( p->HasFlag(wxPGPropertyFlags::NoEditor) )
+                flags = p->GetFlagsAsString(wxPGFlags::NoEditor);
+                if ( p->HasFlag(wxPGFlags::NoEditor) )
                 {
                     ok = (flags == "NOEDITOR");
                 }
@@ -1730,13 +1730,13 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::NoEditor flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::NoEditor flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
                 // Get all flags
-                flags = p->GetFlagsAsString(wxPGPropertyFlags::StringStoredFlags);
-                if ( p->HasFlag(wxPGPropertyFlags::Collapsed) )
+                flags = p->GetFlagsAsString(wxPGFlags::StringStoredFlags);
+                if ( p->HasFlag(wxPGFlags::Collapsed) )
                 {
                     ok = (flags.Find("COLLAPSED") != wxNOT_FOUND);
                 }
@@ -1746,11 +1746,11 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::Collapsed flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::Collapsed flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
-                if ( p->HasFlag(wxPGPropertyFlags::Disabled) )
+                if ( p->HasFlag(wxPGFlags::Disabled) )
                 {
                     ok = (flags.Find("DISABLED") != wxNOT_FOUND);
                 }
@@ -1760,11 +1760,11 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::Disabled flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::Disabled flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
-                if ( p->HasFlag(wxPGPropertyFlags::Hidden) )
+                if ( p->HasFlag(wxPGFlags::Hidden) )
                 {
                     ok = (flags.Find("HIDDEN") != wxNOT_FOUND);
                 }
@@ -1774,11 +1774,11 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::Hidden flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::Hidden flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
-                if ( p->HasFlag(wxPGPropertyFlags::NoEditor) )
+                if ( p->HasFlag(wxPGFlags::NoEditor) )
                 {
                     ok = (flags.Find("NOEDITOR") != wxNOT_FOUND);
                 }
@@ -1788,15 +1788,15 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
                 }
                 if ( !ok )
                 {
-                    FAIL_CHECK(wxString::Format("Invalid string for wxPGPropertyFlags::NoEditor flag for property '%s'",
+                    FAIL_CHECK(wxString::Format("Invalid string for wxPGFlags::NoEditor flag for property '%s'",
                         p->GetName()).c_str());
                 }
 
                 // Restore original flags
-                p->ChangeFlag(wxPGPropertyFlags::Collapsed, !!(oldFlags & wxPGPropertyFlags::Collapsed));
-                p->ChangeFlag(wxPGPropertyFlags::Disabled, !!(oldFlags & wxPGPropertyFlags::Disabled));
-                p->ChangeFlag(wxPGPropertyFlags::Hidden, !!(oldFlags & wxPGPropertyFlags::Hidden));
-                p->ChangeFlag(wxPGPropertyFlags::NoEditor, !!(oldFlags & wxPGPropertyFlags::NoEditor));
+                p->ChangeFlag(wxPGFlags::Collapsed, !!(oldFlags & wxPGFlags::Collapsed));
+                p->ChangeFlag(wxPGFlags::Disabled, !!(oldFlags & wxPGFlags::Disabled));
+                p->ChangeFlag(wxPGFlags::Hidden, !!(oldFlags & wxPGFlags::Hidden));
+                p->ChangeFlag(wxPGFlags::NoEditor, !!(oldFlags & wxPGFlags::NoEditor));
             }
         }
     }


### PR DESCRIPTION
Defining wxPG_XXX of type different from (and not convertible to) "int" wasn't enough to make all code using these constants compile, as it could rely on storing them in int variables.

Change the type of these compatibility constants to "int" to be really compatible and also remove deprecation messages from them, as getting such message when passing them to any function taking a new style enum is enough, there is no need for multiple deprecation messages for the same line of code.

Closes #25627.