### PR TITLE
Support EGL 1.4 instead of previously required 1.5

### DIFF
--- a/include/wx/unix/glegl.h
+++ b/include/wx/unix/glegl.h
@@ -131,6 +131,15 @@ public:
     wl_egl_window *m_wlEGLWindow = nullptr;
 
 private:
+    // Call eglCreatePlatformWindowSurface() when using EGL 1.5 or later,
+    // otherwise try eglCreatePlatformWindowSurfaceEXT() if it's available and
+    // fall back on eglCreateWindowSurface() otherwise.
+    //
+    // This function uses m_display and m_config which must be initialized
+    // before using it and should be passed either m_xwindow or m_wlEGLWindow
+    // depending on whether we are using X11 or Wayland.
+    EGLSurface CallCreatePlatformWindowSurface(void *window) const;
+
 
     EGLConfig m_config = nullptr;
     EGLDisplay m_display = nullptr;

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -37,7 +37,16 @@
 
 #include <memory>
 
+namespace
+{
+
 constexpr const char* TRACE_EGL = "glegl";
+
+// EGL version initialized by InitConfig().
+EGLint gs_eglMajor = 0;
+EGLint gs_eglMinor = 0;
+
+} // anonymous namespace
 
 // ----------------------------------------------------------------------------
 // wxGLContextAttrs: OpenGL rendering context attributes
@@ -508,6 +517,63 @@ static void gtk_glcanvas_size_callback(GtkWidget *widget,
 } // extern "C"
 #endif // GDK_WINDOWING_WAYLAND
 
+EGLSurface wxGLCanvasEGL::CallCreatePlatformWindowSurface(void *window) const
+{
+    // Type of eglCreatePlatformWindowSurface[EXT]().
+    typedef EGLSurface (*CreatePlatformWindowSurface)(EGLDisplay display,
+                                                      EGLConfig config,
+                                                      void* window,
+                                                      EGLAttrib const* attrib_list);
+
+    if ( gs_eglMajor > 1 || (gs_eglMajor == 1 && gs_eglMinor >= 5) )
+    {
+        // EGL 1.5 or later: use eglCreatePlatformWindowSurface() which must be
+        // available.
+        static CreatePlatformWindowSurface s_eglCreatePlatformWindowSurface = nullptr;
+        if ( !s_eglCreatePlatformWindowSurface )
+        {
+            s_eglCreatePlatformWindowSurface = reinterpret_cast<CreatePlatformWindowSurface>(
+                eglGetProcAddress("eglCreatePlatformWindowSurface"));
+        }
+
+        // This check is normally superfluous but avoid crashing just in case
+        // it isn't.
+        if ( s_eglCreatePlatformWindowSurface )
+        {
+            return s_eglCreatePlatformWindowSurface(m_display, m_config,
+                                                    window,
+                                                    nullptr);
+        }
+    }
+
+    // Try loading the appropriate EGL function on first use.
+    static CreatePlatformWindowSurface s_eglCreatePlatformWindowSurfaceEXT = nullptr;
+    static bool s_extFuncInitialized = false;
+    if ( !s_extFuncInitialized )
+    {
+        s_extFuncInitialized = true;
+
+        if ( IsExtensionSupported("EGL_EXT_platform_base") )
+        {
+            s_eglCreatePlatformWindowSurfaceEXT = reinterpret_cast<CreatePlatformWindowSurface>(
+                eglGetProcAddress("eglCreatePlatformWindowSurfaceEXT"));
+        }
+    }
+
+    if ( s_eglCreatePlatformWindowSurfaceEXT )
+    {
+        return s_eglCreatePlatformWindowSurfaceEXT(m_display, m_config,
+                                                   window,
+                                                   nullptr);
+    }
+    else
+    {
+        return eglCreateWindowSurface(m_display, m_config,
+                                      reinterpret_cast<EGLNativeWindowType>(window),
+                                      nullptr);
+    }
+}
+
 bool wxGLCanvasEGL::CreateSurface()
 {
     m_display = GetDisplay();
@@ -528,8 +594,7 @@ bool wxGLCanvasEGL::CreateSurface()
         }
 
         m_xwindow = GDK_WINDOW_XID(window);
-        m_surface = eglCreatePlatformWindowSurface(m_display, m_config,
-                                                   &m_xwindow, nullptr);
+        m_surface = CallCreatePlatformWindowSurface(&m_xwindow);
     }
 #endif
 #ifdef GDK_WINDOWING_WAYLAND
@@ -560,8 +625,7 @@ bool wxGLCanvasEGL::CreateSurface()
         wl_surface_set_buffer_scale(m_wlSurface, scale);
         m_wlEGLWindow = wl_egl_window_create(m_wlSurface, w * scale,
                                              h * scale);
-        m_surface = eglCreatePlatformWindowSurface(m_display, m_config,
-                                                   m_wlEGLWindow, nullptr);
+        m_surface = CallCreatePlatformWindowSurface(m_wlEGLWindow);
 
         // We need to use "map-event" instead of "map" to ensure that the
         // widget's underlying Wayland surface has been created.
@@ -671,22 +735,20 @@ EGLConfig wxGLCanvasEGL::InitConfig(const wxGLAttributes& dispAttrs)
         return nullptr;
     }
 
-    EGLint eglMajor = 0;
-    EGLint eglMinor = 0;
-    if ( !eglInitialize(dpy, &eglMajor, &eglMinor) )
+    if ( !eglInitialize(dpy, &gs_eglMajor, &gs_eglMinor) )
     {
         wxFAIL_MSG("eglInitialize failed");
         return nullptr;
     }
 
     // The runtime EGL version cannot be known until EGL has been initialized.
-    if ( eglMajor < 1 || (eglMajor == 1 && eglMinor < 5) )
+    if ( gs_eglMajor < 1 || (gs_eglMajor == 1 && gs_eglMinor < 4) )
     {
         // Ignore the return value here, we cannot recover at this point.
         eglTerminate(dpy);
         wxLogError(wxString::Format(
-            "EGL version is %d.%d. EGL version 1.5 or greater is required.",
-            eglMajor, eglMinor));
+            "EGL version is %d.%d. EGL version 1.4 or greater is required.",
+            gs_eglMajor, gs_eglMinor));
         return nullptr;
     }
 


### PR DESCRIPTION
Check for the availability of eglCreatePlatformWindowSurfaceEXT() if EGL version is < 1.5 and use it if it's available, as it allows applications using wxGLCanvasEGL to work on some (many?) systems without EGL 1.5 support.

Closes #22325.