### PR TITLE
Fix assert checking for wxSocket flags compatibility

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -1716,12 +1716,18 @@ void wxSocketBase::SetTimeout(long seconds)
 
 void wxSocketBase::SetFlags(wxSocketFlags flags)
 {
-    // Do some sanity checking on the flags used: not all values can be used
-    // together.
-    wxASSERT_MSG( !(flags & wxSOCKET_NOWAIT) ||
-                  !(flags & (wxSOCKET_WAITALL | wxSOCKET_BLOCK)),
-                  "Using wxSOCKET_WAITALL or wxSOCKET_BLOCK with "
-                  "wxSOCKET_NOWAIT doesn't make sense" );
+    // Do some sanity checking on the flags used: we can't not wait at all and
+    // wait for all data in the same direction (but using wxSOCKET_NOWAIT_READ
+    // with wxSOCKET_WAITALL_WRITE, or vice versa, is fine).
+    wxASSERT_MSG( (!(flags & wxSOCKET_NOWAIT_READ) ||
+                   !(flags & wxSOCKET_WAITALL_READ)) &&
+                  (!(flags & wxSOCKET_NOWAIT_WRITE) ||
+                   !(flags & wxSOCKET_WAITALL_WRITE)),
+                  "wxSOCKET_WAITALL and wxSOCKET_NOWAIT are incompatible" );
+
+    // And blocking is not compatible with not waiting, in any direction.
+    wxASSERT_MSG( !(flags & wxSOCKET_BLOCK) || !(flags & wxSOCKET_NOWAIT),
+                  "wxSOCKET_BLOCK and wxSOCKET_NOWAIT are incompatible" );
 
     // Blocking sockets are very different from non-blocking ones and we need
     // to [un]register the socket with the event loop if wxSOCKET_BLOCK is


### PR DESCRIPTION
While wxSOCKET_NOWAIT is incompatible with wxSOCKET_WAITALL, using wxSOCKET_NOWAIT_READ and wxSOCKET_WAITALL_WRITE should be allowed, but it was not.

Fix this and also split the assert in two for a bit more clarity.

Closes #17114.