### PR TITLE
Fix DrawLabel under Retina display

### DIFF
--- a/src/common/dcbase.cpp
+++ b/src/common/dcbase.cpp
@@ -1131,8 +1131,8 @@ void wxDC::DrawLabel(const wxString& text,
     wxCoord width, height;
     if ( bitmap.IsOk() )
     {
-        width = widthText + static_cast<wxCoord>(std::floor(bitmap.GetScaledWidth()));
-        height = static_cast<wxCoord>(std::floor(bitmap.GetScaledHeight()));
+        width = widthText + wxRound(bitmap.GetLogicalWidth());
+        height = wxRound(bitmap.GetLogicalHeight());
     }
     else // no bitmap
     {
@@ -1175,7 +1175,7 @@ void wxDC::DrawLabel(const wxString& text,
     {
         DrawBitmap(bitmap, x, y, true /* use mask */);
 
-        wxCoord offset = static_cast<wxCoord>(std::floor(bitmap.GetScaledWidth())) + 4;
+        wxCoord offset = wxRound(bitmap.GetLogicalWidth()) + 4;
         x += offset;
         width -= offset;
 

--- a/src/common/dcbase.cpp
+++ b/src/common/dcbase.cpp
@@ -1131,8 +1131,8 @@ void wxDC::DrawLabel(const wxString& text,
     wxCoord width, height;
     if ( bitmap.IsOk() )
     {
-        width = widthText + bitmap.GetWidth();
-        height = bitmap.GetHeight();
+        width = widthText + static_cast<wxCoord>(std::floor(bitmap.GetScaledWidth()));
+        height = static_cast<wxCoord>(std::floor(bitmap.GetScaledHeight()));
     }
     else // no bitmap
     {
@@ -1175,7 +1175,7 @@ void wxDC::DrawLabel(const wxString& text,
     {
         DrawBitmap(bitmap, x, y, true /* use mask */);
 
-        wxCoord offset = bitmap.GetWidth() + 4;
+        wxCoord offset = static_cast<wxCoord>(std::floor(bitmap.GetScaledWidth())) + 4;
         x += offset;
         width -= offset;
 


### PR DESCRIPTION
Use the scaled versions of bitmap width/height so that `wxDC::DrawLabel` correctly positions the text under macOS Retina displays.

Before:

<img width="272" height="338" alt="Screenshot 2025-10-17 at 8 03 12 AM" src="https://github.com/user-attachments/assets/412f2039-c066-4f12-bb02-566ea00f57b5" />

After:

<img width="247" height="321" alt="Screenshot 2025-10-17 at 7 59 25 AM" src="https://github.com/user-attachments/assets/5b0f7f81-3dfd-4745-a4ab-cc5c7efbd7cb" />

I use floor and the cast for deterministic rounding and to avoid compile warnings, sorry that it looks so much more cryptic now.