### PR TITLE
Fix for `wxStaticText::Wrap()` bug shown by wxPG

### DIFF
--- a/include/wx/stattext.h
+++ b/include/wx/stattext.h
@@ -79,6 +79,13 @@ protected:      // functions required for wxST_ELLIPSIZE_* support
     // display.
     void UpdateLabel();
 
+    // This helper function must be called to update m_labelOrig instead of
+    // doing it directly.
+    //
+    // It returns false if the label didn't change.
+    bool UpdateLabelOrig(const wxString& label);
+
+
     // If m_currentWrap is non-zero, contains the label value before wrapping it.
     // This is used to allow re-wrapping it at different widths. Note that
     // wxControlBase::m_labelOrig is changed when Wrap() is called and so can't

--- a/src/common/stattextcmn.cpp
+++ b/src/common/stattextcmn.cpp
@@ -263,18 +263,22 @@ void wxStaticTextBase::Wrap(int width)
 
     m_currentWrap = width;
 
-    // Allow for repeated calls to Wrap with different values
-    if (m_unwrappedLabel.empty())
-    {
-        m_unwrappedLabel = GetLabel();
-    }
-    else
+    // Allow for repeated calls to Wrap() with different values by storing the
+    // original label, before wrapping it. We also need to preserve the value
+    // of the unwrapped label if it's already set because the calls to
+    // SetLabel() (including from inside wxLabelWrapper) reset it.
+    auto const unwrappedLabel = m_unwrappedLabel.empty()
+                                    ? GetLabel()
+                                    : m_unwrappedLabel;
+    if ( !m_unwrappedLabel.empty() )
     {
         SetLabel( m_unwrappedLabel );
     }
     wxLabelWrapper wrapper;
     wrapper.WrapLabel(this, width);
     InvalidateBestSize();
+
+    m_unwrappedLabel = unwrappedLabel;
 }
 
 wxSize
@@ -353,6 +357,11 @@ bool wxStaticTextBase::UpdateLabelOrig(const wxString& label)
         return false;
 
     m_labelOrig = label;
+
+    // We need to clear the existing unwrapped label as it doesn't correspond
+    // to the new value of the actual label any longer.
+    m_unwrappedLabel.clear();
+
     return true;
 }
 

--- a/src/common/stattextcmn.cpp
+++ b/src/common/stattextcmn.cpp
@@ -347,6 +347,15 @@ void wxStaticTextBase::AutoResizeIfNecessary()
     SetSize(GetBestSize());
 }
 
+bool wxStaticTextBase::UpdateLabelOrig(const wxString& label)
+{
+    if ( label == m_labelOrig )
+        return false;
+
+    m_labelOrig = label;
+    return true;
+}
+
 // ----------------------------------------------------------------------------
 // wxStaticTextBase - generic implementation for wxST_ELLIPSIZE_* support
 // ----------------------------------------------------------------------------

--- a/src/gtk/stattext.cpp
+++ b/src/gtk/stattext.cpp
@@ -152,10 +152,8 @@ void wxStaticText::GTKDoSetLabel(GTKLabelSetter setter, const wxString& label)
 
 void wxStaticText::SetLabel(const wxString& label)
 {
-    if ( label == m_labelOrig )
+    if ( !UpdateLabelOrig(label) )
         return;
-
-    m_labelOrig = label;
 
     GTKDoSetLabel(&wxStaticText::GTKSetLabelForLabel, label);
 }
@@ -168,7 +166,7 @@ bool wxStaticText::DoSetLabelMarkup(const wxString& markup)
     if ( stripped.empty() && !markup.empty() )
         return false;
 
