### PR TITLE
Fix SetFont for rich wxTextCtrl when in dark mode

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -3131,7 +3131,7 @@ bool wxTextCtrl::SetFont(const wxFont& font)
         // the default font for it.
         wxTextAttr attr;
         attr.SetFont(font);
-        SetStyle(-1, -1, attr);
+        SetStyle(-1, -1, wxTextAttr::Combine(attr, GetDefaultStyle(), this));
     }
 
     return true;


### PR DESCRIPTION
Calling `wxTextCtrl::SetFont'` on a `wxTextCtrl` with `wxTE_RICH2` style results in black text on dark background when in dark mode. 
This affects also the function `wxShowTip`. This can be seen in unmodified dialogs sample (Show tip of the day CTRL+T).
The PR fixes this by copying the default style into the modified style with the new font.

- wxWidgets version  3.3.2 
- wxWidgets port wxMSW
- OS Windows 11 24h2 Build 26100.6584