### PR TITLE
Fix wxGetBestTreeSize function

### DIFF
--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -220,7 +220,8 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size)
 {
     wxRect rect;
 
-    if ( treeCtrl->GetBoundingRect(id, rect, true /* just the item */) )
+    if ( treeCtrl->GetBoundingRect(id, rect, true /* just the item */)
+         && rect.width > 0 && rect.height > 0 ) // check for valid rect
     {
         // Translate to logical position so we get the full extent
 #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -209,7 +209,7 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size,
     wxRect rect;
 
     if ( treeCtrl->GetBoundingRect(id, rect, true /* just the item */)
-         && rect.width > 0 && rect.height > 0 ) // check for valid rect
+         && !rect.IsEmpty() ) // check for valid rect
     {
         // Translate to logical position so we get the full extent
 #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -26,6 +26,7 @@
 #include "wx/imaglist.h"
 #include "wx/dcclient.h"
 #include "wx/string.h"
+#include <algorithm>
 
 extern WXDLLEXPORT_DATA(const char) wxTreeCtrlNameStr[] = "treeCtrl";
 
@@ -244,9 +245,10 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size)
         if (treeCtrl->GetImageList() && imageIndex != -1)
             treeCtrl->GetImageList()->GetSize(imageIndex, iconWidth, h);
         int depth = wxGetTreeItemDepth(treeCtrl, id);
+        int height = std::max(h, textSize.GetHeight());
         int extraPadding = 20; // experience-based value, can be adjusted
         int totalWidth = indent * depth + iconWidth + textSize.GetWidth() + extraPadding;
-        size.IncTo(wxSize(totalWidth, size.GetHeight()));
+        size.IncTo(wxSize(totalWidth, height));
     }
 
     wxTreeItemIdValue cookie;

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -203,21 +203,8 @@ void wxTreeCtrlBase::SetItemState(const wxTreeItemId& item, int state)
     DoSetItemState(item, state);
 }
 
-// Helper to get depth of a tree node
-static int wxGetTreeItemDepth(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id)
-{
-    int depth = 0;
-    wxTreeItemId parent = treeCtrl->GetItemParent(id);
-    while (parent.IsOk())
-    {
-        depth++;
-        parent = treeCtrl->GetItemParent(parent);
-    }
-    return depth;
-}
-
 static void
-wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size)
+wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size, int depth)
 {
     wxRect rect;
 
@@ -244,7 +231,6 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size)
         int imageIndex = treeCtrl->GetItemImage(id);
         if (treeCtrl->GetImageList() && imageIndex != -1)
             treeCtrl->GetImageList()->GetSize(imageIndex, iconWidth, h);
-        int depth = wxGetTreeItemDepth(treeCtrl, id);
         int height = std::max(h, textSize.GetHeight());
         int extraPadding = 20; // experience-based value, can be adjusted
         int totalWidth = indent * depth + iconWidth + textSize.GetWidth() + extraPadding;
@@ -256,7 +242,7 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size)
           item.IsOk();
           item = treeCtrl->GetNextChild(id, cookie) )
     {
-        wxGetBestTreeSize(treeCtrl, item, size);
+        wxGetBestTreeSize(treeCtrl, item, size, depth + 1);
     }
 }
 
@@ -293,7 +279,7 @@ wxSize wxTreeCtrlBase::DoGetBestSize() const
         // iterate over all items recursively
         wxTreeItemId idRoot = GetRootItem();
         if ( idRoot.IsOk() )
-            wxGetBestTreeSize(this, idRoot, size);
+            wxGetBestTreeSize(this, idRoot, size, 0);
     }
 
     // need some minimal size even for empty tree

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -227,13 +227,13 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size,
         dc.SetFont(treeCtrl->GetFont());
         wxSize textSize = dc.GetTextExtent(label);
         int indent = treeCtrl->GetIndent();
-        int iconWidth = 0, h = 0;
+        wxSize iconSize;
         int imageIndex = treeCtrl->GetItemImage(id);
         if (treeCtrl->GetImageList() && imageIndex != -1)
-            treeCtrl->GetImageList()->GetSize(imageIndex, iconWidth, h);
-        int height = std::max(h, textSize.GetHeight());
+            iconSize = treeCtrl->GetImageLogicalSize(treeCtrl, imageIndex);
+        int height = std::max(iconSize.GetHeight(), textSize.GetHeight());
         int extraPadding = 20; // experience-based value, can be adjusted
-        int totalWidth = indent * depth + iconWidth + textSize.GetWidth() + extraPadding;
+        int totalWidth = indent * depth + iconSize.GetWidth() + textSize.GetWidth() + extraPadding;
         size.IncTo(wxSize(totalWidth, height));
     }
 

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -223,13 +223,12 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size,
     {
         // Estimate width for collapsed (invisible) node
         wxString label = treeCtrl->GetItemText(id);
-        wxClientDC dc(const_cast<wxTreeCtrlBase*>(treeCtrl));
-        dc.SetFont(treeCtrl->GetFont());
+        wxInfoDC dc(const_cast<wxTreeCtrlBase*>(treeCtrl));
         wxSize textSize = dc.GetTextExtent(label);
         int indent = treeCtrl->GetIndent();
         wxSize iconSize;
         int imageIndex = treeCtrl->GetItemImage(id);
-        if (treeCtrl->GetImageList() && imageIndex != -1)
+        if ( treeCtrl->HasImages() && imageIndex != wxTreeCtrl::NO_IMAGE )
             iconSize = treeCtrl->GetImageLogicalSize(treeCtrl, imageIndex);
         int height = std::max(iconSize.GetHeight(), textSize.GetHeight());
         int extraPadding = 20; // experience-based value, can be adjusted

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -231,7 +231,12 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size,
         if ( treeCtrl->HasImages() && imageIndex != wxTreeCtrl::NO_IMAGE )
             iconSize = treeCtrl->GetImageLogicalSize(treeCtrl, imageIndex);
         int height = std::max(iconSize.GetHeight(), textSize.GetHeight());
-        int totalWidth = indent * depth + iconSize.GetWidth() + textSize.GetWidth() + indent;
+        int extraPadding = 0;
+#if defined(__WXMSW__)
+        // On Windows there should be some extra space to the right of the text
+        extraPadding = indent / 2;
+#endif
+        int totalWidth = indent * depth + iconSize.GetWidth() + textSize.GetWidth() + extraPadding;
         size.IncTo(wxSize(totalWidth, height));
     }
 

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -231,8 +231,7 @@ wxGetBestTreeSize(const wxTreeCtrlBase* treeCtrl, wxTreeItemId id, wxSize& size,
         if ( treeCtrl->HasImages() && imageIndex != wxTreeCtrl::NO_IMAGE )
             iconSize = treeCtrl->GetImageLogicalSize(treeCtrl, imageIndex);
         int height = std::max(iconSize.GetHeight(), textSize.GetHeight());
-        int extraPadding = 20; // experience-based value, can be adjusted
-        int totalWidth = indent * depth + iconSize.GetWidth() + textSize.GetWidth() + extraPadding;
+        int totalWidth = indent * depth + iconSize.GetWidth() + textSize.GetWidth() + indent;
         size.IncTo(wxSize(totalWidth, height));
     }
 


### PR DESCRIPTION
This PR will close #25839 . 

It also includes the invisible child nodes of the tree control in the best estimate width calculation.

The demo file is here [hello.zip](https://github.com/user-attachments/files/22613813/hello.zip)

And the fixed screenshot is here.

<img width="455" height="329" alt="image" src="https://github.com/user-attachments/assets/fc7a2f0d-b603-437e-baeb-649fe412b487" />
