### PR TITLE
Allow for cross compilation on iPhone on Silicon Macs

### DIFF
--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -104,6 +104,14 @@ jobs:
           skip_samples: true
           skip_testing: true
           allow_warnings: true
+        - name: wxiOS Simulator on Silicon Mac
+          runner: macos-15
+          arch: arm64
+          configure_flags: --with-iphonesimulator --enable-monolithic --disable-shared --with-macosx-sdk=$(xcrun --sdk iphonesimulator --show-sdk-path) --host=aarch64-apple-darwin24.6.0 --build=aarch64-apple-darwin --without-libtiff
+          xcode_sdk: iphonesimulator
+          skip_samples: true
+          skip_testing: true
+          allow_warnings: true
 
     env:
       wxUSE_ASAN: ${{ matrix.use_asan && 1 || 0 }}

--- a/configure
+++ b/configure
@@ -1093,6 +1093,7 @@ with_osx_iphone
 with_osx
 with_cocoa
 with_iphone
+with_iphonesimulator
 with_mac
 with_wine
 with_msw
@@ -2379,6 +2380,7 @@ Optional Packages:
   --with-osx              use macOS (default port, Cocoa)
   --with-cocoa            same as --with-osx_cocoa
   --with-iphone           same as --with-osx_iphone
+  --with-iphonesimulator     same as --with-osx_iphonesimulator
   --with-mac              same as --with-osx
   --with-wine             use Wine
   --with-msw              use MS-Windows
@@ -4472,6 +4474,19 @@ if test "${with_iphone+set}" = set; then :
                 as_fn_error $? "Option --with-iphone doesn't accept any arguments" "$LINENO" 5
             fi
             wxUSE_OSX_IPHONE="$withval" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1
+
+fi
+
+
+
+
+# Check whether --with-iphonesimulator was given.
+if test "${with_iphonesimulator+set}" = set; then :
+  withval=$with_iphonesimulator;
+            if test "$withval" != yes; then
+                as_fn_error $? "Option --with-iphonesimulator doesn't accept any arguments" "$LINENO" 5
+            fi
+            wxUSE_OSX_IPHONE="$withval" wxUSE_IPHONESIMULATOR="yes" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1
 
 fi
 
@@ -23176,7 +23191,11 @@ fi
 
 if test "x$wxUSE_MACOSX_VERSION_MIN" != "x"; then
     if test "$wxUSE_OSX_IPHONE" = 1; then
