### PR TITLE
Avoid slow drawing of bitmaps with alpha in wxAUI

### DIFF
--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -90,7 +90,7 @@ public:
     {
         InitCommon(dc, style);
 
-        UseBuffer(area.x, area.y);
+        UseBuffer(area);
     }
 
     // Blits the buffer to the dc, and detaches the dc from the buffer (so it
@@ -116,7 +116,7 @@ private:
     }
 
     // check that the bitmap is valid and use it
-    void UseBuffer(wxCoord w = -1, wxCoord h = -1);
+    void UseBuffer(wxSize size = wxDefaultSize);
 
     // the underlying DC to which we copy everything drawn on this one in
     // UnMask()

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -901,34 +901,15 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
 // Render() renders the tab catalog to the specified DC
 // It is a virtual function and can be overridden to
 // provide custom drawing capabilities
-void wxAuiTabContainer::Render(wxDC* raw_dc, wxWindow* wnd)
+void wxAuiTabContainer::Render(wxDC* pdc, wxWindow* wnd)
 {
-    if (!raw_dc || !raw_dc->IsOk())
-        return;
-
     if (m_rect.IsEmpty())
         return;
 
     size_t i;
     size_t page_count = m_pages.GetCount();
 
-#if wxALWAYS_NATIVE_DOUBLE_BUFFER
-    wxDC& dc = *raw_dc;
-#else
-    wxMemoryDC dc;
-
-    // use the same layout direction as the window DC uses to ensure that the
-    // text is rendered correctly
-    dc.SetLayoutDirection(raw_dc->GetLayoutDirection());
-
-    wxBitmap bmp;
-    // create off-screen bitmap
-    bmp.Create(m_rect.GetWidth(), m_rect.GetHeight(),*raw_dc);
-    dc.SelectObject(bmp);
-
-    if (!dc.IsOk())
-        return;
-#endif
+    wxDC& dc = *pdc;
 
     // draw background
     m_art->DrawBackground(dc, wnd, m_rect);
@@ -1015,13 +996,6 @@ void wxAuiTabContainer::Render(wxDC* raw_dc, wxWindow* wnd)
     {
         m_art->DrawPageTab(dc, wnd, m_pages.Item(active), active_rect);
     }
-
-
-#if !wxALWAYS_NATIVE_DOUBLE_BUFFER
-    raw_dc->Blit(m_rect.x, m_rect.y,
-                 m_rect.GetWidth(), m_rect.GetHeight(),
-                 &dc, 0, 0);
-#endif
 }
 
 // Is the tab visible?
@@ -1409,7 +1383,7 @@ wxRect wxAuiTabCtrl::GetHintScreenRect() const
 
 void wxAuiTabCtrl::OnPaint(wxPaintEvent&)
 {
-    wxPaintDC dc(this);
+    wxAutoBufferedPaintDC dc(this);
 
     if (GetPageCount() > 0)
         Render(&dc, this);

--- a/src/common/dcbufcmn.cpp
+++ b/src/common/dcbufcmn.cpp
@@ -85,7 +85,21 @@ private:
         // size 0 would fail, so create a 1*1 bitmap in this case
         size.IncTo(wxSize(1, 1));
 
-        buffer->CreateWithLogicalSize(size, scale);
+        // Explicitly request 24bpp bitmap under MSW to avoid slow down when
+        // drawing bitmaps with alpha channel on 32bpp bitmap: as explained in
+        // AlphaBlt() implementation in src/msw/dc.cpp, we need to manually
+        // reset alpha values in this case, which involves converting the
+        // bitmap to DIB and back and may be very slow. As we don't really care
+        // about the alpha values in the backing store bitmap (everything is
+        // already blended when drawing to it), use 24bpp bitmap to avoid this.
+        constexpr int depth =
+#if defined(__WXMSW__)
+            24;
+#else
+            wxBITMAP_SCREEN_DEPTH;
+#endif
+
+        buffer->CreateWithLogicalSize(size, scale, depth);
 
         return buffer;
     }


### PR DESCRIPTION
See #23841.

If no problems are found with this, it should be backported to 3.2 by just adding `24` to the code creating the bitmap (i.e. without the first commit here).