### PR TITLE
Move wxWebViewBackendChromium name into common webview header

### DIFF
--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -180,6 +180,7 @@ extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendDefault[];
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendIE[];
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendEdge[];
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendWebKit[];
+extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendChromium[];
 
 class WXDLLIMPEXP_WEBVIEW wxWebViewFactory : public wxObject
 {

--- a/include/wx/webview_chromium.h
+++ b/include/wx/webview_chromium.h
@@ -16,8 +16,6 @@
 
 class WXDLLIMPEXP_FWD_BASE wxFileName;
 
-extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendChromium[];
-
 class CefClient;
 
 // Private namespace containing classes used only in the implementation.

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -466,7 +466,6 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
     wxString backend;
     if ( !wxGetEnv("WX_WEBVIEW_BACKEND", &backend) )
         backend = wxWebViewBackendDefault;
-#if wxUSE_WEBVIEW_CHROMIUM
     // Allow specifying shorter "CEF" instead of having to type the full class
     // name.
     //
@@ -477,7 +476,6 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
     // wouldn't be available during run-time at all.
     else if ( backend.CmpNoCase("cef") == 0 )
         backend = wxWebViewBackendChromium;
-#endif // wxUSE_WEBVIEW_CHROMIUM
 
     if ( backend != wxWebViewBackendDefault &&
             !wxWebView::IsBackendAvailable(backend) )
@@ -588,7 +586,6 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
                 wxLogError("Could not add script message handler");
         };
 
-#if wxUSE_WEBVIEW_CHROMIUM
         if ( backend == wxWebViewBackendChromium )
         {
             m_browser->Bind(wxEVT_WEBVIEW_CREATED, [initShow](wxWebViewEvent& event) {
@@ -598,7 +595,6 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
             });
         }
         else
-#endif // wxUSE_WEBVIEW_CHROMIUM
         {
             initShow();
         }

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -35,6 +35,7 @@ extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewDefaultURLStr[] = "about:bl
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendIE[] = "wxWebViewIE";
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendEdge[] = "wxWebViewEdge";
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendWebKit[] = "wxWebViewWebKit";
+extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendChromium[] = "wxWebViewChromium";
 
 #ifdef __WXMSW__
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendDefault[] = "";

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -96,8 +96,6 @@ constexpr const char* TRACE_CEF = "cef";
 
 } // anonymous namespace
 
-extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendChromium[] = "wxWebViewChromium";
-
 bool wxWebViewChromium::ms_cefInitialized = false;
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxWebViewChromium, wxWebView);


### PR DESCRIPTION
This allows to check for Chromium back-end availability without needing `wxUSE_WEBVIEW_CHROMIUM` guards.