### PR TITLE
wxDialogValidateEvent as an alternative to Validate()

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -689,6 +689,7 @@ class WXDLLIMPEXP_FWD_CORE wxPaletteChangedEvent;
 class WXDLLIMPEXP_FWD_CORE wxJoystickEvent;
 class WXDLLIMPEXP_FWD_CORE wxDropFilesEvent;
 class WXDLLIMPEXP_FWD_CORE wxInitDialogEvent;
+class WXDLLIMPEXP_FWD_CORE wxDialogValidateEvent;
 class WXDLLIMPEXP_FWD_CORE wxUpdateUIEvent;
 class WXDLLIMPEXP_FWD_CORE wxClipboardTextEvent;
 class WXDLLIMPEXP_FWD_CORE wxHelpEvent;
@@ -854,6 +855,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_JOY_MOVE, wxJoystickEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_JOY_ZMOVE, wxJoystickEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_DROP_FILES, wxDropFilesEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_INIT_DIALOG, wxInitDialogEvent);
+wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_DIALOG_VALIDATE, wxDialogValidateEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_BASE, wxEVT_IDLE, wxIdleEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_UPDATE_UI, wxUpdateUIEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_SIZING, wxSizeEvent);
@@ -2629,6 +2631,24 @@ private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxInitDialogEvent);
 };
 
+// DialogValidate event class
+/*
+ wxEVT_DIALOG_VALIDATE
+ */
+
+class WXDLLIMPEXP_CORE wxDialogValidateEvent : public wxNotifyEvent
+{
+public:
+    wxDialogValidateEvent(int Id = 0)
+        : wxNotifyEvent(wxEVT_DIALOG_VALIDATE, Id)
+        { }
+
+    wxNODISCARD virtual wxEvent *Clone() const override { return new wxDialogValidateEvent(*this); }
+
+private:
+    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxDialogValidateEvent);
+};
+
 // Miscellaneous menu event class
 /*
  wxEVT_MENU_OPEN,
@@ -4298,6 +4318,7 @@ typedef void (wxEvtHandler::*wxMenuEventFunction)(wxMenuEvent&);
 typedef void (wxEvtHandler::*wxJoystickEventFunction)(wxJoystickEvent&);
 typedef void (wxEvtHandler::*wxDropFilesEventFunction)(wxDropFilesEvent&);
 typedef void (wxEvtHandler::*wxInitDialogEventFunction)(wxInitDialogEvent&);
+typedef void (wxEvtHandler::*wxDialogValidateEventFunction)(wxDialogValidateEvent&);
 typedef void (wxEvtHandler::*wxSysColourChangedEventFunction)(wxSysColourChangedEvent&);
 typedef void (wxEvtHandler::*wxSysMetricChangedEventFunction)(wxSysMetricChangedEvent&);
 typedef void (wxEvtHandler::*wxDisplayChangedEventFunction)(wxDisplayChangedEvent&);
@@ -4363,6 +4384,8 @@ typedef void (wxEvtHandler::*wxFullScreenEventFunction)(wxFullScreenEvent&);
     wxEVENT_HANDLER_CAST(wxDropFilesEventFunction, func)
 #define wxInitDialogEventHandler(func) \
     wxEVENT_HANDLER_CAST(wxInitDialogEventFunction, func)
+#define wxDialogValidateEventHandler(func) \
+    wxEVENT_HANDLER_CAST(wxDialogValidateEventFunction, func)
 #define wxSysColourChangedEventHandler(func) \
     wxEVENT_HANDLER_CAST(wxSysColourChangedEventFunction, func)
 #define wxSysMetricChangedEventHandler(func) \
@@ -4628,6 +4651,7 @@ typedef void (wxEvtHandler::*wxFullScreenEventFunction)(wxFullScreenEvent&);
 #define EVT_QUERY_END_SESSION(func)  wx__DECLARE_EVT0(wxEVT_QUERY_END_SESSION, wxCloseEventHandler(func))
 #define EVT_DROP_FILES(func)  wx__DECLARE_EVT0(wxEVT_DROP_FILES, wxDropFilesEventHandler(func))
 #define EVT_INIT_DIALOG(func)  wx__DECLARE_EVT0(wxEVT_INIT_DIALOG, wxInitDialogEventHandler(func))
+#define EVT_DIALOG_VALIDATE(func)  wx__DECLARE_EVT0(wxEVT_DIALOG_VALIDATE, wxDialogValidateEventHandler(func))
 #define EVT_SYS_COLOUR_CHANGED(func) wx__DECLARE_EVT0(wxEVT_SYS_COLOUR_CHANGED, wxSysColourChangedEventHandler(func))
 #define EVT_SYS_METRIC_CHANGED(func) wx__DECLARE_EVT0(wxEVT_SYS_METRIC_CHANGED, wxSysMetricChangedEventHandler(func))
 #define EVT_DISPLAY_CHANGED(func)  wx__DECLARE_EVT0(wxEVT_DISPLAY_CHANGED, wxDisplayChangedEventHandler(func))

--- a/interface/wx/dialog.h
+++ b/interface/wx/dialog.h
@@ -148,6 +148,8 @@ enum wxDialogLayoutAdaptationMode
         (see the @c wxCLOSE_BOX style).
     @event{EVT_INIT_DIALOG(func)}
         Process a @c wxEVT_INIT_DIALOG event. See wxInitDialogEvent.
+    @event{EVT_DIALOG_VALIDATE(func)}
+        Process a @c wxEVT_DIALOG_VALIDATE event. See wxDialogValidateEvent.
     @endEventTable
 
     @library{wxcore}
@@ -476,7 +478,10 @@ public:
 
     /**
         Sets the identifier to be used as OK button. When the button with this
-        identifier is pressed, the dialog calls wxWindow::Validate() and
+        identifier is pressed, a wxDialogValidateEvent is sent which can be
+        vetoed to prevent the dialog from getting closed (this is an
+        event based alternative to the Validate() call described below).
+        Then the dialog calls wxWindow::Validate() and
         wxWindow::TransferDataFromWindow() and, if they both return @true,
         closes the dialog with the affirmative id return code.
 

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -4505,7 +4505,7 @@ public:
     @library{wxcore}
     @category{events}
 
-    @see @ref overview_events
+    @see @ref overview_events, wxDialogValidateEvent
 */
 class wxInitDialogEvent : public wxEvent
 {
@@ -4514,6 +4514,38 @@ public:
         Constructor.
     */
     wxInitDialogEvent(int id = 0);
+};
+
+/**
+    @class wxDialogValidateEvent
+
+    A wxDialogValidateEvent is sent as a dialog receives an affirmative
+    button press (such as OK or Apply) to indicate that the data should
+    now be validated and/or could be transfered from the dialog. This
+    event is derived from wxNotifyEvent so that it can veto the affirmative
+    action. In other words: when wxDialogValidateEvent::Veto() is called
+    in the event handler, then the dialog is not closed.
+
+    This is an alternative to overriding wxDialog::Validate() or the
+    use the validators.
+
+    @beginEventTable{wxDialogValidateEvent}
+    @event{EVT_DIALOG_VALIDATE(func)}
+        Process a @c wxEVT_DIALOG_VALIDATE event.
+    @endEventTable
+
+    @library{wxcore}
+    @category{events}
+
+    @see @ref overview_events, wxInitDialogEvent, wxWindow::Validate()
+*/
+class wxDialogValidateEvent : public wxNotifyEvent
+{
+public:
+    /**
+        Constructor.
+    */
+    wxDialogValidateEvent(int id = 0);
 };
 
 

