### PR TITLE
Correct wxSpinEvent GetPosition() if start value is non-zero

### DIFF
--- a/interface/wx/spinctrl.h
+++ b/interface/wx/spinctrl.h
@@ -244,7 +244,7 @@ public:
 
         @since 3.1.6
     */
-    void SetIncrement(int value);
+    void SetIncrement(int inc);
 };
 
 /**

--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -250,7 +250,12 @@ bool wxSpinCtrlGenericBase::Create(wxWindow *parent,
 #endif
 
     m_textCtrl   = new wxSpinCtrlTextGeneric(this, DoValueToText(m_value), style);
+    // see comment on style above: the border should be around the text control,
+    // not around the spin button
+    style = (style & ~wxBORDER_MASK) | wxBORDER_NONE;
     m_spinButton = new wxSpinCtrlButtonGeneric(this, style);
+    // ensre correct start value also if non-zero
+    m_spinButton->SetValue( m_value );
 
 #if wxUSE_TOOLTIPS
     m_textCtrl->SetToolTip(GetToolTipText());


### PR DESCRIPTION
  - Set wxSpinButton start value to start value of wxSpinCtrl, otherwise the generic control used in OSX would report a wrong value in EVT_SPIN
  - Very minor doc update
  - Limit explicit border to be around text control, not the spin button, which look very wrong