### PR TITLE
Improvements to `wxWebRequest` handling of redirects

### DIFF
--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -90,6 +90,11 @@ public:
 
     virtual void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs) = 0;
 
+    void UseBasicAuth(const wxWebCredentials& cred)
+    {
+        m_basicAuthCred = cred;
+    }
+
     virtual wxWebResponseImplPtr GetResponse() const = 0;
 
     virtual wxWebAuthChallengeImplPtr GetAuthChallenge() const = 0;
@@ -125,6 +130,16 @@ public:
     wxEvtHandler* GetHandler() const { return m_handler; }
 
 protected:
+    // Used by the implementation which don't support preemptive basic
+    // authentication natively.
+    void AddBasicAuthHeaderIfNecessary();
+
+    // Direct access for those that do support it natively (don't use it just
+    // to redo what AddBasicAuthHeaderIfNecessary() does).
+    const wxWebCredentials& GetBasicAuthCredentials() const
+        { return m_basicAuthCred; }
+
+
     wxString m_method;
     wxWebRequest::Storage m_storage = wxWebRequest::Storage_Memory;
     wxWebRequestHeaderMap m_headers;
@@ -204,6 +219,9 @@ private:
     wxWebRequest::State m_state = wxWebRequest::State_Idle;
     wxFileOffset m_bytesReceived = 0;
     wxCharBuffer m_dataText;
+
+    // If not empty, use preemptive basic authentication.
+    wxWebCredentials m_basicAuthCred;
 
     // Initially false, set to true after the first call to Cancel().
     bool m_cancelled = false;

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -89,8 +89,9 @@ public:
 
     wxString GetError() const;
 
-    // Method called from libcurl callback
+    // These functions implement libcurl callbacks.
     size_t CURLOnRead(char* buffer, size_t size);
+    int CURLOnSeek(curl_off_t offset, int origin);
 
 private:
     // Common initialization for sync and async requests performed when the

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -26,6 +26,8 @@ public:
     {
     }
 
+    bool IsOk() const { return !m_user.empty(); }
+
     const wxString& GetUser() const { return m_user; }
     const wxSecretValue& GetPassword() const { return m_password; }
 

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -221,6 +221,8 @@ public:
 
     void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 
+    void UseBasicAuth(const wxWebCredentials& cred);
+
     Storage GetStorage() const;
 
     wxWebResponse GetResponse() const;

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -478,6 +478,26 @@ public:
     void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
 
     /**
+        Explicitly request using HTTP "Basic" authentication with the provided
+        credentials.
+
+        If this function is not called, wxWebRequest initially makes a request
+        without using any authentication and then requests credentials from the
+        application, using the preferred authentication method among those
+        supported by both the client and the server, using wxWebAuthChallenge.
+        This is the most flexible approach, but it always requires making an
+        extra HTTP request.
+
+        If the application knows that "Basic" authentication should be used, it
+        can avoid this extra request by calling this function before calling
+        Execute(): this will use the provided credentials for the initial
+        request.
+
+        @since 3.3.2
+     */
+    void UseBasicAuth(const wxWebCredentials& cred);
+
+    /**
         Flags for disabling security features.
 
         @since 3.3.0
@@ -609,16 +629,17 @@ public:
     }
     @endcode
 
-    To handle authentication with this class the username and password must be
-    specified in the URL itself and wxWebAuthChallenge is not used with it.
+    wxWebAuthChallenge is not used with this class, to access protected
+    resources the username and password may be specified in the URL itself or
+    UseBasicAuth() must be called prior to Execute().
 
     @note Any reserved characters (see RFC 3986) in the username or password
         must be percent encoded. wxURI::SetUserAndPassword() can be used to
         ensure that this is done correctly.
 
     @note macOS backend using NSURLSession doesn't handle encoded characters in
-        the password (but does handle them in the username). Async wxWebSession
-        must be used if you need to support them under this platform.
+        the password (but does handle them in the username). Use wxWebSession or
+        UseBasicAuth() if you need to support them under this platform.
 
     @see wxWebRequest
 
@@ -964,6 +985,25 @@ public:
         @since 3.3.2
     */
     void SetTimeouts(long connectionTimeoutMs, long dataTimeoutMs);
+
+    /**
+        Explicitly request using HTTP "Basic" authentication with the provided
+        credentials.
+
+        If this function is not called, wxWebRequestSync will use the
+        credentials from the URL itself to authenticate with the server if
+        necessary. This has the advantage of supporting multiple authentication
+        methods, but requires an extra HTTP request to be made to discover the
+        methods supported by the server.
+
+        If the application knows that "Basic" authentication should be used, it
+        can avoid this extra request by calling this function before calling
+        Execute(): this will use the provided credentials for the initial
+        request.
+
+        @since 3.3.2
+     */
+    void UseBasicAuth(const wxWebCredentials& cred);
 
     /**
         Make connection insecure by disabling security checks.

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -1070,6 +1070,16 @@ public:
     wxWebCredentials(const wxString& user = wxString(),
                      const wxSecretValue& password = wxSecretValue());
 
+    /**
+        Return true if user name is set.
+
+        This can be used to distinguish this object from the
+        default-constructed one.
+
+        @since 3.3.2
+     */
+    bool IsOk() const;
+
     /// Return the user.
     const wxString& GetUser() const;
 

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -673,8 +673,11 @@ wxWebRequest::Result wxWebRequestWinHTTP::DoPrepareRequest()
         return FailWithLastError("Parsing URL");
     }
 
