### PR TITLE
Adding configurable timeout for wxWebRequest.

### DIFF
--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -85,6 +85,8 @@ public:
 
     void Start() override;
 
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs) override;
+
     wxWebResponseImplPtr GetResponse() const override
         { return m_response; }
 
@@ -120,6 +122,7 @@ private:
     // returned later and this argument must be null.
     wxNODISCARD Result DoWriteData(DWORD* bytesWritten = nullptr);
 
+    void DoSetTimeouts();
 
     wxWebSessionWinHTTP& m_sessionImpl;
     wxString m_url;
@@ -139,6 +142,12 @@ private:
     // Proxy credentials (if any) are stored in the session, but we need store
     // the same flag for them as for the server credentials here.
     bool m_tryProxyCredentials = false;
+
+    // Store timeouts, in order to set these before sending request.
+    bool m_isTimeoutsSet = false;
+    long m_connectionTimeoutMs = 60000;
+    long m_dataTimeoutMs = 30000;
+
 
 
     wxNODISCARD Result SendRequest();

--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -144,9 +144,8 @@ private:
     bool m_tryProxyCredentials = false;
 
     // Store timeouts, in order to set these before sending request.
-    bool m_isTimeoutsSet = false;
-    long m_connectionTimeoutMs = 60000;
-    long m_dataTimeoutMs = 30000;
+    long m_connectionTimeoutMs = wxWebRequest::Timeout_Default;
+    long m_dataTimeoutMs = wxWebRequest::Timeout_Default;
 
 
 

--- a/include/wx/osx/private/webrequest_urlsession.h
+++ b/include/wx/osx/private/webrequest_urlsession.h
@@ -97,6 +97,9 @@ public:
 
     void Start() override;
 
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs) override;
+
+
     wxWebResponseImplPtr GetResponse() const override
         { return m_response; }
 

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -88,6 +88,8 @@ public:
     // cancelled.
     void Cancel();
 
+    virtual void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs) = 0;
+
     virtual wxWebResponseImplPtr GetResponse() const = 0;
 
     virtual wxWebAuthChallengeImplPtr GetAuthChallenge() const = 0;

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -64,6 +64,8 @@ public:
 
     void Start() override;
 
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs) override;
+
     wxWebResponseImplPtr GetResponse() const override
         { return m_response; }
 

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -194,6 +194,12 @@ public:
         wxString error;
     };
 
+    enum Timeout
+    {
+        Timeout_Default = -1,
+        Timeout_Infinite = 0
+    };
+
     bool IsOk() const { return m_impl.get() != nullptr; }
 
     void SetHeader(const wxString& name, const wxString& value);

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -211,6 +211,8 @@ public:
 
     void SetStorage(Storage storage);
 
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
+
     Storage GetStorage() const;
 
     wxWebResponse GetResponse() const;

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -228,6 +228,21 @@ public:
     };
 
     /**
+        Constant timeout values. Can be use as argument when calling wxWebRequest::SetTimeouts.
+    */
+    enum Timeout
+    {
+        /**
+            Use the default value for the current timeout and implementation.
+        */
+        Timeout_Default,
+        /**
+            Set the timeout to infinite (No timeout).
+        */
+        Timeout_Infinite
+    };
+
+    /**
         Default constructor creates an invalid object.
 
         Initialize it by assigning wxWebSession::CreateRequest() to it before
@@ -423,22 +438,26 @@ public:
     void SetStorage(Storage storage);
 
     /**
-        Sets the timeouts in milliseconds for the webrequest.
+        Set the timeouts for the connection and total request time.
 
         @param connectionTimeoutMs
-            Maximum time in milliseconds allowed for name resolution and connection to the server.
+            Maximum time in milliseconds allowed for connection to the server, including its name resolution.
         @param dataTimeoutMs
-            Maximum time in milliseconds allowed to send and to receive data.
+            Maximum time in milliseconds allowed for the remaining operations (post connection).
 
-        @note On Linux those parameters can't be distinguish. They are added to form one value used to set
-        the maximum time in seconds that you allow the entire transfer operation to take. The whole thing, from start to end.
+        @note Use wxWebRequest::Timeout_Default to set the timeout to the default value (default depends on implementation).
+        Use wxWebRequest::Timeout_Infinite to set an infinite timeout.\n
 
-        @remarks The default timeouts may vary depending on Implementation.
+        @note On Linux @c connectionTimeoutMs can't be set to infinite instead the timeout will be set to the maximal value that can be stored in a long.
+        @c connectionTimeoutMs and @c dataTimeoutMs are added to form one value used to set the maximum time in milliseconds that you allow the entire transfer operation to take. The whole thing, from start to end.
+
+        @remarks The default timeouts vary depending on implementation.
             For more details take a look at the natives function (@ref descriptions).
             - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
-            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS option.
+            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS and CURLOPT_CONNECTTIMEOUT_MS options.
             - For macOS backend, this is not implemented yet.
 
+        @see Timeout
     */
     void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 
