### PR TITLE
Silence warning about non-virtual dtor on VC++ <=2017

### DIFF
--- a/include/wx/msw/ownerdrawnbutton.h
+++ b/include/wx/msw/ownerdrawnbutton.h
@@ -10,6 +10,15 @@
 #ifndef _WX_MSW_OWNERDRAWNBUTTON_H_
 #define _WX_MSW_OWNERDRAWNBUTTON_H_
 
+// With MSVC 2017 and earlier, explicitly defining the destructor below
+// _causes_ exactly the kind of compiler warnings (C4265) the definition
+// was meant to avoid (on GCC). With later versions of MSVC, there is no
+// warning either way. We'll disable C4265 temporarily here.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4265) // non-virtual destructor with virtual functions
+#endif
+
 // ----------------------------------------------------------------------------
 // wxMSWOwnerDrawnButton: base class for any kind of Windows buttons
 // ----------------------------------------------------------------------------
@@ -128,5 +137,9 @@ public:
 protected:
     bool IsOwnerDrawn() const { return MSWIsOwnerDrawn(); }
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // _WX_MSW_OWNERDRAWNBUTTON_H_


### PR DESCRIPTION
Explicitly defining a destructor in `wxMSWOwnerDrawnButtonBase` causes precisely the kind of compiler warnings (C4265) that the definition was meant to suppress on GCC.

C4265 is not enabled by default in VC++, but if you have it enabled, you'll get plenty of pointless warnings through anything that #includes `wx/msw/ownerdrawnbutton.h`. This is also the only spot in wx headers that triggers C4265.

The issue appears to be 3.2-specific.