### PR TITLE
Fix compilation problem due to memset_s() when using PCH

### DIFF
--- a/include/wx/platform.h
+++ b/include/wx/platform.h
@@ -269,6 +269,12 @@
 #        if !defined(wxSIZE_T_IS_UINT) && !defined(wxSIZE_T_IS_ULONG)
 #            define wxSIZE_T_IS_ULONG
 #        endif
+
+        /* Define this as soon as possible and before string.h is included to
+           get memset_s() declaration from it if available. */
+#       ifndef __STDC_WANT_LIB_EXT1__
+#           define __STDC_WANT_LIB_EXT1__ 1
+#       endif
 #    endif
 
 /*

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -18,10 +18,6 @@
 // for compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
-// Define this as soon as possible and before string.h is included to get
-// memset_s() declaration from it if available.
-#define __STDC_WANT_LIB_EXT1__ 1
-
 #include "wx/utils.h"
 
 #if !defined(HAVE_SETENV) && defined(HAVE_PUTENV)


### PR DESCRIPTION
Define __STDC_WANT_LIB_EXT1__ in wx/platform.h, which is included before the standard headers even when using PCH, to make sure memset_s() declaration is available in this case too.

Closes #24687.