@@ -896,21 +915,26 @@ public:
     };
 
     /**
-        Sets the timeouts in milliseconds for the webrequest.
+        Set the timeouts for the connection and total request time.
 
         @param connectionTimeoutMs
-            Maximum time in milliseconds allowed for name resolution and connection to the server.
+            Maximum time in milliseconds allowed for connection to the server, including its name resolution.
         @param dataTimeoutMs
-            Maximum time in milliseconds allowed to send and to receive data.
+            Maximum time in milliseconds allowed for the remaining operations (post connection).
 
-        @note On Linux those parameters can't be distinguish. They are added to form one value.
+        @note Use wxWebRequest::Timeout_Default to set the timeout to the default value (default depends on implementation).
+        Use wxWebRequest::Timeout_Infinite to set an infinite timeout.\n
 
-        @remarks The default timeouts may vary depending on Implementation.
+        @note On Linux @c connectionTimeoutMs can't be set to infinite instead the timeout will be set to the maximal value that can be stored in a long.
+        @c connectionTimeoutMs and @c dataTimeoutMs are added to form one value used to set the maximum time in milliseconds that you allow the entire transfer operation to take. The whole thing, from start to end.
+
+        @remarks The default timeouts vary depending on implementation.
             For more details take a look at the natives function (@ref descriptions).
             - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
-            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS option.
+            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS and CURLOPT_CONNECTTIMEOUT_MS options.
             - For macOS backend, this is not implemented yet.
 
+        @see Timeout
     */
     void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -228,7 +228,11 @@ public:
     };
 
     /**
-        Constant timeout values. Can be use as argument when calling wxWebRequest::SetTimeouts.
+        Special timeout values.
+
+        Can be used as argument when calling wxWebRequest::SetTimeouts().
+
+        @since 3.3.2
     */
     enum Timeout
     {
@@ -236,6 +240,7 @@ public:
             Use the default value for the current timeout and implementation.
         */
         Timeout_Default,
+
         /**
             Set the timeout to infinite (No timeout).
         */
@@ -438,26 +443,37 @@ public:
     void SetStorage(Storage storage);
 
     /**
-        Set the timeouts for the connection and total request time.
+        Set the timeouts for the connection and data exchange time.
 
         @param connectionTimeoutMs
-            Maximum time in milliseconds allowed for connection to the server, including its name resolution.
+            Maximum time in milliseconds allowed for connection to the server.
+            For WinHTTP backend, this timeout is used for both the server name
+            resolution and the connection establishment. For libcurl backend,
+            this timeout is used for the complete connection establishment,
+            including name resolution.
         @param dataTimeoutMs
-            Maximum time in milliseconds allowed for the remaining operations (post connection).
+            The exact meaning of this parameter depends on the implementation:
+            for WinHTTP backend, it is the maximum time allowed for each read
+            or write operation. For libcurl backend it is the total time for
+            the entire operation, not counting the connection establishment
+            time.
 
-        @note Use wxWebRequest::Timeout_Default to set the timeout to the default value (default depends on implementation).
-        Use wxWebRequest::Timeout_Infinite to set an infinite timeout.\n
+        @note Use wxWebRequest::Timeout_Default to set the timeout to the
+            default value (default depends on implementation). Use
+            wxWebRequest::Timeout_Infinite to set an infinite timeout.
 
-        @note On Linux @c connectionTimeoutMs can't be set to infinite instead the timeout will be set to the maximal value that can be stored in a long.
-        @c connectionTimeoutMs and @c dataTimeoutMs are added to form one value used to set the maximum time in milliseconds that you allow the entire transfer operation to take. The whole thing, from start to end.
-
-        @remarks The default timeouts vary depending on implementation.
-            For more details take a look at the natives function (@ref descriptions).
-            - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
-            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS and CURLOPT_CONNECTTIMEOUT_MS options.
-            - For macOS backend, this is not implemented yet.
+        @remarks The default timeout values vary depending on implementation:
+            - For WinHTTP backend, default connection timeout is infinite while
+              data timeout is 30 seconds.
+            - For CURL backend, default connection timeout is 5 minutes and
+              there is no data timeout.
 
         @see Timeout
+
+        @note This function is currently not implemented for macOS backend and
+            does nothing when it is called when using it.
+
+        @since 3.3.2
     */
     void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 
@@ -915,26 +931,37 @@ public:
     };
 
     /**
-        Set the timeouts for the connection and total request time.
+        Set the timeouts for the connection and data exchange time.
 
         @param connectionTimeoutMs
-            Maximum time in milliseconds allowed for connection to the server, including its name resolution.
+            Maximum time in milliseconds allowed for connection to the server.
+            For WinHTTP backend, this timeout is used for both the server name
+            resolution and the connection establishment. For libcurl backend,
+            this timeout is used for the complete connection establishment,
+            including name resolution.
         @param dataTimeoutMs
-            Maximum time in milliseconds allowed for the remaining operations (post connection).
+            The exact meaning of this parameter depends on the implementation:
+            for WinHTTP backend, it is the maximum time allowed for each read
+            or write operation. For libcurl backend it is the total time for
+            the entire operation, not counting the connection establishment
+            time.
 
-        @note Use wxWebRequest::Timeout_Default to set the timeout to the default value (default depends on implementation).
-        Use wxWebRequest::Timeout_Infinite to set an infinite timeout.\n
+        @note Use wxWebRequest::Timeout_Default to set the timeout to the
+            default value (default depends on implementation). Use
+            wxWebRequest::Timeout_Infinite to set an infinite timeout.
 
-        @note On Linux @c connectionTimeoutMs can't be set to infinite instead the timeout will be set to the maximal value that can be stored in a long.
-        @c connectionTimeoutMs and @c dataTimeoutMs are added to form one value used to set the maximum time in milliseconds that you allow the entire transfer operation to take. The whole thing, from start to end.
-
-        @remarks The default timeouts vary depending on implementation.
-            For more details take a look at the natives function (@ref descriptions).
-            - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
-            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS and CURLOPT_CONNECTTIMEOUT_MS options.
-            - For macOS backend, this is not implemented yet.
+        @remarks The default timeout values vary depending on implementation:
+            - For WinHTTP backend, default connection timeout is infinite while
+              data timeout is 30 seconds.
+            - For CURL backend, default connection timeout is 5 minutes and
+              there is no data timeout.
 
         @see Timeout
+
+        @note This function is currently not implemented for macOS backend and
+            does nothing when it is called when using it.
+
+        @since 3.3.2
     */
     void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -423,6 +423,26 @@ public:
     void SetStorage(Storage storage);
 
     /**
+        Sets the timeouts in milliseconds for the webrequest.
+
+        @param connectionTimeoutMs
+            Maximum time in milliseconds allowed for name resolution and connection to the server.
+        @param dataTimeoutMs
+            Maximum time in milliseconds allowed to send and to receive data.
+
+        @note On Linux those parameters can't be distinguish. They are added to form one value used to set
+        the maximum time in seconds that you allow the entire transfer operation to take. The whole thing, from start to end.
+
+        @remarks The default timeouts may vary depending on Implementation.
+            For more details take a look at the natives function (@ref descriptions).
+            - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
+            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS option.
+            - For macOS backend, this is not implemented yet.
+
+    */
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
+
+    /**
         Flags for disabling security features.
 
         @since 3.3.0
@@ -874,6 +894,25 @@ public:
          */
         Ignore_All = Ignore_Certificate | Ignore_Host
     };
