### PR TITLE
No longer deactivate wxDataViewCtrl, wxHtml and more on iOS.

### DIFF
--- a/include/wx/osx/iphone/chkconf.h
+++ b/include/wx/osx/iphone/chkconf.h
@@ -58,16 +58,6 @@
 #define wxUSE_TOOLTIPS 0
 #endif
 
-#if wxUSE_DATAVIEWCTRL
-#undef wxUSE_DATAVIEWCTRL
-#define wxUSE_DATAVIEWCTRL 0
-#endif
-
-#if wxUSE_TREELISTCTRL
-#undef wxUSE_TREELISTCTRL
-#define wxUSE_TREELISTCTRL 0
-#endif
-
 #if wxUSE_DRAG_AND_DROP
 #undef wxUSE_DRAG_AND_DROP
 #define wxUSE_DRAG_AND_DROP 0
@@ -85,11 +75,6 @@
 #define wxUSE_CARET 0
 #endif
 
-#if wxUSE_CHOICE
-#undef wxUSE_CHOICE
-#define wxUSE_CHOICE 0
-#endif
-
 #if wxUSE_COMBOBOX
 #undef wxUSE_COMBOBOX
 #define wxUSE_COMBOBOX 0
@@ -105,7 +90,6 @@
 #undef wxUSE_ABOUTDLG
 #undef wxUSE_STATLINE
 #undef wxUSE_COLLPANE
-#undef wxUSE_STATBMP
 #undef wxUSE_STATBOX
 #undef wxUSE_RADIOBTN
 #undef wxUSE_RADIOBOX
@@ -117,15 +101,10 @@
 #define wxUSE_ABOUTDLG 0
 #define wxUSE_STATLINE 0
 #define wxUSE_COLLPANE 0
-#define wxUSE_STATBMP 0
 #define wxUSE_STATBOX 0
 #define wxUSE_RADIOBTN 0
 #define wxUSE_RADIOBOX 0
 #define wxUSE_TOGGLEBTN 0
-
-#undef wxUSE_HTML
-
-#define wxUSE_HTML 0
 
 #undef wxUSE_RICHTEXT
 #define wxUSE_RICHTEXT 0
@@ -143,9 +122,7 @@
 #undef wxUSE_LISTCTRL
 #undef wxUSE_SPINBTN
 #undef wxUSE_SPINCTRL
-#undef wxUSE_TREECTRL
 #undef wxUSE_DATEPICKCTRL
-#undef wxUSE_DATAVIEWCTRL
 #undef wxUSE_EDITABLELISTBOX
 #undef wxUSE_FILEPICKERCTRL
 #undef wxUSE_DIRPICKERCTRL
@@ -172,9 +149,7 @@
 #define wxUSE_LISTCTRL 0
 #define wxUSE_SPINBTN 0
 #define wxUSE_SPINCTRL 0
-#define wxUSE_TREECTRL 0
 #define wxUSE_DATEPICKCTRL 0
-#define wxUSE_DATAVIEWCTRL 0
 #define wxUSE_EDITABLELISTBOX 0
 #define wxUSE_FILEPICKERCTRL 0
 #define wxUSE_DIRPICKERCTRL 0

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -13,7 +13,7 @@
 #include "testprec.h"
 
 #if wxUSE_HTML
-
+#if wxUSE_PRINTING_ARCHITECTURE
 
 #ifndef WX_PRECOMP
     #include "wx/dcmemory.h"
@@ -195,4 +195,5 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
     CHECK( CountPages(pr) == 3 );
 }
 
+#endif //wxUSE_PRINTING_ARCHITECTURE
 #endif //wxUSE_HTML


### PR DESCRIPTION
Remove the checks that deactivate these controls. They actually work now.