### PR TITLE
Test only one wxDateTimeHolidayAuthority at a time

### DIFF
--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -1689,7 +1689,7 @@ protected:
     bool DoIsHoliday(const wxDateTime& dt) const override
     {
         if (dt.IsSameDate(GetEaster(dt.GetYear())) ||
-            (dt.GetMonth() == 12 && dt.GetDay() == 25))
+            (dt.GetMonth() == wxDateTime::Month::Dec && dt.GetDay() == 25))
         {
             return true;
         }

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -2383,7 +2383,6 @@ size_t wxDateTimeUSCatholicFeasts::DoGetHolidaysInRange(const wxDateTime& dtStar
         if (DoIsHoliday(dt) )
         {
             holidays.Add(dt);
-            continue;
         }
     }
 
@@ -2405,7 +2404,6 @@ size_t wxDateTimeChristianHolidays::DoGetHolidaysInRange(const wxDateTime& dtSta
         if (DoIsHoliday(dt) )
         {
             holidays.Add(dt);
-            continue;
         }
     }
 

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -2550,6 +2550,7 @@ TEST_CASE("US Catholic Holidays", "[datetime][holiday]")
     }
     SECTION("Fixed date feasts")
     {
+        wxDateTimeHolidayAuthority::ClearAllAuthorities();
         wxDateTimeHolidayAuthority::AddAuthority(new wxDateTimeUSCatholicFeasts);
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime( 1, wxDateTime::Month::Jan, 2024)));
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(15, wxDateTime::Month::Aug, 2023)));
@@ -2560,6 +2561,7 @@ TEST_CASE("US Catholic Holidays", "[datetime][holiday]")
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime( 1, wxDateTime::Month::Dec, 2023)));
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(31, wxDateTime::Month::Oct, 2023)));
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(14, wxDateTime::Month::Feb, 2023)));
+        wxDateTimeHolidayAuthority::ClearAllAuthorities();
     }
 }
 
@@ -2577,6 +2579,7 @@ TEST_CASE("Christian Holidays", "[datetime][holiday][christian]")
     }
     SECTION("Christmas")
     {
+        wxDateTimeHolidayAuthority::ClearAllAuthorities();
         wxDateTimeHolidayAuthority::AddAuthority(new wxDateTimeChristianHolidays);
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(25, wxDateTime::Month::Dec, 1990)));
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(25, wxDateTime::Month::Dec, 1700)));
@@ -2584,6 +2587,7 @@ TEST_CASE("Christian Holidays", "[datetime][holiday][christian]")
         // random days that are not Christmas or weekends
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(1, wxDateTime::Month::Dec, 2023)));
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(29, wxDateTime::Month::Dec, 2023)));
+        wxDateTimeHolidayAuthority::ClearAllAuthorities();
     }
 }
 

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -21,6 +21,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/wxcrt.h"       // for wxStrstr()
+#include "wx/scopeguard.h"
 
 #include "wx/private/localeset.h"
 
