### PR TITLE
OSX - support POWER events suspend(ed)/resume in wxWdgets

### DIFF
--- a/include/wx/power.h
+++ b/include/wx/power.h
@@ -40,7 +40,7 @@ enum wxBatteryState
 // compiling in the code for handling them which is never going to be invoked
 // under the other platforms, we define wxHAS_POWER_EVENTS symbol if this event
 // is available, it should be used to guard all code using wxPowerEvent
-#if defined(__WINDOWS__) || defined(__WXGTK__)
+#if defined(__WINDOWS__) || defined(__WXGTK__) || defined(__WXOSX_COCOA__)
 
 #define wxHAS_POWER_EVENTS
 

--- a/interface/wx/power.h
+++ b/interface/wx/power.h
@@ -67,9 +67,9 @@ enum wxPowerBlockKind
     system is suspended, hibernated, plugged into or unplugged from the wall socket
     and so on. wxPowerEvents are emitted by wxWindows.
 
-    Notice that currently these events are generated only under MSW and Linux
-    and that under Linux you @e must use wxPowerResource::Acquire() to receive
-    them, e.g. typically an application interested in these events should
+    Notice that currently these events are generated only under MSW, Linux and
+    MacOS (cocoa). Under Linux and MacOS you @e must use wxPowerResource::Acquire()
+    to receive them, e.g. typically an application interested in these events should
     initialize wxPowerResourceBlocker for ::wxPOWER_RESOURCE_SYSTEM resource
     using ::wxPOWER_DELAY block kind when initializing either the application
     itself or its main window. E.g. for an application that wants to handle

--- a/src/osx/cocoa/power.mm
+++ b/src/osx/cocoa/power.mm
@@ -114,10 +114,10 @@ void wxPowerResource::Release(wxPowerResourceKind kind)
 #import <Cocoa/Cocoa.h>
 #import "wx/power.h" // Assuming you have wxPowerEvent defined or a custom event
 
-@interface CocoaPowerEventsObserver : NSObject
+@interface wxCocoaPowerEventsObserver : NSObject
 @end
 
-@implementation CocoaPowerEventsObserver
+@implementation wxCocoaPowerEventsObserver
 
 - (id)init {
     self = [super init];
@@ -169,7 +169,7 @@ wxDECLARE_DYNAMIC_CLASS(wxCocoaPowerModule);
 public:
     bool OnInit() override
     {
-         m_powerObserver = [[CocoaPowerEventsObserver alloc] init];
+         m_powerObserver = [[wxCocoaPowerEventsObserver alloc] init];
          return true;
     }
 
@@ -183,7 +183,7 @@ public:
     }
 
 private:
-    CocoaPowerEventsObserver* m_powerObserver;
+    wxCocoaPowerEventsObserver* m_powerObserver;
 };
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxCocoaPowerModule, wxModule)

--- a/src/osx/cocoa/power.mm
+++ b/src/osx/cocoa/power.mm
@@ -25,94 +25,13 @@
 
 #include <IOKit/pwr_mgt/IOPMLib.h>
 
-// ----------------------------------------------------------------------------
-// wxPowerResource
-// ----------------------------------------------------------------------------
+#import <Cocoa/Cocoa.h>
 
 static wxAtomicInt g_powerResourceSystemRefCount = 0;
-static NSObject* g_processInfoActivity = nil;
 
-bool UpdatePowerResourceUsage(wxPowerResourceKind kind, const wxString& reason)
-{
-    if ( g_powerResourceSystemRefCount >= 1 )
-    {
-        wxCFStringRef cfreason(reason);
-        if( reason.IsEmpty())
-            cfreason = wxString("User Activity");
-
-        if ( !g_processInfoActivity )
-        {
-            NSActivityOptions
-                options = NSActivityUserInitiated |
-                          NSActivityIdleSystemSleepDisabled;
-
-            if ( kind == wxPOWER_RESOURCE_SCREEN )
-                options |= NSActivityIdleDisplaySleepDisabled;
-
-            g_processInfoActivity = [[NSProcessInfo processInfo]
-                                     beginActivityWithOptions:options
-                                     reason:cfreason.AsNSString()];
-            [g_processInfoActivity retain];
-            return true;
-        }
-    }
-    else if ( g_powerResourceSystemRefCount == 0 )
-    {
-        if ( g_processInfoActivity )
-        {
-            [[NSProcessInfo processInfo]
-             endActivity:(id)g_processInfoActivity];
-            g_processInfoActivity = nil;
-
-            return true;
-        }
-    }
-
-    return true;
-}
-
-bool
-wxPowerResource::Acquire(wxPowerResourceKind kind,
-                         const wxString& reason,
-                         wxPowerBlockKind blockKind)
-{
-    if ( blockKind == wxPOWER_DELAY )
-    {
-        // We don't support this mode under macOS because it's not needed there.
-        return true;
-    }
-
-    wxAtomicInc(g_powerResourceSystemRefCount);
-
-    bool success = UpdatePowerResourceUsage(kind, reason);
-    if (!success)
-        wxAtomicDec(g_powerResourceSystemRefCount);
-
-    return success;
-}
-
-void wxPowerResource::Release(wxPowerResourceKind kind)
-{
-    switch ( kind )
-    {
-        case wxPOWER_RESOURCE_SCREEN:
-        case wxPOWER_RESOURCE_SYSTEM:
-            if ( g_powerResourceSystemRefCount > 0 )
-            {
-                wxAtomicDec(g_powerResourceSystemRefCount);
-            }
-            else
-            {
-                wxFAIL_MSG("Power resource was not acquired");
-            }
-
-            UpdatePowerResourceUsage(kind, "");
-            break;
-    }
-}
-
-#import <Cocoa/Cocoa.h>
-#import "wx/power.h" // Assuming you have wxPowerEvent defined or a custom event
+// ----------------------------------------------------------------------------
+// wxCocoaPowerModule
+// ----------------------------------------------------------------------------
 
 @interface wxCocoaPowerEventsObserver : NSObject
 @end
