### PR TITLE
Fix shared CMake build using external WebP library

### DIFF
--- a/build/cmake/modules/FindWebP.cmake
+++ b/build/cmake/modules/FindWebP.cmake
@@ -3,7 +3,7 @@ find_package(WebP CONFIG)
 if(NOT WebP_FOUND)
     find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND)
-        pkg_check_modules(WebP libwebp)
+        pkg_check_modules(WebP libwebp libwebpdemux)
     endif()
 endif()
 


### PR DESCRIPTION
Building an application against wxWidgets built as a shared
library using libwep found with pkg-config fails with:

```
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPDemuxDelete'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPAnimDecoderReset'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPAnimDecoderOptionsInitInternal'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPDemuxInternal'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPAnimDecoderGetNext'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPDemuxGetI'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPAnimDecoderHasMoreFrames'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPAnimDecoderDelete'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPAnimDecoderGetInfo'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPAnimDecoderNewInternal'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPDemuxReleaseIterator'
x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libwx_gtk3u_core-3.3.so: undefined reference to `WebPDemuxGetFrame'
```
