### PR TITLE
Assorted controls fixes for macOS 26 Tahoe

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -226,6 +226,8 @@ public :
     // from the same pimpl class.
     virtual void                controlTextDidChange();
 
+    virtual void                ClipsToBounds(bool clip) override;
+
     virtual void                AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical) override;
     virtual void                UseClippingView() override;
     virtual WXWidget            GetContainer() const override { return m_osxClipView ? m_osxClipView : m_osxView; }

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -367,6 +367,8 @@ public :
 
     virtual bool        EnableTouchEvents(int eventsMask) = 0;
 
+    virtual void        ClipsToBounds(bool clip);
+
     // scrolling views need a clip subview that acts as parent for native children
     // (except for the scollbars) which are children of the view itself
     virtual void        AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical);

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -221,6 +221,9 @@ public:
     // returns the visible region of this control in window ie non-client coordinates
     const wxRegion&     MacGetVisibleRegion( bool includeOuterStructures = false ) ;
 
+    // sets NSView.clipsToBounds property
+    void                MacClipsToBounds( bool clip );
+
     // returns true if children have to clipped to the content area
     // (e.g., scrolled windows)
     bool                MacClipChildren() const { return m_clipChildren ; }

--- a/include/wx/platform.h
+++ b/include/wx/platform.h
@@ -470,6 +470,9 @@
 #        ifndef MAC_OS_VERSION_14_0
 #           define MAC_OS_VERSION_14_0 140000
 #        endif
+#        ifndef MAC_OS_VERSION_26_0
+#           define MAC_OS_VERSION_26_0 260000
+#        endif
 #        if __MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13
 #            ifndef NSAppKitVersionNumber10_10
 #                define NSAppKitVersionNumber10_10 1343

--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -49,11 +49,15 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxSpinDoubleEvent, wxNotifyEvent);
 // ----------------------------------------------------------------------------
 
 // The margin between the text control and the spin: the value here is the same
-// as the margin between the spin button and its "buddy" text control in wxMSW
-// so the generic control looks similarly to the native one there, we might
-// need to use different value for the other platforms (and maybe even
-// determine it dynamically?).
+// as the margin between the spin button and its "buddy" text control in wxMSW,
+// and the commonly used spacing on macOS, so the generic control looks
+// similarly to the native one there, we might need to use different value for
+// other platforms (and maybe even determine it dynamically?).
+#ifdef __WXOSX__
+static const wxCoord MARGIN = 4;
+#else
 static const wxCoord MARGIN = 1;
+#endif
 
 #define SPINCTRLBUT_MAX 32000 // large to avoid wrap around trouble
 
@@ -240,6 +244,10 @@ bool wxSpinCtrlGenericBase::Create(wxWindow *parent,
         if ( DoTextToValue(value, &d) )
             m_value = AdjustAndSnap(d);
     }