@@ -161,31 +80,143 @@ void wxPowerResource::Release(wxPowerResourceKind kind)
 @end
 
 namespace {
-// add power observers on init and remove on exit
-class wxCocoaPowerModule : public wxModule
+// wrapper around obj-c interface, usable as std::unique_ptr
+class wxCocoaPowerEventsObserverWrapper
 {
-wxDECLARE_DYNAMIC_CLASS(wxCocoaPowerModule);
-
 public:
-    bool OnInit() override
+    wxCocoaPowerEventsObserverWrapper()
+        : m_powerEventsObserver( [[wxCocoaPowerEventsObserver alloc] init] )
     {
-         m_powerObserver = [[wxCocoaPowerEventsObserver alloc] init];
-         return true;
     }
 
-    void OnExit() override
+    ~wxCocoaPowerEventsObserverWrapper()
     {
-         if (m_powerObserver != nullptr)
-         {
-             [m_powerObserver release];
-             m_powerObserver = nullptr;
-         }
+        [m_powerEventsObserver release];
     }
 
 private:
-    wxCocoaPowerEventsObserver* m_powerObserver;
+    wxCocoaPowerEventsObserver* m_powerEventsObserver;
+
+    wxDECLARE_NO_COPY_CLASS(wxCocoaPowerEventsObserverWrapper);
 };
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxCocoaPowerModule, wxModule)
+// the global power events observer
+static std::unique_ptr<wxCocoaPowerEventsObserverWrapper> g_powerEventsObserver;
 
+// add power observers on init and remove on exit
+class wxCocoaPowerModule : public wxModule
+{
+public:
+    bool OnInit() override { return true; }
+    void OnExit() override
+    {
+        // There should be no other threads by now, so no locking is needed.
+        if ( g_powerResourceSystemRefCount )
+        {
+            if ( g_powerEventsObserver )
+            {
+                delete g_powerEventsObserver.release();
+            }
+
+            g_powerResourceSystemRefCount = 0;
+        }
+    }
+
+private:
+    wxDECLARE_NO_COPY_CLASS(wxCocoaPowerModule);
+};
 }; // anonymous namespace
+
+// ----------------------------------------------------------------------------
+// wxPowerResource
+// ----------------------------------------------------------------------------
+
+static NSObject* g_processInfoActivity = nil;
+
+bool UpdatePowerResourceUsage(wxPowerResourceKind kind, const wxString& reason)
+{
+    if ( g_powerResourceSystemRefCount >= 1 )
+    {
+        wxCFStringRef cfreason(reason);
+        if( reason.IsEmpty())
+            cfreason = wxString("User Activity");
+
+        if ( !g_processInfoActivity )
+        {
+            NSActivityOptions
+                options = NSActivityUserInitiated |
+                          NSActivityIdleSystemSleepDisabled;
+
+            if ( kind == wxPOWER_RESOURCE_SCREEN )
+                options |= NSActivityIdleDisplaySleepDisabled;
+
+            g_processInfoActivity = [[NSProcessInfo processInfo]
+                                     beginActivityWithOptions:options
+                                     reason:cfreason.AsNSString()];
+            [g_processInfoActivity retain];
+            return true;
+        }
+    }
+    else if ( g_powerResourceSystemRefCount == 0 )
+    {
+        if ( g_processInfoActivity )
+        {
+            [[NSProcessInfo processInfo]
+             endActivity:(id)g_processInfoActivity];
+            g_processInfoActivity = nil;
+
+            return true;
+        }
+    }
+
+    return true;
+}
+
+bool
+wxPowerResource::Acquire(wxPowerResourceKind kind,
+                         const wxString& reason,
+                         wxPowerBlockKind blockKind)
+{
+    if ( blockKind == wxPOWER_DELAY )
+    {
+        if ( kind == wxPOWER_RESOURCE_SYSTEM )
+        {
+            wxAtomicInc(g_powerResourceSystemRefCount);
+
+            if ( !g_powerEventsObserver )
+            {
+                g_powerEventsObserver.reset( new wxCocoaPowerEventsObserverWrapper() );
+            }
+        }
+
+        return true;
+    }
+
+    wxAtomicInc(g_powerResourceSystemRefCount);
+
+    bool success = UpdatePowerResourceUsage(kind, reason);
+    if (!success)
+        wxAtomicDec(g_powerResourceSystemRefCount);
+
+    return success;
+}
+
+void wxPowerResource::Release(wxPowerResourceKind kind)
+{
+    switch ( kind )
+    {
+        case wxPOWER_RESOURCE_SCREEN:
+        case wxPOWER_RESOURCE_SYSTEM:
+            if ( g_powerResourceSystemRefCount > 0 )
+            {
+                wxAtomicDec(g_powerResourceSystemRefCount);
+            }
+            else
+            {
+                wxFAIL_MSG("Power resource was not acquired");
+            }
+
+            UpdatePowerResourceUsage(kind, "");
+            break;
+    }
+}


### PR DESCRIPTION
Register observers with notifications center, with callbacks for NSWorkspaceWillSleepNotification and NSWorkspaceDidWakeNotification notifications.

These callbacks inform the top level window to handle POWER SUSPENDED and/or RESUME.