### PR TITLE
AUI inconsistency with wxCursor between macOS and Windows

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3981,7 +3981,7 @@ void wxAuiManager::OnSetCursor(wxSetCursorEvent& event)
 {
     // determine cursor
     wxAuiDockUIPart* part = HitTest(event.GetX(), event.GetY());
-    wxCursor cursor;
+    wxCursor cursor(*wxSTANDARD_CURSOR);
 
     if (part)
     {


### PR DESCRIPTION
Fix for resetting the cursor back to default when not over a gripper. Solves an inconsistency between macOS and Windows

issue #25811