--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -368,6 +368,11 @@ void wxDialogBase::EndDialog(int rc)
 
 void wxDialogBase::AcceptAndClose()
 {
+    wxDialogValidateEvent vevent( GetId() );
+    vevent.SetEventObject( this );
+    HandleWindowEvent( vevent );
+    if (!vevent.IsAllowed()) return;
+
     if ( Validate() && TransferDataFromWindow() )
     {
         EndDialog(m_affirmativeId);
@@ -461,6 +466,13 @@ void wxDialogBase::OnButton(wxCommandEvent& event)
     }
     else if ( id == wxID_APPLY )
     {
+        // Allow validation in event handler...
+        wxDialogValidateEvent vevent( GetId() );
+        vevent.SetEventObject( this );
+        HandleWindowEvent( vevent );
+        if (!vevent.IsAllowed()) return;
+
+        // and/or in Validate() method        
         if ( Validate() )
             TransferDataFromWindow();
 

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -88,6 +88,7 @@
     wxIMPLEMENT_DYNAMIC_CLASS(wxDropFilesEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxActivateEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxInitDialogEvent, wxEvent);
+    wxIMPLEMENT_DYNAMIC_CLASS(wxDialogValidateEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxSetCursorEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxSysColourChangedEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxSysMetricChangedEvent, wxEvent);
@@ -300,6 +301,7 @@ wxDEFINE_EVENT( wxEVT_JOY_MOVE, wxJoystickEvent );
 wxDEFINE_EVENT( wxEVT_JOY_ZMOVE, wxJoystickEvent );
 wxDEFINE_EVENT( wxEVT_DROP_FILES, wxDropFilesEvent );
 wxDEFINE_EVENT( wxEVT_INIT_DIALOG, wxInitDialogEvent );
+wxDEFINE_EVENT( wxEVT_DIALOG_VALIDATE, wxDialogValidateEvent );
 wxDEFINE_EVENT( wxEVT_UPDATE_UI, wxUpdateUIEvent );
 
 // Clipboard events


### PR DESCRIPTION
   - Replaces identical PR that got mixed with other commits
   - adds documentation
   - This adds the above mentioend event that is sent after pressing OK or APPLY to validate the dialog data and or transfer its data
   - Derived from wxNotifyEvent to allow veto
   - It is the sister event of wxInitDialog that can be used to transfer data to the dialog
   - This event is helpful if deriving from wxDialog and overriding wxWindow::Validate() is not (easily) possible and it happens to be useful for language bindings