-        MACOSX_VERSION_MIN_OPTS="-miphoneos-version-min=$wxUSE_MACOSX_VERSION_MIN"
+        if test "$wxUSE_IPHONESIMULATOR" = "yes"; then
+            MACOSX_VERSION_MIN_OPTS="-miphonesimulator-version-min=$wxUSE_MACOSX_VERSION_MIN"
+        else
+            MACOSX_VERSION_MIN_OPTS="-miphoneos-version-min=$wxUSE_MACOSX_VERSION_MIN"
+        fi
     else
         MACOSX_VERSION_MIN_OPTS="-mmacosx-version-min=$wxUSE_MACOSX_VERSION_MIN"
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -425,7 +425,7 @@ WX_ARG_ONLY_WITH(directfb,      [  --with-directfb         use DirectFB], [wxUSE
 WX_ARG_ONLY_WITH(x11,           [  --with-x11              use X11], [wxUSE_X11="$withval" wxUSE_UNIVERSAL="yes" CACHE_X11=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(qt,            [  --with-qt               use Qt], [wxUSE_QT="$withval" CACHE_QT=1 TOOLKIT_GIVEN=1])
 WX_ARG_ENABLE(nanox,       [  --enable-nanox          use NanoX], wxUSE_NANOX)
-WX_ARG_ENABLE(iphonesimulator,  [  --enable-iphonesimulator   commpile for iPhone simulator], wxUSE_IPHONESIMULATOR)
+WX_ARG_ENABLE(iphonesimulator,  [  --enable-iphonesimulator   compile for iPhone simulator], wxUSE_IPHONESIMULATOR)
 
 dnl check that no more than one toolkit is given and that if none are given that
 dnl we have a default one

--- a/configure.ac
+++ b/configure.ac
@@ -427,7 +427,6 @@ WX_ARG_ONLY_WITH(directfb,      [  --with-directfb         use DirectFB], [wxUSE
 WX_ARG_ONLY_WITH(x11,           [  --with-x11              use X11], [wxUSE_X11="$withval" wxUSE_UNIVERSAL="yes" CACHE_X11=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(qt,            [  --with-qt               use Qt], [wxUSE_QT="$withval" CACHE_QT=1 TOOLKIT_GIVEN=1])
 WX_ARG_ENABLE(nanox,       [  --enable-nanox          use NanoX], wxUSE_NANOX)
-WX_ARG_ENABLE(iphonesimulator,  [  --enable-iphonesimulator   commpile for iPhone simulator], wxUSE_IPHONESIMULATOR)
 
 dnl check that no more than one toolkit is given and that if none are given that
 dnl we have a default one

--- a/configure.ac
+++ b/configure.ac
@@ -425,6 +425,7 @@ WX_ARG_ONLY_WITH(directfb,      [  --with-directfb         use DirectFB], [wxUSE
 WX_ARG_ONLY_WITH(x11,           [  --with-x11              use X11], [wxUSE_X11="$withval" wxUSE_UNIVERSAL="yes" CACHE_X11=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(qt,            [  --with-qt               use Qt], [wxUSE_QT="$withval" CACHE_QT=1 TOOLKIT_GIVEN=1])
 WX_ARG_ENABLE(nanox,       [  --enable-nanox          use NanoX], wxUSE_NANOX)
+WX_ARG_ENABLE(iphonesimulator,  [  --enable-iphonesimulator   commpile for iPhone simulator], wxUSE_IPHONESIMULATOR)
 
 dnl check that no more than one toolkit is given and that if none are given that
 dnl we have a default one
@@ -1339,7 +1340,11 @@ fi
 
 if test "x$wxUSE_MACOSX_VERSION_MIN" != "x"; then
     if test "$wxUSE_OSX_IPHONE" = 1; then
-        MACOSX_VERSION_MIN_OPTS="-miphoneos-version-min=$wxUSE_MACOSX_VERSION_MIN"
+        if test "$wxUSE_IPHONESIMULATOR" = "yes"; then
+            MACOSX_VERSION_MIN_OPTS="-miphonesimulator-version-min=$wxUSE_MACOSX_VERSION_MIN"
+        else
+            MACOSX_VERSION_MIN_OPTS="-miphoneos-version-min=$wxUSE_MACOSX_VERSION_MIN"
+        fi
     else
         MACOSX_VERSION_MIN_OPTS="-mmacosx-version-min=$wxUSE_MACOSX_VERSION_MIN"
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -415,7 +415,6 @@ dnl shouldn't default to wxUSE_ALL_FEATURES
 AC_ARG_WITH(gtk,          [[  --with-gtk[=VERSION]    use GTK+, VERSION can be 3 (default), 2, or "any"]], [wxUSE_GTK="$withval" CACHE_GTK=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(osx_cocoa,     [  --with-osx_cocoa        use macOS (Cocoa)], [wxUSE_OSX_COCOA="$withval" CACHE_OSX_COCOA=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(osx_iphone,    [  --with-osx_iphone       use iOS], [wxUSE_OSX_IPHONE="$withval" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1])
-WX_ARG_ONLY_WITH(iphonesimulator, [  --with-osx_iphonesimulator  use iPhone simulator], [wxUSE_OSX_IPHONE="$withval" wxUSE_IPHONESIMULATOR="yes" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(osx,           [  --with-osx              use macOS (default port, Cocoa)], [wxUSE_OSX_COCOA="$withval" CACHE_OSX_COCOA=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(cocoa,         [  --with-cocoa            same as --with-osx_cocoa], [wxUSE_OSX_COCOA="$withval" CACHE_OSX_COCOA=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(iphone,        [  --with-iphone           same as --with-osx_iphone], [wxUSE_OSX_IPHONE="$withval" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1])

--- a/configure.ac
+++ b/configure.ac
@@ -415,9 +415,11 @@ dnl shouldn't default to wxUSE_ALL_FEATURES
 AC_ARG_WITH(gtk,          [[  --with-gtk[=VERSION]    use GTK+, VERSION can be 3 (default), 2, or "any"]], [wxUSE_GTK="$withval" CACHE_GTK=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(osx_cocoa,     [  --with-osx_cocoa        use macOS (Cocoa)], [wxUSE_OSX_COCOA="$withval" CACHE_OSX_COCOA=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(osx_iphone,    [  --with-osx_iphone       use iOS], [wxUSE_OSX_IPHONE="$withval" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1])
+WX_ARG_ONLY_WITH(iphonesimulator, [  --with-osx_iphonesimulator  use iPhone simulator], [wxUSE_OSX_IPHONE="$withval" wxUSE_IPHONESIMULATOR="yes" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(osx,           [  --with-osx              use macOS (default port, Cocoa)], [wxUSE_OSX_COCOA="$withval" CACHE_OSX_COCOA=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(cocoa,         [  --with-cocoa            same as --with-osx_cocoa], [wxUSE_OSX_COCOA="$withval" CACHE_OSX_COCOA=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(iphone,        [  --with-iphone           same as --with-osx_iphone], [wxUSE_OSX_IPHONE="$withval" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1])
+WX_ARG_ONLY_WITH(iphonesimulator, [  --with-iphonesimulator     same as --with-osx_iphonesimulator], [wxUSE_OSX_IPHONE="$withval" wxUSE_IPHONESIMULATOR="yes" CACHE_OSX_IPHONE=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(mac,           [  --with-mac              same as --with-osx], [wxUSE_OSX_COCOA="$withval" CACHE_OSX_COCOA=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(wine,          [  --with-wine             use Wine], [wxUSE_WINE="$withval" CACHE_WINE=1])
 WX_ARG_ONLY_WITH(msw,           [  --with-msw              use MS-Windows], [wxUSE_MSW="$withval" CACHE_MSW=1 TOOLKIT_GIVEN=1])
@@ -425,7 +427,7 @@ WX_ARG_ONLY_WITH(directfb,      [  --with-directfb         use DirectFB], [wxUSE
 WX_ARG_ONLY_WITH(x11,           [  --with-x11              use X11], [wxUSE_X11="$withval" wxUSE_UNIVERSAL="yes" CACHE_X11=1 TOOLKIT_GIVEN=1])
 WX_ARG_ONLY_WITH(qt,            [  --with-qt               use Qt], [wxUSE_QT="$withval" CACHE_QT=1 TOOLKIT_GIVEN=1])
 WX_ARG_ENABLE(nanox,       [  --enable-nanox          use NanoX], wxUSE_NANOX)
-WX_ARG_ENABLE(iphonesimulator,  [  --enable-iphonesimulator   compile for iPhone simulator], wxUSE_IPHONESIMULATOR)
+WX_ARG_ENABLE(iphonesimulator,  [  --enable-iphonesimulator   commpile for iPhone simulator], wxUSE_IPHONESIMULATOR)
 
 dnl check that no more than one toolkit is given and that if none are given that
 dnl we have a default one

--- a/docs/ios/install.md
+++ b/docs/ios/install.md
@@ -25,3 +25,12 @@ The library can also be build via configure/make:
         --enable-macosx_arch=i386 \
         --with-macosx-sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)
     make
+
+On a recent Silicon Mac in the 3.3 branch you need this configure
+to compile for the iPhone simulator (exchange 24.6.0 with your 
+actual host system):
+
+    ../configure --with-osx_iphone --enable-iphonesimulator --enable-monolithic  \
+        --disable-shared --with-macosx-sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)  \
+        --host=aarch64-apple-darwin24.6.0 --build=aarch64-apple-darwin --without-libtiff
+    make

--- a/docs/ios/install.md
+++ b/docs/ios/install.md
@@ -27,8 +27,7 @@ The library can also be build via configure/make:
     make
 
 On a recent Silicon Mac in the 3.3 branch you need this configure
-to compile for the iPhone simulator (exchange 24.6.0 with your 
-actual host system):
+to compile for the iPhone simulator:
 
     ../wxWidgets/configure --with-iphonesimulator --enable-monolithic  \
         --disable-shared --with-macosx-sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)  \

--- a/docs/ios/install.md
+++ b/docs/ios/install.md
@@ -30,7 +30,7 @@ On a recent Silicon Mac in the 3.3 branch you need this configure
 to compile for the iPhone simulator (exchange 24.6.0 with your 
 actual host system):
 
-    ../configure --with-osx_iphonesimulator --enable-monolithic  \
+    ../wxWidgets/configure --with-iphonesimulator --enable-monolithic  \
         --disable-shared --with-macosx-sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)  \
-        --host=aarch64-apple-darwin24.6.0 --build=aarch64-apple-darwin --without-libtiff
+        --host=$(../wxWidgets/config.guess) --build=aarch64-apple-darwin --without-libtiff
     make

--- a/docs/ios/install.md
+++ b/docs/ios/install.md
@@ -30,7 +30,7 @@ On a recent Silicon Mac in the 3.3 branch you need this configure
 to compile for the iPhone simulator (exchange 24.6.0 with your 
 actual host system):
 
-    ../configure --with-osx_iphone --enable-iphonesimulator --enable-monolithic  \
+    ../configure --with-osx_iphonesimulator --enable-monolithic  \
         --disable-shared --with-macosx-sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)  \
         --host=aarch64-apple-darwin24.6.0 --build=aarch64-apple-darwin --without-libtiff
     make


### PR DESCRIPTION
  Added compile flag --enable-iphonesimulator
  Documented this build instructions