### PR TITLE
Improve wxListCtrl in MSW darkmode

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3410,6 +3410,14 @@ WXLPARAM HandleItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
     }
 
     wxItemAttr* attr = listctrl->MSWGetItemColumnAttr(pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem);
+
+    pLVCD->clrText = attr && attr->HasTextColour()
+        ? wxColourToRGB(attr->GetTextColour())
+        : wxColourToRGB(listctrl->GetTextColour());
+    pLVCD->clrTextBk = attr && attr->HasBackgroundColour()
+        ? wxColourToRGB(attr->GetBackgroundColour())
+        : wxColourToRGB(listctrl->GetBackgroundColour());
+
     if ( !attr )
     {
         // nothing to do for this item

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3254,8 +3254,6 @@ void HandleItemPostpaint(NMCUSTOMDRAW nmcd)
     if ( nmcd.uItemState & CDIS_FOCUS )
     {
         RECT rc = GetCustomDrawnItemRect(nmcd);
-        // subtract 2px so the right border is visible
-        rc.right -= 2;
 
         ::DrawFocusRect(nmcd.hdc, &rc);
     }
@@ -3589,8 +3587,8 @@ void wxListCtrl::OnPaint(wxPaintEvent& event)
 
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(GetBackgroundColour());
-        dc.DrawRectangle(lastRect.GetRight(), 0, clientSize.x - lastRect.GetRight(), lastRect.GetBottom());
-        dc.DrawRectangle(0, lastRect.GetBottom(), clientSize.x, clientSize.y - lastRect.GetBottom());
+        dc.DrawRectangle(lastRect.GetRight() + 1, 0, clientSize.x - lastRect.GetRight(), clientSize.GetHeight());
+        dc.DrawRectangle(0, lastRect.GetBottom() + 1, clientSize.x, clientSize.y - lastRect.GetBottom());
     }
 
     if ( !needToDraw )

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3087,6 +3087,9 @@ HandleSubItemPrepaint(wxListCtrl* listctrl,
         return;
     }
 
