### PR TITLE
CMake: Support finding system libwebp using pkg-config

### DIFF
--- a/build/cmake/lib/webp.cmake
+++ b/build/cmake/lib/webp.cmake
@@ -69,6 +69,4 @@ if(wxUSE_LIBWEBP STREQUAL "builtin")
         )
     endif()
 
-elseif(wxUSE_LIBWEBP)
-    find_package(WebP REQUIRED)
 endif()

--- a/build/cmake/modules/FindWebP.cmake
+++ b/build/cmake/modules/FindWebP.cmake
@@ -1,0 +1,8 @@
+find_package(WebP CONFIG)
+
+if(NOT WebP_FOUND)
+    find_package(PkgConfig)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(WebP libwebp)
+    endif()
+endif()

--- a/build/cmake/modules/FindWebP.cmake
+++ b/build/cmake/modules/FindWebP.cmake
@@ -1,7 +1,7 @@
 find_package(WebP CONFIG)
 
 if(NOT WebP_FOUND)
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND)
         pkg_check_modules(WebP libwebp)
     endif()


### PR DESCRIPTION
Installing libwebp using autotools is still supported.

---

The autotools libwebp build allows control over individual CPU flags, whereas the CMake one has a SIMD option which then automatically selects the CPU flags supported on the build machine.
