### PR TITLE
Fix a few issues in the translations

### DIFF
--- a/locale/an.po
+++ b/locale/an.po
@@ -7553,7 +7553,7 @@ msgstr "Unidatz ta l'amplaria d'o canto cucho."
 #: ../src/richtext/richtextborderspage.cpp:536
 #: ../src/richtext/richtextborderspage.cpp:538
 msgid "The border line style."
-msgstr "O estilo d'a linia d'o canto"
+msgstr "O estilo d'a linia d'o canto."
 
 #: ../src/richtext/richtextborderspage.cpp:276
 #: ../src/richtext/richtextborderspage.cpp:444
@@ -7643,7 +7643,7 @@ msgstr "Cantonada"
 
 #: ../src/richtext/richtextborderspage.cpp:574
 msgid "Corner &radius:"
-msgstr "&Radio d'a cantonada"
+msgstr "&Radio d'a cantonada:"
 
 #: ../src/richtext/richtextborderspage.cpp:576
 #: ../src/richtext/richtextborderspage.cpp:578
@@ -7653,12 +7653,12 @@ msgstr "Un radio de cantonada opcional ta adhibir cantonadas redondiadas."
 #: ../src/richtext/richtextborderspage.cpp:584
 #: ../src/richtext/richtextborderspage.cpp:586
 msgid "The value of the corner radius."
-msgstr "A valor d'o radio de cantonada"
+msgstr "A valor d'o radio de cantonada."
 
 #: ../src/richtext/richtextborderspage.cpp:595
 #: ../src/richtext/richtextborderspage.cpp:597
 msgid "Units for the corner radius."
-msgstr "Unidatz ta lo radio de cantonada"
+msgstr "Unidatz ta lo radio de cantonada."
 
 #: ../src/richtext/richtextborderspage.cpp:609
 #: ../src/richtext/richtextsizepage.cpp:247

--- a/locale/ca@valencia.po
+++ b/locale/ca@valencia.po
@@ -13,7 +13,7 @@ msgstr ""
 
 #: ../include/wx/defs.h:2582
 msgid "All files (*.*)|*.*"
-msgstr "Tots els fitxers (*.*) *.*  "
+msgstr "Tots els fitxers (*.*)|*.*"
 
 #: ../include/wx/defs.h:2585
 msgid "All files (*)|*"
@@ -783,7 +783,7 @@ msgstr "especifiqueu el mode de pantalla a utilitzar (p. ex. 640x480-16)"
 #: ../src/common/appcmn.cpp:292
 #, c-format
 msgid "Unsupported theme '%s'."
-msgstr "Tema '%s' no suportat"
+msgstr "Tema '%s' no suportat."
 
 #: ../src/common/appcmn.cpp:309
 #, c-format

--- a/locale/de.po
+++ b/locale/de.po
@@ -5154,7 +5154,7 @@ msgstr "Rechter Rand (mm):"
 
 #: ../src/generic/prntdlgg.cpp:873
 msgid "Bottom margin (mm):"
-msgstr "Unterer Rand (mm)"
+msgstr "Unterer Rand (mm):"
 
 #: ../src/generic/prntdlgg.cpp:896
 msgid "Printer..."

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -1745,7 +1745,7 @@ msgstr "Unicode 32 bit (UTF-32)"
 
 #: ../src/common/fmapbase.cpp:184
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
-msgstr "Unicode 32 bit petit-boutiste (UTF-8)"
+msgstr "Unicode 32 bit petit-boutiste (UTF-32LE)"
 
 #: ../src/common/fmapbase.cpp:186
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
@@ -2856,7 +2856,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
 #: ../src/common/paper.cpp:127
 msgid "Letter Plus 8 1/2 x 12.69 in"
-msgstr "Lettre Plus 8,5 x 11.69 pouces"
+msgstr "Lettre Plus 8,5 x 12.69 pouces"
 
 #: ../src/common/paper.cpp:128
 msgid "A4 Plus 210 x 330 mm"
@@ -9371,7 +9371,7 @@ msgstr "Erreur d'analyse XML : « %s » à la ligne %d"
 #: ../src/xrc/xh_propgrid.cpp:239
 #, c-format
 msgid "Page %i"
-msgstr "Page %d"
+msgstr "Page %i"
 
 #: ../src/xrc/xmlres.cpp:448
 #, c-format

--- a/locale/gl_ES.po
+++ b/locale/gl_ES.po
@@ -1510,7 +1510,7 @@ msgid ""
 "exists."
 msgstr ""
 "Non se puido cambiar o nome do ficheiro de '%s' a '%s' porque o ficheiro de "
-"destino xa existe. "
+"destino xa existe."
 
 #: ../src/common/filefn.cpp:623
 #, c-format
@@ -4342,7 +4342,7 @@ msgstr "Documentación de "
 
 #: ../src/generic/aboutdlgg.cpp:75
 msgid "Graphics art by "
