### PR TITLE
Fix to make tree buttons use the right colour on OS X

### DIFF
--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2870,7 +2870,7 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
 #ifdef __WXMAC__
                 // this flag is required under OSX as this will make it
                 // choose the NSCell.highlighted mode. The chevron will
-                // otherwise be light grey on white background and be 
+                // otherwise be light grey on white background and be
                 // barely visible
                 flag |= wxCONTROL_PRESSED;
 #endif

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2867,14 +2867,6 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
                 if (item == m_underMouse)
                     flag |= wxCONTROL_CURRENT;
 
-#ifdef __WXMAC__
-                // this flag is required under OSX as this will make it
-                // choose the NSCell.highlighted mode. The chevron will
-                // otherwise be light grey on white background and be
-                // barely visible
-                flag |= wxCONTROL_PRESSED;
-#endif
-
                 wxRendererNative::Get().DrawTreeItemButton
                                         (
                                             this,

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2867,6 +2867,14 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
                 if (item == m_underMouse)
                     flag |= wxCONTROL_CURRENT;
 
+#ifdef __WXMAC__
+                // this flag is required under OSX as this will make it
+                // choose the NSCell.highlighted mode. The chevron will
+                // otherwise be light grey on white background and be 
+                // barely visible
+                flag |= wxCONTROL_PRESSED;
+#endif
+
                 wxRendererNative::Get().DrawTreeItemButton
                                         (
                                             this,

--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -421,6 +421,12 @@ void wxRendererMac::DrawTreeItemButton( wxWindow *win,
     else
     {
 #if wxOSX_USE_NSCELL_RENDERER
+        // this flag is required as this will make it choose
+        // the NSCell.highlighted mode. The chevron will
+        // otherwise be light grey on white background and be
+        // barely visible
+        flags |= wxCONTROL_PRESSED;
+
         NSControlStateValue stateValue = (flags & wxCONTROL_EXPANDED) ? NSControlStateValueOn : NSControlStateValueOff;
         DrawMacCell(win, dc, GetDisclosureButtonCell(), rect, flags, stateValue);
 #else


### PR DESCRIPTION
  - This may not be the right fix, but I am not sure if changing wxRendererNative is right and what the consequences would be of changing ApplyMacControlFlags() in wxRenderer. This change only affects the tree button on OSX and it now looks correct in light and dark mode.