### PR TITLE
Suppress clang static analysis warnings

### DIFF
--- a/src/common/statbar.cpp
+++ b/src/common/statbar.cpp
@@ -226,7 +226,7 @@ wxArrayInt wxStatusBarBase::CalculateAbsWidths(wxCoord widthTotal) const
                 widths.Add(pane.GetWidth());
             else
             {
-                int nVarWidth = widthExtra > 0 ? (widthExtra * (-pane.GetWidth())) / nVarCount : 0;
+                int nVarWidth = (widthExtra > 0 && nVarCount != 0) ? (widthExtra * (-pane.GetWidth())) / nVarCount : 0;
                 nVarCount += pane.GetWidth();
                 widthExtra -= nVarWidth;
                 widths.Add(nVarWidth);

--- a/src/common/stream.cpp
+++ b/src/common/stream.cpp
@@ -350,7 +350,7 @@ char wxStreamBuffer::Peek()
         return 0;
     }
 
-    char c;
+    char c = 0;
     GetFromBuffer(&c, sizeof(c));
     m_buffer_pos--;
 
@@ -363,7 +363,7 @@ char wxStreamBuffer::GetChar()
 
     wxCHECK_MSG( inStream, 0, wxT("should have a stream in wxStreamBuffer") );
 
-    char c;
+    char c = 0;
     if ( !HasBuffer() )
     {
         inStream->OnSysRead(&c, sizeof(c));

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1494,7 +1494,7 @@ ToNumeric(T* pVal,
     PreserveErrno preserveErrno;
     errno = 0;
 
-    wxStringCharType *end;
+    wxStringCharType *end = nullptr;
 
     const R res = convert(start, &end, base);
     if ( rangeCheck && !rangeCheck(res) )


### PR DESCRIPTION
Don't appear to be real issues, but doesn't hurt to init values and add a div by zero check.