### PR TITLE
Add Clang-Format Configuration File for wxWidgets Coding Style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,89 @@
+---
+# clang-format configuration based on wxWidgets coding style
+Language: Cpp
+BasedOnStyle: LLVM
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+AccessModifierOffset: -4
+ConstructorInitializerIndentWidth: 4
+
+# Bracing
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+# Function declaration/definition
+AlwaysBreakAfterReturnType: None
+AllowShortFunctionsOnASingleLine: None
+BinPackParameters: OnePerLine
+
+# Spacing
+SpaceBeforeParens: ControlStatements
+SpacesInParens: Custom
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InConditionalStatements: true
+  InEmptyParentheses: false
+
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceInEmptyParentheses: false
+SpacesInParentheses: true
+SpacesInSquareBrackets: false
+SpacesInAngles: Never
+SpaceBeforeCpp11BracedList: true
+
+# Line breaking
+ColumnLimit: 80
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+AlwaysBreakBeforeMultilineStrings: false
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+# Pointer and reference alignment
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+# Include sorting
+SortIncludes: false
+
+# Comments
+ReflowComments: false
+
+# Other
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+CompactNamespaces: false
+FixNamespaceComments: true
+AllowShortLambdasOnASingleLine: false


### PR DESCRIPTION
Introduce a .clang-format configuration file to enforce consistent code formatting across the project. This configuration is based on the wxWidgets coding style and will enable automatic code formatting with clang-format.

The configuration enforces the following key formatting rules:
- 4-space indentation (no tabs)
- Custom brace wrapping with braces on new lines for most constructs (classes, functions, control statements, etc.)
- 80-character line limit
- Spaces inside parentheses for conditional statements
- Left-aligned pointers and references
- No short-form single-line functions, if statements, or loops
- One parameter per line for function declarations

This will help maintain consistent code style across contributors and reduce manual formatting effort during code reviews. Developers can now use clang-format to automatically format their code according to project standards.