### PR TITLE
macOS: Fixes to incorrect NSImage creation from wxBitmapBundle and missing menu bitmaps

### DIFF
--- a/include/wx/menu.h
+++ b/include/wx/menu.h
@@ -260,7 +260,7 @@ public:
     //
     // NB: avoid calling SetInvokingWindow() directly if possible, use
     //     wxMenuInvokingWindowSetter class below instead
-    virtual void SetInvokingWindow(wxWindow *win);
+    void SetInvokingWindow(wxWindow *win);
     wxWindow *GetInvokingWindow() const { return m_invokingWindow; }
 
     // the window associated with this menu: this is the invoking window for

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -161,7 +161,7 @@ public :
     }
 
     virtual ~wxMenuItemImpl() ;
-    virtual void SetBitmap( const wxBitmap& bitmap ) = 0;
+    virtual void SetBitmap( const wxBitmapBundle& bitmap ) = 0;
     virtual void Enable( bool enable ) = 0;
     virtual void Check( bool check ) = 0;
     virtual void SetLabel( const wxString& text, wxAcceleratorEntry *entry ) = 0;

--- a/include/wx/osx/menu.h
+++ b/include/wx/osx/menu.h
@@ -35,8 +35,6 @@ public:
 
     virtual void SetTitle(const wxString& title) override;
 
-    virtual void SetInvokingWindow(wxWindow* win) override;
-
     bool ProcessCommand(wxCommandEvent& event);
 
     // get the menu handle
@@ -66,12 +64,6 @@ public:
     // at given position belongs. Return false if there is no radio group
     // containing this position.
     bool OSXGetRadioGroupRange(int pos, int *start, int *end) const;
-
-#if wxUSE_MENUBAR
-    virtual void Attach(wxMenuBarBase *menubar) override;
-#endif
-
-    void SetupBitmaps();
 
 protected:
     // hide special menu items like exit, preferences etc
@@ -167,10 +159,6 @@ public:
     static wxMenuBar* MacGetInstalledMenuBar() { return s_macInstalledMenuBar ; }
     static void MacSetCommonMenuBar(wxMenuBar* menubar) { s_macCommonMenuBar=menubar; }
     static wxMenuBar* MacGetCommonMenuBar() { return s_macCommonMenuBar; }
-
-    virtual void Attach(wxFrame *frame) override;
-    void SetupBitmaps();
-
 
     static WXHMENU MacGetWindowMenuHMenu() { return s_macWindowMenuHandle ; }
 

--- a/include/wx/osx/menuitem.h
+++ b/include/wx/osx/menuitem.h
@@ -37,6 +37,7 @@ public:
 
     // override base class virtuals
     virtual void SetItemLabel(const wxString& strName) override;
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) override;
 
     virtual void Enable(bool bDoEnable = true) override;
     virtual void Check(bool bDoCheck = true) override;

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -3287,7 +3287,7 @@ bool wxDataViewIconTextRenderer::MacRender()
     cell = (wxImageTextCell*) GetNativeData()->GetItemCell();
     iconText << GetValue();
     const wxDataViewCtrl* const dvc = GetOwner()->GetOwner();
-    [cell setImage:iconText.GetBitmapBundle().GetBitmapFor(dvc).GetNSImage()];
+    [cell setImage:wxOSXGetImageFromBundle(iconText.GetBitmapBundle())];
     [cell setStringValue:wxCFStringRef(iconText.GetText()).AsNSString()];
     return true;
 }
@@ -3401,7 +3401,7 @@ bool wxDataViewCheckIconTextRenderer::MacRender()
     {
         wxNSTextAttachmentCellWithBaseline* const attachmentCell =
             [[wxNSTextAttachmentCellWithBaseline alloc]
-             initImageCell: icon.GetBitmapFor(GetOwner()->GetOwner()).GetNSImage()];
+             initImageCell: wxOSXGetImageFromBundle(icon)];
         NSTextAttachment* const attachment = [NSTextAttachment new];
         [attachment setAttachmentCell: attachmentCell];
 
@@ -3649,12 +3649,7 @@ void wxDataViewColumn::SetBitmap(const wxBitmapBundle& bitmap)
     // the title is removed:
     m_title.clear();
     wxDataViewColumnBase::SetBitmap(bitmap);
