### PR TITLE
make wxScrolled<> autoscroll region configurable

### DIFF
--- a/include/wx/scrolwin.h
+++ b/include/wx/scrolwin.h
@@ -152,6 +152,27 @@ public:
     // returns 0 if no scrollbars are there.
     int GetScrollLines( int orient ) const;
 
+    // wxWidgets <= 3.3.1 autoscrolled exactly when the (captured) mouse cursor
+    // was outside the entire window.  Starting with wxWidgets 3.3.2, the
+    // region where the mouse cursor triggers autoscrolling is configurable.
+    // If the inner scroll zone is default, then the autoscroll region is
+    // relative to the WINDOW rect, and has width of size outer scroll zone.
+    // If the outer scroll zone width is default, then it extends infinitely
+    // outward from the WINDOW rect, and the behavior is the same as
+    // wxWidgets 3.3.1.  If the inner scroll zone is non-default, then the
+    // autoscroll region is relative to the CLIENT rect since that avoids
+    // requiring the user to figure out how the width of scroll region
+    // interacts with the scrollbar.
+    void SetInnerScrollZone(wxCoord innerZone);
+    void SetOuterScrollZone(wxCoord outerZone);
+
+    // Check whether clientPt triggers autoscrolling in each direction: return
+    // true if it does and fill the corresponing output parameter with the
+    // event type to generate.
+    bool AutoscrollTest(wxPoint clientPt,
+                        wxEventType& evtHorzScroll,
+                        wxEventType& evtVertScroll) const;
+
     // Set the x, y scrolling increments.
     void SetScrollRate( int xstep, int ystep );
 
@@ -263,8 +284,10 @@ public:
     // the methods to be called from the window event handlers
     void HandleOnScroll(wxScrollWinEvent& event);
     void HandleOnSize(wxSizeEvent& event);
-    void HandleOnMouseEnter(wxMouseEvent& event);
-    void HandleOnMouseLeave(wxMouseEvent& event);
+    void OnMotion(wxMouseEvent& event);
+    void OnLeftDown(wxMouseEvent& event);
+    void OnLeaveAutoScrollRegion();
+    void OnEnterAutoScrollRegion();
 #if wxUSE_MOUSEWHEEL
     void HandleOnMouseWheel(wxMouseEvent& event);
 #endif // wxUSE_MOUSEWHEEL
@@ -344,6 +367,10 @@ protected:
         return true;
     }
 
+
+    wxCoord               m_innerScrollZone = wxDefaultCoord;
+    wxCoord               m_outerScrollZone = wxDefaultCoord;
+    bool                  m_inAutoScrollRegion = false;
 
     double                m_scaleX;
     double                m_scaleY;

--- a/include/wx/scrolwin.h
+++ b/include/wx/scrolwin.h
@@ -167,7 +167,7 @@ public:
     void SetOuterScrollZone(wxCoord outerZone);
 
     // Check whether clientPt triggers autoscrolling in each direction: return
-    // true if it does and fill the corresponing output parameter with the
+    // true if it does and fill the corresponding output parameter with the
     // event type to generate.
     bool AutoscrollTest(wxPoint clientPt,
                         wxEventType& evtHorzScroll,

--- a/include/wx/scrolwin.h
+++ b/include/wx/scrolwin.h
@@ -155,16 +155,11 @@ public:
     // wxWidgets <= 3.3.1 autoscrolled exactly when the (captured) mouse cursor
     // was outside the entire window.  Starting with wxWidgets 3.3.2, the
     // region where the mouse cursor triggers autoscrolling is configurable.
-    // If the inner scroll zone is default, then the autoscroll region is
-    // relative to the WINDOW rect, and has width of size outer scroll zone.
-    // If the outer scroll zone width is default, then it extends infinitely
-    // outward from the WINDOW rect, and the behavior is the same as
-    // wxWidgets 3.3.1.  If the inner scroll zone is non-default, then the
-    // autoscroll region is relative to the CLIENT rect since that avoids
-    // requiring the user to figure out how the width of scroll region
-    // interacts with the scrollbar.
-    void SetInnerScrollZone(wxCoord innerZone);
-    void SetOuterScrollZone(wxCoord outerZone);
+    // Allow autoscrolling when the mouse is inside the window but within
+    // insideWidth pixels of the edge.
+    void EnableAutoScrollInside(wxCoord insideWidth);
+    // Forbid autoscrolling when the mouse is outside the window
+    void DisableAutoScrollOutside();
 
     // Check whether clientPt triggers autoscrolling in each direction: return
     // true if it does and fill the corresponding output parameter with the
@@ -368,8 +363,8 @@ protected:
     }
 
 