+
+#ifdef __WXOSX__
+    MacClipsToBounds(false);
+#endif
 
     m_textCtrl   = new wxSpinCtrlTextGeneric(this, DoValueToText(m_value), style);
     m_spinButton = new wxSpinCtrlButtonGeneric(this, style);

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -128,11 +128,14 @@ wxStatusBar *wxFrame::OnCreateStatusBar(int number, long style, wxWindowID id,
 void wxFrame::SetStatusBar(wxStatusBar *statbar)
 {
     wxFrameBase::SetStatusBar(statbar);
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
     if ( WX_IS_MACOS_AVAILABLE(11, 0) )
     {
         // textured borders are unwanted, statusbar renders w/o them
     }
     else
+#endif
     {
         m_nowpeer->SetBottomBorderThickness(statbar ? GetMacStatusbarHeight() : 0);
     }

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -73,6 +73,7 @@ bool wxStatusBarMac::Create(wxWindow *parent, wxWindowID id,
 
 void wxStatusBarMac::InitColours()
 {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_26_0
     if ( WX_IS_MACOS_AVAILABLE(26, 0) )
     {
         if ( wxSystemSettings::GetAppearance().IsDark() )
@@ -90,7 +91,10 @@ void wxStatusBarMac::InitColours()
             m_separator = wxColour(0xD9, 0xD9, 0xD9);
         }
     }
-    else if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    else
+#endif // MAC_OS_VERSION_26_0
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
     {
         if ( wxSystemSettings::GetAppearance().IsDark() )
         {
@@ -111,7 +115,10 @@ void wxStatusBarMac::InitColours()
             m_separator = wxColour(0xCC, 0xCC, 0xCC);
         }
     }
-    else if ( WX_IS_MACOS_AVAILABLE(10, 14) )
+    else
+#endif // MAC_OS_VERSION_11_0
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
+    if ( WX_IS_MACOS_AVAILABLE(10, 14) )
     {
         if ( wxSystemSettings::GetAppearance().IsDark() )
         {
@@ -124,7 +131,9 @@ void wxStatusBarMac::InitColours()
             m_textInactive = wxColour(0xB1, 0xB1, 0xB1);
         }
     }
-    else // 10.10 Yosemite to 10.13:
+    else
+#endif // MAC_OS_X_VERSION_10_14
+    // 10.10 Yosemite to 10.13:
     {
         m_textActive = wxColour(0x40, 0x40, 0x40);
         m_textInactive = wxColour(0x4B, 0x4B, 0x4B);
@@ -153,11 +162,15 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
             break;
     }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_26_0
     if ( WX_IS_MACOS_AVAILABLE(26, 0) )
     {
         // don't paint the background, handled by the OS
     }
-    else if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    else
+#endif
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
     {
         // we _do_ need to paint the background on Big Sur up to Tahoe
         // to match Finder's appearance:
@@ -165,13 +178,16 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
         dc.Clear();
     }
     // else: background is rendered by OS, it is part of NSWindow border
+#endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
     // Draw horizontal separator above the status bar:
     if ( WX_IS_MACOS_AVAILABLE(11, 0) )
     {
         dc.SetPen(m_separator);
         dc.DrawLine(0, 0, GetSize().x, 0);
     }
+#endif
 
     // Draw the text:
 
@@ -188,11 +204,16 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
 
 void wxStatusBarMac::InitCornerInset()
 {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_26_0
     if ( WX_IS_MACOS_AVAILABLE(26, 0) )
         m_cornerInset = 8;
-    else if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    else
+#endif
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
         m_cornerInset = 4;
     else
+#endif
         m_cornerInset = 0;
 }
 

--- a/src/osx/cocoa/anybutton.mm
+++ b/src/osx/cocoa/anybutton.mm
@@ -44,5 +44,5 @@ wxSize wxAnyButton::DoGetBestSize() const
 
 wxSize wxAnyButton::GetDefaultSize()
 {
-    return wxSize(84, 20);
+    return wxSize(74, 20);
 }

--- a/src/osx/cocoa/notebook.mm
+++ b/src/osx/cocoa/notebook.mm
@@ -91,11 +91,13 @@
         // On macOS 26 Tahoe, the mere presence of drawRect: in derived class,
         // even if it just calls super's implementation, triggers legacy
         // rendering of NSTabView.
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_26_0
         if (WX_IS_MACOS_AVAILABLE(26, 0))
         {
             wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DRAW);
         }
         else
+#endif
         {
             wxOSXCocoaClassAddWXMethods(self);
         }

--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -918,7 +918,7 @@ wxSize wxRendererMac::GetCollapseButtonSize(wxWindow *WXUNUSED(win), wxReadOnlyD
     }
 
     // strict metrics size cutoff the button, increase the size
-    size.IncBy(1);
+    size.IncBy(3);
 
     return size;
 }

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1836,6 +1836,14 @@ wxSize wxNSTextFieldControl::GetBestSize() const
         sz.x = (int)ceil(best.size.width);
         sz.y = (int)ceil(best.size.height);
 
+        // never be smaller than single-line NSMiniControlSize field:
+        sz.y = wxMax(sz.y, 16);
+
+        // !!! Any changes to these adjustments must be mirrored in wxTextCtrl::DoGetSizeFromTextSize() !!!
+
+        sz.x -= 4;
+        sz.y -= 2;
+
         if ( [m_textField isBezeled] || [m_textField isBordered] )
         {
             // since this will be added again in DoGetSizeFromTextSize

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2734,7 +2734,9 @@ wxWidgetImpl( peer, flags )
     if ( m_osxView )
         CFRetain(m_osxView);
     [m_osxView release];
-    m_osxView.clipsToBounds = YES;
+
+    if ( IsUserPane() )
+        ClipsToBounds(true);
 }
 
 
@@ -4290,6 +4292,11 @@ void wxWidgetCocoaImpl::UseClippingView()
         }
     }
 #endif
