### PR TITLE
Silence MSVC warning in WebP

### DIFF
--- a/src/common/imagwebp.cpp
+++ b/src/common/imagwebp.cpp
@@ -230,8 +230,8 @@ bool wxWEBPHandler::LoadAnimation(std::vector<wxWebPAnimationFrame>& frames, wxI
 
     while (WebPAnimDecoderHasMoreFrames(decoder.get()))
     {
-        uint8_t* buf;
-        int timestamp;
+        uint8_t* buf = nullptr;
+        int timestamp = 0;
         WebPAnimDecoderGetNext(decoder.get(), &buf, &timestamp);
         if (buf == nullptr)
         {


### PR DESCRIPTION
Silence MSVC warning about using an uninitialized variable.