### PR TITLE
TYMED_ISTREAM should be used for CFSTR_FILECONTENTS

### DIFF
--- a/src/msw/ole/dataobj.cpp
+++ b/src/msw/ole/dataobj.cpp
@@ -448,6 +448,10 @@ STDMETHODIMP wxIEnumFORMATETC::Next(ULONG      celt,
         format.lindex   = -1;
         format.tymed    = TYMED_HGLOBAL;
 
+        if (RegisterClipboardFormat(CFSTR_FILECONTENTS) == format.cfFormat) {
+            format.tymed = TYMED_ISTREAM;
+        }
+
         *rgelt++ = format;
         numFetched++;
     }
@@ -837,6 +841,13 @@ STDMETHODIMP wxIDataObject::QueryGetData(FORMATETC *pformatetc)
                    pformatetc->dwAspect);
 
         return DV_E_DVASPECT;
+    }
+
+    // CFSTR_FILECONTENTS should use TYMED_ISTREAM
+    if (RegisterClipboardFormat(CFSTR_FILECONTENTS) == pformatetc->cfFormat) {
+        if (!(pformatetc->tymed & TYMED_ISTREAM)) {
+            return DV_E_TYMED;
+        }
     }
 
     // and now check the type of data requested


### PR DESCRIPTION
When we drop files to a HTML webpage in Chrome that has a dropzone which handles "drop" events, then files are dropped twice in chrome and Edge. Firefox behaves differently, there only one file is dropped. Debugging showed that Chrome internally calls QueryGetData twice, first with tymed=TYMED_HGLOBAL and second with tymed=TYMED_HGLOBAL|TYMED_ISTREAM|TYMED_ISTORAGE. When we allow both, then two files (the same) are available in event.dataTransfer.files. When we only allow one, then only one file is available.

MS does not recommend TYMED_HGLOBAL for virtual files. So, an easy solution to this is to check for TYMED_ISTREAM in QueryGetData. I have tested with several other drop targets like Windows Explorer, Outlook, Firefox, Edge, Chrome, ... and the behavior is OK.

In my opinion, this is a Chrome issue. However, since wxWidgets should support virtual files in the future, and TYMED_HGLOBAL is less efficient for larger files, this fix and the limitation to TYMED_ISTREAM are acceptable.