### PR TITLE
wxTreeCtrl chevron/triangle colour and behaviour fix generic control

### DIFF
--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -735,11 +735,15 @@ wxGenericTreeItem *wxGenericTreeItem::HitTest(const wxPoint& point,
                 flags |= wxTREE_HITTEST_ONITEMLOWERPART;
 
             int xCross = m_x - theCtrl->FromDIP(theCtrl->GetSpacing());
-#ifdef __WXMAC__
+#if defined(__WXMAC__) || defined(__WXGTK__)
             // according to the drawing code the triangels are drawn
-            // at -4 , -4  from the position up to +10/+10 max
-            const int triangleStart = theCtrl->FromDIP(4);
-            const int triangleEnd = theCtrl->FromDIP(10);
+            // at -4/-4  from the position up to +10/+10 max, but
+            // we have to detect the clicks at -10,-10 as also the 
+            // native controls react to mouse click on the full 
+            // height of the entry, not just where the triangle or
+            // chevron or drawn
+            const int triangleStart = theCtrl->FromDIP(10); // -10,-10
+            const int triangleEnd = theCtrl->FromDIP(10);   // +10, +10
             if ((point.x > xCross - triangleStart) && (point.x < xCross + triangleEnd) &&
                 (point.y > y_mid - triangleStart) && (point.y < y_mid + triangleEnd) &&
                 HasPlus() && theCtrl->HasButtons() )
@@ -2866,6 +2870,8 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
                     flag |= wxCONTROL_EXPANDED;
                 if (item == m_underMouse)
                     flag |= wxCONTROL_CURRENT;
+                if (item->IsSelected())
+                    flag |= wxCONTROL_SELECTED;
 
                 wxRendererNative::Get().DrawTreeItemButton
                                         (

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -741,7 +741,7 @@ wxGenericTreeItem *wxGenericTreeItem::HitTest(const wxPoint& point,
             // we have to detect the clicks at -10,-10 as also the 
             // native controls react to mouse click on the full 
             // height of the entry, not just where the triangle or
-            // chevron or drawn
+            // chevron is drawn
             const int triangleStart = theCtrl->FromDIP(10); // -10,-10
             const int triangleEnd = theCtrl->FromDIP(10);   // +10, +10
             if ((point.x > xCross - triangleStart) && (point.x < xCross + triangleEnd) &&

--- a/src/gtk/renderer.cpp
+++ b/src/gtk/renderer.cpp
@@ -334,6 +334,8 @@ wxRendererGTK::DrawTreeItemButton(wxWindow* WXUNUSED_IN_GTK3(win),
     }
     if (flags & wxCONTROL_CURRENT)
         state |= GTK_STATE_FLAG_PRELIGHT;
+    if (flags & wxCONTROL_SELECTED)
+        state |= GTK_STATE_FLAG_SELECTED;
 
     int expander_size;
     gtk_widget_style_get(tree, "expander-size", &expander_size, nullptr);


### PR DESCRIPTION
- The chevron is now drawn in the correct colour if the item is selected on GTK+
- The click area is now bigger, not just the triangle/chevron itself, as in the native controls. I believe this is the right thing to do on all ports, IMO, but I tested GTK+ and OSX