### PR TITLE
Use correct column attributes when drawing wxListCtrl

### DIFF
--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -379,6 +379,10 @@ public:
                                     WXWPARAM wParam,
                                     WXLPARAM lParam) override;
 
+    // public function to get ItemColumnAttr
+    wxItemAttr* MSWGetItemColumnAttr(long item, long column) const
+        { return DoGetItemColumnAttr(item, column); }
+
 protected:
     // common part of all ctors
     void Init();


### PR DESCRIPTION
When a column is custom drawn, it uses the `wxItemAttr` of the column being updated to redraw all columns. Fix this by requesting the column attributes of each column that is drawn.

See #25633 (not sure if you can close this, because it is about more than `wxListCtrl`)

cc @Crementif This shouldn't affect your fixes from #25950 but I'd appreciate if you could review this to make sure all still works fine. Thank you.

You can reproduce the problem with the following patch. Open the listctrl sample in dark mode, and select the virtual view (f7). Without this PR, all columns have the same colour, with this PR columns have the correct different colour.

```diff
 samples/listctrl/listtest.cpp | 12 ++++++++++++
 samples/listctrl/listtest.h   |  1 +
 2 files changed, 13 insertions(+)

diff --git a/samples/listctrl/listtest.cpp b/samples/listctrl/listtest.cpp
index 6cb49bcf871..48dac3cef12 100644
--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1536,6 +1536,18 @@ int MyListCtrl::OnGetItemColumnImage(long item, long column) const
     return -1;
 }
 
+wxItemAttr* MyListCtrl::OnGetItemColumnAttr(long item, long column) const
+{
+    static wxItemAttr attr(*wxRED, wxNullColour, wxNullFont);
+    if (column == 0)
+        attr.SetTextColour(wxColour(0xFF, 0x00, 0x00));
+    if (column == 1)
+        attr.SetTextColour(wxColour(0x00, 0x00, 0xFF));
+    if ((item + column) % 5 == 0)
+        attr.SetTextColour(wxColour(0x00, 0xFF, 0x00));
+    return &attr;
+}
+
 wxItemAttr *MyListCtrl::OnGetItemAttr(long item) const
 {
     // test to check that RefreshItem() works correctly: when m_updated is
diff --git a/samples/listctrl/listtest.h b/samples/listctrl/listtest.h
index ffa4190548a..2b1e8369560 100644
--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -84,6 +84,7 @@ private:
     virtual wxString OnGetItemText(long item, long column) const override;
     virtual bool OnGetItemIsChecked(long item) const override;
     virtual int OnGetItemColumnImage(long item, long column) const override;
+    virtual wxItemAttr *OnGetItemColumnAttr(long item, long column) const override;
     virtual wxItemAttr *OnGetItemAttr(long item) const override;
 
     long m_updated;
```