### PR TITLE
Fix assert in `wxNotebook::GetTabRect()` when using dark mode

### DIFF
--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -537,12 +537,9 @@ wxRect wxNotebook::GetTabRect(size_t page) const
     wxRect r;
     wxCHECK_MSG(IS_VALID_PAGE(page), r, wxT("invalid notebook page"));
 
-    if (GetPageCount() > 0)
-    {
-        RECT rect;
-        if (TabCtrl_GetItemRect(GetHwnd(), page, &rect))
-            r = wxRectFromRECT(rect);
-    }
+    RECT rect;
+    if (TabCtrl_GetItemRect(GetHwnd(), page, &rect))
+        r = wxRectFromRECT(rect);
 
     return r;
 }

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1262,7 +1262,12 @@ void wxNotebook::MSWNotebookPaint()
     // for some reason (this happens at least when using multiple tab rows), so
     // we need to call it before creating wxPaintDC as otherwise the current
     // paint DC would be invalidated by EndPaint() while we use it, see #25700.
-    wxRect rectTabArea = GetTabRect(0);
+    wxRect rectTabArea;
+
+    // This is more than just an optimization: calling GetTabRect(0) for an
+    // empty control is not allowed and would assert.
+    if ( GetPageCount() > 0 )
+        rectTabArea = GetTabRect(0);
 
     // Now create and use the DC.
     wxPaintDC dc(this);


### PR DESCRIPTION
Fixes #26007 and minor cleanup.