### PR TITLE
Make `wxDC`-derived objects moveable

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -164,6 +164,8 @@ public:
 // wxDCImpl
 //-----------------------------------------------------------------------------
 
+// This class is only used by wxDC and wxWidgets itself, do not use it in the
+// application code.
 class WXDLLIMPEXP_CORE wxDCImpl: public wxObject
 {
 public:

--- a/include/wx/dcgraph.h
+++ b/include/wx/dcgraph.h
@@ -35,6 +35,13 @@ public:
     wxGCDC(wxGraphicsContext* context);
 
     wxGCDC();
+
+    wxGCDC(const wxGCDC&) = delete;
+    wxGCDC& operator=(const wxGCDC&) = delete;
+
+    wxGCDC(wxGCDC&&) = default;
+    wxGCDC& operator=(wxGCDC&&) = default;
+
     virtual ~wxGCDC();
 
 #ifdef __WXMSW__
@@ -46,7 +53,6 @@ public:
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxGCDC);
-    wxDECLARE_NO_COPY_CLASS(wxGCDC);
 };
 
 

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -789,12 +789,6 @@ public:
     of the two wxCoord ones or wxPoint and wxSize instead of the four
     wxCoord parameters.
 
-    Beginning with wxWidgets 2.9.0 the entire wxDC code has been
-    reorganized. All platform dependent code (actually all drawing code)
-    has been moved into backend classes which derive from a common
-    wxDCImpl class. The user-visible classes such as wxClientDC and
-    wxPaintDC merely forward all calls to the backend implementation.
-
     In wxWidgets 3.3.0 the new wxReadOnlyDC class was extracted from wxDC: it
     contains all the functions that don't actually draw on the device context,
     but just return information about it. This class should be rarely used

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -797,6 +797,9 @@ public:
     and such functions can now also be called with wxInfoDC objects as
     arguments.
 
