### PR TITLE
Fix wxQt build on Arch Linux under Clang 21

### DIFF
--- a/src/qt/uiaction.cpp
+++ b/src/qt/uiaction.cpp
@@ -177,7 +177,7 @@ static bool SimulateKeyboardKey( KeyAction keyAction, Key key, int modifiers )
     // always produces a lowercase of that char! (which must be in uppercase)
     if ( modifiers == wxMOD_SHIFT && key < 256 )
     {
-        const QChar qChar(key);
+        const QChar qChar(static_cast<int>(key));
         if ( qChar.isLetter() )
         {
             widget->windowHandle() != nullptr ?


### PR DESCRIPTION
Fixes ~~#25969~~ #25484 (although this was tested with a different setup).

This PR makes a simple fix to get wxWidgets building under Arch Linux with Clang 21. It simply adds a cast inside `SimulateKeyboardKey()` inside `src/qt/uiaction.cpp` to convert the given `Qt::Key` to a character.

Note that in the issue I used a C-style cast as a proposed fix. In this PR, to follow the [coding guidelines](https://wxwidgets.org/develop/coding-guidelines), I used a `static_cast` instead of a regular C-style cast.