+
+    /**
+        Sets the timeouts in milliseconds for the webrequest.
+
+        @param connectionTimeoutMs
+            Maximum time in milliseconds allowed for name resolution and connection to the server.
+        @param dataTimeoutMs
+            Maximum time in milliseconds allowed to send and to receive data.
+
+        @note On Linux those parameters can't be distinguish. They are added to form one value.
+
+        @remarks The default timeouts may vary depending on Implementation.
+            For more details take a look at the natives function (@ref descriptions).
+            - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
+            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS option.
+            - For macOS backend, this is not implemented yet.
+
+    */
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 
     /**
         Make connection insecure by disabling security checks.

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -423,6 +423,26 @@ public:
     void SetStorage(Storage storage);
 
     /**
+        Sets the timeouts in milliseconds for the webrequest.
+
+        @param connectionTimeoutMs
+            Maximum time in milliseconds allowed for name resolution and connection to the server.
+        @param dataTimeoutMs
+            Maximum time in milliseconds allowed to send and to receive data.
+
+        @note On Linux those parameters can't be distinguish. They are added to form one value used to set
+        the maximum time in seconds that you allow the entire transfer operation to take. The whole thing, from start to end.
+
+        @remarks The default timeouts may vary depending on Implementation.
+            For more details take a look at the natives function (@ref descriptions).
+            - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
+            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS option.
+            - For macOS backend, this is not implemented yet.
+
+    */
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
+
+    /**
         Flags for disabling security features.
 
         @since 3.3.0
@@ -874,6 +894,26 @@ public:
          */
         Ignore_All = Ignore_Certificate | Ignore_Host
     };
