### PR TITLE
Improve wxStyledTextCtrl compatibility with screen readers

### DIFF
--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -746,8 +746,15 @@ void ScintillaWX::FineTickerCancel(TickReason reason) {
 //----------------------------------------------------------------------
 
 
-sptr_t ScintillaWX::DefWndProc(unsigned int /*iMessage*/, uptr_t /*wParam*/, sptr_t /*lParam*/) {
+sptr_t ScintillaWX::DefWndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam) {
+#ifdef __WXMSW__
+    return stc->wxControl::MSWWindowProc(iMessage, wParam, lParam);
+#else
+    wxUnusedVar(iMessage);
+    wxUnusedVar(wParam);
+    wxUnusedVar(lParam);
     return 0;
+#endif
 }
 
 sptr_t ScintillaWX::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam) {
@@ -779,7 +786,7 @@ sptr_t ScintillaWX::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam)
                     InvalidateStyleRedraw();
                 }
             }
-            break;
+            return 0;
 #endif
 
         case SCI_GETDIRECTFUNCTION:
@@ -793,18 +800,18 @@ sptr_t ScintillaWX::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam)
         case WM_IME_STARTCOMPOSITION:
             // Always use windowed IME in ScintillaWX for now. Inline IME not implemented yet
             ImeStartComposition();
-            return stc->wxControl::MSWWindowProc(iMessage, wParam, lParam);
+            break;
 
         case WM_IME_ENDCOMPOSITION:
             ImeEndComposition();
-            return stc->wxControl::MSWWindowProc(iMessage, wParam, lParam);
+            break;
 
         case WM_IME_KEYDOWN:
         case WM_IME_REQUEST:
         case WM_IME_COMPOSITION:
         case WM_IME_SETCONTEXT:
             // These events are forwarded here for future inline IME implementation
-            return stc->wxControl::MSWWindowProc(iMessage, wParam, lParam);
+            break;
 #endif
 
         case SCI_SETLEXER:
@@ -813,7 +820,7 @@ sptr_t ScintillaWX::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam)
             const char* name = LexerNameFromID(lexLanguage);
             ILexer5* pLexer = name ? CreateLexer(name) : nullptr;
             stc->SetILexer(pLexer);
-            break;
+            return 0;
         }
 
         case SCI_SETLEXERLANGUAGE:
@@ -821,19 +828,20 @@ sptr_t ScintillaWX::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam)
             const char* name = ConstCharPtrFromSPtr(lParam);
             ILexer5* pLexer = name ? CreateLexer(name) : nullptr;
             stc->SetILexer(pLexer);
-            break;
+            return 0;
         }
 
         case SCI_LOADLEXERLIBRARY:
         {
             Lexilla::Load(ConstCharPtrFromSPtr(lParam));
-            break;
+            return 0;
         }
 
         default:
-            return ScintillaBase::WndProc(iMessage, wParam, lParam);
+            break;
     }
-    return 0;
+
+    return ScintillaBase::WndProc(iMessage, wParam, lParam);
 }
 
 

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -6035,18 +6035,10 @@ WXLRESULT wxStyledTextCtrl::MSWWindowProc(WXUINT nMsg,
     WXWPARAM wParam,
     WXLPARAM lParam)
 {
-    switch(nMsg) {
-    // Forward IME messages to ScintillaWX
-    case WM_IME_KEYDOWN:
-    case WM_IME_REQUEST:
-    case WM_IME_STARTCOMPOSITION:
-    case WM_IME_ENDCOMPOSITION:
-    case WM_IME_COMPOSITION:
-    case WM_IME_SETCONTEXT:
+    if ( m_swx )
         return SendMsg(nMsg, wParam, lParam);
-    default:
+    else
         return wxControl::MSWWindowProc(nMsg, wParam, lParam);
-    }
 }
 #endif
 

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -187,10 +187,22 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
                               long style,
                               const wxString& name)
 {
-    style |= wxVSCROLL | wxHSCROLL;
-    if (!wxControl::Create(parent, id, pos, size,
-                           style | wxWANTS_CHARS | wxCLIP_CHILDREN,
-                           wxDefaultValidator, name))
+    style |= wxVSCROLL | wxHSCROLL | wxWANTS_CHARS | wxCLIP_CHILDREN;
+
+    // We want to use a specific class name for this window in wxMSW to make it
+    // possible to configure screen readers to handle it specifically.
+    bool created =
+#ifdef __WXMSW__
+        CreateUsingMSWClass(
+            wxApp::GetRegisteredClassName(wxT("Scintilla")),
+            parent, id, pos, size, style, name
+        );
+#else
+        wxControl::Create(
+            parent, id, pos, size, style, wxDefaultValidator, name
+        );
+#endif
+    if ( !created )
         return false;
 
     m_swx = new ScintillaWX(this);

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -187,10 +187,22 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
                               long style,
                               const wxString& name)
 {
-    style |= wxVSCROLL | wxHSCROLL;
-    if (!wxControl::Create(parent, id, pos, size,
-                           style | wxWANTS_CHARS | wxCLIP_CHILDREN,
-                           wxDefaultValidator, name))
+    style |= wxVSCROLL | wxHSCROLL | wxWANTS_CHARS | wxCLIP_CHILDREN;
+
+    // We want to use a specific class name for this window in wxMSW to make it
+    // possible to configure screen readers to handle it specifically.
+    bool created =
+#ifdef __WXMSW__
+        CreateUsingMSWClass(
+            wxApp::GetRegisteredClassName(wxT("Scintilla")),
+            parent, id, pos, size, style, name
+        );
+#else
+        wxControl::Create(
+            parent, id, pos, size, style, wxDefaultValidator, name
+        );
+#endif
+    if ( !created )
         return false;
 
     m_swx = new ScintillaWX(this);

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -1227,18 +1227,10 @@ WXLRESULT wxStyledTextCtrl::MSWWindowProc(WXUINT nMsg,
     WXWPARAM wParam,
     WXLPARAM lParam)
 {
-    switch(nMsg) {
-    // Forward IME messages to ScintillaWX
-    case WM_IME_KEYDOWN:
-    case WM_IME_REQUEST:
-    case WM_IME_STARTCOMPOSITION:
-    case WM_IME_ENDCOMPOSITION:
-    case WM_IME_COMPOSITION:
-    case WM_IME_SETCONTEXT:
+    if ( m_swx )
         return SendMsg(nMsg, wParam, lParam);
-    default:
+    else
         return wxControl::MSWWindowProc(nMsg, wParam, lParam);
-    }
 }
 #endif
 


### PR DESCRIPTION
Use `Scintilla` as win32 classname for `wxStyledTextCtrl`. This way applications like screen readers know how to interface with it.

And forward all win32 messages to the Scintilla control.

Fixes #18683

This can/should also be backported to 3.2.