+    bool checkboxShown = false;
+    bool imageShown = false;
+
     if ( !col && listctrl->HasCheckBoxes() )
     {
         const HIMAGELIST himl = ListView_GetImageList(hwndList, LVSIL_STATE);
@@ -3126,6 +3129,7 @@ HandleSubItemPrepaint(wxListCtrl* listctrl,
                 ILD_TRANSPARENT
             );
 
+            checkboxShown = true;
             rc.left += GAP_AFTER_CHECKBOX;
 
             // move left edge for further drawing
@@ -3194,6 +3198,7 @@ HandleSubItemPrepaint(wxListCtrl* listctrl,
         // images align?)
         if ( it.iImage != -1 )
         {
+            imageShown = true;
             rc.left += xOffset;
         }
     }
@@ -3203,6 +3208,9 @@ HandleSubItemPrepaint(wxListCtrl* listctrl,
 
     // draw attribute background after drawing any images or checkboxes
     RECT fillRect = rc;
+    if ( !checkboxShown && !imageShown && listctrl->GetColumnOrder(col) != 0 )
+        fillRect.left -= PADDING_LEFT_SIDE;
+    fillRect.right += (PADDING_RIGHT_SIDE - 1);
     ::FillRect(hdc, &fillRect, AutoHBRUSH(pLVCD->clrTextBk));
 
     ::SetBkMode(hdc, TRANSPARENT);

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3345,7 +3345,7 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
 
     // determine if the item is hot (mouse hovering over it)
     POINT point;
-    ::wxGetCursorPosMSW(&point);
+    wxGetCursorPosMSW(&point);
     ::ScreenToClient(GetHwndOf(listctrl), &point);
     if ( listctrl->IsEnabled() && ::PtInRect(&rc, point) != 0 )
     {
@@ -3402,7 +3402,8 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
         pLVCD->clrTextBk = clrFullBG;
         if ( nmcd.uItemState & CDIS_SELECTED )
             pLVCD->clrText = wxColourToRGB(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
-        else if ( !nmcd.uItemState && attr && attr->HasBackgroundColour() )
+        if ( !(nmcd.uItemState & CDIS_SELECTED) && !(nmcd.uItemState & CDIS_HOT)
+                                          && attr && attr->HasBackgroundColour() )
             pLVCD->clrTextBk = wxColourToRGB(attr->GetBackgroundColour());
 
         COLORREF colTextOld = ::SetTextColor(hdc, pLVCD->clrText);

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1388,16 +1388,15 @@ bool wxListCtrl::GetSubItemRect(long item, long subItem, wxRect& rect, int code)
     {
         // Because the columns can be reordered, we need to sum the widths of
         // all preceding columns to get the correct x position.
-        rect.x = 0;
         for ( auto col : GetColumnsOrder() )
         {
-            if ( col == 0 )
+            if ( col == subItem )
                 break;
 
             rect.x += GetColumnWidth(col);
         }
 
-        rect.width = GetColumnWidth(0);
+        rect.width = GetColumnWidth(subItem);
     }
 
     return true;

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3250,6 +3250,8 @@ void HandleItemPostpaint(NMCUSTOMDRAW nmcd)
     if ( nmcd.uItemState & CDIS_FOCUS )
     {
         RECT rc = GetCustomDrawnItemRect(nmcd);
+        // subtract 2px so the right border is visible
+        rc.right -= 2;
 
         ::DrawFocusRect(nmcd.hdc, &rc);
     }

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -707,6 +707,8 @@ bool wxListCtrl::SetHeaderAttr(const wxItemAttr& attr)
 
         delete m_headerCustomDraw;
         m_headerCustomDraw = nullptr;
+
+        MSWInitHeader();
     }
     else // We do have custom attributes.
     {

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3307,6 +3307,9 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
     const HWND hwndList = nmcd.hdr.hwndFrom;
     const int item = nmcd.dwItemSpec;
 
+    RECT rc = GetCustomDrawnItemRect(nmcd);
+    HDC hdc = nmcd.hdc;
+
     // unfortunately we can't trust CDIS_SELECTED, it is often set even when
     // the item is not at all selected for some reason (comctl32 6), but we
     // also can't always trust ListView_GetItem() as it could return the old
@@ -3340,11 +3343,10 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
     }
 
     // determine if the item is hot (mouse hovering over it)
-    LV_HITTESTINFO lvhti;
-    wxZeroMemory(lvhti);
-    wxGetCursorPosMSW(&(lvhti.pt));
-    ::ScreenToClient(GetHwndOf(listctrl), &lvhti.pt);
-    if ( listctrl->IsEnabled() && ListView_HitTest(GetHwndOf(listctrl), &lvhti) == item )
+    POINT point;
+    ::wxGetCursorPosMSW(&point);
+    ::ScreenToClient(GetHwndOf(listctrl), &point);
+    if ( listctrl->IsEnabled() && ::PtInRect(&rc, point) != 0 )
     {
         nmcd.uItemState |= CDIS_HOT;
     }
@@ -3352,9 +3354,6 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
     {
         nmcd.uItemState &= ~CDIS_HOT;
     }
-
-    HDC hdc = nmcd.hdc;
-    RECT rc = GetCustomDrawnItemRect(nmcd);
 
     wxColour clrBg = listctrl->GetBackgroundColour();
     if ( nmcd.uItemState & CDIS_SELECTED )

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3052,12 +3052,13 @@ RECT GetCustomDrawnItemRect(const NMCUSTOMDRAW& nmcd)
 // These values try to replicate the native listctrl rendering as close as
 // possible. Notice that they are not scaled with DPI because the native
 // control doesn't do it either.
-constexpr int PADDING_LEFT_SIDE = 1;
+constexpr int PADDING_LEFT_SIDE = 3;
 constexpr int PADDING_RIGHT_SIDE = 2;
 constexpr int GAP_AFTER_CHECKBOX = 2;
 constexpr int GAP_BEFORE_IMAGE = 2;
 constexpr int GAP_BEFORE_CHECKBOX = 4;
-constexpr int PADDING_FOR_TEXT = 1;
+constexpr int PADDING_LEFT_FOR_TEXT = 2;
+constexpr int PADDING_RIGHT_FOR_TEXT = 4;
 
 void
 HandleSubItemPrepaint(wxListCtrl* listctrl,
@@ -3220,16 +3221,18 @@ HandleSubItemPrepaint(wxListCtrl* listctrl,
         {
             case LVCFMT_LEFT:
                 fmt |= DT_LEFT;
-                rc.left += PADDING_FOR_TEXT;
+                rc.left += PADDING_LEFT_FOR_TEXT;
                 break;
 
             case LVCFMT_CENTER:
+                rc.left += PADDING_LEFT_FOR_TEXT;
+                rc.right -= PADDING_RIGHT_FOR_TEXT;
                 fmt |= DT_CENTER;
                 break;
 
             case LVCFMT_RIGHT:
                 fmt |= DT_RIGHT;
-                rc.right -= PADDING_FOR_TEXT;
+                rc.right -= PADDING_RIGHT_FOR_TEXT;
                 break;
         }
     }


### PR DESCRIPTION
Draw the background color outside the list-items area on all Windows version, both below and behind the items, and when the list is empty.

Set the text foreground and background colors when custom drawing. So the disabled list will use the correct colors in list or icon view.

Fixes #25990