### PR TITLE
Fix check for extended locale functions in CMake

### DIFF
--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -587,12 +587,20 @@ if(wxUSE_FSWATCHER)
 endif()
 
 if(wxUSE_XLOCALE)
+    list(APPEND xlocale_headers locale.h stdlib.h)
     check_include_file(xlocale.h HAVE_XLOCALE_H)
-    set(CMAKE_EXTRA_INCLUDE_FILES locale.h)
     if(HAVE_XLOCALE_H)
-        list(APPEND CMAKE_EXTRA_INCLUDE_FILES xlocale.h)
+        list(APPEND xlocale_headers xlocale.h)
     endif()
-    check_type_size(locale_t LOCALE_T)
+    wx_check_c_source_compiles("
+        locale_t t;
+        strtod_l(NULL, NULL, t);
+        strtol_l(NULL, NULL, 0, t);
+        strtoul_l(NULL, NULL, 0, t);
+"
+        HAVE_LOCALE_T
+        ${xlocale_headers}
+        )
     set(CMAKE_EXTRA_INCLUDE_FILES)
 endif()
 


### PR DESCRIPTION
HAVE_LOCALE_T is misnamed, as it must only be defined not just when locale_t type is available but when the functions using it, such as strxxx_l(), are available.

Due to the confusion about the nature of this symbol, CMake didn't check for it correctly and only checked for its existence, but musl (used by e.g. Alpine) does define the type without providing any of the functions using it, which resulted in build errors later.

Fix this by checking for both the type and the functions in CMake too, just as we do in configure.

Closes #25749.