### PR TITLE
OSX NSCell Rendering (native renderer) fix

### DIFF
--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -657,6 +657,19 @@ void wxRendererMac::ApplyMacControlFlags(wxWindow* win, NSCell* cell, int flags)
     cell.controlTint = (flags & wxCONTROL_FOCUSED) ? NSColor.currentControlTint : NSClearControlTint;
 }
 
+namespace
+{
+
+// Cell Drawing seems to run into problems with clipping when the device origin has changed
+// so undo this and restore with GState later
+void CellDrawHelper ( wxDC& dc, CGContextRef cgContext, NSRect& controlRect )
+{
+    wxPoint offset = dc.GetDeviceOrigin();
+    CGContextTranslateCTM( cgContext, -offset.x, -offset.y );
+    controlRect = NSOffsetRect(controlRect, offset.x, offset.y);
+}
+
+} // anonymous namespace
 
 void wxRendererMac::DrawMacCell(wxWindow *win,
                             wxDC& dc,
@@ -687,6 +700,8 @@ void wxRendererMac::DrawMacCell(wxWindow *win,
         CGContextRef cgContext = (CGContextRef) impl->GetGraphicsContext()->GetNativeContext();
 
         CGContextSaveGState(cgContext);
+
+        CellDrawHelper( dc, cgContext, controlRect );
 
         NSGraphicsContext* formerContext = NSGraphicsContext.currentContext;
         NSGraphicsContext.currentContext = [NSGraphicsContext graphicsContextWithCGContext:cgContext
@@ -761,6 +776,8 @@ void wxRendererMac::DrawMacHeaderCell(wxWindow *win,
         CGContextRef cgContext = (CGContextRef) impl->GetGraphicsContext()->GetNativeContext();
 
         CGContextSaveGState(cgContext);
+
+        CellDrawHelper( dc, cgContext, controlRect );
 
         NSGraphicsContext* formerContext = NSGraphicsContext.currentContext;
         NSGraphicsContext.currentContext = [NSGraphicsContext graphicsContextWithCGContext:cgContext


### PR DESCRIPTION
The NSCell drawing routines seem to use a different clipping area than the one of the current context. This workaround undoes the offsetting of the dc but then moves the drawing frame accordingly, see #26014