### PR TITLE
Make restoring window size with XFCE/MATE work again

### DIFF
--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -1610,11 +1610,17 @@ void wxTopLevelWindowGTK::GTKUpdateDecorSize(const DecorSize& decorSize)
             if (size.x >= m_minWidth - (decorSize.left + decorSize.right) &&
                 size.y >= m_minHeight - (decorSize.top + decorSize.bottom))
             {
+                wxLogTrace(TRACE_TLWSIZE, "Setting adjusted size for %s to %d*%d",
+                           wxDumpWindow(this), size.x, size.y);
+
                 gtk_window_resize(GTK_WINDOW(m_widget), size.x, size.y);
                 if (!isResizeable)
                     gtk_widget_set_size_request(GTK_WIDGET(m_widget), size.x, size.y);
                 resized = true;
             }
+
+            // Don't do this again.
+            m_deferShowAllowed = false;
         }
         if (!resized)
         {


### PR DESCRIPTION
Workaround for Mutter from 9537141500 (Fix handling window total size under GNOME with X11, 2025-04-28) broke the well behaving WMs used by other desktop environments, such as XFCE, as it resulted in the window size being mistakenly adjusted after the decorations size was changed due to restoring a previous maximized window.

Prevent this from happening by not adjusting the size after the first correct decorations size change.

See #25348, #25349.

Closes #25708.