### PR TITLE
CMake: Install wx/config and wx/include into wxBUILD_INSTALL_LIBRARY_DIR

### DIFF
--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -106,11 +106,12 @@ function(wx_write_config_inplace)
 endfunction()
 
 function(wx_write_config)
+    wx_get_install_dir(library "lib")
 
     set(prefix ${CMAKE_INSTALL_PREFIX})
     set(exec_prefix "\${prefix}")
     set(includedir "\${prefix}/include")
-    set(libdir "\${exec_prefix}/lib")
+    set(libdir "\${exec_prefix}/${library_dir}")
     set(bindir "\${exec_prefix}/bin")
 
     if(wxBUILD_MONOLITHIC)

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -44,9 +44,9 @@ if(WIN32_MSVC_NAMING)
     # non-existent path when only Release or Debug build has been installed
     set(lib_unicode "u")
     install(DIRECTORY
-        DESTINATION "lib/${wxPLATFORM_LIB_DIR}/${wxBUILD_TOOLKIT}${lib_unicode}")
+        DESTINATION "${library_dir}/${wxBUILD_TOOLKIT}${lib_unicode}")
     install(DIRECTORY
-        DESTINATION "lib/${wxPLATFORM_LIB_DIR}/${wxBUILD_TOOLKIT}${lib_unicode}d")
+        DESTINATION "${library_dir}/${wxBUILD_TOOLKIT}${lib_unicode}d")
     install(
         DIRECTORY "${wxSETUP_HEADER_PATH}"
         DESTINATION "lib/${wxPLATFORM_LIB_DIR}")

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -49,11 +49,11 @@ if(WIN32_MSVC_NAMING)
         DESTINATION "${library_dir}/${wxBUILD_TOOLKIT}${lib_unicode}d")
     install(
         DIRECTORY "${wxSETUP_HEADER_PATH}"
-        DESTINATION "lib/${wxPLATFORM_LIB_DIR}")
+        DESTINATION "${library_dir}")
 else()
     install(
         DIRECTORY "${wxSETUP_HEADER_PATH}"
-        DESTINATION "lib/wx/include")
+        DESTINATION "${library_dir}/wx/include")
 
     install(
         FILES "${wxOUTPUT_DIR}/wx/config/${wxBUILD_FILE_ID}"

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -64,7 +64,7 @@ else()
     install(DIRECTORY DESTINATION "bin")
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
-        \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID}\" \
+        \"${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID}\" \
         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wx-config\" \
         )"
     )

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -36,6 +36,8 @@ if(MSVC)
     )
 endif()
 
+wx_get_install_dir(library "lib")
+
 # setup header and wx-config
 if(WIN32_MSVC_NAMING)
     # create both Debug and Release directories, so CMake doesn't complain about
@@ -55,7 +57,7 @@ else()
 
     install(
         FILES "${wxOUTPUT_DIR}/wx/config/${wxBUILD_FILE_ID}"
-        DESTINATION "lib/wx/config"
+        DESTINATION "${library_dir}/wx/config"
         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                     GROUP_EXECUTE GROUP_READ
                     WORLD_EXECUTE WORLD_READ
@@ -64,7 +66,7 @@ else()
     install(DIRECTORY DESTINATION "bin")
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
-        \"${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID}\" \
+        \"${CMAKE_INSTALL_PREFIX}/${library_dir}/wx/config/${wxBUILD_FILE_ID}\" \
         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wx-config\" \
         )"
     )

--- a/build/cmake/utils/CMakeLists.txt
+++ b/build/cmake/utils/CMakeLists.txt
@@ -40,7 +40,7 @@ if(wxUSE_XRC)
         # Don't use wx_install() here to preserve escaping.
         install(CODE "execute_process( \
             COMMAND ${CMAKE_COMMAND} -E create_symlink \
-            \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX}\" \
+            \"${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX}\" \
             \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX}\" \
             )"
         )


### PR DESCRIPTION
I've tried this on 3.3.1 and 3.2.8.1 + f5ee95f88c6c9806a1b938cf39f4e2ffea0ceebc.

This plus #25736 is enough for me to install a copy of wxWidgets that I can build applications on with existing scripting.

Some cautions: 
- `DESTINATION "lib/wx/config"` was a relative path - the change doesn't seem to matter
- There are still some uses of `lib/wx/config/` in  `wx-config-inplace.in`, `build/tools/build-wxwidgets.py` and `build/cmake/config.cmake`

Is a trailing `/` guaranteed in `library_dir` or was that just me?