### PR TITLE
Improve wxStatusBar appearance on macOS 11-26

### DIFF
--- a/include/wx/generic/statusbr.h
+++ b/include/wx/generic/statusbr.h
@@ -87,6 +87,9 @@ protected:
     // returns the position and the size of the size grip
     wxRect GetSizeGripRect() const;
 
+    // returns the width available for fields drawing given total width
+    virtual int GetAvailableWidthForFields(int width) const;
+
     // common part of all ctors
     void Init();
 

--- a/include/wx/osx/statusbr.h
+++ b/include/wx/osx/statusbr.h
@@ -28,13 +28,22 @@ public:
     // Implementation
     virtual void MacHiliteChanged() override;
     void OnPaint(wxPaintEvent& event);
+    virtual bool GetFieldRect(int i, wxRect& rect) const override;
+
+    void MacSetCornerInset(int inset);
+    int MacGetCornerInset() const { return m_cornerInset; }
 
 protected:
     virtual int GetEffectiveFieldStyle(int WXUNUSED(i)) const override { return wxSB_NORMAL; }
 
     virtual void InitColours() override;
 
+    void InitCornerInset();
+
+    virtual int GetAvailableWidthForFields(int width) const override;
+
 private:
+    int m_cornerInset;
     wxColour m_textActive, m_textInactive, m_bgActive, m_bgInactive, m_separator;
 
     wxDECLARE_DYNAMIC_CLASS(wxStatusBarMac);

--- a/include/wx/osx/statusbr.h
+++ b/include/wx/osx/statusbr.h
@@ -35,7 +35,7 @@ protected:
     virtual void InitColours() override;
 
 private:
-    wxColour m_textActive, m_textInactive;
+    wxColour m_textActive, m_textInactive, m_bgActive, m_bgInactive, m_separator;
 
     wxDECLARE_DYNAMIC_CLASS(wxStatusBarMac);
     wxDECLARE_EVENT_TABLE();

--- a/src/generic/statusbr.cpp
+++ b/src/generic/statusbr.cpp
@@ -177,13 +177,19 @@ void wxStatusBarGeneric::SetStatusWidths(int n, const int widths_field[])
     DoUpdateFieldWidths();
 }
 
+int wxStatusBarGeneric::GetAvailableWidthForFields(int width) const
+{
+    if ( ShowsSizeGrip() )
+        width -= GetSizeGripRect().width;
+
+    return width;
+}
+
 void wxStatusBarGeneric::DoUpdateFieldWidths()
 {
     m_lastClientSize = GetClientSize();
 
-    int width = m_lastClientSize.x;
-    if ( ShowsSizeGrip() )
-        width -= GetSizeGripRect().width;
+    const int width = GetAvailableWidthForFields(m_lastClientSize.x);
 
     // recompute the cache of the field widths if the status bar width has changed
     m_widthsAbs = CalculateAbsWidths(width);

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -128,7 +128,14 @@ wxStatusBar *wxFrame::OnCreateStatusBar(int number, long style, wxWindowID id,
 void wxFrame::SetStatusBar(wxStatusBar *statbar)
 {
     wxFrameBase::SetStatusBar(statbar);
-    m_nowpeer->SetBottomBorderThickness(statbar ? GetMacStatusbarHeight() : 0);
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        // textured borders are unwanted, statusbar renders w/o them
+    }
+    else
+    {
+        m_nowpeer->SetBottomBorderThickness(statbar ? GetMacStatusbarHeight() : 0);
+    }
 }
 
 void wxFrame::PositionStatusBar()

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -25,9 +25,6 @@
 #include "wx/osx/private.h"
 #include "wx/osx/private/available.h"
 
-// Margin between the field text and the field rect
-#define wxFIELD_TEXT_MARGIN 2
-
 
 wxBEGIN_EVENT_TABLE(wxStatusBarMac, wxStatusBarGeneric)
     EVT_PAINT(wxStatusBarMac::OnPaint)
@@ -69,6 +66,7 @@ bool wxStatusBarMac::Create(wxWindow *parent, wxWindowID id,
     SetWindowVariant( wxWINDOW_VARIANT_SMALL );
 
     InitColours();
+    InitCornerInset();
 
     return true;
 }
@@ -186,6 +184,38 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
 
     for ( size_t i = 0; i < m_panes.GetCount(); i ++ )
         DrawField(dc, i, textHeight);
+}
+
+void wxStatusBarMac::InitCornerInset()
+{
+    if ( WX_IS_MACOS_AVAILABLE(26, 0) )
+        m_cornerInset = 8;
+    else if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+        m_cornerInset = 4;
+    else
+        m_cornerInset = 0;
+}
+
+void wxStatusBarMac::MacSetCornerInset(int inset)
+{
+    m_cornerInset = inset;
+    // force recalculation of the fields:
+    m_lastClientSize = wxDefaultSize;
+    Refresh();
+}
+
+int wxStatusBarMac::GetAvailableWidthForFields(int width) const
+{
+    return wxStatusBarGeneric::GetAvailableWidthForFields(width) - 2 * m_cornerInset;
+}
+
+bool wxStatusBarMac::GetFieldRect(int i, wxRect& rect) const
+{
+    if ( !wxStatusBarGeneric::GetFieldRect(i, rect) )
+        return false;
+
+    rect.x += MacGetCornerInset();
+    return true;
 }
 
 void wxStatusBarMac::MacHiliteChanged()

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -75,7 +75,45 @@ bool wxStatusBarMac::Create(wxWindow *parent, wxWindowID id,
 
 void wxStatusBarMac::InitColours()
 {
-    if ( WX_IS_MACOS_AVAILABLE(10, 14) )
+    if ( WX_IS_MACOS_AVAILABLE(26, 0) )
+    {
+        if ( wxSystemSettings::GetAppearance().IsDark() )
+        {
+            m_textActive = wxColour(0x9B, 0x9F, 0x9F);
+            m_textInactive = wxColour(0x59, 0x5F, 0x60);
+            // native separator uses hairline black plus some shading,
+            // this approximates it well visually:
+            m_separator = wxColour(0x18, 0x18, 0x18);
+        }
+        else
+        {
+            m_textActive = wxColour(0x80, 0x80, 0x80);
+            m_textInactive = wxColour(0xB8, 0xB8, 0xB8);
+            m_separator = wxColour(0xD9, 0xD9, 0xD9);
+        }
+    }
+    else if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        if ( wxSystemSettings::GetAppearance().IsDark() )
+        {
+            m_textActive = wxColour(0xB1, 0xB2, 0xB2);
+            m_textInactive = wxColour(0x68, 0x69, 0x6A);
+            m_bgActive = wxColour(0x35, 0x36, 0x36);
+            m_bgInactive = wxColour(0x27, 0x28, 0x29);
+            // native separator uses hairline black plus some shading,
+            // this approximates it well visually:
+            m_separator = wxColour(0x18, 0x18, 0x18);
+        }
+        else
+        {
+            m_textActive = wxColour(0x73, 0x74, 0x74);
+            m_textInactive = wxColour(0xA5, 0xA6, 0xA6);
+            m_bgActive = wxColour(0xF3, 0xF3, 0xF3);
+            m_bgInactive = wxColour(0xE6, 0xE6, 0xE6);
+            m_separator = wxColour(0xCC, 0xCC, 0xCC);
+        }
+    }
+    else if ( WX_IS_MACOS_AVAILABLE(10, 14) )
     {
         if ( wxSystemSettings::GetAppearance().IsDark() )
         {
@@ -90,7 +128,6 @@ void wxStatusBarMac::InitColours()
     }
     else // 10.10 Yosemite to 10.13:
     {
-
         m_textActive = wxColour(0x40, 0x40, 0x40);
         m_textInactive = wxColour(0x4B, 0x4B, 0x4B);
     }
@@ -118,7 +155,27 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
             break;
     }
 
-    // Don't paint any background, that's handled by the OS. Only draw text:
+    if ( WX_IS_MACOS_AVAILABLE(26, 0) )
+    {
+        // don't paint the background, handled by the OS
+    }
+    else if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        // we _do_ need to paint the background on Big Sur up to Tahoe
+        // to match Finder's appearance:
+        dc.SetBackground(tlw == keyWindow ? m_bgActive : m_bgInactive);
+        dc.Clear();
+    }
+    // else: background is rendered by OS, it is part of NSWindow border
+
+    // Draw horizontal separator above the status bar:
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        dc.SetPen(m_separator);
+        dc.DrawLine(0, 0, GetSize().x, 0);
+    }
+
+    // Draw the text:
 
     dc.SetTextForeground(tlw == keyWindow ? m_textActive : m_textInactive);
 


