### PR TITLE
Avoid collapsing wxDVC node if already done by event handler

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -4120,6 +4120,12 @@ void wxDataViewMainWindow::Collapse(unsigned int row)
         if ( m_selection.OnItemsDeleted(row + 1, countDeletedRows) )
         {
             SendSelectionChangedEvent(GetItemByRow(row));
+
+            // The event handler for wxEVT_DATAVIEW_SELECTION_CHANGED could
+            // have called Collapse() itself, in which case the node would be
+            // already closed and we shouldn't try to close it again.
+            if ( !node->IsOpen() )
+                return;
         }
 
         node->ToggleOpen(this);


### PR DESCRIPTION
If an event handler for wxEVT_DATAVIEW_SELECTION_CHANGED called Collapse() itself (which is weird but allowed), Collapse() still tried to collapse it again, which could result in the count of items becoming negative and all sorts of other problems.

Avoid them by not doing anything if the item has been collapsed after the selection change.

Closes #25631.