### PR TITLE
Use a helper class with no member variables for storing per-thread untranslated strings

### DIFF
--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1469,11 +1469,11 @@ private:
     static std::map<wxThreadIdType, std::unordered_set<wxString> > setsMap;
     std::unordered_set<wxString> *holder;
 public:
-    UntranslatedStringHolder(): holder(NULL) {
+    UntranslatedStringHolder(): holder(nullptr) {
     }
 
     const wxString &get(const wxString &str) {
-        if (holder == NULL) {
+        if (holder == nullptr) {
             wxCriticalSectionLocker locker(UntranslatedStringHolder::criticalSection);
             holder = &setsMap[wxThread::GetCurrentId()];
         }

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1455,11 +1455,11 @@ wxString wxTranslations::DoGetBestAvailableTranslation(const wxString& domain, c
 namespace {
 
 /* As of October 2025, MinGW has a bug regarding thread_local
- * variables, de-allocating their memory before calling their
- * destructor.
+ * variables: their memory is de-allocated, and then their destructor
+ * is called.
  *
  * The UntranslatedStringHolder class works around this issue, having
- * its constructor access no data members.
+ * its destructor access no data members.
  */
 #if defined __MINGW32__ || defined __MINGW64__
 


### PR DESCRIPTION
This PR has the purpose of fixing issue #25897

MinGW builds are affected by destroy-after-free situations on `thread_local` variables.
The proposed class has no data members, and thus its destructor should be callable also on non-existing objects, without triggering exceptions (segmentation faults and the like).

The type of key used in the map must be selected carefully in order to avoid memory leaks.
I tried using the `this` pointer in the first place, but I saw that freed objects had it corrupted.

IMHO the code will need a good explanation of its purpose; I would like to have an agreement on the code before starting to comment it. For this reason, I am leaving this PR in the draft state.