### PR DESCRIPTION
This fixes incorrect appearance of `wxStatusBar` on modern macOS. It's a not a *dramatic* change, but still worth doing. It's a generic control for what is effectively legacy thing on macOS (only Finder uses it, literally nothing else), so I took the same approach as before, which is mimicking native appearance within reasonable limits.

It comes in two parts:

[Improve wxStatusBar appearance on macOS 11-26](https://github.com/wxWidgets/wxWidgets/commit/12dfc19f8ec7bcbf12e6bd4c17b62e2a31ca0212)

This is clear-cut, just visual tweaks. It doesn't change how things work in this part of the code, just updates the visuals. It presents some difficulty for 3.2 backporting due to new fields. Perhaps using global variables would be fine here?

[Don't put wxStatusBar fields into corners on macOS](https://github.com/wxWidgets/wxWidgets/commit/f323430a087fa389a2fa4458eec044dd59148b96)

I have mixed feelings about this one, and don't have a strong opinion on whether it should be merged (master only I guess, too difficult to backport) or rejected. Eventually, I decided I'm not going to use it myself in Poedit and that I'll want to center the statusbar, as Finder does (which is more involved than just centering, because I have a wxSplitterWindow-based sidebar in the app and the statusbar should be centered under the area that isn't the sidebar, not under the whole window).

The issue is that macOS 26 Tahoe has *very* rounded corners (macOS 11+ has too, but to much lesser extent):

<img width="1011" height="422" alt="toolbar_before" src="https://github.com/user-attachments/assets/1cf626da-f624-48d0-be0e-01f3f098a74a" />

So for wx applications to took better, I added indentation:

<img width="952" height="415" alt="toolbar_after" src="https://github.com/user-attachments/assets/5b74001e-b47c-4aa3-9299-8d5351496925" />

Notice how it is still not very good in the right-side window. There are *differently-rounded* windows in macOS 26! However, normal wxWidgets applications shouldn't be able to end with the large radius (it requires native toolbar, which is something I do on top of wxOSX), so it should be fine. There is a native API for determining the "safe area", but I think it would be overkill to use it for just a legacy control and just some obscure uses like Poedit's.

I *do* think, however, that if this is merged, it should be in this form where the offset is configurable from user code, in the spirit of doing a reasonable thing by default, but allowing being more native.