### PR TITLE
Remove unused, commented-out wxGetCurrentDir() that was never used

### DIFF
--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -470,40 +470,6 @@ wxString wxGetHomeDir()
     return home;
 }
 
-#if 0
-
-wxString wxGetCurrentDir()
-{
-    wxString dir;
-    size_t len = 1024;
-    bool ok;
-    do
-    {
-        ok = getcwd(dir.GetWriteBuf(len + 1), len) != nullptr;
-        dir.UngetWriteBuf();
-
-        if ( !ok )
-        {
-            if ( errno != ERANGE )
-            {
-                wxLogSysError(wxT("Failed to get current directory"));
-
-                return wxEmptyString;
-            }
-            else
-            {
-                // buffer was too small, retry with a larger one
-                len *= 2;
-            }
-        }
-        //else: ok
-    } while ( !ok );
-
-    return dir;
-}
-
-#endif // 0
-
 // ----------------------------------------------------------------------------
 // Environment
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This implementation was surrounded by `#if 0` ever since it was added in 7c07201 (don't disable hidden windows in wxWindowDisabler, it's at best useless, 2003-06-21)