### PR TITLE
Fix installation of webkit2_ext ignores wxBUILD_INSTALL_LIBRARY_DIR

### DIFF
--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -153,7 +153,9 @@ if(WXGTK AND wxUSE_WEBVIEW_WEBKIT2)
         ${WEBKIT2_LIBRARIES}
         )
 
-    wx_install(TARGETS wxwebkit2_ext LIBRARY DESTINATION "lib/wx/${WX_WEB_EXT_VERSION}/web-extensions")
+    wx_get_install_dir(library "lib")
+
+    wx_install(TARGETS wxwebkit2_ext LIBRARY DESTINATION "${library_dir}/wx/${WX_WEB_EXT_VERSION}/web-extensions")
 
     wx_add_dependencies(wxwebview wxwebkit2_ext)
 endif()


### PR DESCRIPTION
If I configure a CMake installation with `-DwxBUILD_INSTALL_LIBRARY_DIR=/usr/lib64`
`webkit2_extu-3.3.1.so` is installed in `/usr/lib/wx/3.3.1/web-extensions`  - unlike when using autotools, when it is installed with the other binary libraries under `/usr/lib64`.

Fixed by using `wx_get_install_dir()` from build/cmake/functions.cmake as used there by `wx_add_library()`.

These two also install in /usr/lib/:

```
/usr/lib/wx/config/gtk3-unicode-3.3
/usr/lib/wx/include/gtk3-unicode-3.3/wx/setup.h
```
which is also a change when installing with CMake as compared to autotools, which might cause some downstream scripting changes, but they aren't binary, so...

3.3.1 on Linux.