-    wxBitmap bmp = m_owner ? bitmap.GetBitmapFor(m_owner) : bitmap.GetBitmap(
-        bitmap.GetPreferredBitmapSizeAtScale(
-            wxOSXGetMainScreenContentScaleFactor()
-        )
-    );
-    [[m_NativeDataPtr->GetNativeColumnPtr() headerCell] setImage:bmp.GetNSImage()];
+    [[m_NativeDataPtr->GetNativeColumnPtr() headerCell] setImage:wxOSXGetImageFromBundle(bitmap)];
 }
 
 void wxDataViewColumn::SetMaxWidth(int maxWidth)

--- a/src/osx/cocoa/menuitem.mm
+++ b/src/osx/cocoa/menuitem.mm
@@ -18,6 +18,7 @@
     #include "wx/menu.h"
 #endif // WX_PRECOMP
 
+#include "wx/private/bmpbndl.h"
 #include "wx/osx/private.h"
 #include "wx/osx/private/available.h"
 
@@ -248,9 +249,9 @@ public :
 
     ~wxMenuItemCocoaImpl();
 
-    void SetBitmap( const wxBitmap& bitmap ) override
+    void SetBitmap( const wxBitmapBundle& bitmap ) override
     {
-        [m_osxMenuItem setImage:bitmap.GetNSImage()];
+        [m_osxMenuItem setImage:wxOSXGetImageFromBundle(bitmap)];
     }
 
     void Enable( bool enable ) override

--- a/src/osx/iphone/menuitem.mm
+++ b/src/osx/iphone/menuitem.mm
@@ -191,7 +191,7 @@ public :
 
     ~wxMenuItemCocoaImpl();
 
-    void SetBitmap( const wxBitmap& bitmap ) override
+    void SetBitmap( const wxBitmapBundle& bitmap ) override
     {
     }
 

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -156,14 +156,6 @@ bool wxMenu::DoInsertOrAppend(wxMenuItem *item, size_t pos)
     // if we're already attached to the menubar, we must update it
     if ( IsAttached() && GetMenuBar()->IsAttached() )
     {
-        if ( item->IsSubMenu() )
-        {
-            item->GetSubMenu()->SetupBitmaps();
-        }
-        if ( !item->IsSeparator() )
-        {
-            item->UpdateItemBitmap();
-        }
         GetMenuBar()->Refresh();
     }
 #endif // wxUSE_MENUBAR
@@ -415,44 +407,6 @@ void wxMenu::HandleMenuClosed()
 }
 
 #if wxUSE_MENUBAR
-void wxMenu::Attach(wxMenuBarBase *menubar)
-{
-    wxMenuBase::Attach(menubar);
-
-    if (menubar->IsAttached())
-    {
-        SetupBitmaps();
-    }
-}
-#endif
-
-void wxMenu::SetInvokingWindow(wxWindow* win)
-{
-    wxMenuBase::SetInvokingWindow(win);
-
-    if ( win )
-        SetupBitmaps();
-}
-
-void wxMenu::SetupBitmaps()
-{
-    for ( wxMenuItemList::compatibility_iterator node = m_items.GetFirst();
-          node;
-          node = node->GetNext() )
-    {
-        wxMenuItem *item = node->GetData();
-        if ( item->IsSubMenu() )
-        {
-            item->GetSubMenu()->SetupBitmaps();
-        }
-        if ( !item->IsSeparator() )
-        {
-            item->UpdateItemBitmap();
-        }
-    }
-}
-
-#if wxUSE_MENUBAR
 
 // Menu Bar
 
@@ -690,21 +644,6 @@ wxString wxMenuBar::GetMenuLabel(size_t pos) const
                  wxT("invalid menu index in wxMenuBar::GetMenuLabel") );
 
     return GetMenu(pos)->GetTitle();
