### PR TITLE
Do not log bogus system error in wxRenameFile() on non-Windows

### DIFF
--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -601,7 +601,7 @@ wxRenameFile(const wxString& file1, const wxString& file2, bool overwrite)
 
     if ( !overwrite && wxFileExists(file2) )
     {
-        wxLogSysError
+        wxLogError
         (
             _("Failed to rename the file '%s' to '%s' because the destination file already exists."),
             file1.c_str(), file2.c_str()


### PR DESCRIPTION
On non-Windows, there is no failed system call in the case when destination file exists, so there is no relevant system error available either.