### PR TITLE
Remove notifier from the old model in generic wxDataViewCtrl

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5889,6 +5889,14 @@ bool wxDataViewCtrl::Enable(bool enable)
 
 bool wxDataViewCtrl::AssociateModel( wxDataViewModel *model )
 {
+    if (wxDataViewModel* const oldModel = GetModel())
+    {
+        // Remove the notifier from the model before calling the base class
+        // version which may (or not) delete the model.
+        oldModel->RemoveNotifier( m_notifier );
+        m_notifier = nullptr;
+    }
+
     if (!wxDataViewCtrlBase::AssociateModel( model ))
         return false;
 
@@ -5896,14 +5904,6 @@ bool wxDataViewCtrl::AssociateModel( wxDataViewModel *model )
     {
         m_notifier = new wxGenericDataViewModelNotifier( m_clientArea );
         model->AddNotifier( m_notifier );
-    }
-    else
-    {
-        // Our previous notifier has either been already deleted when the
-        // previous model was DecRef()'d in the base class AssociateModel() or
-        // is not associated with us any more because if the model is still
-        // alive, it's not used by this control.
-        m_notifier = nullptr;
     }
 
     m_clientArea->DestroyTree();


### PR DESCRIPTION
Failure to do so could result in a crash later if the old model was not destroyed but continued to exist independently of the control.

This also makes the code more natural and removes the need for the comment explaining why we reset the notifier if we don't have any model.

Closes #25686.