### PR TITLE
Build wxNet without wxSocket if wxWebRequest is used

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -45,7 +45,14 @@ endmacro()
 
 # Define base libraries
 set(LIBS base)
-add_opt_lib(net wxUSE_SOCKETS)
+
+# wxNet should be built if either wxUSE_SOCKETS or wxUSE_WEBREQUEST is on.
+if(wxUSE_SOCKETS OR wxUSE_WEBREQUEST)
+    set(wxUSE_NET ON)
+else()
+    set(wxUSE_NET OFF)
+endif()
+add_opt_lib(net wxUSE_NET)
 
 # Define UI libraries
 if(wxUSE_GUI)

--- a/configure
+++ b/configure
@@ -40985,7 +40985,7 @@ STD_BASE_LIBS="base"
 STD_GUI_LIBS=""
 BUILT_WX_LIBS="base"
 
-if test "$wxUSE_SOCKETS" = "yes" ; then
+if test "$wxUSE_SOCKETS" = "yes" -o "$wxUSE_WEBREQUEST" = "yes"; then
     STD_BASE_LIBS="net $STD_BASE_LIBS"
     BUILT_WX_LIBS="net $BUILT_WX_LIBS"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -7564,7 +7564,7 @@ STD_BASE_LIBS="base"
 STD_GUI_LIBS=""
 BUILT_WX_LIBS="base"
 
-if test "$wxUSE_SOCKETS" = "yes" ; then
+if test "$wxUSE_SOCKETS" = "yes" -o "$wxUSE_WEBREQUEST" = "yes"; then
     STD_BASE_LIBS="net $STD_BASE_LIBS"
     BUILT_WX_LIBS="net $BUILT_WX_LIBS"
 fi

--- a/include/wx/msw/private/sockmsw.h
+++ b/include/wx/msw/private/sockmsw.h
@@ -13,7 +13,7 @@
 #ifndef _WX_MSW_GSOCKMSW_H_
 #define _WX_MSW_GSOCKMSW_H_
 
-#include "wx/msw/wrapwin.h"
+#include "wx/private/sockettype.h"
 
 #if defined(__CYGWIN__)
     //CYGWIN gives annoying warning about runtime stuff if we don't do this
@@ -33,8 +33,6 @@
 #ifndef wxIoctlSocketArg_t
     #define wxIoctlSocketArg_t u_long
 #endif
-
-#define wxCloseSocket closesocket
 
 // ----------------------------------------------------------------------------
 // MSW-specific socket implementation

--- a/include/wx/private/sockettype.h
+++ b/include/wx/private/sockettype.h
@@ -1,0 +1,25 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/sockettype.h
+// Purpose:     Low-level header defining wxCloseSocket()
+// Author:      Vadim Zeitlin
+// Created:     2025-07-29
+// Copyright:   (c) 2025 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_SOCKETTYPE_H_
+#define _WX_PRIVATE_SOCKETTYPE_H_
+
+// Note that this header is not affected by wxUSE_SOCKETS as wxCloseSocket() is
+// also used by wxWebRequestCURL.
+#if defined(__WINDOWS__)
+    #include "wx/msw/wrapwin.h"
+
+    #define wxCloseSocket closesocket
+#else
+    #include <unistd.h>
+
+    #define wxCloseSocket close
+#endif
+
+#endif // _WX_PRIVATE_SOCKETTYPE_H_

--- a/include/wx/protocol/protocol.h
+++ b/include/wx/protocol/protocol.h
@@ -84,10 +84,12 @@ public:
 
     virtual void SetDefaultTimeout(wxUint32 Value);
 
+#if wxUSE_SOCKETS
     // override wxSocketBase::SetTimeout function to avoid that the internal
     // m_uiDefaultTimeout goes out-of-sync:
     virtual void SetTimeout(long seconds) override
         { SetDefaultTimeout(static_cast<wxUint32>(seconds)); }
+#endif // wxUSE_SOCKETS
 
 
     // logging support: each wxProtocol object may have the associated logger

--- a/include/wx/unix/private/sockunix.h
+++ b/include/wx/unix/private/sockunix.h
@@ -11,7 +11,8 @@
 #ifndef _WX_UNIX_GSOCKUNX_H_
 #define _WX_UNIX_GSOCKUNX_H_
 
-#include <unistd.h>
+#include "wx/private/sockettype.h"
+
 #include <sys/ioctl.h>
 
 // Under older (Open)Solaris versions FIONBIO is declared in this header only.
@@ -22,8 +23,6 @@
 #endif
 
 #include "wx/private/fdiomanager.h"
-
-#define wxCloseSocket close
 
 class wxSocketImplUnix : public wxSocketImpl,
                          public wxFDIOHandler

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -23,7 +23,7 @@
 #endif
 
 #include "wx/uri.h"
-#include "wx/private/socket.h"
+#include "wx/private/sockettype.h"
 #include "wx/evtloop.h"
 
 #ifdef __WINDOWS__


### PR DESCRIPTION
I'm thinking about deprecating `wxSocket` eventually and while it's not going to be done yet, I'd like to be able to build without it — but still with `wxWebRequest`. And this PR makes this work.