### PR TITLE
MSW: Make wxListCtrl dark mode closer to native, white mode rendering

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1382,11 +1382,26 @@ bool wxListCtrl::GetSubItemRect(long item, long subItem, wxRect& rect, int code)
 
     wxCopyRECTToRect(rectWin, rect);
 
-    // there is no way to retrieve the first sub item bounding rectangle using
-    // wxGetListCtrlSubItemRect() as 0 means the whole item, so we need to
-    // truncate it at first column ourselves
+    // the 0th subitem always returns the entire row bounds
+    // this causes rc.left to always be 0, regardless of the column order
+    // workaround:
+    // calculate the x position based on preceding, reordered columns
+    // also, use the column width for the width of the 0th column item
+    // since rc.right is also the end of the entire row
     if ( subItem == 0 && code == wxLIST_RECT_BOUNDS )
+    {
+        int precedingWidth = 0;
+        wxArrayInt columnOrder = GetColumnsOrder();
+        for ( int col = 0; col < columnOrder.GetCount(); col++ )
+        {
+            if ( columnOrder[col] == 0 )
+                break;
+
+            precedingWidth += GetColumnWidth(columnOrder[col]);
+        }
+        rect.x = precedingWidth;
         rect.width = GetColumnWidth(0);
+    }
 
     return true;
 }
@@ -3035,9 +3050,15 @@ RECT GetCustomDrawnItemRect(const NMCUSTOMDRAW& nmcd)
     return rc;
 }
 
-constexpr int GAP_BETWEEN_CHECKBOX_AND_TEXT = 2;
+// these are the values used to replicate the native listctrl rendering as close as possible
+constexpr int PADDING_LEFT_SIDE = 1;
+constexpr int PADDING_RIGHT_SIDE = 2;
+constexpr int GAP_AFTER_CHECKBOX = 2;
+constexpr int GAP_BEFORE_IMAGE = 2;
+constexpr int GAP_BEFORE_CHECKBOX = 4;
+constexpr int PADDING_LEFT_FOR_TEXT = 1;
 
-bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont, int colCount)
+bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont, int colCount, RECT rc, COLORREF bgFillRectColor)
 {
     NMCUSTOMDRAW& nmcd = pLVCD->nmcd;
 
@@ -3050,40 +3071,43 @@ bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT h
     if ( hfont )
         selFont.Init(hdc, hfont);
 
-    // get the rectangle to paint
-    RECT rc;
-    wxGetListCtrlSubItemRect(hwndList, item, col, LVIR_BOUNDS, rc);
-    if ( !col && colCount > 1 )
-    {
-        // ListView_GetSubItemRect() returns the entire item rect for 0th
-        // subitem while we really need just the part for this column
-        RECT rc2;
-        wxGetListCtrlSubItemRect(hwndList, item, 1, LVIR_BOUNDS, rc2);
-        rc.right = rc2.left;
-    }
+    // there's some padding on both sides of the column item
+    const int maxColumnWidth = wxMax(listctrl->GetColumnWidth(col) - PADDING_LEFT_SIDE - PADDING_RIGHT_SIDE, 0);
+    rc.left += PADDING_LEFT_SIDE;
+    rc.right -= PADDING_RIGHT_SIDE;
 
-    if ( !col && listctrl->HasCheckBoxes() )
+    if ( col == 0 && listctrl->HasCheckBoxes() )
     {
         const HIMAGELIST himl = ListView_GetImageList(hwndList, LVSIL_STATE);
 
         if ( himl && ImageList_GetImageCount(himl) == 2 )
         {
-            int cbX, cbY, cbWidth, cbHeight;
+            rc.left += GAP_BEFORE_CHECKBOX;
 
+            int cbWidth, cbHeight;
             ImageList_GetIconSize(himl, &cbWidth, &cbHeight);
-            cbX = listctrl->FromDIP(GAP_BETWEEN_CHECKBOX_AND_TEXT);
-            cbY = rc.top + ((rc.bottom - rc.top) / 2 - cbHeight / 2);
-            // When using style flag ILD_SELECTED or ILD_FOCUS, the checkboxes
-            // for selected items are drawn with a blue background, which we want to avoid.
-            ImageList_Draw(himl, listctrl->IsItemChecked(item) ? 1 : 0, hdc, cbX, cbY, ILD_TRANSPARENT);
-            rc.left += cbX + cbWidth;
+
+            // center checkbox vertically
+            int cbY = rc.top + ((rc.bottom - rc.top) / 2 - cbHeight / 2);
+
+            // prevent drawing checkbox farther than the column width or negative width
+            cbWidth = wxMin(cbWidth, rc.right - rc.left);
+            cbWidth = wxClip(cbWidth, 0, maxColumnWidth);
+
+            if ( rc.left < rc.right )
+            {
+                // When using style flag ILD_SELECTED or ILD_FOCUS, the checkboxes
+                // for selected items are drawn with a blue background, which we want to avoid.
+                ImageList_DrawEx(himl, listctrl->IsItemChecked(item) ? 1 : 0, hdc, rc.left, cbY, cbWidth, cbHeight,
+                                CLR_DEFAULT, CLR_DEFAULT, ILD_TRANSPARENT);
+            }
+
+            rc.left += GAP_AFTER_CHECKBOX;
+            
+            // move left edge for further drawing
+            rc.left += cbWidth;
         }
     }
-
-    // This mysterious offset is necessary for the owner drawn items to align
-    // with the non-owner-drawn ones. Note that it's intentionally *not* scaled
-    // by DPI factor because it doesn't seem to depend on the resolution.
-    rc.left += 6;
 
     // get the image and text to draw
     wxChar text[512];
@@ -3100,25 +3124,44 @@ bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT h
     HIMAGELIST himl = ListView_GetImageList(hwndList, LVSIL_SMALL);
     if ( himl && ImageList_GetImageCount(himl) )
     {
+        // only the first column has padding for the image, in the native listctrl rendering
+        if ( col == 0 )
+        {
+            rc.left += GAP_BEFORE_IMAGE;
+        }
+
         int wImage, hImage;
         ImageList_GetIconSize(himl, &wImage, &hImage);
 
-        if ( it.iImage != -1 )
+        // center image vertically
+        const int yImage = rc.top + ((rc.bottom - rc.top) / 2 - hImage / 2);
+
+        // prevent drawing image farther than the column width
+        const int xOffset = wxClip(rc.right - rc.left, 0, wImage);
+        const int yOffset = hImage;
+
+        // only draw the image if there's enough space for it
+        if ( it.iImage != -1 && rc.left < rc.right )
         {
-            const int yImage = rc.top + ((rc.bottom - rc.top) / 2 - hImage / 2);
-            ImageList_Draw(himl, it.iImage, hdc, rc.left, yImage,
-                           nmcd.uItemState & CDIS_SELECTED ? ILD_SELECTED
-                                                           : ILD_TRANSPARENT);
+            const UINT fStyle = nmcd.uItemState & CDIS_SELECTED ? ILD_SELECTED : ILD_TRANSPARENT;
+            ImageList_DrawEx(himl, it.iImage, hdc, rc.left, yImage, xOffset, yOffset, CLR_DEFAULT, CLR_DEFAULT, fStyle);
         }
 
         // notice that even if this item doesn't have any image, the list
         // control still leaves space for the image in the first column if the
         // image list is not empty (presumably so that items with and without
         // images align?)
-        if ( it.iImage != -1 || it.iSubItem == 0 )
+        if ( it.iImage != -1 )
         {
-            rc.left += wImage + 2;
+            rc.left += xOffset;
         }
+    }
+
+    // draw attribute background after drawing any images or checkboxes
+    if ( rc.left < rc.right )
+    {
+        RECT fillRect = rc;
+        ::FillRect(hdc, &fillRect, AutoHBRUSH(bgFillRectColor));
     }
 
     ::SetBkMode(hdc, TRANSPARENT);
@@ -3150,7 +3193,11 @@ bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT h
     }
     //else: failed to get alignment, assume it's DT_LEFT (default)
 
