### PR TITLE
allow pformatetc->lindex = 0 for CFSTR_FILECONTENTS

### DIFF
--- a/src/msw/ole/dataobj.cpp
+++ b/src/msw/ole/dataobj.cpp
@@ -612,7 +612,7 @@ STDMETHODIMP wxIDataObject::GetData(FORMATETC *pformatetcIn, STGMEDIUM *pmedium)
     if ((pformatetcIn->tymed & (TYMED_HGLOBAL | TYMED_ISTREAM)) == TYMED_ISTREAM) {
         IStream* stream = nullptr;
         hr = CreateStreamOnHGlobal(pmedium->hGlobal, TRUE, &stream);
-        if (FAILED(hr)) {
+        if ( FAILED(hr) ) {
             GlobalFree(pmedium->hGlobal);
             return hr;
         }

--- a/src/msw/ole/dataobj.cpp
+++ b/src/msw/ole/dataobj.cpp
@@ -610,7 +610,7 @@ STDMETHODIMP wxIDataObject::GetData(FORMATETC *pformatetcIn, STGMEDIUM *pmedium)
     }
 
     if ((pformatetcIn->tymed & (TYMED_HGLOBAL | TYMED_ISTREAM)) == TYMED_ISTREAM) {
-        IStream* stream = NULL;
+        IStream* stream = nullptr;
         hr = CreateStreamOnHGlobal(pmedium->hGlobal, TRUE, &stream);
         if (FAILED(hr)) {
             GlobalFree(pmedium->hGlobal);

--- a/src/msw/ole/dataobj.cpp
+++ b/src/msw/ole/dataobj.cpp
@@ -804,8 +804,12 @@ STDMETHODIMP wxIDataObject::QueryGetData(FORMATETC *pformatetc)
         return E_INVALIDARG;
     }
 
-    // the only one allowed by current COM implementation
-    if ( pformatetc->lindex != -1 ) {
+    // the only ones allowed by current COM implementation
+    static UINT cfFileContents = ::RegisterClipboardFormat(CFSTR_FILECONTENTS);
+    if (
+        (pformatetc->cfFormat != cfFileContents && pformatetc->lindex != -1) ||
+        (pformatetc->cfFormat == cfFileContents && pformatetc->lindex != 0)
+    ) {
         wxLogTrace(wxTRACE_OleCalls,
                    wxT("wxIDataObject::QueryGetData: bad lindex %ld"),
                    pformatetc->lindex);


### PR DESCRIPTION
This pull requests allows pformatetc->lindex = 0, which is required for CFSTR_FILECONTENTS data objects. This change is required for dragging and dropping virtual files, e.g. dropping to Windows explorer.

Widows Explorer queries for CFSTR_FILEDESCRIPTORW and CFSTR_FILECONTENTS data. This is currently not supported by wxWidgets itself, but can be easily implemented in an application.

Virtual file drag & drop is required for files that are not available when the drag & drop operation is started.

If Windows Explorer request a CFSTR_FILECONTENTS data object, then the lindex is no longer -1. The lindex here is an index of the requested file contents. Since GetDataHere does not support indexed contents, I have limited lindex to the first item which means lindex = 0.