### PR TITLE
Catch change of monitor scaling under GTK+

### DIFF
--- a/include/wx/gtk/toplevel.h
+++ b/include/wx/gtk/toplevel.h
@@ -96,6 +96,7 @@ public:
     virtual void GTKHandleRealized() override;
 
     void GTKConfigureEvent(int x, int y);
+    void GTKScaleFactorChanged();
 
     // do *not* call this to iconize the frame, this is a private function!
     void SetIconizeState(bool iconic);

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -333,7 +333,15 @@ gtk_frame_configure_callback( GtkWidget*,
 }
 }
 
-void wxTopLevelWindowGTK::GTKConfigureEvent(int x, int y)
+extern "C" {
+static void
+notify_gtk_scale_factor(GObject*, GParamSpec*, wxTopLevelWindowGTK* win)  // "notify::scale-factor"
+{
+    win->GTKScaleFactorChanged();
+}
+}
+
+void wxTopLevelWindowGTK::GTKScaleFactorChanged()
 {
 #ifdef __WXGTK3__
     // First of all check if our DPI has changed.
@@ -349,6 +357,10 @@ void wxTopLevelWindowGTK::GTKConfigureEvent(int x, int y)
         WXNotifyDPIChange(oldScaleFactor, newScaleFactor);
     }
 #endif // __WXGTK3__
+}
+
+void wxTopLevelWindowGTK::GTKConfigureEvent(int x, int y)
+{
 
     wxPoint point;
 #ifdef GDK_WINDOWING_X11
@@ -840,6 +852,9 @@ bool wxTopLevelWindowGTK::Create( wxWindow *parent,
     // for wxMoveEvent
     g_signal_connect (m_widget, "configure_event",
                       G_CALLBACK (gtk_frame_configure_callback), this);
+
+    g_signal_connect_after(m_widget, "notify::scale-factor",
+        G_CALLBACK(notify_gtk_scale_factor), this);
 
     // activation
     g_signal_connect_after (m_widget, "focus_in_event",


### PR DESCRIPTION
Allows to relayout controls when scaling is changed in large monitor Previous code assumed the configure event would be triggered by GTK+ Hopefully fixes #25733