### PR TITLE
Fix OnEditUpdate to Propagate wxEVT_STC_UPDATEUI Event

### DIFF
--- a/src/stc/minimap.cpp
+++ b/src/stc/minimap.cpp
@@ -544,6 +544,7 @@ void wxStyledTextCtrlMiniMap::OnEditPaint(wxPaintEvent& event)
 
 void wxStyledTextCtrlMiniMap::OnEditUpdate(wxStyledTextEvent& event)
 {
+    event.Skip();
     if ( event.GetUpdated() & wxSTC_UPDATE_V_SCROLL )
     {
         auto const editFirst = m_edit->GetFirstVisibleLine();


### PR DESCRIPTION
Insert a call to `event.Skip()` at the start of `wxStyledTextCtrlMiniMap::OnEditUpdate` so the event continues its propagation.

Without this, subclass handlers are never get called...

* src/stc/minimap.cpp