### PR TITLE
Fix bug in drawing sample when using wxGC to draw on a scrolled window

### DIFF
--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -2100,13 +2100,11 @@ void MyCanvas::OnPaint(wxPaintEvent &WXUNUSED(event))
     if ( m_useBuffer )
     {
         wxBufferedPaintDC bpdc(this);
-        PrepareDC(bpdc); // Adjust scrolled contents.
         Draw(bpdc);
     }
     else
     {
         wxPaintDC pdc(this);
-        PrepareDC(pdc); // Adjust scrolled contents.
         Draw(pdc);
     }
 }
@@ -2150,6 +2148,7 @@ void MyCanvas::Draw(wxDC& pdc)
     wxDC &dc = pdc ;
 #endif
 
+    PrepareDC(dc); // Adjust scrolled contents.
     m_owner->PrepareDC(dc);
 
     dc.SetBackgroundMode( m_owner->m_backgroundMode );


### PR DESCRIPTION
A clip region set using SetDeviceClippingRegion() on a DC should not scroll when the canvas we are drawing on scrolls.  The drawing sample behaves like this if the DC is a wxDC instance but not if it is a wxGC instance (because it is not properly prepared when the canvas is scrolled, i.e.: GetDeviceOrigin() always returns (0, 0) for a wxGC). So this bug should be fixed by preparing the correct DC that we are actually using for drawing.