-    wxCoord               m_innerScrollZone = wxDefaultCoord;
-    wxCoord               m_outerScrollZone = wxDefaultCoord;
+    wxCoord               m_innerScrollWidth = 0;
+    bool                  m_outerScrollEnabled = true;
     bool                  m_inAutoScrollRegion = false;
 
     double                m_scaleX;

--- a/interface/wx/scrolwin.h
+++ b/interface/wx/scrolwin.h
@@ -107,14 +107,14 @@ enum wxScrollbarVisibility
     By default, autoscrolling is triggered when the mouse is anywhere outside
     of the window, i.e. the window starts scrolling when the (captured) mouse
     pointer leaves the window and stops when it re-enters the window. However,
-    this behaviour can be customized using SetInnerScrollZone() and
-    SetOuterScrollZone() functions. The first of them allows to enable
+    this behaviour can be customized using EnableAutoScrollInside() and
+    DisableAutoScrollOutside() functions. The first of them allows to enable
     autoscrolling even when mouse is inside the window, but close to its
     border, while the second one allows to disable autoscrolling when mouse is
     outside the window.
 
-    To disable autoscrolling completely, call SetOuterScrollZone() with 0
-    argument.
+    To disable autoscrolling completely, call DisableAutoScrollOutside()
+    without calling EnableAutoScrollInside().
 
 
     @beginStyleTable
@@ -626,10 +626,10 @@ public:
     int GetScrollLines( int orient ) const;
 
     /**
-        Set the width of the autoscroll zone inside the client rectangle.
+        Set the width of the autoscroll zone inside the window rectangle.
 
         Setting inner scroll zone to a non-zero value enables autoscrolling if
-        the distance between the mouse and the closest edge of the client
+        the distance between the mouse and the closest edge of the window
         rectangle is less than the given value.
 
         By default, autoscrolling is not triggered when the mouse is inside the
@@ -637,7 +637,7 @@ public:
 
         @see @ref scrolled_autoscroll, SetOuterScrollZone()
 
-        @param innerZone
+        @param insideWidth
             The width of the inner scroll zone in pixels. If this parameter is
             set to either 0 or ::wxDefaultCoord, there is no inner scroll zone
             and autoscrolling may be triggered only when the mouse is outside
@@ -645,26 +645,19 @@ public:
 
         @since 3.3.2
     */
-    void SetInnerScrollZone(wxCoord innerZone);
+    void EnableAutoScrollInside(wxCoord insideWidth);
 
     /**
-        Set the width of the auto-scroll zone outside the window.
-
         By default, autoscrolling is triggered when the mouse is anywhere
-        outside of the window.
+        outside of the window.  This function disables autoscrolling
+        when the mouse is outside the window.  (Autoscrolling could
+        still be enabled when the mouse is inside the window.)
 
-        @see @ref scrolled_autoscroll, SetInnerScrollZone()
-
-        @param outerZone
-            The width of the outer scroll zone in pixels. If this parameter is
-            set to ::wxDefaultCoord, autoscrolling is triggered when the mouse
-            is anywhere outside of the window. May be set to 0 to disable
-            autoscrolling when the mouse is outside of the window entirely.
-            It is typically not useful to set it at any other value.
+        @see @ref scrolled_autoscroll, EnableAutoScrollInside()
 
         @since 3.3.2
     */
