### PR TITLE
Improve HitTest in generic wxListCtrl

### DIFF
--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -914,7 +914,7 @@ private:
     // Check if the given point is inside the checkbox of this item.
     //
     // Always returns false if there are no checkboxes.
-    bool IsInsideCheckBox(long item, int x, int y);
+    bool IsInsideCheckBox(long item, int x, int y) const;
 
     // the height of one line using the current font
     wxCoord m_lineHeight;

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1491,6 +1491,7 @@ void MyListCtrl::OnRightClick(wxMouseEvent& event)
         case wxLIST_HITTEST_NOWHERE: where = "nowhere near"; break;
         case wxLIST_HITTEST_ONITEMICON: where = "on icon of"; break;
         case wxLIST_HITTEST_ONITEMLABEL: where = "on label of"; break;
+        case wxLIST_HITTEST_ONITEMSTATEICON: where = "on checkbox of"; break;
         case wxLIST_HITTEST_TOLEFT: where = "to the left of"; break;
         case wxLIST_HITTEST_TORIGHT: where = "to the right of"; break;
         default: where = "not clear exactly where on"; break;


### PR DESCRIPTION
Detect when a checkbox is hit and return `wxLIST_HITTEST_ONITEMSTATEICON`.
Determine the correct location of the icon, it might be preceded by a checkbox.
Return only the icon rectangle in `GetSubItemRect` with `wxLIST_RECT_ICON`, not the padding or margins above/below the icon.