### PR TITLE
Adjust methods `CanRunTests()` of numberformatter tests

### DIFF
--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -375,10 +375,13 @@ protected:
         if (ok)
         {
             wxLocaleNumberFormatting numForm = wxUILocale::GetCurrent().GetNumberFormatting();
+            wxLocaleNumberFormatting curForm = wxUILocale::GetCurrent().GetCurrencyInfo().currencyFormat;
 #ifdef __GLIBC__
-            ok = numForm.groupSeparator == ".";
+            ok = numForm.groupSeparator == "."
+                && curForm.groupSeparator == wxString::FromUTF8(NNBSP);
 #else
-            ok = numForm.groupSeparator == wxString::FromUTF8(NBSP);
+            ok = numForm.groupSeparator == wxString::FromUTF8(NBSP)
+                && curForm.groupSeparator == ".";
 #endif
         }
         return ok;
@@ -770,7 +773,16 @@ public:
     }
 
 protected:
-    bool CanRunTest() const { return m_locale.IsOk(); }
+    bool CanRunTest() const
+    {
+        bool ok = m_locale.IsOk();
+        if (ok)
+        {
+            wxLocaleNumberFormatting numForm = wxUILocale::GetCurrent().GetNumberFormatting();
+            ok = (!numForm.grouping.empty() && numForm.grouping.back() == 0);
+        }
+        return ok;
+    }
 
 private:
     wxLocale m_locale;

--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -375,13 +375,16 @@ protected:
         if (ok)
         {
             wxLocaleNumberFormatting numForm = wxUILocale::GetCurrent().GetNumberFormatting();
-            wxLocaleNumberFormatting curForm = wxUILocale::GetCurrent().GetCurrencyInfo().currencyFormat;
+            wxLocaleCurrencyInfo currencyInfo = wxUILocale::GetCurrent().GetCurrencyInfo();
+            wxLocaleNumberFormatting curForm = currencyInfo.currencyFormat;
 #ifdef __GLIBC__
             ok = numForm.groupSeparator == "."
-                && curForm.groupSeparator == wxString::FromUTF8(NNBSP);
+                && curForm.groupSeparator == wxString::FromUTF8(NNBSP)
+                && currencyInfo.currencySymbolPos == wxCurrencySymbolPosition::PrefixWithSep;
 #else
             ok = numForm.groupSeparator == wxString::FromUTF8(NBSP)
-                && curForm.groupSeparator == ".";
+                && curForm.groupSeparator == "."
+                && currencyInfo.currencySymbolPos == wxCurrencySymbolPosition::PrefixWithSep;
 #endif
         }
         return ok;


### PR DESCRIPTION
On some Windows platforms locale information used in the number formatting tests is not reported correctly. On such platforms the affected tests are not run.