-    void SetOuterScrollZone(wxCoord outerZone);
+    void DisableAutoScrollOutside();
 
     /**
         Set the scaling factor for the window.

--- a/interface/wx/scrolwin.h
+++ b/interface/wx/scrolwin.h
@@ -95,6 +95,28 @@ enum wxScrollbarVisibility
     window out of the visible area), the child window will report a position
     of (10,-90).
 
+    @section scrolled_autoscroll Automatic scrolling
+
+    Scrolled windows implement automatic scrolling behaviour: when the mouse is
+    captured by the application and the user holds the mouse button down, the
+    window may start and keep scrolling even if the mouse doesn't move,
+    provided that it is in the "autoscroll zone". This is convenient to allow
+    extending selection to the parts of the window currently outside of the
+    visible area, for example.
+
+    By default, autoscrolling is triggered when the mouse is anywhere outside
+    of the window, i.e. the window starts scrolling when the (captured) mouse
+    pointer leaves the window and stops when it re-enters the window. However,
+    this behaviour can be customized using SetInnerScrollZone() and
+    SetOuterScrollZone() functions. The first of them allows to enable
+    autoscrolling even when mouse is inside the window, but close to its
+    border, while the second one allows to disable autoscrolling when mouse is
+    outside the window.
+
+    To disable autoscrolling completely, call SetOuterScrollZone() with 0
+    argument.
+
+
     @beginStyleTable
     @style{wxHSCROLL}
            If this style is specified and ::wxVSCROLL isn't, the window will be
@@ -602,6 +624,47 @@ public:
     int GetScrollPageSize(int orient) const;
     void SetScrollPageSize(int orient, int pageSize);
     int GetScrollLines( int orient ) const;
+
+    /**
+        Set the width of the autoscroll zone inside the client rectangle.
+
+        Setting inner scroll zone to a non-zero value enables autoscrolling if
+        the distance between the mouse and the closest edge of the client
+        rectangle is less than the given value.
+
+        By default, autoscrolling is not triggered when the mouse is inside the
+        window.
+
+        @see @ref scrolled_autoscroll, SetOuterScrollZone()
+
+        @param innerZone
+            The width of the inner scroll zone in pixels. If this parameter is
+            set to either 0 or ::wxDefaultCoord, there is no inner scroll zone
+            and autoscrolling may be triggered only when the mouse is outside
+            of the window (unless it is disabled too).
+
+        @since 3.3.2
+    */
+    void SetInnerScrollZone(wxCoord innerZone);
+
+    /**
+        Set the width of the auto-scroll zone outside the window.
+
+        By default, autoscrolling is triggered when the mouse is anywhere
+        outside of the window.
+
+        @see @ref scrolled_autoscroll, SetInnerScrollZone()
+
+        @param outerZone
+            The width of the outer scroll zone in pixels. If this parameter is
+            set to ::wxDefaultCoord, autoscrolling is triggered when the mouse
+            is anywhere outside of the window. May be set to 0 to disable
+            autoscrolling when the mouse is outside of the window entirely.
+            It is typically not useful to set it at any other value.
+
+        @since 3.3.2
+    */
+    void SetOuterScrollZone(wxCoord outerZone);
 
     /**
         Set the scaling factor for the window.

--- a/interface/wx/scrolwin.h
+++ b/interface/wx/scrolwin.h
@@ -639,9 +639,10 @@ public:
 
         @param insideWidth
             The width of the inner scroll zone in pixels. If this parameter is
-            set to either 0 or ::wxDefaultCoord, there is no inner scroll zone
+            set to 0, there is no inner scroll zone
             and autoscrolling may be triggered only when the mouse is outside
-            of the window (unless it is disabled too).
+            of the window (unless it is disabled too).  (Negative values,
+            including ::wxDefaultCoord, are forbidden.)
 
         @since 3.3.2
     */

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -272,6 +272,24 @@ public:
     }
 #endif // wxUSE_GRAPHICS_CONTEXT
 
+    void OnAutoscrollOuter(wxCommandEvent& WXUNUSED(event))
+    {
+        m_canvas->SetInnerScrollZone(wxDefaultCoord);
+        m_canvas->SetOuterScrollZone(wxDefaultCoord);
+    }
+
+    void OnAutoscrollInner(wxCommandEvent& WXUNUSED(event))
+    {
+        m_canvas->SetInnerScrollZone(FromDIP(16));
+        m_canvas->SetOuterScrollZone(0);
+    }
+
+    void OnAutoscrollDisable(wxCommandEvent& WXUNUSED(event))
+    {
+        m_canvas->SetInnerScrollZone(0);
+        m_canvas->SetOuterScrollZone(0);
+    }
+
     void OnBuffer(wxCommandEvent& event);
     void OnCopy(wxCommandEvent& event);
 #if wxUSE_FILEDLG
@@ -374,6 +392,9 @@ enum
 #if wxUSE_GRAPHICS_CONTEXT
     File_AntiAliasing,
 #endif