+    Although copying wxDC objects is not allowed because it wouldn't make
+    sense, objects of wxDC-derived classes can be moved, in C++ sense, allowing
+    to return them from functions since wxWidgets 3.3.2.
 
     @section dc_units Device and logical units
 

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -442,7 +442,7 @@ public:
     virtual wxString GetUserLocalDataDir() const;
 
     /**
-        Return OS specific directory where project shared liraries are.
+        Return OS specific directory where project shared libraries are.
 
         The function does the same thing as GetPluginsDir() under non-Mac platforms
         but differs from it under Mac, where plugins (shared libraries loaded by the

--- a/tests/graphics/boundingbox.cpp
+++ b/tests/graphics/boundingbox.cpp
@@ -34,26 +34,25 @@ public:
     {
         m_bmp.Create(100, 100);
         m_dc.SelectObject(m_bmp);
-        m_gcdc = new wxGCDC(m_dc);
+        m_gcdc = wxGCDC(m_dc);
     }
 
     ~GCDCBoundingBoxTestCase()
     {
-        delete m_gcdc;
         m_dc.SelectObject(wxNullBitmap);
         m_bmp = wxNullBitmap;
     }
 
     virtual void setUp() override
     {
-        m_gcdc->ResetBoundingBox();
+        m_gcdc.ResetBoundingBox();
     }
 
 private:
     wxBitmap m_bmp;
     wxMemoryDC m_dc;
 
-    wxGCDC *m_gcdc;
+    wxGCDC m_gcdc;
 
     void AssertBox(int minX, int minY, int width, int height, int margin = 0)
     {
@@ -68,19 +67,19 @@ private:
                 WX_ASSERT_MESSAGE(("%d != %d", actual, expected), \
                                   abs(actual - expected) <= delta)
 
-            WX_ASSERT_CLOSE(minX, m_gcdc->MinX(), margin);
-            WX_ASSERT_CLOSE(minY, m_gcdc->MinY(), margin);
-            WX_ASSERT_CLOSE(maxX, m_gcdc->MaxX(), margin);
-            WX_ASSERT_CLOSE(maxY, m_gcdc->MaxY(), margin);
+            WX_ASSERT_CLOSE(minX, m_gcdc.MinX(), margin);
+            WX_ASSERT_CLOSE(minY, m_gcdc.MinY(), margin);
+            WX_ASSERT_CLOSE(maxX, m_gcdc.MaxX(), margin);
+            WX_ASSERT_CLOSE(maxY, m_gcdc.MaxY(), margin);
 
             #undef WX_ASSERT_CLOSE
         }
         else
         {
-            CPPUNIT_ASSERT_EQUAL(minX, m_gcdc->MinX());
-            CPPUNIT_ASSERT_EQUAL(minY, m_gcdc->MinY());
-            CPPUNIT_ASSERT_EQUAL(maxX, m_gcdc->MaxX());
-            CPPUNIT_ASSERT_EQUAL(maxY, m_gcdc->MaxY());
+            CPPUNIT_ASSERT_EQUAL(minX, m_gcdc.MinX());
+            CPPUNIT_ASSERT_EQUAL(minY, m_gcdc.MinY());
+            CPPUNIT_ASSERT_EQUAL(maxX, m_gcdc.MaxX());
+            CPPUNIT_ASSERT_EQUAL(maxY, m_gcdc.MaxY());
         }
     }
 
@@ -155,7 +154,7 @@ void GCDCBoundingBoxTestCase::DrawBitmap()
     wxBitmap bitmap;
     bitmap.Create(12, 12);
 
-    m_gcdc->DrawBitmap(bitmap, 5, 5);
+    m_gcdc.DrawBitmap(bitmap, 5, 5);
     AssertBox(5, 5, 12, 12);
 }
 
@@ -166,40 +165,40 @@ void GCDCBoundingBoxTestCase::DrawIcon()
     wxIcon icon;
     icon.CopyFromBitmap(bitmap);
 
-    m_gcdc->DrawIcon(icon, 42, 42);
+    m_gcdc.DrawIcon(icon, 42, 42);
     AssertBox(42, 42, 16, 16);
 }
 
 void GCDCBoundingBoxTestCase::DrawLine()
 {
-    m_gcdc->DrawLine(10, 10, 20, 15);
+    m_gcdc.DrawLine(10, 10, 20, 15);
     AssertBox(10, 10, 10, 5);
 }
 
 void GCDCBoundingBoxTestCase::CrossHair()
 {
     int w, h;
-    m_gcdc->GetSize(&w, &h);
+    m_gcdc.GetSize(&w, &h);
 
-    m_gcdc->CrossHair(33, 33);
+    m_gcdc.CrossHair(33, 33);
     AssertBox(0, 0, w, h);
 }
 
 void GCDCBoundingBoxTestCase::DrawArc()
 {
-    m_gcdc->DrawArc(25, 30, 15, 40, 25, 40);  // quarter circle
+    m_gcdc.DrawArc(25, 30, 15, 40, 25, 40);  // quarter circle
     AssertBox(15, 30, 10, 10, 3);
 }
 
 void GCDCBoundingBoxTestCase::DrawEllipticArc()
 {
-    m_gcdc->DrawEllipticArc(40, 50, 30, 20, 0, 180);  // half circle
+    m_gcdc.DrawEllipticArc(40, 50, 30, 20, 0, 180);  // half circle
     AssertBox(40, 50, 30, 10, 3);
 }
 
 void GCDCBoundingBoxTestCase::DrawPoint()
 {
-    m_gcdc->DrawPoint(20, 20);
+    m_gcdc.DrawPoint(20, 20);
     AssertBox(20, 20, 0, 0);
 }
 
@@ -211,7 +210,7 @@ void GCDCBoundingBoxTestCase::DrawLines()
     points[2] = wxPoint(30, 20);
     points[3] = wxPoint(20, 30);
 
-    m_gcdc->DrawLines(4, points, 7, 8);
+    m_gcdc.DrawLines(4, points, 7, 8);
     AssertBox(17, 18, 20, 20);
 }
 
@@ -223,7 +222,7 @@ void GCDCBoundingBoxTestCase::DrawSpline()
     points[1] = wxPoint(20, 20);
     points[2] = wxPoint(40, 50);
 
-    m_gcdc->DrawSpline(3, points);
+    m_gcdc.DrawSpline(3, points);
     AssertBox(10, 20, 30, 30, 5);
 }
 #endif  // wxUSE_SPLINES
@@ -235,7 +234,7 @@ void GCDCBoundingBoxTestCase::DrawPolygon()
     points[1] = wxPoint(20, 10);
     points[2] = wxPoint(30, 30);
 
-    m_gcdc->DrawPolygon(3, points, -5, -7);
+    m_gcdc.DrawPolygon(3, points, -5, -7);
     AssertBox(5, 3, 20, 20);
 }
 
@@ -252,25 +251,25 @@ void GCDCBoundingBoxTestCase::DrawPolyPolygon()
     points[4] = wxPoint(30, 40);
     points[5] = wxPoint(40, 60);
 
-    m_gcdc->DrawPolyPolygon(2, lenghts, points, 12, 5);
+    m_gcdc.DrawPolyPolygon(2, lenghts, points, 12, 5);
     AssertBox(22, 15, 30, 50, 4);
 }
 
 void GCDCBoundingBoxTestCase::DrawRectangle()
 {
-    m_gcdc->DrawRectangle(2, 2, 12, 12);
+    m_gcdc.DrawRectangle(2, 2, 12, 12);
     AssertBox(2, 2, 12, 12);
 }
 
 void GCDCBoundingBoxTestCase::DrawRoundedRectangle()
 {
-    m_gcdc->DrawRoundedRectangle(27, 27, 12, 12, 2);
+    m_gcdc.DrawRoundedRectangle(27, 27, 12, 12, 2);
     AssertBox(27, 27, 12, 12);
 }
 
 void GCDCBoundingBoxTestCase::DrawEllipse()
 {
-    m_gcdc->DrawEllipse(54, 45, 23, 12);
+    m_gcdc.DrawEllipse(54, 45, 23, 12);
     AssertBox(54, 45, 23, 12);
 }
 
@@ -280,7 +279,7 @@ void GCDCBoundingBoxTestCase::Blit()
     bitmap.Create(20, 20);
     wxMemoryDC dc(bitmap);
 
-    m_gcdc->Blit(20, 10, 12, 7, &dc, 0, 0);
+    m_gcdc.Blit(20, 10, 12, 7, &dc, 0, 0);
     AssertBox(20, 10, 12, 7);
 
     dc.SelectObject(wxNullBitmap);
@@ -292,7 +291,7 @@ void GCDCBoundingBoxTestCase::StretchBlit()
     bitmap.Create(20, 20);
     wxMemoryDC dc(bitmap);
 
-    m_gcdc->StretchBlit(30, 50, 5, 5, &dc, 0, 0, 12, 4);
+    m_gcdc.StretchBlit(30, 50, 5, 5, &dc, 0, 0, 12, 4);
     AssertBox(30, 50, 5, 5);
 
     dc.SelectObject(wxNullBitmap);
@@ -302,9 +301,9 @@ void GCDCBoundingBoxTestCase::DrawRotatedText()
 {
     wxString text("vertical");
     wxCoord w, h;
-    m_gcdc->GetTextExtent(text, &w, &h);
+    m_gcdc.GetTextExtent(text, &w, &h);
 
-    m_gcdc->DrawRotatedText(text, 43, 22, -90);
+    m_gcdc.DrawRotatedText(text, 43, 22, -90);
     AssertBox(43 - h, 22, h, w, 3);
 }
 
@@ -312,52 +311,52 @@ void GCDCBoundingBoxTestCase::DrawText()
 {
     wxString text("H");
     wxCoord w, h;
-    m_gcdc->GetTextExtent(text, &w, &h);
+    m_gcdc.GetTextExtent(text, &w, &h);
 
-    m_gcdc->DrawText(text, 3, 3);
+    m_gcdc.DrawText(text, 3, 3);
     AssertBox(3, 3, w, h, 3);
 }
 
 void GCDCBoundingBoxTestCase::GradientFillLinear()
 {
     wxRect rect(16, 16, 30, 40);
-    m_gcdc->GradientFillLinear(rect, *wxWHITE, *wxBLACK, wxNORTH);
+    m_gcdc.GradientFillLinear(rect, *wxWHITE, *wxBLACK, wxNORTH);
     AssertBox(16, 16, 30, 40);
 }
 
 void GCDCBoundingBoxTestCase::GradientFillConcentric()
 {
     wxRect rect(6, 6, 30, 40);
-    m_gcdc->GradientFillConcentric(rect, *wxWHITE, *wxBLACK, wxPoint(10, 10));
+    m_gcdc.GradientFillConcentric(rect, *wxWHITE, *wxBLACK, wxPoint(10, 10));
     AssertBox(6, 6, 30, 40);
 }
 
 void GCDCBoundingBoxTestCase::DrawCheckMark()
 {
-    m_gcdc->DrawCheckMark(32, 24, 16, 16);
+    m_gcdc.DrawCheckMark(32, 24, 16, 16);
     AssertBox(32, 24, 16, 16);
 }
 
 void GCDCBoundingBoxTestCase::DrawRectangleAndReset()
 {
-    m_gcdc->DrawRectangle(2, 2, 12, 12);
-    m_gcdc->ResetBoundingBox();
+    m_gcdc.DrawRectangle(2, 2, 12, 12);
+    m_gcdc.ResetBoundingBox();
     AssertBox(0, 0, 0, 0);
 }
 
 void GCDCBoundingBoxTestCase::DrawTwoRectangles()
 {
-    m_gcdc->DrawRectangle(10, 15, 50, 30);
-    m_gcdc->DrawRectangle(15, 20, 55, 35);
+    m_gcdc.DrawRectangle(10, 15, 50, 30);
+    m_gcdc.DrawRectangle(15, 20, 55, 35);
     AssertBox(10, 15, 60, 40);
 }
 
 void GCDCBoundingBoxTestCase::DrawRectsOnTransformedDC()
 {
-    m_gcdc->DrawRectangle(10, 15, 50, 30);
-    m_gcdc->SetDeviceOrigin(15, 20);
-    m_gcdc->DrawRectangle(15, 20, 45, 35);
-    m_gcdc->SetDeviceOrigin(5, 10);
+    m_gcdc.DrawRectangle(10, 15, 50, 30);
+    m_gcdc.SetDeviceOrigin(15, 20);
+    m_gcdc.DrawRectangle(15, 20, 45, 35);
+    m_gcdc.SetDeviceOrigin(5, 10);
     AssertBox(5, 5, 65, 60);
 }
 


### PR DESCRIPTION
This can be nice as it allows to return them from functions.