### PR TITLE
OSX: allow setting GL context on any thread

### DIFF
--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -199,8 +199,12 @@ bool wxGLContext::SetCurrent(const wxGLCanvas& win) const
     if ( !m_glContext )
         return false;
 
-    [m_glContext setView: win.GetHandle() ];
-    [m_glContext update];
+    // View can only be set on the UI thread, but context can be set on any thread
+    if (wxIsMainThread())
+    {
+        [m_glContext setView: win.GetHandle() ];
+        [m_glContext update];
+    }
 
     [m_glContext makeCurrentContext];
 


### PR DESCRIPTION
I'm working on an OpenGL renderer for my wxWidgets-based project [3Beans](https://github.com/Hydr8gon/3Beans), and I need to maintain a GL context that is potentially used across different threads. The addition of `wxGLContext::ClearCurrent()` allowed this to work flawlessly on Linux and Windows, but on macOS it was impossible to set the GL context on a non-UI thread. It crashes with the error `[NSOpenGLContext setView:] must be called from the main thread`. This change allows the context to be set without touching the UI if it's off the main thread, which makes threaded OpenGL work perfectly on macOS as well.