### PR TITLE
[#25678][MSW] Use wxNotebook's background color for tab background if specified

### DIFF
--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1288,7 +1288,10 @@ void wxNotebook::MSWNotebookPaint(wxDC& dc)
         rectTabArea.SetRight(sizeWindow.x);
     else
         rectTabArea.SetBottom(sizeWindow.y);
-    dc.SetBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    if (m_backgroundColour.IsOk())
+        dc.SetBrush(m_backgroundColour);
+    else
+        dc.SetBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
     dc.SetPen(*wxTRANSPARENT_PEN);
     dc.DrawRectangle(rectTabArea);
 


### PR DESCRIPTION
This commit updates the logic that draws wxNotebook on MSW in Dark mode. Previously, the row with tabs was cleared with the background color set as `wxSYS_COLOUR_BTNFACE` which may looked okay by default, but didn't allow for customizing this as with the Light theme. In Light theme, the color of backgrounds of both "page area" and "tab row" can be overwritten with calling `wxNotebook::SetBackgroundColor()` which didn't work in Dark mode.

With this commit, if the background color is specified, it will be used for that tab row area as well, which should match behavior with Light mode.