### PR TITLE
Update wxAuiToolBar after wxSysColourChangedEvent

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2461,6 +2461,7 @@ void wxAuiToolBar::OnSysColourChanged(wxSysColourChangedEvent& event)
     event.Skip();
 
     m_art->UpdateColoursFromSystem();
+    UpdateBackgroundBitmap(GetClientSize());
     Refresh();
 }
 


### PR DESCRIPTION
The background bitmap of the toolbar is cached and should be recreated after the colour change. Otherwise it will not be updated until a wxSizeEvent is generated.