-    m_labelOrig = stripped;
+    UpdateLabelOrig(stripped);
 
     GTKDoSetLabel(&wxStaticText::GTKSetLabelWithMarkupForLabel, markup);
 

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -217,7 +217,7 @@ wxStaticText::MSWHandleMessage(WXLRESULT *result,
 void wxStaticText::SetLabel(const wxString& label)
 {
     // If the label doesn't really change, avoid flicker by not doing anything.
-    if ( label == m_labelOrig )
+    if ( !UpdateLabelOrig(label) )
         return;
 
 #if wxUSE_MARKUP
@@ -247,10 +247,6 @@ void wxStaticText::SetLabel(const wxString& label)
 
     updateStyle.Apply();
 #endif // SS_ENDELLIPSIS
-
-    // save the label in m_labelOrig with both the markup (if any) and
-    // the mnemonics characters (if any)
-    m_labelOrig = label;
 
 #ifdef SS_ENDELLIPSIS
     if ( updateStyle.IsOn(SS_ENDELLIPSIS) )
@@ -298,7 +294,7 @@ bool wxStaticText::DoSetLabelMarkup(const wxString& markup)
     if ( label.empty() && !markup.empty() )
         return false;
 
-    m_labelOrig = label;
+    UpdateLabelOrig(label);
 
     // Don't do anything if the label didn't change.
     if ( m_markupText && !m_markupText->SetMarkup(markup) )

--- a/src/osx/stattext_osx.cpp
+++ b/src/osx/stattext_osx.cpp
@@ -57,10 +57,8 @@ bool wxStaticText::Create( wxWindow *parent,
 
 void wxStaticText::SetLabel(const wxString& label)
 {
-    if ( label == m_labelOrig )
+    if ( !UpdateLabelOrig(label) )
         return;
-
-    m_labelOrig = label;
 
     // middle/end ellipsization is handled by the OS:
     if ( HasFlag(wxST_ELLIPSIZE_END) || HasFlag(wxST_ELLIPSIZE_MIDDLE)

--- a/src/propgrid/manager.cpp
+++ b/src/propgrid/manager.cpp
@@ -1475,7 +1475,6 @@ void wxPropertyGridManager::UpdateDescriptionBox( int new_splittery, int new_wid
     }
     else
     {
-        m_pTxtHelpCaption->Wrap(-1);
         m_pTxtHelpCaption->Show( true );
         if ( cnt_hei <= 2 )
         {
@@ -1484,7 +1483,6 @@ void wxPropertyGridManager::UpdateDescriptionBox( int new_splittery, int new_wid
         else
         {
             m_pTxtHelpContent->SetSize(3,cnt_y,use_width,cnt_hei);
-            m_pTxtHelpContent->Wrap(use_width);
             m_pTxtHelpContent->Show( true );
         }
     }
@@ -1841,7 +1839,9 @@ void wxPropertyGridManager::RecreateControls()
                                                  wxString(),
                                                  wxDefaultPosition,
                                                  wxDefaultSize,
-                                                 wxALIGN_LEFT|wxST_NO_AUTORESIZE);
+                                                 wxALIGN_LEFT|
+                                                 wxST_NO_AUTORESIZE|
+                                                 wxST_WRAP);
             m_pTxtHelpContent->SetCursor( *wxSTANDARD_CURSOR );
         }
 

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -91,12 +91,8 @@ QLabel* wxStaticText::GetQLabel() const
 void wxStaticText::SetLabel(const wxString& label)
 {
     // If the label doesn't really change, avoid flicker by not doing anything.
-    if ( label == m_labelOrig )
+    if ( !UpdateLabelOrig(label) )
         return;
-
-    // save the label in m_labelOrig with both the markup (if any) and
-    // the mnemonics characters (if any)
-    m_labelOrig = label;
 
     WXSetVisibleLabel(GetEllipsizedLabel());
 

--- a/src/univ/stattext.cpp
+++ b/src/univ/stattext.cpp
@@ -66,11 +66,8 @@ void wxStaticText::DoDraw(wxControlRenderer *renderer)
 
 void wxStaticText::SetLabel(const wxString& str)
 {
-    if ( str == m_labelOrig )
+    if ( !UpdateLabelOrig(str) )
         return;
-
-    // save original label
-    m_labelOrig = str;
 
     // draw as real label the abbreviated version of it
     WXSetVisibleLabel(GetEllipsizedLabel());


### PR DESCRIPTION
This solves the bug/regression reported in [this comment](https://github.com/wxWidgets/wxWidgets/issues/25795#issuecomment-3453054879) and also addresses the original issue.