### PR TITLE
macOS 26 Tahoe: Fix wxNotebook tabs appearance

### DIFF
--- a/src/osx/cocoa/notebook.mm
+++ b/src/osx/cocoa/notebook.mm
@@ -23,6 +23,7 @@
 #include "wx/string.h"
 #include "wx/private/bmpbndl.h"
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 //
 // controller
@@ -86,7 +87,18 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+
+        // On macOS 26 Tahoe, the mere presence of drawRect: in derived class,
+        // even if it just calls super's implementation, triggers legacy
+        // rendering of NSTabView.
+        if (WX_IS_MACOS_AVAILABLE(26, 0))
+        {
+            wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DRAW);
+        }
+        else
+        {
+            wxOSXCocoaClassAddWXMethods(self);
+        }
     }
 }
 


### PR DESCRIPTION
On macOS 26 Tahoe, just the mere presence of `drawRect:` in class derived from `NSTabView` prevents native appearance rendering and triggers legacy appearance code path.

Before:
<img width="608" height="150" alt="before" src="https://github.com/user-attachments/assets/f9e5e79f-103b-4a90-a611-a62e63ad1060" />

After:
<img width="608" height="150" alt="after" src="https://github.com/user-attachments/assets/92337d7f-95ba-43d2-a814-ac35bfeaf1a5" />

Apple Mail:
<img width="884" height="259" alt="apple_mail" src="https://github.com/user-attachments/assets/968ee6e6-d9ec-4864-9c43-3bc1b0b24631" />


This isn't caused by wx's handling of `drawRect:`, but really by just its presence. Even applying this change and adding a minimal
```objc
- (void)drawRect:(NSRect)dirtyRect {
    [super drawRect:dirtyRect];
}
```
to `wxNSTabView` reintroduces the bad rendering. In other words, there's nothing else to be done other than using `wxOSXSKIP_DRAW`.

Out of abundance of caution, I made this conditional on running on macOS 26 (and being compiled with Xcode version aware of it), so that it doesn't break customized rendering on the off chance that somebody does it. But AFAIK the official position is that customizing native controls like that may or may not work, and so may be better to just do it unconditionally (or perhaps conditionally on the 3.2 branch only)...?

P.S. This is probably related to internal implementation changes to share code with SwiftUI and risks being a problem in other controls too. See https://mastodon.social/@macmade/114670766027908350