-    DrawText(hdc, text, -1, &rc, fmt);
+    // text is drawn 1 unit away from the background rectangle
+    rc.left += PADDING_LEFT_FOR_TEXT;
+
+    if ( rc.left < rc.right )
+        DrawText(hdc, text, -1, &rc, fmt);
 
     return true;
 }
@@ -3179,6 +3226,7 @@ void HandleItemPostpaint(NMCUSTOMDRAW nmcd)
 void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont)
 {
     NMCUSTOMDRAW& nmcd = pLVCD->nmcd; // just a shortcut
+    HDC hdc = nmcd.hdc;
 
     const HWND hwndList = nmcd.hdr.hwndFrom;
     const int item = nmcd.dwItemSpec;
@@ -3215,35 +3263,50 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont)
         nmcd.uItemState &= ~CDIS_FOCUS;
     }
 
-    HDC hdc = nmcd.hdc;
-    RECT rc = GetCustomDrawnItemRect(nmcd);
 
+    COLORREF clrFullBG = pLVCD->clrTextBk;
     if ( nmcd.uItemState & CDIS_SELECTED )
     {
         pLVCD->clrText = wxColourToRGB(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
         pLVCD->clrTextBk = wxColourToRGB(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
+
+        clrFullBG = pLVCD->clrTextBk;
     }
     else
     {
-        // use normal colours from pLVCD
-
-        // do not draw item background colour under the checkbox/image
-        RECT rcIcon;
-        wxGetListCtrlItemRect(nmcd.hdr.hwndFrom, nmcd.dwItemSpec, LVIR_ICON, rcIcon);
-        if ( !::IsRectEmpty(&rcIcon) )
-            rc.left = rcIcon.right + listctrl->FromDIP(GAP_BETWEEN_CHECKBOX_AND_TEXT);
+        clrFullBG = wxColourToRGB(listctrl->GetBackgroundColour());
     }
-
+    
+    // clear the entire row with the listctrl's bg colour
+    // otherwise, it'd keep the hover color but only for the regions
+    // like the image/checkboxes since those aren't cleared inside
+    // HandleSubItemPrepaint, where it clears using the passed bg color
+    // but only for the text area
+    RECT rcFullClear = GetCustomDrawnItemRect(nmcd);
+    ::FillRect(hdc, &rcFullClear, AutoHBRUSH(clrFullBG));
+    
     COLORREF colTextOld = ::SetTextColor(hdc, pLVCD->clrText);
-    ::FillRect(hdc, &rc, AutoHBRUSH(pLVCD->clrTextBk));
 
     // we could use CDRF_NOTIFYSUBITEMDRAW here but it results in weird repaint
     // problems so just draw everything except the focus rect from here instead
-    const int colCount = Header_GetItemCount(ListView_GetHeader(hwndList));
-    for ( int col = 0; col < colCount; col++ )
+    
+    // draw the subitems in visual order, not logical one
+    // not necessary, but might improve any overflow issues
+    wxArrayInt columnOrder = listctrl->GetColumnsOrder();
+    int colCount = columnOrder.GetCount();
+    for ( int orderIdx = 0; orderIdx < colCount; orderIdx++ )
     {
+        const int col = columnOrder[orderIdx];
         pLVCD->iSubItem = col;
-        HandleSubItemPrepaint(listctrl, pLVCD, hfont, colCount);
+
+        // get the rectangle of this entire subitem
+        wxRect wxRCSubItem;
+        if ( !listctrl->GetSubItemRect(item, col, wxRCSubItem, wxLIST_RECT_BOUNDS) )
+            continue;
+        RECT rcSubItem;
+        wxCopyRectToRECT(wxRCSubItem, rcSubItem);
+
+        HandleSubItemPrepaint(listctrl, pLVCD, hfont, colCount, rcSubItem, pLVCD->clrTextBk);
     }
 
     ::SetTextColor(hdc, colTextOld);

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1392,7 +1392,7 @@ bool wxListCtrl::GetSubItemRect(long item, long subItem, wxRect& rect, int code)
     {
         int precedingWidth = 0;
         wxArrayInt columnOrder = GetColumnsOrder();
-        for ( int col = 0; col < columnOrder.GetCount(); col++ )
+        for ( unsigned int col = 0; col < columnOrder.GetCount(); col++ )
         {
             if ( columnOrder[col] == 0 )
                 break;
@@ -3058,7 +3058,7 @@ constexpr int GAP_BEFORE_IMAGE = 2;
 constexpr int GAP_BEFORE_CHECKBOX = 4;
 constexpr int PADDING_LEFT_FOR_TEXT = 1;
 
-bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont, int colCount, RECT rc, COLORREF bgFillRectColor)
+bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont, RECT rc, COLORREF bgFillRectColor)
 {
     NMCUSTOMDRAW& nmcd = pLVCD->nmcd;
 
@@ -3103,7 +3103,7 @@ bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT h
             }
 
             rc.left += GAP_AFTER_CHECKBOX;
-            
+
             // move left edge for further drawing
             rc.left += cbWidth;
         }
@@ -3276,7 +3276,7 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont)
     {
         clrFullBG = wxColourToRGB(listctrl->GetBackgroundColour());
     }
