### PR TITLE
Fix wrong origin offset when using wxRenderer with wxGCDC

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -483,14 +483,11 @@ public:
 
 #ifdef __WXMSW__
     // Native Windows functions using the underlying HDC don't honour GDI+
-    // transformations which may be applied to it. Using this function we can
-    // transform the coordinates manually before passing them to such functions
-    // (as in e.g. wxRendererMSW code). It doesn't do anything if this is not a
-    // wxGCDC.
-    virtual wxRect MSWApplyGDIPlusTransform(const wxRect& r) const
-    {
-        return r;
-    }
+    // transformations which may be applied to it and also don't know anything
+    // about wxDC origin as it handles it on its own to avoid limitations
+    // imposed by Windows. Use this function to transform the coordinates
+    // before passing them to such functions (as in e.g. wxRendererMSW code).
+    virtual wxRect MSWApplyWXTransform(const wxRect& r) const { return r; }
 #endif // __WXMSW__
 
 

--- a/include/wx/dcgraph.h
+++ b/include/wx/dcgraph.h
@@ -223,7 +223,7 @@ public:
     virtual bool DoGetPartialTextExtents(const wxString& text, wxArrayInt& widths) const override;
 
 #ifdef __WXMSW__
-    virtual wxRect MSWApplyGDIPlusTransform(const wxRect& r) const override;
+    virtual wxRect MSWApplyWXTransform(const wxRect& r) const override;
 #endif // __WXMSW__
 
     // update the internal clip box variables

--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -96,6 +96,8 @@ public:
     virtual void ResetTransformMatrix() override;
 #endif // wxUSE_DC_TRANSFORM_MATRIX
 
+    virtual wxRect MSWApplyWXTransform(const wxRect& r) const override;
+
     virtual void SetLogicalFunction(wxRasterOperationMode function) override;
 
     // implementation from now on

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -1440,7 +1440,7 @@ void wxGCDCImpl::DoDrawCheckMark(wxCoord x, wxCoord y,
 }
 
 #ifdef __WXMSW__
-wxRect wxGCDCImpl::MSWApplyGDIPlusTransform(const wxRect& r) const
+wxRect wxGCDCImpl::MSWApplyWXTransform(const wxRect& r) const
 {
     wxCHECK_MSG( IsOk(), r, wxS("Invalid wxGCDC") );
 

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -1933,6 +1933,16 @@ void wxMSWDCImpl::SetLogicalScale(double x, double y)
     RealizeScaleAndOrigin();
 }
 
+wxRect wxMSWDCImpl::MSWApplyWXTransform(const wxRect& r) const
+{
+    // We need to handle the origin offset here as we don't use Windows support
+    // for this, see SetDeviceOrigin() below.
+    wxRect rect = r;
+    rect.x += m_deviceOriginX;
+    rect.y += m_deviceOriginY;
+    return rect;
+}
+
 void wxMSWDCImpl::SetDeviceOrigin(wxCoord x, wxCoord y)
 {
     if ( x == m_deviceOriginX && y == m_deviceOriginY )

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -78,16 +78,8 @@ protected:
     // adjusted for the given wxDC.
     static RECT ConvertToRECT(wxDC& dc, const wxRect& rect)
     {
-        // Theme API doesn't know anything about GDI+ transforms, so apply them
-        // manually.
-        wxRect rectDevice = dc.GetImpl()->MSWApplyGDIPlusTransform(rect);
-
-        // We also need to handle the origin offset manually as we don't use
-        // Windows support for this, see wxDC code.
-        rectDevice.Offset(dc.GetDeviceOrigin());
-
         RECT rc;
-        wxCopyRectToRECT(rectDevice, rc);
+        wxCopyRectToRECT(dc.GetImpl()->MSWApplyWXTransform(rect), rc);
         return rc;
     }
 };


### PR DESCRIPTION
ConvertToRECT() in wxRenderer code accounted for the origin shift twice when using wxGCDC since the changes of 4f9186f1a1 (Increase usable scrolling range in wxMSW by a factor of 10,000, 2022-04-30) which added Offset(dc.GetDeviceOrigin()) call to it as for wxGCDC this offset is already accounted for by MSWApplyGDIPlusTransform().

Fix this by replacing MSWApplyGDIPlusTransform() with a more generic MSWApplyWXTransform() which does the same thing as before for wxGCDC but applies the origin offset for other wxDCs. This ensures that this offset is properly accounted for in both cases.

Closes #25966.