### PR TITLE
Use current, not best, size for controls in wxGTK toolbars

### DIFF
--- a/src/gtk/toolbar.cpp
+++ b/src/gtk/toolbar.cpp
@@ -645,9 +645,18 @@ bool wxToolBar::DoInsertTool(size_t pos, wxToolBarToolBase *toolBase)
             tool->m_item = GTK_TOOL_ITEM(gtk_widget_get_parent(gtk_widget_get_parent(control->m_widget)));
 #endif
             // The widget size is not controlled by wx, so at least make sure
-            // that its minimal size is respected by GTK (note that this works
-            // fine even if minSize is not set).
-            const wxSize minSize = control->GetBestSize();
+            // that its minimal size is respected by GTK.
+            wxSize minSize = control->GetMinSize();
+            if ( !minSize.IsFullySpecified() )
+            {
+                // Note that we intentionally don't use GetBestSize() here as
+                // the control may be explicitly given smaller size than its
+                // best size when adding it to the toolbar to prevent it from
+                // taking too much space, see b0ad9ccffd (Use control current,
+                // not best, size in wxMSW wxToolBar layout code, 2019-03-31).
+                minSize.SetDefaults(control->GetSize());
+            }
+
             gtk_widget_set_size_request(control->m_widget, minSize.x, minSize.y);
 
             if (gtk_toolbar_get_item_index(m_toolbar, tool->m_item) != int(pos))


### PR DESCRIPTION
The changes of 8f9f1a42ec (Respect best control size when adding it to wxGTK wxToolBar, 2025-03-02) did in wxGTK what earlier b0ad9ccffd (Use control current, not best, size in wxMSW wxToolBar layout code, 2019-03-31) undid in wxMSW, so tweak them to work as in wxMSW and use the current control size if it's specified instead of the best size to make sure the control doesn't take too much space in the toolbar.

This makes appearance of the toolbar containing wxChoice in the toolbar sample much more reasonable.

-----

Not sure if anybody has any comments about this, but it doesn't seem right to have very different behaviour in wxMSW and wxGTK and the (current) wxMSW one seems more reasonable.