### PR TITLE
Clarify wxLog::SetActiveTarget

### DIFF
--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -331,6 +331,10 @@ public:
         active log target is set to @NULL a new default log target will be
         created when logging occurs.
 
+        @note The logging system will take ownership of the target you pass
+        in here. However, it is your responsibility to delete the target you
+        are replacing (i.e., the return value of this function).
+
         @see SetThreadActiveTarget()
     */
     static wxLog* SetActiveTarget(wxLog* logtarget);


### PR DESCRIPTION
This explanation is a bit redundant with the rest of the docs, but really helps clarify how `wxLog::SetActiveTarget` should work.