-msgstr "Gráficos de"
+msgstr "Gráficos de "
 
 #: ../src/generic/aboutdlgg.cpp:78
 msgid "Translations by "
@@ -4350,7 +4350,7 @@ msgstr "Traducións de "
 
 #: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
-msgstr "Versión"
+msgstr "Versión "
 
 #. TRANSLATORS: %s is application name
 #: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
@@ -5842,7 +5842,7 @@ msgstr "Non se puido terminar o bucle de aviso co servidor DDE"
 
 #: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
-msgstr "Erro ao enviar notificación de recomendación de DDE "
+msgstr "Erro ao enviar notificación de recomendación de DDE"
 
 #: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
@@ -5917,7 +5917,7 @@ msgstr "expirou unha solicitude de transacción síncrona de asignación."
 
 #: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
-msgstr "erro nunha chamada interna á función PostMessage."
+msgstr "erro nunha chamada interna á función PostMessage. "
 
 #: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."

--- a/locale/hi.po
+++ b/locale/hi.po
@@ -1697,7 +1697,7 @@ msgstr "विण्डो सायरिलिक (सीपी १२५१)"
 
 #: ../src/common/fmapbase.cpp:162
 msgid "Windows Thai (CP 874)"
-msgstr "विण्डो थाई (सीपी १२५७)"
+msgstr "विण्डो थाई (सीपी ८७४)"
 
 #: ../src/common/fmapbase.cpp:163
 #, fuzzy

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -5567,7 +5567,7 @@ msgstr "フォントの大きさ"
 
 #: ../src/html/helpwnd.cpp:1256
 msgid "Normal face<br>and <u>underlined</u>. "
-msgstr "通常<br> と <u>下線付き</u>"
+msgstr "通常<br> と <u>下線付き</u>。 "
 
 #: ../src/html/helpwnd.cpp:1257
 msgid "<i>Italic face.</i> "
@@ -5583,7 +5583,7 @@ msgstr "<b><i>太字でイタリック体。</i></b><br>"
 
 #: ../src/html/helpwnd.cpp:1262
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
-msgstr "固定幅。<br> <b>太字</b><i>イタリック</i>"
+msgstr "固定幅。<br> <b>太字</b><i>イタリック</i> "
 
 #: ../src/html/helpwnd.cpp:1263
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
@@ -5836,7 +5836,7 @@ msgstr "非同期 poke トランザクションの要求が時間切れになり
 
 #: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
-msgstr "PostMessage関数の内部呼び出しが失敗しました。"
+msgstr "PostMessage関数の内部呼び出しが失敗しました。 "
 
 #: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -8848,7 +8848,7 @@ msgstr "(ნორმალური ტექსტი)"
 
 #: ../src/richtext/richtexttabspage.cpp:109
 msgid "&Position (tenths of a mm):"
-msgstr "&მდებარეობა (მმ-ის მეათედებში)"
+msgstr "&მდებარეობა (მმ-ის მეათედებში):"
 
 #: ../src/richtext/richtexttabspage.cpp:113
 #: ../src/richtext/richtexttabspage.cpp:115

--- a/locale/ko_KR.po
+++ b/locale/ko_KR.po
@@ -782,7 +782,7 @@ msgstr "'%s' 테마는 지원하지 않습니다."
 #: ../src/common/appcmn.cpp:309
 #, c-format
 msgid "Invalid display mode specification '%s'."
-msgstr "설정된 디스플레이 모드('%s')가 없습니다. "
+msgstr "설정된 디스플레이 모드('%s')가 없습니다."
 
 #: ../src/common/cmdline.cpp:875
 #, fuzzy, c-format
@@ -1623,7 +1623,7 @@ msgstr "남유럽어 (ISO-8859-3)"
 
 #: ../src/common/fmapbase.cpp:147
 msgid "Baltic (old) (ISO-8859-4)"
-msgstr "발트어 (old)(ISO-8859-13)"
+msgstr "발트어 (old)(ISO-8859-4)"
 
 #: ../src/common/fmapbase.cpp:148
 msgid "Cyrillic (ISO-8859-5)"
@@ -2847,7 +2847,7 @@ msgstr "일본 옆서 100 x 148 mm"
 
 #: ../src/common/paper.cpp:114
 msgid "9 x 11 in"
-msgstr "확대(_I)"
+msgstr "9 x 11 in"
 
 #: ../src/common/paper.cpp:115
 msgid "10 x 11 in"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -1170,7 +1170,7 @@ msgstr "Nie udało się zapisać dokumentu do pliku \"%s\"."
 #: ../src/common/docview.cpp:702
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
-msgstr "Nie udało się otworzyć pliku '%s' do odczytu"
+msgstr "Nie udało się otworzyć pliku '%s' do odczytu."
 
 #: ../src/common/docview.cpp:714
 #, c-format
