### PR TITLE
Suppress false positive warning from MSVC

### DIFF
--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -261,7 +261,7 @@ wxIntegerValidatorBase::FromString(const wxString& s,
     else
     {
         // Parse as unsigned to ensure we don't accept minus sign here.
-        ULongestValueType uvalue;
+        ULongestValueType uvalue = 0;
         if ( !wxNumberFormatter::FromString(s, &uvalue) )
             return false;
 


### PR DESCRIPTION
When compiling a release build in MSVC, I sometimes get a (false positive) warning about this line:

`*value = static_cast<LongestValueType>(uvalue);`

saying that `uvalue` may be uninitialized. `FromString` actually sets this value, but initializing this value to zero probably isn't a bad idea and will suppress the warning.