+}
+
+void wxWidgetCocoaImpl::ClipsToBounds(bool clip)
+{
+    m_osxView.clipsToBounds = clip;
 }
 
 

--- a/src/osx/spinbutt_osx.cpp
+++ b/src/osx/spinbutt_osx.cpp
@@ -81,11 +81,13 @@ bool wxSpinButton::OSXHandleClicked( double WXUNUSED(timestampsec) )
 
 wxSize wxSpinButton::DoGetBestSize() const
 {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_26_0
     if ( WX_IS_MACOS_AVAILABLE(26, 0) )
     {
         return wxSize(21, 28);
     }
     else
+#endif
     {
         return wxSize(13, 22);
     }

--- a/src/osx/spinbutt_osx.cpp
+++ b/src/osx/spinbutt_osx.cpp
@@ -13,6 +13,7 @@
 
 #include "wx/spinbutt.h"
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 
 wxSpinButton::wxSpinButton()
@@ -80,7 +81,14 @@ bool wxSpinButton::OSXHandleClicked( double WXUNUSED(timestampsec) )
 
 wxSize wxSpinButton::DoGetBestSize() const
 {
-    return wxSize( 16, 24 );
+    if ( WX_IS_MACOS_AVAILABLE(26, 0) )
+    {
+        return wxSize(21, 28);
+    }
+    else
+    {
+        return wxSize(13, 22);
+    }
 }
 
 void wxSpinButton::TriggerScrollEvent(wxEventType scrollEvent)

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -232,8 +232,10 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
                 break ;
         }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_26_0
         if ( WX_IS_MACOS_AVAILABLE(26, 0) )
             hText += 3;
+#endif
 
         // the numbers above include the border size, so subtract it before
         // possibly adding it back below

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -38,6 +38,7 @@
 #include "wx/thread.h"
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 wxBEGIN_EVENT_TABLE(wxTextCtrl, wxTextCtrlBase)
     EVT_DROP_FILES(wxTextCtrl::OnDropFiles)
@@ -217,22 +218,22 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
         // these are the numbers from the HIG:
         switch ( m_windowVariant )
         {
-            case wxWINDOW_VARIANT_NORMAL :
-                hText = 22;
-                break ;
-
             case wxWINDOW_VARIANT_SMALL :
                 hText = 19;
                 break ;
 
             case wxWINDOW_VARIANT_MINI :
-                hText = 15;
+                hText = 16;
                 break ;
 
+            case wxWINDOW_VARIANT_NORMAL :
             default :
-                hText = 22;
+                hText = 21;
                 break ;
         }
+
+        if ( WX_IS_MACOS_AVAILABLE(26, 0) )
+            hText += 3;
 
         // the numbers above include the border size, so subtract it before
         // possibly adding it back below
@@ -249,6 +250,8 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
     // since this method is now called with native field widths, an empty field still
     // has small positive xlen, therefore don't compare just with > 0 anymore
     wxSize size(xlen > TEXTCTRL_MAX_EMPTY_WIDTH ? xlen : 100, hText);
+
+    // !!! Any changes to these adjustments must be mirrored in wxNSTextFieldControl::GetBestSize() !!!
 
     // Use extra margin size which works under macOS 10.15: note that we don't
     // need the vertical margin when using the automatically determined hText.

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -1062,13 +1062,6 @@ wxSize wxWindowMac::DoGetBestSize() const
             }
             else
 #endif
