### PR TITLE
Fix MSVS debug visualizer of wxStrings

### DIFF
--- a/misc/msvc/wxWidgets.natvis
+++ b/misc/msvc/wxWidgets.natvis
@@ -12,11 +12,12 @@ More information can be found at https://learn.microsoft.com/en-us/visualstudio/
     <!-- We want to avoid showing 'L' before the string, this is useless and
          makes the display less readable. But we still do want to put quotes
          around the string to show that it is, in fact, a string. So we use
-         "sb" qualifier to get rid of L"..." around the string and then add
-		 the quotes back. This also has a (nice) side effect of not doubling
-		 the backslashes inside the string. -->
+         "sub" or "s8b" qualifier to get rid of L"..." around the string and
+         then add the quotes back. This also has a (nice) side effect of not
+         doubling the backslashes inside the string. -->
     <Type Name="wxString">
-        <DisplayString>"{m_impl,sb}"</DisplayString>
+        <DisplayString Condition="sizeof(m_impl[0])==2">"{m_impl,sub}"</DisplayString> <!-- wxUSE_UNICODE_WCHAR -->
+        <DisplayString Condition="sizeof(m_impl[0])==1">"{m_impl,s8b}"</DisplayString> <!-- wxUSE_UNICODE_UTF8 -->
         <StringView>m_impl</StringView>
     </Type>
 


### PR DESCRIPTION
Fix the visualizer to display full Unicode string, instead of just its first character.

I'm not surprised the visualizer misbehaved - it used the `sb` format specifier, [which is for `const char*` string](https://learn.microsoft.com/en-us/visualstudio/debugger/format-specifiers-in-cpp?view=vs-2022). I'm surprised it (I think) worked until relatively recent MSVS versions.

Since wx uses Unicode strings internally for some time now, it can be simply changed into `sub`.

Harmless for 3.2 branch too.