+
+    /**
+        Sets the timeouts in milliseconds for the webrequest.
+
+        @param connectionTimeoutMs
+            Maximum time in milliseconds allowed for name resolution and connection to the server.
+        @param dataTimeoutMs
+            Maximum time in milliseconds allowed to send and to receive data.
+
+        @note On Linux those parameters can't be distinguish. They are added to form one value used to set
+        the maximum time in seconds that you allow the entire transfer operation to take. The whole thing, from start to end.
+
+        @remarks The default timeouts may vary depending on Implementation.
+            For more details take a look at the natives function (@ref descriptions).
+            - For WinHTTP backend, <a target=_new href="https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsettimeouts">WinHttpSetTimeouts</a> function.
+            - For CURL backend, <a target=_new href="https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html">curl_easy_setopt</a> function with CURLOPT_TIMEOUT_MS option.
+            - For macOS backend, this is not implemented yet.
+
+    */
+    void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 
     /**
         Make connection insecure by disabling security checks.

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -470,6 +470,14 @@ void wxWebRequestBase::SetStorage(Storage storage)
     m_impl->SetStorage(storage);
 }
 
+void wxWebRequestBase::SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs)
+{
+    wxCHECK_IMPL_VOID();
+
+    m_impl->SetTimeouts(connectionTimeoutMs, dataTimeoutMs);
+}
+
+
 wxWebRequestBase::Storage wxWebRequestBase::GetStorage() const
 {
     wxCHECK_IMPL( Storage_None );

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -524,6 +524,13 @@ void wxWebRequestCURL::Start()
     StartRequest();
 }
 
+void wxWebRequestCURL::SetTimeouts(long connectionTimeoutMs,
+                                   long dataTimeoutMs)
+{
+    long timeout = connectionTimeoutMs + dataTimeoutMs;
+    wxCURLSetOpt(m_handle, CURLOPT_TIMEOUT_MS, timeout);
+}
+
 bool wxWebRequestCURL::StartRequest()
 {
     m_bytesSent = 0;

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -60,6 +60,7 @@ public:
         wxLOAD_FUNC(WinHttpQueryAuthSchemes)
         wxLOAD_FUNC(WinHttpSetCredentials)
         wxLOAD_FUNC(WinHttpOpen)
+        wxLOAD_FUNC(WinHttpSetTimeouts)
 
         if ( !result )
             m_winhttp.Unload();
@@ -99,6 +100,8 @@ public:
     static WinHttpSetCredentials_t WinHttpSetCredentials;
     typedef HINTERNET(WINAPI* WinHttpOpen_t)(LPCWSTR, DWORD, LPCWSTR, LPCWSTR, DWORD);
     static WinHttpOpen_t WinHttpOpen;
+    typedef BOOL(WINAPI* WinHttpSetTimeouts_t)(HINTERNET, int, int, int, int);
+    static WinHttpSetTimeouts_t WinHttpSetTimeouts;
 
 private:
     static wxDynamicLibrary m_winhttp;
@@ -121,6 +124,7 @@ wxWinHTTP::WinHttpReadData_t wxWinHTTP::WinHttpReadData;
 wxWinHTTP::WinHttpQueryAuthSchemes_t wxWinHTTP::WinHttpQueryAuthSchemes;
 wxWinHTTP::WinHttpSetCredentials_t wxWinHTTP::WinHttpSetCredentials;
 wxWinHTTP::WinHttpOpen_t wxWinHTTP::WinHttpOpen;
+wxWinHTTP::WinHttpSetTimeouts_t wxWinHTTP::WinHttpSetTimeouts;
 
 
 // Define constants potentially missing in old SDKs
@@ -536,6 +540,9 @@ wxWebRequest::Result wxWebRequestWinHTTP::Execute()
     if ( !result )
         return result;
 
+    if (m_isTimeoutsSet)
+        DoSetTimeouts();
+
     // This loop executes until we exhaust all authentication possibilities: we
     // may need to authenticate with the proxy first and then with the server
     // and we even may need to authenticate with the proxy again after failing
@@ -727,6 +734,9 @@ void wxWebRequestWinHTTP::Start()
     if ( !CheckResult(DoPrepareRequest()) )
         return;
 
+    if (m_isTimeoutsSet)
+        DoSetTimeouts();
+
     // Register callback
     if ( wxWinHTTP::WinHttpSetStatusCallback
            (
@@ -746,6 +756,28 @@ void wxWebRequestWinHTTP::Start()
     SetState(wxWebRequest::State_Active);
 
     CheckResult(SendRequest());
+}
+
+void wxWebRequestWinHTTP::SetTimeouts(long connectionTimeoutMs,
+                                      long dataTimeoutMs)
+{
+    m_isTimeoutsSet = true;
+    m_connectionTimeoutMs = connectionTimeoutMs;
+    m_dataTimeoutMs = dataTimeoutMs;
+}
+
+void wxWebRequestWinHTTP::DoSetTimeouts()
+{
+    if (!wxWinHTTP::WinHttpSetTimeouts(
+        m_request,
+        m_connectionTimeoutMs,
+        m_connectionTimeoutMs,
+        m_dataTimeoutMs,
+        m_dataTimeoutMs))
+    {
+        wxLogTrace(wxTRACE_WEBREQUEST,
+                   "Error while setting timeout. Error code: %d", ::GetLastError());
+    }
 }
 
 wxWebRequest::Result wxWebRequestWinHTTP::SendRequest()

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -330,7 +330,6 @@ void wxWebRequestURLSession::Start()
 void wxWebRequestURLSession::SetTimeouts(long WXUNUSED(connectionTimeoutMs),
                                          long WXUNUSED(dataTimeoutMs))
 {
-    wxFAIL_MSG(wxT("Unimplemented"));
 }
 
 void wxWebRequestURLSession::DoCancel()

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -327,6 +327,12 @@ void wxWebRequestURLSession::Start()
     [m_task resume];
 }
 
+void wxWebRequestURLSession::SetTimeouts(long WXUNUSED(connectionTimeoutMs),
+                                         long WXUNUSED(dataTimeoutMs))
+{
+    wxFAIL_MSG(wxT("Unimplemented"));
+}
+
 void wxWebRequestURLSession::DoCancel()
 {
     [m_task cancel];


### PR DESCRIPTION
Summary
----------------------------------------------------------------
As discussed in [issue 25307](https://github.com/wxWidgets/wxWidgets/issues/25307). This pr implement configurable timeout for wxWebRequest.

Implementation
--------------------
Adding two functions to wxWebRequestBase, one to set the timeouts concerning the connection phase and another one to set the timeouts for the whole request.
There are the prototypes for the functions:
```
void SetConnectionTimeouts(long resolveTimeoutMs, long connectTimeoutMs);
void SetTimeouts(long resolveTimeoutMs, long connectTimeoutMs, long sendTimeoutMs, long receiveTimeoutMs);
```
As those two functions have been added to wxWebRequestBase we can use it both on wxWebRequest and wxWebRequestSync.

Those functions have been also added to wxWebRequestImpl as pure virtual function.

Those two functions are implemented for wxWebRequestCURL (Linux) and wxWebRequestWinHTTP (Windows).
As the functions are defined as pure virtual in wxWebRequestImpl we must declare it for each class inheriting from it so, for wxWebRequestURLSession (mac) the functions are defined but only call a fail message to signal that the feature is not implemented.

Documentation
-------------------
The functions have been added to the documentation for the two classes concerned and mentioned the OS specificity to take into account when calling one of those.