### PR TITLE
Generate help events with the IDs of wxToolBar tools

### DIFF
--- a/include/wx/tbarbase.h
+++ b/include/wx/tbarbase.h
@@ -509,6 +509,12 @@ public:
     // Argument is wxID_ANY if mouse is exiting the toolbar.
     virtual void OnMouseEnter(int toolid);
 
+#if wxUSE_HELP
+    // override to return the ID of the tool at the given point
+    virtual int GetHelpIdAtPoint(const wxPoint& pt) override;
+#endif // wxUSE_HELP
+
+
     // more deprecated functions
     // -------------------------
 

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -1448,6 +1448,12 @@ public:
         return GetHelpTextAtPoint(wxDefaultPosition, wxHelpEvent::Origin_Unknown);
     }
 
+        // may be overridden to return a more appropriate ID for the help event
+        // generated at the given point (in client window coordinates)
+    virtual int GetHelpIdAtPoint(const wxPoint& WXUNUSED(pt))
+    {
+        return GetId();
+    }
 #else // !wxUSE_HELP
     // silently ignore SetHelpText() calls
     void SetHelpText(const wxString& WXUNUSED(text)) { }

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -3831,6 +3831,11 @@ public:
     clicked-on window, and then either show some suitable help or call wxEvent::Skip()
     if the identifier is unrecognised.
 
+    Note that for some windows, such as wxToolBar, the event uses the ID of the
+    tool that was under the mouse, if any, and not the ID of the window itself.
+    If necessary, wxEvent::GetEventObject() may be used to get the pointer to
+    the toolbar itself.
+
     Calling Skip is important because it allows wxWidgets to generate further
     events for ancestors of the clicked-on window. Otherwise it would be impossible to
     show help for container windows, since processing would stop after the first window

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -3140,6 +3140,21 @@ public:
     ///@{
 
     /**
+        Get the ID to be used for help events generated at the given point.
+
+        By default help events use the ID of the window for which they are
+        generated, but in some cases it may be preferable to use an ID for a
+        sub-element of the window instead, e.g. this is used by wxToolBar to
+        generate help events with the ID of the tool under the mouse, if any.
+
+        Similarly, this function may be overridden in other composite controls
+        in the application code.
+
+        @since 3.3.2
+     */
+    virtual int GetHelpIdAtPoint(const wxPoint& pt);
+
+    /**
         Gets the help text to be used as context-sensitive help for this window.
         Note that the text is actually stored by the current wxHelpProvider
         implementation, and not in the window object itself.

--- a/src/common/cshelp.cpp
+++ b/src/common/cshelp.cpp
@@ -199,7 +199,9 @@ bool wxContextHelp::DispatchEvent(wxWindow* win, const wxPoint& pt)
 {
     wxCHECK_MSG( win, false, wxT("win parameter can't be null") );
 
-    wxHelpEvent helpEvent(wxEVT_HELP, win->GetId(), pt,
+    wxHelpEvent helpEvent(wxEVT_HELP,
+                          win->GetHelpIdAtPoint(win->ScreenToClient(pt)),
+                          pt,
                           wxHelpEvent::Origin_HelpButton);
     helpEvent.SetEventObject(win);
 

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -810,6 +810,17 @@ void wxToolBarBase::UpdateWindowUI(long flags)
     }
 }
 
+#if wxUSE_HELP
+int wxToolBarBase::GetHelpIdAtPoint(const wxPoint& pt)
+{
+    if ( wxToolBarToolBase* const tool = FindToolForPosition(pt.x, pt.y) )
+        return tool->GetId();
+
+    return wxControl::GetHelpIdAtPoint(pt);
+}
+#endif // wxUSE_HELP
+
+
 #if wxUSE_MENUS
 bool wxToolBarBase::SetDropdownMenu(int toolid, wxMenu* menu)
 {


### PR DESCRIPTION
This is more useful than generating the events with the ID of the toolbar itself, as help is typically associated with a particular tool and not the entire toolbar.

Add wxWindow::GetHelpIdAtPoint() virtual function to allow customizing this for the other controls as well.

Closes #25802.