@@ -2100,7 +2100,7 @@ msgstr ""
 #: ../src/common/fontmap.cpp:241
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
-msgstr "Nie udało się zapamiętać kodowania dla zestawu znaków '%s'"
+msgstr "Nie udało się zapamiętać kodowania dla zestawu znaków '%s'."
 
 #: ../src/common/fontmap.cpp:321
 msgid "can't load any font, aborting"
@@ -4351,7 +4351,7 @@ msgstr "Wystąpił błąd DirectFB: %d"
 
 #: ../src/generic/aboutdlgg.cpp:69
 msgid "Developed by "
-msgstr "Opracowane przez"
+msgstr "Opracowane przez "
 
 #: ../src/generic/aboutdlgg.cpp:72
 msgid "Documentation by "
@@ -4359,11 +4359,11 @@ msgstr "Dokumentacja autorstwa"
 
 #: ../src/generic/aboutdlgg.cpp:75
 msgid "Graphics art by "
-msgstr "Grafika autorstwa"
+msgstr "Grafika autorstwa "
 
 #: ../src/generic/aboutdlgg.cpp:78
 msgid "Translations by "
-msgstr "Tłumaczenia autorstwa"
+msgstr "Tłumaczenia autorstwa "
 
 # prawa?
 #: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
@@ -4916,7 +4916,7 @@ msgstr "Anulowanie wyboru czcionki"
 #: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
 #: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
 msgid "Click to confirm the font selection."
-msgstr "Potwierdzenie wyboru czcionki"
+msgstr "Potwierdzenie wyboru czcionki."
 
 #: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
@@ -9428,7 +9428,7 @@ msgstr "Nie można pobrać oficjalnej nazwy serwera"
 
 #: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
-msgstr "Nie udało się utworzyć potoku budzącego używanego przez pętlę zdarzeń"
+msgstr "Nie udało się utworzyć potoku budzącego używanego przez pętlę zdarzeń."
 
 #: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
@@ -9436,7 +9436,7 @@ msgstr "Nie udało się przełączyć potoku budzącego na modus nie-blokujący"
 
 #: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
-msgstr "Nie udało się czytać z potoku budzącego "
+msgstr "Nie udało się czytać z potoku budzącego"
 
 # Pytanie X11
 #: ../src/x11/app.cpp:124

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -3053,7 +3053,7 @@ msgstr "Envelope PRC #2 Rotacionado 176 x 102 mm"
 
 #: ../src/common/paper.cpp:180
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
-msgstr "Envelope B6 #3 Rotacionado 176 x 125 mm"
+msgstr "Envelope PRC #3 Rotacionado 176 x 125 mm"
 
 #: ../src/common/paper.cpp:181
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -4460,7 +4460,7 @@ msgstr "Введите команду для открытия файла \"%s\":
 
 #: ../src/generic/dbgrptg.cpp:230
 msgid "Executable files (*.exe)|*.exe|"
-msgstr "Исполняемые файлы (*.exe)|*.exe"
+msgstr "Исполняемые файлы (*.exe)|*.exe|"
 
 #: ../src/generic/dbgrptg.cpp:300
 #, c-format

--- a/locale/sq.po
+++ b/locale/sq.po
@@ -8917,7 +8917,7 @@ msgstr "(Tekst normal)"
 
 #: ../src/richtext/richtexttabspage.cpp:109
 msgid "&Position (tenths of a mm):"
-msgstr "&Pozicion (të dhjeta të mm-it)"
+msgstr "&Pozicion (të dhjeta të mm-it):"
 
 #: ../src/richtext/richtexttabspage.cpp:113
 #: ../src/richtext/richtexttabspage.cpp:115

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -2843,7 +2843,7 @@ msgstr "特大 A5 纸张，174 x 235 毫米"
 
 #: ../src/common/paper.cpp:133
 msgid "B5 (ISO) Extra 201 x 276 mm"
-msgstr "特大 B4 纸张 (JIS)，201 x 276 毫米"
+msgstr "特大 B5 纸张 (JIS)，201 x 276 毫米"
 
 #: ../src/common/paper.cpp:134
 msgid "A2 420 x 594 mm"
@@ -2915,7 +2915,7 @@ msgstr "横向日式双明信片，148 x 200 毫米"
 
 #: ../src/common/paper.cpp:152
 msgid "A6 Rotated 148 x 105 mm"
-msgstr "横向 A5 纸张，148 x 105 毫米"
+msgstr "横向 A6 纸张，148 x 105 毫米"
 
 #: ../src/common/paper.cpp:153
 msgid "Japanese Envelope Kaku #2 Rotated"


### PR DESCRIPTION
Fix malformed pipes, incorrect numbers, wrong translation, missing trailing punctuations, missing trailing spaces