### PR TITLE
Remove duplicate headers from file list

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3339,7 +3339,6 @@ COND_TOOLKIT_MSW_GUI_HDR =  \
 	wx/msw/headerctrl.h \
 	wx/msw/imaglist.h \
 	wx/msw/iniconf.h \
-	wx/msw/init.h \
 	wx/msw/listbox.h \
 	wx/msw/listctrl.h \
 	wx/msw/mdi.h \
@@ -3969,7 +3968,6 @@ COND_USE_GUI_1_ALL_GUI_HEADERS =  \
 	wx/quantize.h \
 	wx/rawbmp.h \
 	wx/region.h \
-	wx/scopeguard.h \
 	wx/simplebook.h \
 	wx/spinbutt.h \
 	wx/spinctrl.h \

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -1243,7 +1243,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/quantize.h
     wx/rawbmp.h
     wx/region.h
-    wx/scopeguard.h
     wx/simplebook.h
     wx/spinbutt.h
     wx/spinctrl.h
@@ -1933,7 +1932,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/msw/headerctrl.h
     wx/msw/imaglist.h
     wx/msw/iniconf.h
-    wx/msw/init.h
     wx/msw/listbox.h
     wx/msw/listctrl.h
     wx/msw/mdi.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -1144,7 +1144,6 @@ set(GUI_CMN_HDR
     wx/quantize.h
     wx/rawbmp.h
     wx/region.h
-    wx/scopeguard.h
     wx/simplebook.h
     wx/spinbutt.h
     wx/spinctrl.h
@@ -1806,7 +1805,6 @@ set(MSW_HDR
     wx/msw/headerctrl.h
     wx/msw/imaglist.h
     wx/msw/iniconf.h
-    wx/msw/init.h
     wx/msw/listbox.h
     wx/msw/listctrl.h
     wx/msw/mdi.h

--- a/build/files
+++ b/build/files
@@ -1184,7 +1184,6 @@ GUI_CMN_HDR =
     wx/richmsgdlg.h
     wx/richtooltip.h
     wx/sashwin.h
-    wx/scopeguard.h
     wx/scrolbar.h
     wx/scrolbar.h
     wx/scrolwin.h
@@ -1822,7 +1821,6 @@ MSW_HDR =
     wx/msw/hyperlink.h
     wx/msw/imaglist.h
     wx/msw/iniconf.h
-    wx/msw/init.h
     wx/msw/listbox.h
     wx/msw/listctrl.h
     wx/msw/mdi.h

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -2057,7 +2057,6 @@
     <ClInclude Include="..\..\include\wx\region.h" />
     <ClInclude Include="..\..\include\wx\renderer.h" />
     <ClInclude Include="..\..\include\wx\richmsgdlg.h" />
-    <ClInclude Include="..\..\include\wx\scopeguard.h" />
     <ClInclude Include="..\..\include\wx\scrolbar.h" />
     <ClInclude Include="..\..\include\wx\scrolwin.h" />
     <ClInclude Include="..\..\include\wx\selstore.h" />

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -2164,9 +2164,6 @@
     <ClInclude Include="..\..\include\wx\sashwin.h">
       <Filter>Common Headers</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\wx\scopeguard.h">
-      <Filter>Common Headers</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\wx\scrolbar.h">
       <Filter>Common Headers</Filter>
     </ClInclude>


### PR DESCRIPTION
When installing with CMake, I noticed two lines: `Up-to-date: include/wx/scopeguard.h` and `Up-to-date: include/wx/msw/init.h`.
These headers are installed two times, for base and for core. I removed them from core.