### PR TITLE
Fix compilation with wxUSE_OWNER_DRAWN==0

### DIFF
--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -733,12 +733,14 @@ void wxMenuItem::DoSetBitmap(const wxBitmapBundle& bmpNew, bool bChecked)
 
 void wxMenuItem::SetupBitmaps()
 {
+#if wxUSE_OWNER_DRAWN
     // Owner-drawn items must not return valid bitmaps even if they have them,
     // this somehow breaks the item measuring logic and the menu may not become
     // wide enough to accommodate the items text, so just don't do anything at
     // all for them here.
     if ( IsOwnerDrawn() )
         return;
+#endif
 
     const int itemPos = MSGetMenuItemPos();
     if ( itemPos == -1 )


### PR DESCRIPTION
Fixes wxUSE_OWNER_DRAWN-less compilation.

3.2 is also affected.