### PR TITLE
Make wxTopLevelWindow label same as title in all ports

### DIFF
--- a/include/wx/gtk/toplevel.h
+++ b/include/wx/gtk/toplevel.h
@@ -71,9 +71,6 @@ public:
     virtual void SetTitle( const wxString &title ) override;
     virtual wxString GetTitle() const override { return m_title; }
 
-    virtual void SetLabel(const wxString& label) override { SetTitle( label ); }
-    virtual wxString GetLabel() const override            { return GetTitle(); }
-
     virtual wxVisualAttributes GetDefaultAttributes() const override;
 
     virtual bool SetTransparent(wxByte alpha) override;

--- a/include/wx/osx/toplevel.h
+++ b/include/wx/osx/toplevel.h
@@ -82,9 +82,6 @@ public:
     virtual bool EnableMaximizeButton(bool enable = true) override;
     virtual bool EnableMinimizeButton(bool enable = true) override;
 
-    virtual void SetLabel(const wxString& label) override { SetTitle( label ); }
-    virtual wxString GetLabel() const            override { return GetTitle(); }
-
     virtual void OSXSetModified(bool modified) override;
     virtual bool OSXIsModified() const override;
 

--- a/include/wx/toplevel.h
+++ b/include/wx/toplevel.h
@@ -191,6 +191,10 @@ public:
     virtual void SetTitle(const wxString& title) = 0;
     virtual wxString GetTitle() const = 0;
 
+    // label is the same as title for top-level windows
+    virtual void SetLabel(const wxString& label) override { SetTitle( label ); }
+    virtual wxString GetLabel() const override            { return GetTitle(); }
+
     // enable/disable close button [x]
     virtual bool EnableCloseButton(bool WXUNUSED(enable) = true) { return false; }
     virtual bool EnableMaximizeButton(bool WXUNUSED(enable) = true) { return false; }

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -228,6 +228,17 @@ public:
     const wxIconBundle& GetIcons() const;
 
     /**
+        Get the window title.
+
+        This base class function is overridden in this class to behave as
+        GetTitle() and is useful when having only a `wxWindow*` pointer.
+
+        Please call GetTitle() directly instead of this function for clarity if
+        possible.
+     */
+    virtual wxString GetLabel() const;
+
+    /**
         Gets a string containing the window title.
 
         @see SetTitle()
@@ -581,6 +592,20 @@ public:
     void SetSizeHints(const wxSize& minSize,
                       const wxSize& maxSize = wxDefaultSize,
                       const wxSize& incSize = wxDefaultSize);
+
+    /**
+        Sets the window title.
+
+        This base class function is overridden in this class to behave as
+        SetTitle() and is useful when having only a `wxWindow*` pointer.
+
+        Please call SetTitle() directly instead of this function for clarity if
+        possible.
+
+        @param title
+            The window title.
+     */
+    virtual void SetLabel(const wxString& title);
 
     /**
         Sets the window title.

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -1016,12 +1016,16 @@ bool wxTopLevelWindowMSW::ShowFullScreen(bool show, long style)
 
 void wxTopLevelWindowMSW::SetTitle( const wxString& title)
 {
-    SetLabel(title);
+    // The base class version works for TLWs too in wxMSW but take care to
+    // select it explicitly as our overridden SetLabel() just redirects to
+    // SetTitle() itself.
+    wxWindow::SetLabel(title);
 }
 
 wxString wxTopLevelWindowMSW::GetTitle() const
 {
-    return GetLabel();
+    // See comment in SetTitle() above.
+    return wxWindow::GetLabel();
 }
 
 bool wxTopLevelWindowMSW::DoSelectAndSetIcon(const wxIconBundle& icons,


### PR DESCRIPTION
This was previously done for wxGTK in a03b38ef68 (make Set/GetLabel() set and return title in wxTLW, fixes #12371: Dialog::GetLabel() Inconsistent behaviour across operating systems, 2010-08-21) and wxOSX in 033f86db5f (adding SetLabel -> SetTitle redirects, solves missing title updates using wxDocument/wxView, 2012-08-11) but wasn't done for the other ports, including wxMSW and updating the page title in wxAuiMDIChildFrame in docview framework didn't work because of it.

While using SetLabel() for setting the title is suspicious and it might be a good idea to change docview code too, for now make it work by ensuring that this works consistently in all ports.

See #12371.

Closes #25712.