### PR TITLE
Explain that clip paths don't work in NanoSVG, offer workaround

### DIFF
--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -248,13 +248,14 @@ public:
 
         Please note that the current implementation uses NanoSVG library
         (https://github.com/memononen/nanosvg) for parsing and rasterizing SVG
-        images which imposes the following limitations:
+        images, which does not support the following:
 
-        - Text elements are not supported at all (see note for workaround).
-        - SVG 1.1 filters are not supported.
-        - Embedded images are not supported (see note for workaround).
+        - Text elements
+        - SVG 1.1 filters
+        - Embedded images
+        - Clip paths
 
-        These limitations will be relaxed in the future wxWidgets versions.
+        See note below for possible workarounds.
 
         Please also note that this method is only available in the ports
         providing raw bitmap access via wxPixelData. This is the case for all
@@ -278,12 +279,16 @@ public:
         @note Converting text objects to path objects will allow them to be
             rasterized as expected. This can be done in an SVG editor such as
             Inkscape. (In Inkscape, select a text object and choose
-            "Object to Path" from the "Path" menu.)\n
+            "Object to Path" from the "Path" menu.)\n\n
             Converting embedded images to paths from an SVG editor will
             allow them to be rasterized. For example, selecting "Trace Bitmap"
             from the "Path" menu in Inkscape can perform this. This is only
             recommended for simple images, however, as more complex images
-            may not rasterize well.
+            may not rasterize well.\n\n
+            To work around clip paths, you can manually cut and remove portions
+            of objects (rather than using a clip path to hide them).
+            In Inkscape, this can be done via either "Path" → "Difference"
+            or "Path" → "Division" (i.e., cookie-cutter subtraction).
      */
     static wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
 

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -285,7 +285,7 @@ public:
             from the "Path" menu in Inkscape can perform this. This is only
             recommended for simple images, however, as more complex images
             may not rasterize well.\n\n
-            To work around clip paths, you can manually cut and remove portions
+            To work around lack of support for clip paths, you can manually cut and remove portions
             of objects (rather than using a clip path to hide them).
             In Inkscape, this can be done via either "Path" → "Difference"
             or "Path" → "Division" (i.e., cookie-cutter subtraction).


### PR DESCRIPTION
Clip path not being supported was mentioned in a bug report, and I also ran into this issue. The workaround I explain here worked for me.

I also removed "These limitations will be relaxed in the future wxWidgets versions" statement. NanoSVG is no longer supported (according to its repo's README).