### PR TITLE
Introduce system color for GRIDLINES, map to NSColor gridColor on macOS.

### DIFF
--- a/include/wx/settings.h
+++ b/include/wx/settings.h
@@ -80,6 +80,7 @@ enum wxSystemColour
     wxSYS_COLOUR_MENUBAR,
     wxSYS_COLOUR_LISTBOXTEXT,
     wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT,
+    wxSYS_COLOUR_GRIDLINES,
 
     wxSYS_COLOUR_MAX,
 
@@ -91,6 +92,7 @@ enum wxSystemColour
     wxSYS_COLOUR_3DHIGHLIGHT = wxSYS_COLOUR_BTNHIGHLIGHT,
     wxSYS_COLOUR_3DHILIGHT = wxSYS_COLOUR_BTNHIGHLIGHT,
     wxSYS_COLOUR_FRAMEBK = wxSYS_COLOUR_BTNFACE
+    
 };
 
 // possible values for wxSystemSettings::GetMetric() index parameter

--- a/include/wx/settings.h
+++ b/include/wx/settings.h
@@ -92,7 +92,6 @@ enum wxSystemColour
     wxSYS_COLOUR_3DHIGHLIGHT = wxSYS_COLOUR_BTNHIGHLIGHT,
     wxSYS_COLOUR_3DHILIGHT = wxSYS_COLOUR_BTNHIGHLIGHT,
     wxSYS_COLOUR_FRAMEBK = wxSYS_COLOUR_BTNFACE
-    
 };
 
 // possible values for wxSystemSettings::GetMetric() index parameter

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -121,7 +121,7 @@ enum wxSystemColour
         @since 3.3.2
      */
     wxSYS_COLOUR_GRIDLINES,
-    
+
     // synonyms:
 
     wxSYS_COLOUR_BACKGROUND = wxSYS_COLOUR_DESKTOP,

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -115,7 +115,13 @@ enum wxSystemColour
      */
     wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT,
 
-
+    /**
+        On macOS, this maps to [NSColor gridLines], on other platforms
+        it's mapped to wxSYS_COLOUR_BTNFACE
+        @since 3.3
+     */
+    wxSYS_COLOUR_GRIDLINES,
+    
     // synonyms:
 
     wxSYS_COLOUR_BACKGROUND = wxSYS_COLOUR_DESKTOP,

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -118,7 +118,7 @@ enum wxSystemColour
     /**
         On macOS, this maps to [NSColor gridLines], on other platforms
         it's mapped to wxSYS_COLOUR_BTNFACE
-        @since 3.3
+        @since 3.3.2
      */
     wxSYS_COLOUR_GRIDLINES,
     

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3206,7 +3206,7 @@ void wxGrid::Init()
     m_minAcceptableColWidth  =
     m_minAcceptableRowHeight = 0;
 
-    m_gridLineColour = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
+    m_gridLineColour = wxSystemSettings::GetColour(wxSYS_COLOUR_GRIDLINES);
     m_gridLinesEnabled = true;
     m_gridLinesClipHorz =
     m_gridLinesClipVert = true;

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -764,6 +764,7 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
         }
         wxFALLTHROUGH;
 #endif
+    case wxSYS_COLOUR_GRIDLINES:
     case wxSYS_COLOUR_3DLIGHT:
     case wxSYS_COLOUR_ACTIVEBORDER:
     case wxSYS_COLOUR_BTNFACE:

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -330,6 +330,7 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
         case wxSYS_COLOUR_MENU:
             return wxColour(0x2b2b2b);
 
+        case wxSYS_COLOUR_GRIDLINES:
         case wxSYS_COLOUR_BTNFACE:
             return wxColour(0x333333);
 

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -106,7 +106,12 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
             return colDark;
     }
 
-    if ( index == wxSYS_COLOUR_LISTBOXTEXT)
+    if ( index == wxSYS_COLOUR_GRIDLINES)
+    {
+        // there is no standard colour with this index, map to another one
+        index = wxSYS_COLOUR_BTNFACE;
+    }
+    else if ( index == wxSYS_COLOUR_LISTBOXTEXT)
     {
         // there is no standard colour with this index, map to another one
         index = wxSYS_COLOUR_WINDOWTEXT;

--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -113,6 +113,9 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
     case wxSYS_COLOUR_WINDOW:
         sysColor = [NSColor controlBackgroundColor];
         break;
+    case wxSYS_COLOUR_GRIDLINES:
+        sysColor = [NSColor gridColor];
+        break;
     case wxSYS_COLOUR_BTNFACE:
         if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
             sysColor = [NSColor windowBackgroundColor];

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1434,18 +1434,28 @@ void wxPropertyGrid::RegainColours()
 {
     if ( !(m_coloursCustomized & CustomColour_CaptionBg) )
     {
-        wxColour col = wxSystemSettings::GetColour( wxSYS_COLOUR_BTNFACE );
-
-        // Make sure colour is dark enough
-    #ifdef __WXGTK__
-        int colDec = wxPGGetColAvg(col) - 230;
-    #else
-        int colDec = wxPGGetColAvg(col) - 200;
-    #endif
-        if ( colDec > 0 )
-            m_colCapBack = wxPGAdjustColour(col,-colDec);
+        wxColour col = wxSystemSettings::GetColour( wxSYS_COLOUR_GRIDLINES );
+    #ifdef __WXOSX__
+        if (wxSystemSettings::GetAppearance().IsDark())
+        {
+            // Make sure colour is light enough
+            int colDec = wxPGGetColAvg(col);
+            if (colDec < 30)
+                col = wxPGAdjustColour(col, 20);
+        }
         else
-            m_colCapBack = col;
+    #endif
+        {
+            // Make sure colour is dark enough
+        #ifdef __WXGTK__
+            int colDec = wxPGGetColAvg(col) - 230;
+        #else
+            int colDec = wxPGGetColAvg(col) - 200;
+        #endif
+            if ( colDec > 0 )
+                col = wxPGAdjustColour(col,-colDec);
+        }
+        m_colCapBack = col;
         m_categoryDefaultCell.GetData()->SetBgCol(m_colCapBack);
     }
 

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -37,6 +37,7 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
             color = pal.color(QPalette::Light);
             break;
 
+        case wxSYS_COLOUR_GRIDLINES:
         case wxSYS_COLOUR_BTNFACE:
             color = pal.color(QPalette::Button);
             break;


### PR DESCRIPTION
This introduces a new system color enum value for wxSYS_COLOUR_GRIDLINES which maps to BTNFACE on platforms other than macOS.   On macOS, it will use the NSColor gridColor.

This also adjusts the property grid categories when in dark mode.   If the color is too dark, it will lighten it slightly.  This produces a fairly good looking property grid in dark mode:

<img width="390" height="503" alt="Screenshot 2025-09-09 at 7 07 35 PM" src="https://github.com/user-attachments/assets/d47e78b3-03d5-4896-ad76-12ccc0874685" />