+    File_AutoscrollOuter,
+    File_AutoscrollInner,
+    File_AutoscrollDisable,
     File_Copy,
     File_Save,
 
@@ -2521,6 +2542,9 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU      (File_AntiAliasing, MyFrame::OnAntiAliasing)
     EVT_UPDATE_UI (File_AntiAliasing, MyFrame::OnAntiAliasingUpdateUI)
 #endif // wxUSE_GRAPHICS_CONTEXT
+    EVT_MENU      (File_AutoscrollOuter, MyFrame::OnAutoscrollOuter)
+    EVT_MENU      (File_AutoscrollInner, MyFrame::OnAutoscrollInner)
+    EVT_MENU      (File_AutoscrollDisable, MyFrame::OnAutoscrollDisable)
 
     EVT_MENU      (File_Buffer,   MyFrame::OnBuffer)
     EVT_MENU      (File_Copy,     MyFrame::OnCopy)
@@ -2620,6 +2644,10 @@ MyFrame::MyFrame(const wxString& title)
                               "Enable Anti-Aliasing in wxGraphicContext")
             ->Check();
 #endif
+    menuFile->AppendSeparator();
+    menuFile->AppendRadioItem(File_AutoscrollOuter, "&Outer Scroll Zone", "Autoscroll zone outside window");
+    menuFile->AppendRadioItem(File_AutoscrollInner, "&Inner Scroll Zone", "Autoscroll zone inside window");
+    menuFile->AppendRadioItem(File_AutoscrollDisable, "Disab&le AutoScroll Zone", "Disable Autoscroll");
     menuFile->AppendSeparator();
 #if wxUSE_METAFILE && defined(wxMETAFILE_IS_ENH)
     menuFile->Append(File_Copy, "Copy to clipboard");

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -274,20 +274,25 @@ public:
 
     void OnAutoscrollOuter(wxCommandEvent& WXUNUSED(event))
     {
-        m_canvas->SetInnerScrollZone(wxDefaultCoord);
-        m_canvas->SetOuterScrollZone(wxDefaultCoord);
+        m_outerScrollEnabled = false;
+        m_canvas->DisableAutoScrollOutside();
+    }
+
+    void OnAutoscrollOuterUpdateUI(wxUpdateUIEvent& event)
+    {
+        event.Check(m_outerScrollEnabled);
+        event.Enable(m_outerScrollEnabled);
     }
 
     void OnAutoscrollInner(wxCommandEvent& WXUNUSED(event))
     {
-        m_canvas->SetInnerScrollZone(FromDIP(16));
-        m_canvas->SetOuterScrollZone(0);
+        m_innerScrollWidth = FromDIP(16) - m_innerScrollWidth;
+        m_canvas->EnableAutoScrollInside(m_innerScrollWidth);
     }
 
-    void OnAutoscrollDisable(wxCommandEvent& WXUNUSED(event))
+    void OnAutoscrollInnerUpdateUI(wxUpdateUIEvent& event)
     {
-        m_canvas->SetInnerScrollZone(0);
-        m_canvas->SetOuterScrollZone(0);
+        event.Check(m_innerScrollWidth != 0);
     }
 
     void OnBuffer(wxCommandEvent& event);
@@ -332,6 +337,9 @@ public:
     MyCanvas   *m_canvas;
     wxMenuItem *m_menuItemUseDC;
 private:
+    bool        m_outerScrollEnabled = true;
+    int         m_innerScrollWidth = 0;
+
     // any class wishing to process wxWidgets events must use this macro
     wxDECLARE_EVENT_TABLE();
 };
@@ -394,7 +402,6 @@ enum
 #endif
     File_AutoscrollOuter,
     File_AutoscrollInner,
-    File_AutoscrollDisable,
     File_Copy,
     File_Save,
 
@@ -2543,8 +2550,9 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_UPDATE_UI (File_AntiAliasing, MyFrame::OnAntiAliasingUpdateUI)
 #endif // wxUSE_GRAPHICS_CONTEXT
     EVT_MENU      (File_AutoscrollOuter, MyFrame::OnAutoscrollOuter)
+    EVT_UPDATE_UI (File_AutoscrollOuter, MyFrame::OnAutoscrollOuterUpdateUI)
     EVT_MENU      (File_AutoscrollInner, MyFrame::OnAutoscrollInner)
