### PR TITLE
wxOSX: Enable threaded animation for smooth gauge style

### DIFF
--- a/src/osx/cocoa/gauge.mm
+++ b/src/osx/cocoa/gauge.mm
@@ -106,6 +106,10 @@ wxWidgetImplType* wxWidgetImpl::CreateGauge( wxWindowMac* wxpeer,
     {
         [v setBoundsRotation:-90.0];
     }
+    if (style & wxGA_SMOOTH)
+    {
+        [v setUsesThreadedAnimation:YES];
+    }
     wxWidgetCocoaImpl* c = new wxOSXGaugeCocoaImpl( wxpeer, v );
     return c;
 }


### PR DESCRIPTION
Enable threaded animation on macOS when using `wxGA_SMOOTH` style.  This allows the indeterminate progress bar to animate correctly while the main thread is blocked doing work.