-#if wxUSE_SPINBTN
-            if ( IsKindOf( CLASSINFO( wxSpinButton ) ) )
-            {
-                r.height = 24 ;
-            }
-            else
-#endif
             {
                 // return wxWindowBase::DoGetBestSize() ;
             }

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -261,6 +261,13 @@ wxWindowMac::~wxWindowMac()
     delete GetPeer() ;
 }
 
+void wxWindowMac::MacClipsToBounds( bool clip )
+{
+    if ( m_peer )
+        m_peer->ClipsToBounds(clip);
+}
+
+
 void wxWindowMac::MacSetClipChildren()
 {
     m_clipChildren = true ;
@@ -2698,6 +2705,10 @@ bool wxWidgetImpl::NeedsFrame() const
 }
 
 void wxWidgetImpl::SetDrawingEnabled(bool WXUNUSED(enabled))
+{
+}
+
+void wxWidgetImpl::ClipsToBounds(bool WXUNUSED(clip))
 {
 }
 


### PR DESCRIPTION
This PR covers the rest of Tahoe breakages I am aware of (via Poedit). It is best reviewed individually, see the commits' explanations.

This most prominently fixes single-line `wxTextCtrl`, which was outright invisible on macOS 26 Contrast-Is-For-Amateurs Tahoe. `wxSpinCtrl` was subtly broken too, but that's a much less prominent control.

The big commit is the 1st one, [Don't set NSView.clipsToBounds = YES globally](https://github.com/wxWidgets/wxWidgets/commit/3273d289d7ca710a1fd4833c748facbc248e367b) — this slightly undoes the changes to fix wxAUI rendering (and no doubt much more, #23916 was just the canary), by limiting  the `clipsToBounds` change to non-native windows only.

The alternative would be to do it individually for controls that are known to be mis-rendered, but I somewhat strongly prefer doing it like this: we should mess with native controls as little as possible. Unless I'm missing something (@csomor?) it should be safe to differentiate native-vs-wx with this in `wxWidgetCocoaImpl::wxWidgetCocoaImpl`:
https://github.com/wxWidgets/wxWidgets/blob/3273d289d7ca710a1fd4833c748facbc248e367b/src/osx/cocoa/window.mm#L2738-L2739

This assumption is crucial; if I'm wrong about that, it should be done per-control (i.e. so far at least for `wxTextCtrl` and `wxSpinButton`).

Screenshot before:

<img width="644" height="594" alt="before_full" src="https://github.com/user-attachments/assets/47835469-96a1-47e4-895e-bcb06341e26d" />

And after:

<img width="644" height="588" alt="after_full" src="https://github.com/user-attachments/assets/85863d49-43c8-4b68-b4bb-a49512628851" />

And  just the spin control without focus ring:

Before:

<img width="154" height="48" alt="before_spin" src="https://github.com/user-attachments/assets/2f9249ab-c0ff-4564-9fb1-fdb81335d95b" />

After:

<img width="158" height="43" alt="after_spin" src="https://github.com/user-attachments/assets/9f0bfa3c-30fa-4eb5-9d45-c82a8d5b2508" />

In the process of doing this, I spotted some inaccuracies on macOS 15 too, mostly in sizing, so I fixed them there too; it is obvious from the commits where.

---

For [Fix wxTextCtrl sizes on macOS, particularly 26](https://github.com/wxWidgets/wxWidgets/commit/26ee6d248b6e5c96f811ffb34a67c73168157643) my methodology for verifying sizes was as follows:
1. Create test view in wx for measuring, and also create a native xib in Interface Builder, using Xcode 16 for macOS 15 and Xcode 26 for Tahoe, to avoid Xcode 26's metrics changes.
2. I then measures heights of focused text controls with xScope, and also verified regular and small changes against controls present in Apple Safari and Apple Mail.
3. After verifying all sizes were correct, I commented out the code to call `GetPeer()->GetBestSize()` to make sure the fallback switch statement was executed, and again measured all controls on both macOS versions.

Which is to say that I'm reasonably confident in them.