### PR TITLE
OSX iOS update app window layout methods

### DIFF
--- a/src/osx/iphone/nonownedwnd.mm
+++ b/src/osx/iphone/nonownedwnd.mm
@@ -254,7 +254,7 @@ void wxNonOwnedWindowIPhoneImpl::GetContentArea( int& left, int &top, int &width
     r.origin.y += safe.top;
     r.size.width -= (safe.left + safe.right);
     r.size.height -= (safe.top + safe.bottom);
-    
+
     width = r.size.width;
     height = r.size.height;
     left = r.origin.x;

--- a/src/osx/iphone/nonownedwnd.mm
+++ b/src/osx/iphone/nonownedwnd.mm
@@ -140,8 +140,6 @@ long style, long extraStyle, const wxString& name )
     if ( ( style & wxSTAY_ON_TOP ) )
         level = UIWindowLevelAlert;
     CGRect r = CGRectMake( 0, 0, size.x, size.y) ;
-    if ( UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) )
-        std::swap(r.size.width,r.size.height);
 
     [m_macWindow initWithFrame:r ];
     [m_macWindow setHidden:YES];
@@ -228,8 +226,6 @@ bool wxNonOwnedWindowIPhoneImpl::CanSetTransparent()
 void wxNonOwnedWindowIPhoneImpl::MoveWindow(int x, int y, int width, int height)
 {
     CGRect r = CGRectMake( x,y,width,height) ;
-    if ( UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) )
-        std::swap(r.size.width,r.size.height);
 
     [m_macWindow setFrame:r];
 }
@@ -244,8 +240,7 @@ void wxNonOwnedWindowIPhoneImpl::GetPosition( int &x, int &y ) const
 void wxNonOwnedWindowIPhoneImpl::GetSize( int &width, int &height ) const
 {
     CGRect r = [m_macWindow frame];
-    if ( UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) )
-        std::swap(r.size.width,r.size.height);
+
     width = r.size.width;
     height = r.size.height;
 }
@@ -253,8 +248,13 @@ void wxNonOwnedWindowIPhoneImpl::GetSize( int &width, int &height ) const
 void wxNonOwnedWindowIPhoneImpl::GetContentArea( int& left, int &top, int &width, int &height ) const
 {
     CGRect r = [m_macWindow bounds];
-    if ( UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) )
-        std::swap(r.size.width,r.size.height);
+    UIEdgeInsets safe = [m_macWindow safeAreaInsets];
+
+    r.origin.x += safe.left;
+    r.origin.y += safe.top;
+    r.size.width -= (safe.left + safe.right);
+    r.size.height -= (safe.top + safe.bottom);
+    
     width = r.size.width;
     height = r.size.height;
     left = r.origin.x;
@@ -360,9 +360,7 @@ wxWidgetImpl* wxWidgetImpl::CreateContentView( wxNonOwnedWindow* now )
     contentview.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     wxUIContentViewController* controller = [[wxUIContentViewController alloc] initWithNibName:nil bundle:nil];
 
-#ifdef __IPHONE_3_0
     controller.wantsFullScreenLayout = fullscreen;
-#endif
 
     controller.view = contentview;
     [contentview release];

--- a/src/osx/iphone/toolbar.mm
+++ b/src/osx/iphone/toolbar.mm
@@ -233,7 +233,6 @@ bool wxToolBar::Create(
 
     switch ( [[UIApplication sharedApplication] statusBarStyle] )
     {
-#ifdef __IPHONE_3_0
         case UIStatusBarStyleBlackOpaque:
             toolbar.barStyle = UIBarStyleBlack;
             break;
@@ -241,7 +240,6 @@ bool wxToolBar::Create(
             toolbar.barStyle = UIBarStyleBlack;
             toolbar.translucent = YES;
             break;
-#endif
         default:
             toolbar.barStyle = UIBarStyleDefault;
             break;

--- a/src/osx/iphone/utils.mm
+++ b/src/osx/iphone/utils.mm
@@ -144,18 +144,9 @@ public:
         CGRect bounds = [[UIScreen mainScreen] bounds];
 
         int width, height;
-        if ( UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation]) )
-        {
-            // portrait
-            width = (int)bounds.size.width ;
-            height = (int)bounds.size.height;
-        }
-        else
-        {
-            // landscape
-            width = (int)bounds.size.height ;
-            height = (int)bounds.size.width;
-        }
+
+        width = (int)bounds.size.width ;
+        height = (int)bounds.size.height;
 
         return wxRect(0, 0, width, height);
     }

--- a/src/osx/nonownedwnd_osx.cpp
+++ b/src/osx/nonownedwnd_osx.cpp
@@ -465,14 +465,7 @@ void wxNonOwnedWindow::DoGetClientSize( int *width, int *height ) const
         return;
 
     int left, top, w, h;
-    // under iphone with a translucent status bar the m_nowpeer returns the
-    // inner area, while the content area extends under the translucent
-    // status bar, therefore we use the content view's area
-#ifdef __WXOSX_IPHONE__
-    GetPeer()->GetContentArea(left, top, w, h);
-#else
     m_nowpeer->GetContentArea(left, top, w, h);
-#endif
 
     if (width)
        *width = w ;

--- a/src/osx/toplevel_osx.cpp
+++ b/src/osx/toplevel_osx.cpp
@@ -151,7 +151,15 @@ void wxTopLevelWindowMac::Restore()
 
 wxPoint wxTopLevelWindowMac::GetClientAreaOrigin() const
 {
+    // under Cocoa we keep for backwards compatibility the client origin at 0,0
+    // (representing the contentview), while under iOS the entire app has a contentview
+    // which extends under the statusbar, so we need to determine the correct client
+    // area
+#if wxOSX_USE_IPHONE
+    return wxNonOwnedWindow::GetClientAreaOrigin();
+#else
     return wxPoint(0, 0) ;
+#endif
 }
 
 void wxTopLevelWindowMac::SetTitle(const wxString& title)


### PR DESCRIPTION
new iOS versions allow simpler code, also make sure that by default we stay in the ‚safe‘ area for the client area, outside of status bars etc.