-    
+
     // clear the entire row with the listctrl's bg colour
     // otherwise, it'd keep the hover color but only for the regions
     // like the image/checkboxes since those aren't cleared inside
@@ -3284,12 +3284,12 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont)
     // but only for the text area
     RECT rcFullClear = GetCustomDrawnItemRect(nmcd);
     ::FillRect(hdc, &rcFullClear, AutoHBRUSH(clrFullBG));
-    
+
     COLORREF colTextOld = ::SetTextColor(hdc, pLVCD->clrText);
 
     // we could use CDRF_NOTIFYSUBITEMDRAW here but it results in weird repaint
     // problems so just draw everything except the focus rect from here instead
-    
+
     // draw the subitems in visual order, not logical one
     // not necessary, but might improve any overflow issues
     wxArrayInt columnOrder = listctrl->GetColumnsOrder();
@@ -3306,7 +3306,7 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont)
         RECT rcSubItem;
         wxCopyRectToRECT(wxRCSubItem, rcSubItem);
 
-        HandleSubItemPrepaint(listctrl, pLVCD, hfont, colCount, rcSubItem, pLVCD->clrTextBk);
+        HandleSubItemPrepaint(listctrl, pLVCD, hfont, rcSubItem, pLVCD->clrTextBk);
     }
 
     ::SetTextColor(hdc, colTextOld);


### PR DESCRIPTION
## TL;DR