-}
-
-void wxMenuBar::SetupBitmaps()
-{
-    for ( wxMenuList::const_iterator it = m_menus.begin(); it != m_menus.end(); ++it )
-    {
-        (*it)->SetupBitmaps();
-    }
-}
-
-void wxMenuBar::Attach(wxFrame *frame)
-{
-    wxMenuBarBase::Attach(frame);
-
-    SetupBitmaps();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/osx/menuitem_osx.cpp
+++ b/src/osx/menuitem_osx.cpp
@@ -158,9 +158,6 @@ void wxMenuItem::SetBitmap(const wxBitmapBundle& bitmap)
 
 void wxMenuItem::UpdateItemBitmap()
 {
-    if ( !m_parentMenu )
-        return;
-
     if ( m_bitmap.IsOk() )
     {
         GetPeer()->SetBitmap(m_bitmap);
@@ -169,9 +166,6 @@ void wxMenuItem::UpdateItemBitmap()
 
 void wxMenuItem::UpdateItemStatus()
 {
-    if ( !m_parentMenu )
-        return ;
-
     if ( IsSeparator() )
         return ;
 
@@ -185,9 +179,6 @@ void wxMenuItem::UpdateItemStatus()
 
 void wxMenuItem::UpdateItemText()
 {
-    if ( !m_parentMenu )
-        return ;
-
     wxString text = wxStripMenuCodes(m_text, m_parentMenu != nullptr && m_parentMenu->GetNoEventsMode() ? wxStrip_Accel : wxStrip_Menu);
     if (text.IsEmpty() && !IsSeparator())
     {

--- a/src/osx/menuitem_osx.cpp
+++ b/src/osx/menuitem_osx.cpp
@@ -150,6 +150,11 @@ void wxMenuItem::SetItemLabel(const wxString& text)
     UpdateItemText() ;
 }
 
+void wxMenuItem::SetBitmap(const wxBitmapBundle& bitmap)
+{
+    wxMenuItemBase::SetBitmap(bitmap);
+    UpdateItemBitmap();
+}
 
 void wxMenuItem::UpdateItemBitmap()
 {
@@ -158,7 +163,7 @@ void wxMenuItem::UpdateItemBitmap()
 
     if ( m_bitmap.IsOk() )
     {
-        GetPeer()->SetBitmap(GetBitmap());
+        GetPeer()->SetBitmap(m_bitmap);
     }
 }
 


### PR DESCRIPTION
This PR contains two commits that appear unrelated at first, but the underlying problem in both of them is the same thing: misunderstanding of what `NSImage` is (a direct equivalent of `wxBitmapBundle`) and creating it through a lossy conversion to `wxBitmap` (which unlike on other platforms *doesn't* have a native equivalent).

### wxMenu bitmaps

The primary commit throws out all of the `SetupBitmaps()` scaffolding from wxOSX and reverts most of 337940f, 616e7c8, plus bits of c0dbe80; 338cd95 is also related). It then replaces all that code with a straightforward implementation that just directly sets the bundle/NSImage in `wxMenuItemImpl`.

This fixes multiple bugs, introduced by 337940f, in wxOSX implementation of menu icons:

1. Bitmaps set on items in the global Mac menu were ignored.
2. So were the ones set in the (also Mac-specific) app menu.
3. Loosing compatibility with `NSImage`-backed `wxBitmap` and rendering them without appearance awareness and in low resolution in the global menu.

It's the last one that finally tipped me off that something is *seriously* wrong, because starting with a native resolution-independent, appearance-independent SF Symbol and ending up with a blurry dark-on-dark bitmap is something that takes non-obvious code to accomplish!


### wxDataViewCtrl

The other commit fixes similar problem in wxDVC code, introduced by 33d8510. I didn't encounter these bugs in real use, but found them when reviewing wx code looking for other instances of this class of issues [^1].

### 3.2

Menu item bitmaps are important on macOS 26, so I think this part at least should be backported.

wx-3.2 version that I think is ABI-safe (it just adds an override to vtable) is here: https://github.com/poedit/wxWidgets/commit/011f9a2da063a6d756ec6e6a46c278bab6f6c5eb

### NSImage and wxBitmapBundle

 I think the removal of `NSImage` from `wxBitmapBundle` API (#2555, merged as 4eb4c17 and considered improvement) was a mistake — and the bugs addressed in this PR would all be harder to write if only the developer had `wxBitmapBundle::GetNSImage()` at their disposal.

As it is, the conversion has to be done with semi-hidden private API that even wx developers can overlook, and which is less ergonomic to use. For *user* code it is not just hard, but *impossible* to interop between `wxBitmapBundle` and native code w/o using the private API. 

Ideally, this PR would contain two more commits:

1. Introduction of `GetNSImage()` and `FromNSImage()`.
2. Change of wx's internal uses of the private helpers to use these.

Happy to do it, but the comments in #2555 suggest I can expect some pushback, so didn't want to do the work without an explicit ACK first.

[^1]:  In wxOSX basically any use of `wxBitmapBundle::GetBitmapFor()` or `GetIconFor()` is either wrong or highly suspect. Even in drawing code it's at least inefficient and would ideally be avoided.
