### PR TITLE
Don't enable `WS_EX_COMPOSITED` by default in wxMSW any longer

### DIFF
--- a/demos/forty/canvas.cpp
+++ b/demos/forty/canvas.cpp
@@ -34,15 +34,6 @@ FortyCanvas::FortyCanvas(wxWindow* parent, const wxPoint& pos, const wxSize& siz
              m_playerDialog(0),
              m_leftBtnDown(false)
 {
-#ifdef __WXMSW__
-    // Unfortunately the redraw logic here is incompatible with double
-    // buffering under MSW, so we have to disable it. The proper solution would
-    // be to rewrite this logic, as this is also required to make it work under
-    // GTK/Wayland and macOS, where the game currently doesn't update its
-    // display at all.
-    MSWDisableComposited();
-#endif
-
     SetScrollbars(0, 0, 0, 0);
 
 #ifdef __WXGTK__

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -11,19 +11,6 @@ INCOMPATIBLE CHANGES SINCE 3.2.x:
 Changes in behaviour not resulting in compilation errors
 --------------------------------------------------------
 
-- wxMSW now uses double buffering by default, meaning that updating the
-  windows using wxClientDC doesn't work any longer, which is consistent with
-  the behaviour of wxGTK with Wayland backend and of wxOSX, but not with the
-  traditional historic behaviour of wxMSW (or wxGTK/X11). You may call
-  MSWDisableComposited() to restore the previous behaviour, however it is
-  strongly recommended to change your redrawing logic to avoid using wxClientDC
-  instead, as the code using it still won't work with wxGTK/wxOSX.
-
-  You may also choose to globally set the new msw.window.no-composited system
-  option to disable the use of double buffering, but please consider doing it
-  only as a last resort and/or temporary solution, as this _will_ result in
-  flicker and won't be supported at all in the future wxWidgets versions.
-
 - wxMSW doesn't support versions of Microsoft Windows before Windows 7. If you
   need Windows XP or Vista support, please use wxWidgets 3.2.
 

--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -15,9 +15,12 @@
 #include "wx/dcclient.h"
 #include "wx/window.h"
 
-// All current ports use double buffering.
-#define wxALWAYS_NATIVE_DOUBLE_BUFFER       1
-
+// Only wxMSW doesn't use double buffering.
+#ifdef __WXMSW__
+    #define wxALWAYS_NATIVE_DOUBLE_BUFFER       0
+#else
+    #define wxALWAYS_NATIVE_DOUBLE_BUFFER       1
+#endif
 
 // ----------------------------------------------------------------------------
 // Double buffering helper.

--- a/include/wx/msw/statbox.h
+++ b/include/wx/msw/statbox.h
@@ -69,8 +69,6 @@ public:
     // returns true if the platform should explicitly apply a theme border
     virtual bool CanApplyThemeBorder() const override { return false; }
 
-    virtual void MSWOnDisabledComposited() override;
-
 protected:
     virtual wxSize DoGetBestSize() const override;
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -558,10 +558,6 @@ public:
     // incompatible with this style.
     void MSWDisableComposited();
 
-    // This function is called for all child windows when compositing is
-    // disabled for their parent.
-    virtual void MSWOnDisabledComposited() { }
-
     // synthesize a wxEVT_LEAVE_WINDOW event and set m_mouseInWindow to false
     void GenerateMouseLeave();
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -554,8 +554,8 @@ public:
     virtual bool IsDoubleBuffered() const override;
 
     // Ensure that neither this window itself nor any of its parents use
-    // WS_EX_COMPOSITED: this is used by the native wxListCtrl which is
-    // incompatible with this style.
+    // WS_EX_COMPOSITED: this may only be necessary after calling
+    // SetDoubleBuffered() which sets this style.
     void MSWDisableComposited();
 
     // synthesize a wxEVT_LEAVE_WINDOW event and set m_mouseInWindow to false

--- a/interface/wx/dcclient.h
+++ b/interface/wx/dcclient.h
@@ -47,11 +47,11 @@ public:
 
     @note While wxClientDC may also be used for drawing on the client area of a
     window from outside an EVT_PAINT() handler in some ports, this does @em not
-    work on most of the platforms: neither wxOSX nor wxGTK with GTK 3 Wayland
-    backend support this at all, so drawing using wxClientDC simply doesn't
-    have any effect there. CanBeUsedForDrawing() can be used to determine
-    whether wxClientDC can be used for drawing in the current environment, but
-    it is recommended to only draw on the window using wxPaintDC, as this is
+    work on all platforms: neither wxOSX nor wxGTK with GTK 3 Wayland backend
+    support this at all, so drawing using wxClientDC simply doesn't have any
+    effect there. CanBeUsedForDrawing() can be used to determine whether
+    wxClientDC can be used for drawing in the current environment, but it is
+    recommended to only draw on the window using wxPaintDC, as this is
     guaranteed to work everywhere. To redraw a small part of the window, use
     wxWindow::RefreshRect() to invalidate just this part and check
     wxWindow::GetUpdateRegion() in the paint event handler to redraw this part

--- a/interface/wx/statbox.h
+++ b/interface/wx/statbox.h
@@ -20,13 +20,8 @@
     wxWidgets 2.9.1 it is strongly recommended to create them as children of
     wxStaticBox itself, as doing this avoids problems with repainting that
     could happen when creating the other windows as siblings of the box.
-    Notably, in wxMSW, siblings of the static box are not drawn at all inside
-    it when compositing is used, which is the case by default, and
-    wxWindow::MSWDisableComposited() must be explicitly called to fix this.
-    Creating windows located inside the static box as its children avoids this
-    problem and works well whether compositing is used or not.
 
-    To summarize, the correct way to create static box and the controls inside
+    To be clear, the correct way to create static box and the controls inside
     it is:
     @code
         void MyFrame::CreateControls()

--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -82,10 +82,6 @@
         appearance but not all fonts are available in this quality,
         e.g. the Terminal font in small sizes is not and this option may be
         used if wider fonts selection is more important than higher quality.
-    @flag{msw.window.no-composited}
-        If set to 1, disables the use of composited, i.e. double-buffered,
-        windows by default in wxMSW. This is not recommended, but can be useful
-        for debugging or working around redraw problems in the existing code.
     @flag{msw.dark-mode}
         If set to 1, enable experimental support of dark mode if the system is
         using it, i.e. this has the same effect as calling

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -4315,39 +4315,6 @@ public:
     ///@}
 
 
-    /**
-        Disable the use native double buffering in wxMSW.
-
-        This MSW-specific function can be used to disable the use of
-        `WS_EX_COMPOSITED` for this window and all of its parents and so allow
-        using wxClientDC with it.
-
-        `WS_EX_COMPOSITED` style is turned on by default when creating the
-        windows and it is strongly recommended @e not to use this functions to
-        remove it, but to instead change the drawing code to avoid using
-        wxClientDC.
-
-        If you do need to use it, please note that this function doesn't exist
-        in the other ports and has to be explicitly bracketed by the checks for
-        wxMSW, e.g.
-        @code
-        MyFrame::MyFrame(...)
-        {
-            auto p = new wxPanel(this);
-        #ifdef __WXMSW__
-            p->MSWDisableComposited();
-        #endif
-
-            // Using wxClientDC will work now with this panel in wxMSW --
-            // although it still won't with wxOSX nor wxGTK under Wayland.
-        }
-        @endcode
-
-        @see wxClientDC
-
-        @since 3.3.0
-     */
-    void MSWDisableComposited();
 
 protected:
 

--- a/samples/mfc/mfctest.cpp
+++ b/samples/mfc/mfctest.cpp
@@ -297,7 +297,6 @@ wxEND_EVENT_TABLE()
 MyCanvas::MyCanvas(wxWindow *parent, const wxPoint& pos, const wxSize& size)
         : wxScrolledWindow(parent, -1, pos, size)
 {
-    MSWDisableComposited();
 }
 
 // Define the repainting behaviour

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2757,17 +2757,6 @@ bool wxStaticBoxSizer::CheckIfNonBoxChild(wxWindow* win) const
                wxDumpWindow(win),
                wxDumpWindow(win->GetParent()));
 
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
-    // Additionally, under MSW the windows inside a static box are not
-    // drawn at all when compositing is used, so we have to disable it.
-    //
-    // An alternative could be to Reparent() the window to the static
-    // box, but it might break the existing code and as we only allow
-    // this for compatibility in the first place, it seems better not
-    // to risk it.
-    win->MSWDisableComposited();
-#endif // __WXMSW__ && !__WXUNIVERSAL__
-
     return true;
 }
 

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -810,10 +810,6 @@ bool wxWebViewChromium::Create(wxWindow* parent,
     if ( !InitCEF(m_implData->m_config) )
         return false;
 
-#ifdef __WXMSW__
-    MSWDisableComposited();
-#endif // __WXMSW__
-
     m_clientHandler = new ClientHandler{*this};
     m_clientHandler->AddRef();
 

--- a/src/msw/datetimectrl.cpp
+++ b/src/msw/datetimectrl.cpp
@@ -51,40 +51,6 @@
 // wxDateTimePickerCtrl implementation
 // ============================================================================
 
-namespace wxMSWImpl
-{
-
-LRESULT CALLBACK
-DateTimeUDProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam,
-               UINT_PTR uIdSubclass, DWORD_PTR WXUNUSED(dwRefData))
-{
-    switch ( nMsg )
-    {
-        case WM_PAINT:
-            // This is a bit ridiculous, but we have to explicitly paint the
-            // control here, even if all we do is to let it draw itself,
-            // because without this it may not draw the lower arrow at all when
-            // using WS_EX_COMPOSITED (it probably optimizes redraw by assuming
-            // that previously drawn part doesn't change, but this is not the
-            // case when compositing it used).
-            {
-                PAINTSTRUCT ps;
-                ::BeginPaint(hwnd, &ps);
-                ::DefSubclassProc(hwnd, WM_PAINT, (WPARAM)ps.hdc, 0);
-                ::EndPaint(hwnd, &ps);
-            }
-            return 0;
-
-        case WM_NCDESTROY:
-            ::RemoveWindowSubclass(hwnd, DateTimeUDProc, uIdSubclass);
-            break;
-    }
-
-    return ::DefSubclassProc(hwnd, nMsg, wParam, lParam);
-}
-
-} // namespace wxMSWImpl
-
 bool
 wxDateTimePickerCtrl::MSWCreateDateTimePicker(wxWindow *parent,
                                               wxWindowID id,
@@ -110,15 +76,6 @@ wxDateTimePickerCtrl::MSWCreateDateTimePicker(wxWindow *parent,
         SetValue(dt);
     else
         SetValue(wxDateTime::Now());
-
-    // If have an up-down control, we must explicitly paint it ourselves
-    // because otherwise it may be not redrawn at all with WS_EX_COMPOSITED.
-    WinStruct<DATETIMEPICKERINFO> info;
-    ::SendMessage(GetHwnd(), DTM_GETDATETIMEPICKERINFO, 0, (LPARAM)&info);
-    if ( info.hwndUD )
-    {
-        ::SetWindowSubclass(info.hwndUD, wxMSWImpl::DateTimeUDProc, 0, 0);
-    }
 
     return true;
 }

--- a/src/msw/dragimag.cpp
+++ b/src/msw/dragimag.cpp
@@ -271,10 +271,6 @@ bool wxDragImage::BeginDrag(const wxPoint& hotspot, wxWindow* window, bool fullS
     wxASSERT_MSG( (m_hImageList != 0), wxT("Image list must not be null in BeginDrag."));
     wxASSERT_MSG( (window != 0), wxT("Window must not be null in BeginDrag."));
 
-    // Using ImageList_BeginDrag() doesn't work with composited windows,
-    // nothing gets shown, so reset WS_EX_COMPOSITED to make it work.
-    window->MSWDisableComposited();
-
     m_fullScreen = fullScreen;
     if (rect)
         m_boundingRect = * rect;

--- a/src/msw/glcanvas.cpp
+++ b/src/msw/glcanvas.cpp
@@ -735,8 +735,6 @@ bool wxGLCanvas::Create(wxWindow *parent,
     if ( !CreateWindow(parent, id, pos, size, style, name) )
         return false;
 
-    MSWDisableComposited();
-
     // Choose a matching pixel format.
     // Need a PIXELFORMATDESCRIPTOR for SetPixelFormat()
     PIXELFORMATDESCRIPTOR pfd;

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -257,11 +257,6 @@ bool wxListCtrl::Create(wxWindow *parent,
     if ( !MSWCreateControl(WC_LISTVIEW, wxEmptyString, pos, size) )
         return false;
 
-    // LISTVIEW generates and endless stream of LVN_ODCACHEHINT event for a
-    // virtual wxListCtrl, so disable WS_EX_COMPOSITED.
-    if ( IsVirtual() )
-        MSWDisableComposited();
-
     const wxVisualAttributes& defAttrs = GetDefaultAttributes();
 
     if ( wxMSWDarkMode::IsActive() )

--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -22,7 +22,6 @@
 #ifndef WX_PRECOMP
     #include "wx/msw/wrapcctl.h" // include <commctrl.h> "properly"
     #include "wx/app.h"
-    #include "wx/dcclient.h"
     #include "wx/dcmemory.h"
 #endif
 
@@ -253,13 +252,7 @@ void wxSpinButton::OnPaint(wxPaintEvent& event)
     }
     else
     {
-        // We need to always paint this control explicitly instead of letting
-        // DefWndProc() do it, as this avoids whichever optimization the latter
-        // function does when WS_EX_COMPOSITED is on that result in not drawing
-        // parts of the control at all (see #23656).
-        wxPaintDC dc(this);
-
-        wxSpinButtonBase::OnPaint(event);
+        event.Skip();
     }
 }
 

--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -106,13 +106,18 @@ bool wxStaticBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 
 bool wxStaticBox::ShouldUseCustomPaint() const
 {
-    // When not using double buffering, we paint the box ourselves by default
-    // because using the standard control default WM_PAINT handler results in
-    // awful flicker. However this can be disabled by setting a system option
-    // which can be useful if the application paints on the box itself (which
-    // should be avoided, but some existing code does it).
-    return !IsDoubleBuffered() &&
-            !wxSystemOptions::IsFalse(wxT("msw.staticbox.optimized-paint"));
+    // We currently always custom paint the box because we can't rely on double
+    // buffering remaining on even if it is on now, i.e. IsDoubleBuffered()
+    // could return true right but WS_EX_COMPOSITED could get turned off later
+    // because MSWDisableComposited() is called and this would make default
+    // WM_PAINT not work correctly any longer. A probably better solution would
+    // be to notify all windows from MSWDisableComposited() when the double
+    // buffered status changes.
+    //
+    // Still allow be disabling this by setting a system option which can be
+    // useful if the application paints on the box itself (which should be
+    // avoided, but some existing code does it).
+    return !wxSystemOptions::IsFalse(wxT("msw.staticbox.optimized-paint"));
 }
 
 void wxStaticBox::UseCustomPaint()
@@ -122,22 +127,12 @@ void wxStaticBox::UseCustomPaint()
     // means we don't need to do anything.
     if ( GetBackgroundStyle() != wxBG_STYLE_PAINT )
     {
-        wxMSWWinExStyleUpdater(GetHwnd()).TurnOff(WS_EX_TRANSPARENT);
-
         Bind(wxEVT_PAINT, &wxStaticBox::OnPaint, this);
 
         // Our OnPaint() completely erases our background, so don't do it in
         // WM_ERASEBKGND too to avoid flicker.
         SetBackgroundStyle(wxBG_STYLE_PAINT);
     }
-}
-
-void wxStaticBox::MSWOnDisabledComposited()
-{
-    // We need to enable custom painting if we're not using compositing any
-    // longer, as otherwise the window is not drawn correctly due to it using
-    // WS_EX_TRANSPARENT and thus not redrawing its background.
-    UseCustomPaint();
 }
 
 bool wxStaticBox::Create(wxWindow* parent,

--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -106,18 +106,13 @@ bool wxStaticBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 
 bool wxStaticBox::ShouldUseCustomPaint() const
 {
-    // We currently always custom paint the box because we can't rely on double
-    // buffering remaining on even if it is on now, i.e. IsDoubleBuffered()
-    // could return true right but WS_EX_COMPOSITED could get turned off later
-    // because MSWDisableComposited() is called and this would make default
-    // WM_PAINT not work correctly any longer. A probably better solution would
-    // be to notify all windows from MSWDisableComposited() when the double
-    // buffered status changes.
-    //
-    // Still allow be disabling this by setting a system option which can be
-    // useful if the application paints on the box itself (which should be
-    // avoided, but some existing code does it).
-    return !wxSystemOptions::IsFalse(wxT("msw.staticbox.optimized-paint"));
+    // When not using double buffering, we paint the box ourselves by default
+    // because using the standard control default WM_PAINT handler results in
+    // awful flicker. However this can be disabled by setting a system option
+    // which can be useful if the application paints on the box itself (which
+    // should be avoided, but some existing code does it).
+    return !IsDoubleBuffered() &&
+            !wxSystemOptions::IsFalse(wxT("msw.staticbox.optimized-paint"));
 }
 
 void wxStaticBox::UseCustomPaint()

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1078,8 +1078,6 @@ bool wxWebViewEdge::Create(wxWindow* parent,
         return false;
     }
 
-    MSWDisableComposited();
-
     if (!m_impl->Create())
         return false;
     Bind(wxEVT_SIZE, &wxWebViewEdge::OnSize, this);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -472,19 +472,6 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
     msflags &= ~WS_BORDER;
 #endif // wxUniversal
 
-    // Enable double buffering by default for all our own, i.e. not the ones
-    // using native controls, classes.
-    //
-    // Note that this function is not used for top-level windows, so we don't
-    // set this style for them, and also that setting it for children of
-    // windows that already have WS_EX_COMPOSITED set doesn't seem to have any
-    // bad effect as the style is just ignored in this case, so we don't bother
-    // checking it it's already set for the parent, even though we could.
-    if ( !classname )
-    {
-        exstyle |= WS_EX_COMPOSITED;
-    }
-
     if ( IsShown() )
     {
         msflags |= WS_VISIBLE;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -482,11 +482,7 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
     // checking it it's already set for the parent, even though we could.
     if ( !classname )
     {
-        // We also allow disabling the use of this style globally by setting
-        // a system option if nothing else (i.e. turning it off for individual
-        // windows) works.
-        if ( !wxSystemOptions::GetOptionInt("msw.window.no-composited") )
-            exstyle |= WS_EX_COMPOSITED;
+        exstyle |= WS_EX_COMPOSITED;
     }
 
     if ( IsShown() )

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -486,14 +486,7 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
         // a system option if nothing else (i.e. turning it off for individual
         // windows) works.
         if ( !wxSystemOptions::GetOptionInt("msw.window.no-composited") )
-        {
             exstyle |= WS_EX_COMPOSITED;
-
-            // We have to use the class including CS_[HV]REDRAW bits, as
-            // WS_EX_COMPOSITED doesn't work correctly if the entire window is
-            // not redrawn every time it's drawn.
-            style |= wxFULL_REPAINT_ON_RESIZE;
-        }
     }
 
     if ( IsShown() )

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -475,42 +475,25 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
     // Enable double buffering by default for all our own, i.e. not the ones
     // using native controls, classes.
     //
-    // The loop here is a bogus one just to create a block that we can break
-    // from, it never executes more than once.
-    while ( !classname )
+    // Note that this function is not used for top-level windows, so we don't
+    // set this style for them, and also that setting it for children of
+    // windows that already have WS_EX_COMPOSITED set doesn't seem to have any
+    // bad effect as the style is just ignored in this case, so we don't bother
+    // checking it it's already set for the parent, even though we could.
+    if ( !classname )
     {
-        // WS_EX_COMPOSITED seems to be incompatible with WS_EX_TOPMOST, so
-        // don't use it for:
-
-        // Popup windows that get created with this style themselves: this
-        // seems to work under Windows 10, but doesn't under Windows 7 and
-        // using WS_EX_COMPOSITED for these windows that are temporarily
-        // doesn't seem to be very useful anyhow, so don't bother testing for
-        // the OS version and just always disable it for them.
-        if ( exstyle & WS_EX_TOPMOST )
-            break;
-
-        // Children of such windows as this doesn't work neither (see #23078).
-        wxWindow* const tlw = wxGetTopLevelParent(this);
-        if ( tlw && tlw->HasFlag(wxSTAY_ON_TOP) )
-            break;
-
         // We also allow disabling the use of this style globally by setting
         // a system option if nothing else (i.e. turning it off for individual
         // windows) works.
         if ( !wxSystemOptions::GetOptionInt("msw.window.no-composited") )
-            break;
+        {
+            exstyle |= WS_EX_COMPOSITED;
 
-        // Do enable composition for this window.
-
-        exstyle |= WS_EX_COMPOSITED;
-
-        // We have to use the class including CS_[HV]REDRAW bits, as
-        // WS_EX_COMPOSITED doesn't work correctly if the entire window is
-        // not redrawn every time it's drawn.
-        style |= wxFULL_REPAINT_ON_RESIZE;
-
-        break;
+            // We have to use the class including CS_[HV]REDRAW bits, as
+            // WS_EX_COMPOSITED doesn't work correctly if the entire window is
+            // not redrawn every time it's drawn.
+            style |= wxFULL_REPAINT_ON_RESIZE;
+        }
     }
 
     if ( IsShown() )

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -490,7 +490,7 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
         if ( exstyle & WS_EX_TOPMOST )
             break;
 
-        // Children of such windows as this doesn't work either (see #23078).
+        // Children of such windows as this doesn't work neither (see #23078).
         wxWindow* const tlw = wxGetTopLevelParent(this);
         if ( tlw && tlw->HasFlag(wxSTAY_ON_TOP) )
             break;
@@ -498,7 +498,7 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
         // We also allow disabling the use of this style globally by setting
         // a system option if nothing else (i.e. turning it off for individual
         // windows) works.
-        if ( wxSystemOptions::GetOptionInt("msw.window.no-composited") )
+        if ( !wxSystemOptions::GetOptionInt("msw.window.no-composited") )
             break;
 
         // Do enable composition for this window.

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1666,10 +1666,7 @@ void wxWindowMSW::MSWDisableComposited()
         if ( win->IsTopLevel() )
             break;
 
-        wxMSWWinExStyleUpdater updater(GetHwndOf(win));
-        updater.TurnOff(WS_EX_COMPOSITED);
-        if ( updater.Apply() )
-            win->CallForEachChild([](wxWindow* w) { w->MSWOnDisabledComposited(); });
+        wxMSWWinExStyleUpdater(GetHwndOf(win)).TurnOff(WS_EX_COMPOSITED);
     }
 }
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1654,12 +1654,10 @@ void wxWindowMSW::MSWDisableComposited()
 {
     for ( auto win = this; win; win = win->GetParent() )
     {
-        // We never set WS_EX_COMPOSITED on TLWs, and we shouldn't recurse into
-        // different windows, so we can stop here.
+        wxMSWWinExStyleUpdater(GetHwndOf(win)).TurnOff(WS_EX_COMPOSITED);
+
         if ( win->IsTopLevel() )
             break;
-
-        wxMSWWinExStyleUpdater(GetHwndOf(win)).TurnOff(WS_EX_COMPOSITED);
     }
 }
 


### PR DESCRIPTION
This restores pre-3.3 behaviour of _not_ using composition (native double buffering) for all windows and removes many workarounds that are not necessary any more. It wasn't simple to find all such workarounds and I'm not sure if I found all of them, please let me know anything else that could/should be reverted now.

This should fix #25025, #25797 and maybe others I'm forgetting about.

Please test this if you can, TIA!