### PR TITLE
Fix SetCursor(wxNullCursor) behaviour in wxOSX

### DIFF
--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -82,7 +82,6 @@ public:
     virtual void Update() override;
     virtual void ClearBackground() override;
 
-    virtual bool SetCursor( const wxCursor &cursor ) override;
     virtual bool SetFont( const wxFont &font ) override;
     virtual bool SetBackgroundColour( const wxColour &colour ) override;
     virtual bool SetForegroundColour( const wxColour &colour ) override;
@@ -129,6 +128,8 @@ public:
 
     // implementation from now on
     // --------------------------
+
+    virtual void WXUpdateCursor() override;
 
     void MacClientToRootWindow( int *x , int *y ) const;
 

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -844,29 +844,14 @@ void wxWindowMac::DoGetClientSize( int *x, int *y ) const
     }
 }
 
-bool wxWindowMac::SetCursor(const wxCursor& cursor)
+void wxWindowMac::WXUpdateCursor()
 {
-    if (m_cursor.IsSameAs(cursor))
-        return false;
-
-    if (!cursor.IsOk())
-    {
-        if ( ! wxWindowBase::SetCursor( *wxSTANDARD_CURSOR ) )
-            return false ;
-    }
-    else
-    {
-        if ( ! wxWindowBase::SetCursor( cursor ) )
-            return false ;
-    }
-
-    wxASSERT_MSG( m_cursor.IsOk(),
-        wxT("cursor must be valid after call to the base version"));
+    wxWindowBase::WXUpdateCursor();
 
     if ( GetPeer() != nullptr )
-        GetPeer()->SetCursor( m_cursor );
-
-    return true ;
+    {
+        GetPeer()->SetCursor( m_cursor.IsOk() ? m_cursor : *wxSTANDARD_CURSOR ) ;
+    }
 }
 
 #if wxUSE_MENUS


### PR DESCRIPTION
This should set the default cursor for the window instead of doing nothing.

Also simplify the code by overriding just the new WXUpdateCursor() member function instead of SetCursor() itself: this avoids the need for checking if the cursor has really changed.

Closes #25811.