### PR TITLE
Remove broken assert in wxSocketBase::SetFlags.

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -1716,13 +1716,6 @@ void wxSocketBase::SetTimeout(long seconds)
 
 void wxSocketBase::SetFlags(wxSocketFlags flags)
 {
-    // Do some sanity checking on the flags used: not all values can be used
-    // together.
-    wxASSERT_MSG( !(flags & wxSOCKET_NOWAIT) ||
-                  !(flags & (wxSOCKET_WAITALL | wxSOCKET_BLOCK)),
-                  "Using wxSOCKET_WAITALL or wxSOCKET_BLOCK with "
-                  "wxSOCKET_NOWAIT doesn't make sense" );
-
     // Blocking sockets are very different from non-blocking ones and we need
     // to [un]register the socket with the event loop if wxSOCKET_BLOCK is
     // being [un]set.


### PR DESCRIPTION
This does not correctly check for incompatible flag combinations leading to erroneous failed assertions.