@@ -2538,6 +2539,9 @@ TEST_CASE("Easter", "[datetime][holiday][easter]")
 
 TEST_CASE("US Catholic Holidays", "[datetime][holiday]")
 {
+    wxDateTimeHolidayAuthority::ClearAllAuthorities();
+    wxON_BLOCK_EXIT0(wxDateTimeHolidayAuthority::ClearAllAuthorities);
+    wxON_BLOCK_EXIT1(wxDateTimeHolidayAuthority::AddAuthority, new wxDateTimeWorkDays);
     SECTION("Ascension")
     {
         wxDateTime ascension = wxDateTimeUSCatholicFeasts::GetThursdayAscension(2023);
@@ -2550,7 +2554,6 @@ TEST_CASE("US Catholic Holidays", "[datetime][holiday]")
     }
     SECTION("Fixed date feasts")
     {
-        wxDateTimeHolidayAuthority::ClearAllAuthorities();
         wxDateTimeHolidayAuthority::AddAuthority(new wxDateTimeUSCatholicFeasts);
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime( 1, wxDateTime::Month::Jan, 2024)));
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(15, wxDateTime::Month::Aug, 2023)));
@@ -2561,12 +2564,15 @@ TEST_CASE("US Catholic Holidays", "[datetime][holiday]")
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime( 1, wxDateTime::Month::Dec, 2023)));
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(31, wxDateTime::Month::Oct, 2023)));
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(14, wxDateTime::Month::Feb, 2023)));
-        wxDateTimeHolidayAuthority::ClearAllAuthorities();
     }
 }
 
 TEST_CASE("Christian Holidays", "[datetime][holiday][christian]")
 {
+    wxDateTimeHolidayAuthority::ClearAllAuthorities();
+    wxON_BLOCK_EXIT0(wxDateTimeHolidayAuthority::ClearAllAuthorities);
+    wxON_BLOCK_EXIT1(wxDateTimeHolidayAuthority::AddAuthority, new wxDateTimeWorkDays);
+
     SECTION("Easter")
     {
         wxDateTime easter = wxDateTimeChristianHolidays::GetEaster(2023);
@@ -2579,7 +2585,6 @@ TEST_CASE("Christian Holidays", "[datetime][holiday][christian]")
     }
     SECTION("Christmas")
     {
-        wxDateTimeHolidayAuthority::ClearAllAuthorities();
         wxDateTimeHolidayAuthority::AddAuthority(new wxDateTimeChristianHolidays);
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(25, wxDateTime::Month::Dec, 1990)));
         CHECK(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(25, wxDateTime::Month::Dec, 1700)));
@@ -2587,7 +2592,6 @@ TEST_CASE("Christian Holidays", "[datetime][holiday][christian]")
         // random days that are not Christmas or weekends
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(1, wxDateTime::Month::Dec, 2023)));
         CHECK_FALSE(wxDateTimeHolidayAuthority::IsHoliday(wxDateTime(29, wxDateTime::Month::Dec, 2023)));
-        wxDateTimeHolidayAuthority::ClearAllAuthorities();
     }
 }
 

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -2539,9 +2539,12 @@ TEST_CASE("Easter", "[datetime][holiday][easter]")
 
 TEST_CASE("US Catholic Holidays", "[datetime][holiday]")
 {
+    // Clear the wxDateTimeWorkDays that exists by default, and restore it at the end,
+    // after cleaning up the authority tested here.
     wxDateTimeHolidayAuthority::ClearAllAuthorities();
     wxON_BLOCK_EXIT0(wxDateTimeHolidayAuthority::ClearAllAuthorities);
     wxON_BLOCK_EXIT1(wxDateTimeHolidayAuthority::AddAuthority, new wxDateTimeWorkDays);
+
     SECTION("Ascension")
     {
         wxDateTime ascension = wxDateTimeUSCatholicFeasts::GetThursdayAscension(2023);
@@ -2569,6 +2572,8 @@ TEST_CASE("US Catholic Holidays", "[datetime][holiday]")
 
 TEST_CASE("Christian Holidays", "[datetime][holiday][christian]")
 {
+    // Clear the wxDateTimeWorkDays that exists by default, and restore it at the end,
+    // after cleaning up the authority tested here.
     wxDateTimeHolidayAuthority::ClearAllAuthorities();
     wxON_BLOCK_EXIT0(wxDateTimeHolidayAuthority::ClearAllAuthorities);
     wxON_BLOCK_EXIT1(wxDateTimeHolidayAuthority::AddAuthority, new wxDateTimeWorkDays);


### PR DESCRIPTION
`wxDateTimeChristianHolidays` was tested with a `wxDateTimeUSCatholicFeasts` already existing and taking precedence. I.e. the tests for Christmas in ChristianHolidays actually tested (again) the USCatholicFeasts implementation.

This reveals an off-by-one bug in `wxDateTimeChristianHolidays::DoIsHoliday()`, which doesn't use the `enum` symbol for month, and declares Christmas to be on the 25th day of the 13th month.

Further, this raises the question whether it is a bad idea to have the authority implementations in a header. Fixing bugs like this would require recompiling the application, instead of simply updating the DLL/dylib.