### PR TITLE
Add wxMSW-specific wxBitmapBundle accessors to wxMenuItem

### DIFF
--- a/include/wx/msw/menuitem.h
+++ b/include/wx/msw/menuitem.h
@@ -83,6 +83,11 @@ public:
         DoSetBitmap(bmp, bChecked);
     }
 
+    wxBitmapBundle GetBitmapBundle(bool bChecked) const
+    {
+        return bChecked ? m_bitmap : m_bmpUnchecked;
+    }
+
     wxBitmap GetBitmap(bool bChecked) const;
 
 #if wxUSE_OWNER_DRAWN
@@ -91,6 +96,8 @@ public:
         m_bmpDisabled = bmpDisabled;
         SetOwnerDrawn(true);
     }
+
+    wxBitmapBundle GetDisabledBitmapBundle() const { return m_bmpDisabled; }
 
     wxBitmap GetDisabledBitmap() const;
 

--- a/interface/wx/menuitem.h
+++ b/interface/wx/menuitem.h
@@ -179,6 +179,9 @@ public:
     /**
         Returns the checked or unchecked bitmap.
 
+        Prefer using GetBitmapBundle() overload taking @a checked parameter in
+        the new code.
+
         This overload only exists in wxMSW, avoid using it in portable code.
     */
     wxBitmap GetBitmap(bool checked) const;
@@ -196,11 +199,32 @@ public:
     wxBitmapBundle GetBitmapBundle() const;
 
     /**
+        Returns the bitmap bundle containing the checked or unchecked bitmap
+        for this item.
+
+        @onlyfor{wxmsw}
+
+        @since 3.3.2
+     */
+    wxBitmapBundle GetBitmapBundle(bool checked) const;
+
+    /**
         Returns the bitmap used for disabled items.
+
+        @see GetDisabledBitmapBundle()
 
         @onlyfor{wxmsw}
     */
     virtual wxBitmap GetDisabledBitmap() const;
+
+    /**
+        Returns the bitmap bundle used for disabled items.
+
+        @onlyfor{wxmsw}
+
+        @since 3.3.2
+    */
+    wxBitmap GetDisabledBitmapBundle() const;
 
     /**
         Returns the font associated with the menu item.

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -663,7 +663,7 @@ void wxMenuItem::SetItemLabel(const wxString& txt)
 
 wxBitmap wxMenuItem::GetBitmap(bool bChecked) const
 {
-    wxBitmap bmp = GetBitmapFromBundle(bChecked ? m_bitmap : m_bmpUnchecked);
+    wxBitmap bmp = GetBitmapFromBundle(GetBitmapBundle(bChecked));
 #if wxUSE_IMAGE
     if ( bmp.IsOk() )
     {


### PR DESCRIPTION
Provide GetBitmapBundle(bool checked) and GetDisabledBitmapBundle() too in wxMSW, for consistency with the existing MSW-only member functions returning bitmaps.

Closes #25685.