### PR TITLE
Fixes several glitches in wxRendererNative when in dark mode (wxMSW)

### DIFF
--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -189,13 +189,8 @@ public:
         return NewAtStdDPI(0, classes);
     }
 
-    static wxUxThemeHandle ThemeLightOrDark(const wxWindow* win, const wchar_t *classes, const wchar_t *classes_dark);
-
     // wxWindow pointer here must be valid and its DPI is always used.
-    wxUxThemeHandle(const wxWindow *win, const wchar_t *classes) :
-        wxUxThemeHandle(GetHwndOf(win), classes, win->GetDPI().y)
-    {
-    }
+    wxUxThemeHandle(const wxWindow *win, const wchar_t *classes, const wchar_t* classesDark = nullptr);
 
     wxUxThemeHandle(wxUxThemeHandle&& other)
         : m_hTheme{other.m_hTheme}

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -189,6 +189,8 @@ public:
         return NewAtStdDPI(0, classes);
     }
 
+    static wxUxThemeHandle ThemeLightOrDark(const wxWindow* win, const wchar_t *classes, const wchar_t *classes_dark);
+
     // wxWindow pointer here must be valid and its DPI is always used.
     wxUxThemeHandle(const wxWindow *win, const wchar_t *classes) :
         wxUxThemeHandle(GetHwndOf(win), classes, win->GetDPI().y)

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -24,7 +24,6 @@
     #include "wx/window.h"
     #include "wx/control.h"     // for wxControl::Ellipsize()
     #include "wx/dc.h"
-    #include "wx/dcmemory.h"
     #include "wx/settings.h"
 #endif //WX_PRECOMP
 
@@ -37,8 +36,6 @@
 #include "wx/msw/uxtheme.h"
 #include "wx/msw/wrapcctl.h"
 #include "wx/dynlib.h"
-
-#include "wx/msw/private/darkmode.h"
 
 // ----------------------------------------------------------------------------
 // methods common to wxRendererMSW and wxRendererXP
