### PR TITLE
Fix using built-in libjpeg from built-in libtiff

### DIFF
--- a/configure
+++ b/configure
@@ -26531,8 +26531,8 @@ $as_echo "yes" >&6; }
         fi
         if test "$wxUSE_LIBJPEG" = "no"; then
                                                                                     tiff_jpeg_option=--disable-jpeg
-        else
-            tiff_jpeg_option=--enable-jpeg
+        elif test "$wxUSE_LIBJPEG" = "builtin"; then
+                                                tiff_jpeg_option=--with-jpeg-from-wx
         fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2656,8 +2656,11 @@ if test "$wxUSE_LIBTIFF" != "no" ; then
             dnl the top-level script to all the other ones called recursively), so
             dnl we need to hack around this
             tiff_jpeg_option=--disable-jpeg
-        else
-            tiff_jpeg_option=--enable-jpeg
+        elif test "$wxUSE_LIBJPEG" = "builtin"; then
+            dnl JPEG support is enabled by default, but make sure that we use
+            dnl our own libjpeg, even if another version of the library is
+            dnl installed system-wide
+            tiff_jpeg_option=--with-jpeg-from-wx
         fi
 
         dnl if you ever want to enable webp, check if it clashes with the wxUSE_LIBWBP setting


### PR DESCRIPTION
This didn't work before, usually just silently disabling JPEG support in libtiff because libjpeg couldn't be found, but sometimes also resulting in build errors due to libtiff configure detecting a newer version of libjpeg available in the system and then trying to use its features (such as "dual 8/12 bit mode", whatever it is, in libjpeg-turbo > 3) when building using the actually used version resulting in build errors.