### PR TITLE
Don't assert in wxGridSizer::Calc{Cols,Rows}() if sizer is empty

### DIFF
--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -839,24 +839,34 @@ protected:
     // of children (and the fixed number of rows/columns)
     int CalcCols() const
     {
+        // Check the count first because we shouldn't assert if the sizer is
+        // completely empty.
+        const int count = wxSsize(m_children);
+        if ( !count )
+            return 0;
+
         wxCHECK_MSG
         (
             m_rows, 0,
             "Can't calculate number of cols if number of rows is not specified"
         );
 
-        return int(m_children.GetCount() + m_rows - 1) / m_rows;
+        return (count + m_rows - 1) / m_rows;
     }
 
     int CalcRows() const
     {
+        const int count = wxSsize(m_children);
+        if ( !count )
+            return 0;
+
         wxCHECK_MSG
         (
             m_cols, 0,
             "Can't calculate number of cols if number of rows is not specified"
         );
 
-        return int(m_children.GetCount() + m_cols - 1) / m_cols;
+        return (count + m_cols - 1) / m_cols;
     }
 
 private:

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1928,6 +1928,9 @@ public:
         This will depend on the number of children the sizer has if
         the sizer is automatically adjusting the number of columns/rows.
 
+        Note that if the sizer is not empty, the number of rows must have been
+        set, otherwise this function triggers an assert failure and returns 0.
+
         @since 2.9.1
     */
     int GetEffectiveColsCount() const;
@@ -1937,6 +1940,9 @@ public:
 
         This will depend on the number of children the sizer has if
         the sizer is automatically adjusting the number of columns/rows.
+
+        Note that if the sizer is not empty, the number of columns must have been
+        set, otherwise this function triggers an assert failure and returns 0.
 
         @since 2.9.1
     */


### PR DESCRIPTION
When the sizer is completely empty, it makes more sense to return 0 from these functions without asserting.

Closes #25641.