### PR TITLE
BF: Use WIN32_MSVC_NAMING and not wxUSE_MSVC_NAMING

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -482,7 +482,7 @@ macro(wx_add_library name)
         set_target_properties(${name} PROPERTIES PROJECT_LABEL ${name_short})
 
         # Setup install
-        if(wxUSE_MSVC_NAMING)
+        if(WIN32_MSVC_NAMING)
             set(runtime_default_dir "lib")
         else()
             # configure puts the .dll in the bin directory


### PR DESCRIPTION
This PR fixes a small typo in `build/cmake/functions.cmake` which causes `.dll` files to be installed into the wrong location in some circumstances. See https://github.com/wxWidgets/wxWidgets/pull/25643#issuecomment-3103610781