### PR TITLE
CMake: Improve creating wayland protocol files

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -464,6 +464,7 @@ if(wxUSE_GUI)
                     pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
                     if(WAYLAND_SCANNER)
                         set(wx_protocols_input_dir ${wxSOURCE_DIR}/src/unix/protocols)
+                        set(wx_protocols_temp_dir ${wxOUTPUT_DIR}/wx/protocols)
                         set(wx_protocols_output_dir ${wxSETUP_HEADER_PATH}/wx/protocols)
 
                         # Note that we need multiple execute_process()
@@ -471,19 +472,30 @@ if(wxUSE_GUI)
                         # concurrently and not sequentially.
                         execute_process(
                             COMMAND
-                                ${CMAKE_COMMAND} -E make_directory ${wx_protocols_output_dir}
+                                ${CMAKE_COMMAND} -E make_directory ${wx_protocols_temp_dir}
                         )
                         execute_process(
                             COMMAND
                                 ${WAYLAND_SCANNER} client-header
                                     ${wx_protocols_input_dir}/pointer-warp-v1.xml
-                                    ${wx_protocols_output_dir}/pointer-warp-v1-client-protocol.h
+                                    ${wx_protocols_temp_dir}/pointer-warp-v1-client-protocol.h
                         )
                         execute_process(
                             COMMAND
                                 ${WAYLAND_SCANNER} private-code
                                     ${wx_protocols_input_dir}/pointer-warp-v1.xml
-                                    ${wx_protocols_output_dir}/pointer-warp-v1-client-protocol.c
+                                    ${wx_protocols_temp_dir}/pointer-warp-v1-client-protocol.c
+                        )
+
+                        execute_process(
+                            COMMAND
+                                ${CMAKE_COMMAND} -E make_directory ${wx_protocols_output_dir}
+                        )
+                        execute_process(
+                            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                                    ${wx_protocols_temp_dir}/pointer-warp-v1-client-protocol.h
+                                    ${wx_protocols_temp_dir}/pointer-warp-v1-client-protocol.c
+                                    ${wx_protocols_output_dir}
                         )
 
                         set(wxHAVE_WAYLAND_CLIENT ON)

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -53,7 +53,9 @@ if(WIN32_MSVC_NAMING)
 else()
     install(
         DIRECTORY "${wxSETUP_HEADER_PATH}"
-        DESTINATION "${library_dir}/wx/include")
+        DESTINATION "${library_dir}/wx/include"
+        PATTERN "protocols" EXCLUDE
+    )
 
     install(
         FILES "${wxOUTPUT_DIR}/wx/config/${wxBUILD_FILE_ID}"


### PR DESCRIPTION
Create the files in a temporary directory and only copy them to the final directory if the files are different.
This prevents the source files from being rebuilt every time cmake is run and the protocol files are replaced.

Exclude the protocols folder from being installed.

The entire setup header directory is installed, so exclude `protocols`.
see e.g. [this](https://github.com/wxWidgets/wxWidgets/actions/runs/18975885071/job/54195276677#step:10:956) build, and copied below for reference:
```
-- Installing: /usr/local/lib/wx/include/gtk3-unicode-3.3
-- Installing: /usr/local/lib/wx/include/gtk3-unicode-3.3/wx
-- Installing: /usr/local/lib/wx/include/gtk3-unicode-3.3/wx/setup.h
-- Installing: /usr/local/lib/wx/include/gtk3-unicode-3.3/wx/protocols
-- Installing: /usr/local/lib/wx/include/gtk3-unicode-3.3/wx/protocols/pointer-warp-v1-client-protocol.h
-- Installing: /usr/local/lib/wx/include/gtk3-unicode-3.3/wx/protocols/pointer-warp-v1-client-protocol.c
```