### PR TITLE
OSX: choose grey tone for selection background in dark mode

### DIFF
--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -587,7 +587,7 @@ wxRendererMac::DrawItemSelectionRect(wxWindow * WXUNUSED(win),
     else
 #endif
     {
-        col = wxColour( wxMacCreateCGColorFromHITheme( (flags & wxCONTROL_FOCUSED) 
+        col = wxColour( wxMacCreateCGColorFromHITheme( (flags & wxCONTROL_FOCUSED)
                     ? kThemeBrushAlternatePrimaryHighlightColor
                     : kThemeBrushSecondaryHighlightColor ) );
 

--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -577,6 +577,15 @@ wxRendererMac::DrawItemSelectionRect(wxWindow * WXUNUSED(win),
     wxColour col( wxMacCreateCGColorFromHITheme( (flags & wxCONTROL_FOCUSED) ?
                                                  kThemeBrushAlternatePrimaryHighlightColor
                                                                              : kThemeBrushSecondaryHighlightColor ) );
+
+    if (((flags & wxCONTROL_FOCUSED) == 0) && (wxSystemSettings::GetAppearance().IsDark()))
+    {
+        // OS X has two distinct background greys in dark mode. One very dark
+        // gray you can see as the background of e.g. wxListBox and wxTreeCtrl,
+        // and a lesser dark grey in some other cases. This looks good on both.
+        col = wxColour( 110, 110, 110 );
+    }
+
     wxBrush selBrush( col );
 
     wxDCPenChanger setPen(dc, *wxTRANSPARENT_PEN);

--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -574,18 +574,31 @@ wxRendererMac::DrawItemSelectionRect(wxWindow * WXUNUSED(win),
     if ( !(flags & wxCONTROL_SELECTED) )
         return;
 
-    wxColour col( wxMacCreateCGColorFromHITheme( (flags & wxCONTROL_FOCUSED) ?
-                                                 kThemeBrushAlternatePrimaryHighlightColor
-                                                                             : kThemeBrushSecondaryHighlightColor ) );
+    wxColour col;
 
-    if (((flags & wxCONTROL_FOCUSED) == 0) && (wxSystemSettings::GetAppearance().IsDark()))
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_14_0
+    if (WX_IS_MACOS_AVAILABLE(14, 0))
     {
-        // OS X has two distinct background greys in dark mode. One very dark
-        // gray you can see as the background of e.g. wxListBox and wxTreeCtrl,
-        // and a lesser dark grey in some other cases. This looks good on both.
-        col = wxColour( 110, 110, 110 );
+        col = wxColour( (flags & wxCONTROL_FOCUSED)
+            ? [NSColor selectedContentBackgroundColor]
+            : [NSColor unemphasizedSelectedContentBackgroundColor]
+        );
     }
+    else
+#endif
+    {
+        col = wxColour( wxMacCreateCGColorFromHITheme( (flags & wxCONTROL_FOCUSED) 
+                    ? kThemeBrushAlternatePrimaryHighlightColor
+                    : kThemeBrushSecondaryHighlightColor ) );
 
+        if (((flags & wxCONTROL_FOCUSED) == 0) && (wxSystemSettings::GetAppearance().IsDark()))
+        {
+            // OS X has two distinct background greys in dark mode. One very dark
+            // gray you can see as the background of e.g. wxListBox and wxTreeCtrl,
+            // and a lesser dark grey in some other cases. This looks good on both.
+            col = wxColour( 110, 110, 110 );
+        }
+    }
     wxBrush selBrush( col );
 
     wxDCPenChanger setPen(dc, *wxTRANSPARENT_PEN);


### PR DESCRIPTION
  - After hours of testing all available NSColor styles I could not find one that would work in my test cases and/or  is available on all supported version of OSX.
  - 110,110,110 is well readable on super dark grey of e.g. wxListBox and less grey used in other cases, without being too bright like the existing grey