In [Cemu](https://github.com/cemu-project/Cemu) we utilize the ListCtrl to show a list of games.
However, after enabling the experimental dark mode for Windows we encountered quite a few issues. They seem to stem from the fact that the dark mode essentially forces all rendering to be done by wxWidgets instead of windows itself.

After digging, I found a number of fixes that make the dark mode render more identically to the white mode.

Scroll to the bottom of this PR description for the before/after results, and comparisons between the white and dark mode after these changes.

---
## Fixes
### Prevent listctrl row item to overflow beyond the column width

Previously, columns were able to overflow the next column. I made it so that the checkboxes and images can be drawn partially, like the white mode also does.
In Cemu's game list we allow the user to hide columns by setting the column width to 0, which has worked over a number of Windows versions by now. It would suggest that overflowing a row has never been possible with the native white mode rendering that Cemu used.

While testing this bug, you have to make sure that you cause the UI to repaint after you shrink a column. It temporarily looks correct, until that row is hovered over.

### Prevent column with index 0 to always be drawn at the start of the row, despite being reordered

ListView_GetSubItemRect has a bug in the code where if you query the bounds for the first column, it'll always return the bounds of the entire row instead (for example, `rc.left = 0, rc.right = 1000`). The code already had a partial workaround by setting `rc.right` to the next column's starting position.

However, this doesn't account for the fact that a user might've dragged the column with index 0 to be in the middle or end. where the left position should be more then just 0. This causes the column to always be rendered at the left, or to be completely invisible when combined with the change above.

To fix this, I've added another workaround to `wxListCtrl::GetSubItemRect` to accumulate the widths of the preceding, ordered columns to decide where this column (or subItem, technically), starts.

An additional fix is that checkboxes will use the column start for deciding where to draw, instead of using `listctrl->FromDIP(GAP_BETWEEN_CHECKBOX_AND_TEXT);` to decide the starting position. The white mode also allows you to reorder the columns so that the checkboxes are not at the start.

### Avoid drawing the background color behind any checkboxes/images, instead of just any that are at the start of a row

This is a bit of a complicated change, but it was required to replicate the native drawing.
There was already code that tried to prevent drawing the background color of a row behind any icons or checkboxes. However, it assumed that the first row was always at `rc.left = 0` (which isn't the case when the columns are reordered, see the issue above) so it would just clear the entire row at once except for a bit at the start.

However, its not guaranteed that an image or checkbox isn't at the second or third row, or that the 0th column is put later in the list. Hence its required to clear each row item individually, and the code can't clear the entire row at once with, for example, the red background color thats used in the listctrl sample for just that row.

The new code still clears each row entirely too, but this is just done so that we can draw the selected effect background even behind the images. It doesn't use the red background color that's set for that row.

### Refined gap and padding distances to match white mode better

Windows seems to not be super strict with how and where they add gaps and distances. You'll see in the comparisons that I layered the white and dark mode with various DPI settings to get as close as possible. The new values might seem a bit arbitrary, but I've theorized that they might've just been eyeballed by a Microsoft engineer at some point for whatever looked good.

My goal isn't for it to be perfect, but the blanket 6 units that was re-added was definitely inaccurate to whatever the white mode did. It seems in general that the 0th column has some additional padding added, but only when an image is used.
All other columns with images seem to have a tiny 1 unit pixel distance before the image.

There also seems to be a slight y offset. I don't think this is bad enough to require a fix, and might be caused by the headers being slightly different sizes.

I think there's still improvements possible here, but I think this is a big step forwards. It also happens to fix a weird icon offset that Cemu suffered from. Feel free to test it on other Windows versions though.

## Comparisons

For testing, I used the ListCtrl sample with [very minor modifications for testing](https://gist.github.com/Crementif/ee59bbdbbbd9e55008353dd4c1e9c69b). For the DPI testing I changed the compatibility settings in Windows to be controlled by the Application with 400% DPI.
The testing was done on Windows 11 Pro 25H2, OS build was 26200.6899.

To induce all of the bugs listed above, enable checkboxes, drag the 0th column to the right and hover over a row.

### Before and After
**Without this PR, it looks like this on trunk:**
<img width="612" height="540" alt="image" src="https://github.com/user-attachments/assets/3bfbcd89-bc75-4416-9dab-255745811b76" />
**After the PR, it looks like this:**
<img width="612" height="540" alt="Screenshot 2025-11-04 134529" src="https://github.com/user-attachments/assets/52ff22e3-6ec8-4bef-b2f1-4563029f011a" />

### Comparisons between Light and Dark Mode
**At 100%, it looks like this (I used imgsli to make it easier to compare between the white and dark mode):**
https://imgsli.com/NDI2Mzgw

**At 400% DPI, it looks like this:**
https://imgsli.com/NDI2MzYy