### PR TITLE
Document wxObjectRefData as a typedef (vs class)

### DIFF
--- a/interface/wx/object.h
+++ b/interface/wx/object.h
@@ -5,7 +5,7 @@
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
-/** @class wxObjectRefData
+/** @typedef wxObjectRefData
 
     This class is just a typedef to wxRefCounter and is used by wxObject.
 


### PR DESCRIPTION
While this is actually more true to reality, this also helps work around an issue with Doxygen 1.15.0 (and wxPython builds).  See: https://github.com/doxygen/doxygen/issues/11889