### PR TITLE
Remove unused mode_str from wxChmInputStream::OnSysSeek()

### DIFF
--- a/src/html/chm.cpp
+++ b/src/html/chm.cpp
@@ -509,8 +509,6 @@ size_t wxChmInputStream::OnSysRead(void *buffer, size_t bufsize)
 
 wxFileOffset wxChmInputStream::OnSysSeek(wxFileOffset seek, wxSeekMode mode)
 {
-    wxString mode_str;
-
     if ( !m_contentStream || m_contentStream->Eof() )
     {
         m_lasterror = wxSTREAM_EOF;


### PR DESCRIPTION
Looks like it was never used. Saves a compiler warning.

```
wxWidgets-3.3.1/src/html/chm.cpp:512:14: warning: unused variable ‘mode_str’ [-Wunused-variable]
  512 |     wxString mode_str;
```