### PR TITLE
Fix wxTextEntryDialog from being resizable to 0, 0 (and other tweaks)

### DIFF
--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -82,7 +82,7 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
     }
 
     if (sz.IsFullySpecified())
-    SetMinSize( sz );
+        SetMinSize( sz );
 
     m_dialogStyle = style;
     m_value = value;
@@ -120,7 +120,7 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
     SetSizer( topsizer );
 
     if (sz.IsFullySpecified())
-    topsizer->Fit( this );
+        topsizer->Fit( this );
     else
         topsizer->SetSizeHints( this );
 

--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -81,6 +81,7 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
         return false;
     }
 
+    if (sz.IsFullySpecified())
     SetMinSize( sz );
 
     m_dialogStyle = style;
@@ -115,7 +116,10 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
 
     SetSizer( topsizer );
 
+    if (sz.IsFullySpecified())
     topsizer->Fit( this );
+    else
+        topsizer->SetSizeHints( this );
 
     if ( style & wxCENTRE )
         Centre( wxBOTH );

--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -99,7 +99,7 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
         style |= wxTE_RICH2;
 
     m_textctrl = new wxTextCtrl(this, wxID_TEXT, value,
-                                wxDefaultPosition, wxSize(300, wxDefaultCoord),
+                                wxDefaultPosition, wxSize(FromDIP(300), wxDefaultCoord),
                                 style & ~wxTextEntryDialogStyle);
 
     topsizer->Add(m_textctrl,

--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -107,10 +107,13 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
                     Expand().
                     TripleBorder(wxLEFT | wxRIGHT));
 
-    // 3) buttons if any
+    // 3) buttons, if any, and a spacer to force them down to the bottom
+    // when single-line dialog is resized
     wxSizer *buttonSizer = CreateSeparatedButtonSizer(style & (wxOK | wxCANCEL));
     if ( buttonSizer )
     {
+        if ((style & wxTE_MULTILINE) == 0)
+            topsizer->AddStretchSpacer();
         topsizer->Add(buttonSizer, wxSizerFlags().Expand().DoubleBorder());
     }
 


### PR DESCRIPTION
I don't see a way to force a max height (only size, which we don't want since the width should always be resizable). However, for a single-line dialog I fixed it so that the button row remains at the bottom of the dialog when resized. That seems much nicer looking then before.
#25739 