@@ -622,7 +619,7 @@ wxRendererXP::DrawComboBoxDropButton(wxWindow * win,
                                       const wxRect& rect,
                                       int flags)
 {
-    wxUxThemeHandle hTheme(win, L"COMBOBOX");
+    wxUxThemeHandle hTheme=wxUxThemeHandle::ThemeLightOrDark(win, L"COMBOBOX", L"DarkMode_CFD::COMBOBOX");
     if ( !hTheme )
     {
         m_rendererNative.DrawComboBoxDropButton(win, dc, rect, flags);
@@ -654,7 +651,7 @@ wxRendererXP::DrawHeaderButton(wxWindow *win,
                                wxHeaderSortIconType sortArrow,
                                wxHeaderButtonParams* params)
 {
-    wxUxThemeHandle hTheme(win, L"HEADER");
+    wxUxThemeHandle hTheme(win, L"Explorer::HEADER");
     if ( !hTheme )
     {
         return m_rendererNative.DrawHeaderButton(win, dc, rect, flags, sortArrow, params);
@@ -728,7 +725,7 @@ wxRendererXP::DoDrawCheckMark(int kind,
                               const wxRect& rect,
                               int flags)
 {
-    wxUxThemeHandle hTheme(win, L"MENU");
+    wxUxThemeHandle hTheme=wxUxThemeHandle::ThemeLightOrDark(win, L"MENU", L"DarkMode::MENU");
     if ( !hTheme )
         return false;
 
@@ -915,39 +912,8 @@ wxRendererXP::DrawCollapseButton(wxWindow *win,
                                  int flags)
 {
     RECT r = ConvertToRECT(dc, rect);
-
-    // Default theme draws the button on light background which looks very out
-    // of place when using dark mode, so invert it if necessary and fall back
-    // on the generic version if this fails.
-    //
-    // Ideal would be to find the theme drawing the version appropriate for the
-    // dark mode, but it's unknown if there is one providing this.
-    if ( wxMSWDarkMode::IsActive() )
-    {
-        wxBitmap bmp(rect.GetSize());
-
-        bool ok;
-        {
-            wxMemoryDC mdc(bmp);
-            ok = DoDrawCollapseButton(win, GetHdcOf(mdc), r, flags);
-        }
-
-        if ( ok )
-        {
-            wxBitmap bmpInv = wxMSWDarkMode::InvertBitmap(bmp);
-            if ( bmpInv.IsOk() )
-            {
-                dc.DrawBitmap(bmpInv, rect.GetPosition());
-                return;
-            }
-        }
-    }
-    else
-    {
-        if ( DoDrawCollapseButton(win, GetHdcOf(dc.GetTempHDC()), r, flags) )
-            return;
-    }
-
+    if ( DoDrawCollapseButton(win, GetHdcOf(dc.GetTempHDC()), r, flags) )
+        return;
     m_rendererNative.DrawCollapseButton(win, dc, rect, flags);
 }
 
@@ -1194,22 +1160,31 @@ void wxRendererXP::DrawTextCtrl(wxWindow* win,
                                 const wxRect& rect,
                                 int flags)
 {
-    wxUxThemeHandle hTheme(win, L"EDIT");
+    wxUxThemeHandle hTheme=wxUxThemeHandle::ThemeLightOrDark(win, L"EDIT", L"DarkMode_CFD::Combobox");
     if ( !hTheme )
     {
         m_rendererNative.DrawTextCtrl(win,dc,rect,flags);
         return;
     }
 
-    wxColour fill = hTheme.GetColour(EP_EDITTEXT, TMT_FILLCOLOR, ETS_NORMAL);
-    wxColour bdr = hTheme.GetColour(EP_EDITTEXT, TMT_BORDERCOLOR,
-                                    flags & wxCONTROL_DISABLED
-                                        ? ETS_DISABLED
-                                        : ETS_NORMAL);
+    wxCHECK_RET(dc.GetImpl(), wxT("Invalid wxDC"));
 
-    wxDCPenChanger setPen(dc, bdr);
-    wxDCBrushChanger setBrush(dc, fill);
-    dc.DrawRectangle(rect);
+    RECT r = ConvertToRECT(dc, rect);
+
+    int state;
+
+    if (flags & wxCONTROL_DISABLED)
+        state =CBB_DISABLED;
+    else if (flags & wxCONTROL_FOCUSED)
+        state = CBB_FOCUSED;
+    else if (flags & wxCONTROL_CURRENT)
+        state = CBB_HOT;
+    else
+        state = CBB_NORMAL;
+
+    hTheme.DrawBackground(GetHdcOf(dc.GetTempHDC()), r, CP_BACKGROUND);
+    hTheme.DrawBackground(GetHdcOf(dc.GetTempHDC()), r, CP_BORDER, state);
+
 }
 
 void wxRendererXP::DrawGauge(wxWindow* win,

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -619,7 +619,7 @@ wxRendererXP::DrawComboBoxDropButton(wxWindow * win,
                                       const wxRect& rect,
                                       int flags)
 {
-    wxUxThemeHandle hTheme=wxUxThemeHandle::ThemeLightOrDark(win, L"COMBOBOX", L"DarkMode_CFD::COMBOBOX");
+    wxUxThemeHandle hTheme(win, L"COMBOBOX", L"DarkMode_CFD::COMBOBOX");
     if ( !hTheme )
     {
         m_rendererNative.DrawComboBoxDropButton(win, dc, rect, flags);
@@ -725,7 +725,7 @@ wxRendererXP::DoDrawCheckMark(int kind,
                               const wxRect& rect,
                               int flags)
 {
-    wxUxThemeHandle hTheme=wxUxThemeHandle::ThemeLightOrDark(win, L"MENU", L"DarkMode::MENU");
+    wxUxThemeHandle hTheme(win, L"MENU", L"DarkMode::MENU");
     if ( !hTheme )
         return false;
 
@@ -1160,7 +1160,7 @@ void wxRendererXP::DrawTextCtrl(wxWindow* win,
                                 const wxRect& rect,
                                 int flags)
 {
-    wxUxThemeHandle hTheme=wxUxThemeHandle::ThemeLightOrDark(win, L"EDIT", L"DarkMode_CFD::Combobox");
+    wxUxThemeHandle hTheme(win, L"EDIT", L"DarkMode_CFD::Combobox");
     if ( !hTheme )
     {
         m_rendererNative.DrawTextCtrl(win,dc,rect,flags);
@@ -1174,7 +1174,7 @@ void wxRendererXP::DrawTextCtrl(wxWindow* win,
     int state;
 
     if (flags & wxCONTROL_DISABLED)
-        state =CBB_DISABLED;
+        state = CBB_DISABLED;
     else if (flags & wxCONTROL_FOCUSED)
         state = CBB_FOCUSED;
     else if (flags & wxCONTROL_CURRENT)

--- a/src/msw/uxtheme.cpp
+++ b/src/msw/uxtheme.cpp
@@ -45,17 +45,16 @@ bool wxUxThemeIsActive()
     return s_isActive != 0;
 }
 
-wxUxThemeHandle wxUxThemeHandle::ThemeLightOrDark(const wxWindow* win, const wchar_t* classes, const wchar_t* classes_dark)
+wxUxThemeHandle::wxUxThemeHandle(const wxWindow *win, const wchar_t *classes, const wchar_t *classesDark) :
+    // When using dark mode and using the DarkMode classes we have
+    // to use the handle of a control which is *not* in dark mode,
+    // and as we don't have any, just use 0.
+    wxUxThemeHandle(
+        classesDark && wxMSWDarkMode::IsActive() ? 0 : GetHwndOf(win),
+        classesDark && wxMSWDarkMode::IsActive() ? classesDark : classes,
+        win->GetDPI().y
+    )
 {
-    if (wxMSWDarkMode::IsActive())
-    {
-        // for themes starting with DarkMode we have to use the handle of a control which is *not* in dark mode
-        return wxUxThemeHandle(0, classes_dark, win->GetDPI().y);
-    }
-    else
-    {
-        return wxUxThemeHandle(win->GetHWND(), classes, win->GetDPI().y);
-    }
 }
 
 /* static */

--- a/src/msw/uxtheme.cpp
+++ b/src/msw/uxtheme.cpp
@@ -32,6 +32,7 @@
 #include "wx/dynlib.h"
 
 #include "wx/msw/uxtheme.h"
+#include "wx/msw/private/darkmode.h"
 
 bool wxUxThemeIsActive()
 {
@@ -42,6 +43,19 @@ bool wxUxThemeIsActive()
     }
 
     return s_isActive != 0;
+}
+
+wxUxThemeHandle wxUxThemeHandle::ThemeLightOrDark(const wxWindow* win, const wchar_t* classes, const wchar_t* classes_dark)
+{
+    if (wxMSWDarkMode::IsActive())
+    {
+        // for themes starting with DarkMode we have to use the handle of a control which is *not* in dark mode
+        return wxUxThemeHandle(0, classes_dark, win->GetDPI().y);
+    }
+    else
+    {
+        return wxUxThemeHandle(win->GetHWND(), classes, win->GetDPI().y);
+    }
 }
 
 /* static */


### PR DESCRIPTION
The pull request implement some fixes for wxRendererNative for wxMSW when in dark mode (see #25792)

*  I added a new helper function to wxUxThemeHandle to simplify the switch between light/dark themes and use it for DrawCheckMark and DrawComboBoxDropButton.
* Fix DrawHeaderButton with an updated theme name.
*  Removed the manual switch for DrawCollapseButton (reverting https://github.com/wxWidgets/wxWidgets/commit/64d75a55ed25309ff85d589b047b4bf6443cd3f9 )
*  Use native drawing function for DrawTextCtrl (and also for DrawChoice) instead of manual drawing these controls