-    // If we have auth in the URL, remember them but we can't use them yet
-    // because we don't yet know which authentication scheme the server uses.
+    // If basic authentication was explicitly requested, send it in the
+    // "Authorization:" header to avoid an extra round-trip just to get 401
+    // response first.
+    AddBasicAuthHeaderIfNecessary();
+
     if ( urlComps.HasCredentials() )
     {
         m_credentialsFromURL = urlComps.GetCredentials();

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -187,6 +187,9 @@ wxWebRequestURLSession::DoPrepare(void (^completionHandler)(NSData*, NSURLRespon
                                 [NSURL URLWithString:wxCFStringRef(m_url).AsNSString()]];
     req.HTTPMethod = wxCFStringRef(method).AsNSString();
 
+    // Provide basic authorization header if credentials were set
+    AddBasicAuthHeaderIfNecessary();
+
     // Set request headers
     for (wxWebRequestHeaderMap::const_iterator it = m_headers.begin(); it != m_headers.end(); ++it)
     {

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -1065,6 +1065,30 @@ TEST_CASE_METHOD(SyncRequestFixture,
 }
 
 TEST_CASE_METHOD(SyncRequestFixture,
+                 "WebRequest::Sync::PostAfterRedirect", "[net][webrequest][sync]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    // We can't test this when using WinHTTP because we need to use either 307
+    // or 308 redirect status code to preserve the POST method across the
+    // redirect (all backends switch to GET for 301 and 302, although it would
+    // be possible to configure this to preserve POST when using libcurl) and
+    // WinHTTP doesn't handle them automatically.
+    const auto& versionInfo = wxWebSession::GetDefault().GetLibraryVersionInfo();
+    if ( versionInfo.GetName() == "WinHTTP" )
+    {
+        WARN("Skipping POST with redirect test with WinHTTP backend");
+        return;
+    }
+
+    Create("redirect-to?url=post&status_code=307");
+    request.SetData("app=WebRequestRedirect&version=1", "application/x-www-form-urlencoded");
+    REQUIRE( Execute() );
+    CHECK( response.GetStatus() == 200 );
+}
+
+TEST_CASE_METHOD(SyncRequestFixture,
                  "WebRequest::Sync::Put", "[net][webrequest][sync]")
 {
     if ( !InitBaseURL() )

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -654,6 +654,22 @@ TEST_CASE_METHOD(RequestFixture,
 }
 
 TEST_CASE_METHOD(RequestFixture,
+                 "WebRequest::Auth::Basic/Explicit", "[net][webrequest][auth]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    Create("basic-auth/wxtest/wxwidgets");
+
+    request.UseBasicAuth(wxWebCredentials("wxtest", wxSecretValue("wxwidgets")));
+
+    Run();
+
+    CHECK_THAT( request.GetResponse().AsString().utf8_string(),
+                Catch::Contains(AUTHORIZED_SUBSTRING) );
+}
+
+TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Auth::Basic/Reserved", "[net][webrequest][auth]")
 {
     if ( !InitBaseURL() )
@@ -1137,6 +1153,32 @@ TEST_CASE_METHOD(SyncRequestFixture,
     SECTION("Good password")
     {
         CreateWithAuth("basic-auth/wxtest/wxwidgets", "wxtest", "wxwidgets");
+        CHECK( Execute() );
+        CHECK( response.GetStatus() == 200 );
+        CHECK( state == wxWebRequest::State_Completed );
+
+        CHECK_THAT( response.AsString().utf8_string(),
+                    Catch::Contains(AUTHORIZED_SUBSTRING) );
+    }
+
+    SECTION("Explicit basic auth")
+    {
+        Create("basic-auth/wxtest/wxwidgets");
+        request.UseBasicAuth(wxWebCredentials("wxtest", wxSecretValue("wxwidgets")));
+
+        CHECK( Execute() );
+        CHECK( response.GetStatus() == 200 );
+        CHECK( state == wxWebRequest::State_Completed );
+
+        CHECK_THAT( response.AsString().utf8_string(),
+                    Catch::Contains(AUTHORIZED_SUBSTRING) );
+    }
+
+    SECTION("Password after redirect")
+    {
+        Create("redirect-to?url=basic-auth/wxtest/wxwidgets");
+        request.UseBasicAuth(wxWebCredentials("wxtest", wxSecretValue("wxwidgets")));
+
         CHECK( Execute() );
         CHECK( response.GetStatus() == 200 );
         CHECK( state == wxWebRequest::State_Completed );


### PR DESCRIPTION
The net effect of these changes is that `POST` works correctly when using authentication with libcurl, however there are more changes than strictly necessary to just fix this:

1. We now resend request data after redirect when using libcurl.
2. We avoid extra requests in the first place by allowing to preemptively use basic authentication.

So far there is no support for preemptive use of proxy authentication or using any authentication method other than "Basic" just because I don't need this, but this could be easily added later too.