### PR TITLE
Fix wxDirPickerCtrl with GTK >= 3.20

### DIFF
--- a/include/wx/gtk/dirdlg.h
+++ b/include/wx/gtk/dirdlg.h
@@ -45,6 +45,7 @@ public:
 
     void GTKOnAccept();
     void GTKOnCancel();
+    void GTKDropNative();
 
 protected:
     // override this from wxTLW since the native


### PR DESCRIPTION
GtkFileChooserNative will not be used when wxDirDialog is used by wxDirPickerCtrl, so make sure values will be retrieved from GtkFileChooserDialog and not the unused "native" chooser.
See #25901