### PR TITLE
CMake: Fix names of built-in webp libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
     get_property(HAVE_MULTI_CONFIG_GENERATOR GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     # Set default configuration types for multi-config generators
     if(HAVE_MULTI_CONFIG_GENERATOR)
-        set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+        string(CONCAT config_hint "Semicolon separated list of supported "
+            "configuration types, only supports Debug, Release, MinSizeRel, "
+            "and RelWithDebInfo, anything else will be ignored.")
+        set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING ${config_hint})
     endif()
 endif()
 
@@ -21,7 +24,9 @@ endif()
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(default_build_type "Debug")
     message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING
+        "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel"
+    )
     # Set the possible values of build type for cmake-gui
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 endif()

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -598,8 +598,8 @@ macro(wx_add_dependencies name)
     endif()
 endmacro()
 
-# Set common properties for a builtin third party library
-function(wx_set_builtin_target_properties target_name)
+# Set output name for a builtin third party library
+macro(wx_set_builtin_target_ouput_name target target_name)
     set(lib_unicode)
     if(target_name STREQUAL "wxregex")
         set(lib_unicode "u")
@@ -618,10 +618,23 @@ function(wx_set_builtin_target_properties target_name)
         set(lib_version "-${wxMAJOR_VERSION}.${wxMINOR_VERSION}")
     endif()
 
-    set_target_properties(${target_name} PROPERTIES
+    set(lib_prefix "lib")
+    if(MSVC OR (WIN32 AND wxBUILD_SHARED))
+        set(lib_prefix)
+    elseif (CYGWIN AND wxBUILD_SHARED)
+        set(lib_prefix "cyg")
+    endif()
+
+    set_target_properties(${target} PROPERTIES
         OUTPUT_NAME       "${target_name}${lib_unicode}${lib_rls}${lib_flavour}${lib_version}"
         OUTPUT_NAME_DEBUG "${target_name}${lib_unicode}${lib_dbg}${lib_flavour}${lib_version}"
+        PREFIX            "${lib_prefix}"
     )
+endmacro()
+
+# Set common properties for a builtin third party library
+function(wx_set_builtin_target_properties target_name)
+    wx_set_builtin_target_ouput_name(${target_name} "${target_name}")
 
     if(MSVC)
         # we're not interested in deprecation warnings about the use of

--- a/build/cmake/lib/webp.cmake
+++ b/build/cmake/lib/webp.cmake
@@ -43,10 +43,9 @@ if(wxUSE_LIBWEBP STREQUAL "builtin")
 
     get_property(webpTargets DIRECTORY "${WEBP_ROOT}" PROPERTY BUILDSYSTEM_TARGETS)
     foreach(target_name IN LISTS webpTargets)
+        wx_set_builtin_target_ouput_name(${target_name} "wx${target_name}")
         set_target_properties(${target_name} PROPERTIES
             FOLDER "Third Party Libraries/WebP"
-            PREFIX  ""
-            OUTPUT_NAME "wx${target_name}"
             PUBLIC_HEADER ""
         )
     endforeach()

--- a/build/cmake/lib/webp.cmake
+++ b/build/cmake/lib/webp.cmake
@@ -28,7 +28,18 @@ if(wxUSE_LIBWEBP STREQUAL "builtin")
     set(WEBP_BUILD_WEBP_JS    OFF)
     set(WEBP_BUILD_FUZZTEST   OFF)
 
+    # webp sets CMAKE_BUILD_TYPE if it is not defined.
+    # Multi-config generators do not need this, and might even
+    # cause confusion in cmake-gui, so unset it later.
+    if(NOT DEFINED CMAKE_BUILD_TYPE)
+        set(RESET_CMAKE_BUILD_TYPE ON)
+    endif()
+
     add_subdirectory("${WEBP_ROOT}" "${WEBP_BUILD_ROOT}" EXCLUDE_FROM_ALL)
+
+    if(RESET_CMAKE_BUILD_TYPE)
+        unset(CMAKE_BUILD_TYPE CACHE)
+    endif()
 
     mark_as_advanced(WEBP_CHECK_SIMD)
     mark_as_advanced(WEBP_BITTRACE)


### PR DESCRIPTION
Fixes https://github.com/wxWidgets/wxWidgets/issues/25709

And improve dealing with `CMAKE_BUILD_TYPE` and `CMAKE_CONFIGURATION_TYPES` variables.