### PR TITLE
Fix initial scale of wxGLCanvas under EGL/Wayland

### DIFF
--- a/include/wx/unix/glegl.h
+++ b/include/wx/unix/glegl.h
@@ -141,6 +141,7 @@ private:
     wl_region *m_wlRegion = nullptr;
     wl_subsurface *m_wlSubsurface = nullptr;
 
+    int m_scale = 1;
     bool m_readyToDraw = false;
     bool m_swapIntervalSet = false;
 
@@ -148,7 +149,8 @@ private:
     static EGLConfig ms_glEGLConfig;
 
     friend void wxEGLUpdatePosition(wxGLCanvasEGL* win);
-    friend void wxEGLSetScale(wxGLCanvasEGL* win, int scale);
+    friend void wxEGLUpdatePositionAndScale(wxGLCanvasEGL* win, int scale);
+    friend void wxEGLUpdateScaleIfChanged(wxGLCanvasEGL* win, int scale);
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The scale of the canvas was set up correctly only once we received "size-allocate" signal from GTK, but this doesn't necessarily happen when the window is first shown, e.g. the cube sample doesn't get this signal, at least when using Sway.

Ensure that we still use the correct scale by catching "draw" signal as well and updating the scale if it has changed.

See #23733, #25465.

----

This fixes the problem, but I wonder if there is some better way to do it, maybe @paulcor knows of it?

Also cc @Popax21 just FYI as this is related to your changes.