### PR TITLE
Provide default value for wxMkDir() "mode" under all platforms

### DIFF
--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -381,7 +381,7 @@ inline int wxRmDir(const wxString& path)
 inline int wxMkDir(const wxString& path, mode_t WXUNUSED(mode) = 0)
     { return wxCRT_MkDir(path.fn_str()); }
 #else
-inline int wxMkDir(const wxString& path, mode_t mode)
+inline int wxMkDir(const wxString& path, mode_t mode = 0777)
     { return wxCRT_MkDir(path.fn_str(), mode); }
 #endif
 


### PR DESCRIPTION
Previously this function could be called with just path only under Windows and not when using Cygwin. Make it possible to always omit mode and use the appropriate default value in this case.

This improves consistency and fixes build of wxWidgets itself under Cygwin.

Closes #26042.