-    EVT_MENU      (File_AutoscrollDisable, MyFrame::OnAutoscrollDisable)
+    EVT_UPDATE_UI (File_AutoscrollInner, MyFrame::OnAutoscrollInnerUpdateUI)
 
     EVT_MENU      (File_Buffer,   MyFrame::OnBuffer)
     EVT_MENU      (File_Copy,     MyFrame::OnCopy)
@@ -2645,9 +2653,8 @@ MyFrame::MyFrame(const wxString& title)
             ->Check();
 #endif
     menuFile->AppendSeparator();
-    menuFile->AppendRadioItem(File_AutoscrollOuter, "&Outer Scroll Zone", "Autoscroll zone outside window");
-    menuFile->AppendRadioItem(File_AutoscrollInner, "&Inner Scroll Zone", "Autoscroll zone inside window");
-    menuFile->AppendRadioItem(File_AutoscrollDisable, "Disab&le AutoScroll Zone", "Disable Autoscroll");
+    menuFile->AppendCheckItem(File_AutoscrollOuter, "&Outer Scroll Zone", "Autoscroll zone outside window");
+    menuFile->AppendCheckItem(File_AutoscrollInner, "&Inner Scroll Zone", "Autoscroll zone inside window");
     menuFile->AppendSeparator();
 #if wxUSE_METAFILE && defined(wxMETAFILE_IS_ENH)
     menuFile->Append(File_Copy, "Copy to clipboard");

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -710,19 +710,17 @@ void wxScrollHelperBase::DoPrepareReadOnlyDC(wxReadOnlyDC& dc)
 }
 
 // see scrolwin.h for description
-void wxScrollHelperBase::SetInnerScrollZone(wxCoord innerZone)
+void wxScrollHelperBase::EnableAutoScrollInside(wxCoord insideWidth)
 {
-    wxCHECK_RET( innerZone == wxDefaultCoord || innerZone >= 0,
-            "arg should be non-negative or wxDefaultCoord");
-    m_innerScrollZone = innerZone;
+    wxCHECK_RET( insideWidth >= 0,
+            "arg should be non-negative");
+    m_innerScrollWidth = insideWidth;
 }
 
 // see scrolwin.h for description
-void wxScrollHelperBase::SetOuterScrollZone(wxCoord outerZone)
+void wxScrollHelperBase::DisableAutoScrollOutside()
 {
-    wxCHECK_RET( outerZone == wxDefaultCoord || outerZone >= 0,
-            "arg should be non-negative or wxDefaultCoord");
-    m_outerScrollZone = outerZone;
+    m_outerScrollEnabled = false;
 }
 
 // check whether clientPt triggers autoscrolling in each direction
@@ -732,27 +730,13 @@ wxScrollHelperBase::AutoscrollTest(wxPoint clientPt,
                                    wxEventType& evtVertScroll) const
 {
     // is mouse in autoscroll region?
-    wxRect inner, outer;
-    if ( m_innerScrollZone == wxDefaultCoord )
+    if ( !m_outerScrollEnabled &&
+         !m_win->GetRect().Contains(clientPt) )
     {
-        inner = m_win->GetRect();
-        if ( m_outerScrollZone != wxDefaultCoord )
-        {
-            outer = m_win->GetRect().Inflate(m_outerScrollZone);
-        }
+        return false;
     }
-    else
-    {
-        inner = m_win->GetClientRect().Deflate(m_innerScrollZone);
-        if ( m_outerScrollZone != wxDefaultCoord )
-        {
-            outer = m_win->GetClientRect().Inflate(m_outerScrollZone);
-        }
-    }
-
-    bool inScrollRegion = !inner.Contains(clientPt) &&
-                          (outer == wxRect() || outer.Contains(clientPt));
-    if ( !inScrollRegion )
+    wxRect inner = m_win->GetRect().Deflate(m_innerScrollWidth);
+    if ( inner.Contains(clientPt) )
     {
         return false;
     }


### PR DESCRIPTION
This is an initial attempt at configuring `wxScrolled<>`'s autoscroll region.  The default configuration emulates the existing behavior, but can be overridden to change the autoscroll region.  In particular, my personal requirement is for the region to be inside the window, but near the edge, but the configuration functions allow for some other possibilities.

Would anyone prefer a different API?  Or have any other comments?