### PR TITLE
Windows Accessibility: Report checked checked state of items in wxCheckListBox

### DIFF
--- a/include/wx/msw/checklst.h
+++ b/include/wx/msw/checklst.h
@@ -62,6 +62,9 @@ public:
     // so we need to override these functions
     virtual wxOwnerDrawn *CreateLboxItem(size_t n) override;
     virtual bool MSWOnMeasure(WXMEASUREITEMSTRUCT *item) override;
+#if wxUSE_ACCESSIBILITY
+    virtual wxAccessible* CreateAccessible() override;
+#endif
 
 protected:
     virtual wxSize MSWGetFullItemSize(int w, int h) const override;
@@ -87,5 +90,16 @@ protected:
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxCheckListBox);
 };
+
+#if wxUSE_ACCESSIBILITY
+class WXDLLIMPEXP_CORE wxCheckListBoxAccessible : public wxWindowAccessible
+{
+public:
+    explicit wxCheckListBoxAccessible(wxCheckListBox* winm);
+
+    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
+    virtual wxAccStatus GetState(int childId, long* state) override;
+};
+#endif
 
 #endif    //_CHECKLST_H

--- a/include/wx/msw/checklst.h
+++ b/include/wx/msw/checklst.h
@@ -91,15 +91,4 @@ protected:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxCheckListBox);
 };
 
-#if wxUSE_ACCESSIBILITY
-class WXDLLIMPEXP_CORE wxCheckListBoxAccessible : public wxWindowAccessible
-{
-public:
-    explicit wxCheckListBoxAccessible(wxCheckListBox* winm);
-
-    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
-    virtual wxAccStatus GetState(int childId, long* state) override;
-};
-#endif
-
 #endif    //_CHECKLST_H

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3955,7 +3955,7 @@ wxAccStatus wxWindowAccessible::GetParent(wxAccessible** parent)
         if (*parent)
             return wxACC_OK;
         else
-            return wxACC_NOT_IMPLEMENTED;
+            return wxACC_FAIL;
     }
 }
 

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3955,7 +3955,7 @@ wxAccStatus wxWindowAccessible::GetParent(wxAccessible** parent)
         if (*parent)
             return wxACC_OK;
         else
-            return wxACC_FAIL;
+            return wxACC_NOT_IMPLEMENTED;
     }
 }
 

--- a/src/msw/checklst.cpp
+++ b/src/msw/checklst.cpp
@@ -160,6 +160,63 @@ bool wxCheckListBoxItem::OnDrawItem(wxDC& dc, const wxRect& rc,
     return true;
 }
 
+#if wxUSE_ACCESSIBILITY
+
+// ----------------------------------------------------------------------------
+// declaration and implementation of wxCheckListBoxAccessible class
+// ----------------------------------------------------------------------------
+
+class wxCheckListBoxAccessible : public wxWindowAccessible
+{
+public:
+    explicit wxCheckListBoxAccessible(wxCheckListBox* win);
+
+    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
+    virtual wxAccStatus GetState(int childId, long* state) override;
+};
+
+wxCheckListBoxAccessible::wxCheckListBoxAccessible(wxCheckListBox* win)
+    : wxWindowAccessible(win)
+{}
+
+wxAccStatus wxCheckListBoxAccessible::GetRole(int childId, wxAccRole* role)
+{
+    wxCheckListBox* checkListBox = wxDynamicCast(GetWindow(), wxCheckListBox);
+    wxCHECK(checkListBox, wxACC_FAIL);
+
+    *role = (childId == wxACC_SELF) ? wxROLE_SYSTEM_LIST : wxROLE_SYSTEM_CHECKBUTTON;
+    return wxACC_OK;
+}
+
+// Returns a state constant.
+wxAccStatus wxCheckListBoxAccessible::GetState(int childId, long* state)
+{
+    wxCheckListBox* checkListBox = wxDynamicCast(GetWindow(), wxCheckListBox);
+    wxCHECK(checkListBox, wxACC_FAIL);
+
+    if (childId <= 0)
+        return wxACC_NOT_IMPLEMENTED; // Fall back to Windows default
+
+    long st = 0;
+    if (!checkListBox->IsEnabled())
+        st |= wxACC_STATE_SYSTEM_UNAVAILABLE;
+    if (!checkListBox->IsShown())
+        st |= wxACC_STATE_SYSTEM_INVISIBLE;
+
+    if (checkListBox->IsFocusable())
+        st |= wxACC_STATE_SYSTEM_FOCUSABLE;
+
+    // this needs to be returned such that a child below is recognized as focused
+    if (checkListBox->HasFocus())
+        st |= wxACC_STATE_SYSTEM_FOCUSED;
+    if (checkListBox->IsChecked(childId-1))
+        st |= wxACC_STATE_SYSTEM_CHECKED;
+    *state = st;
+    return wxACC_OK;
+}
+
+#endif // wxUSE_ACCESSIBILITY
+
 // ----------------------------------------------------------------------------
 // implementation of wxCheckListBox class
 // ----------------------------------------------------------------------------
@@ -277,7 +334,7 @@ void wxCheckListBox::Check(unsigned int uiIndex, bool bCheck)
     GetItem(uiIndex)->Check(bCheck);
     RefreshItem(uiIndex);
 #if wxUSE_ACCESSIBILITY
-    wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_STATECHANGE, this, wxOBJID_CLIENT, uiIndex+1);
+    wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_STATECHANGE, this, wxOBJID_CLIENT, uiIndex + 1);
 #endif // wxUSE_ACCESSIBILITY
 
 }
@@ -454,47 +511,6 @@ wxAccessible* wxCheckListBox::CreateAccessible()
 {
     return new wxCheckListBoxAccessible(this);
 }
-
-wxCheckListBoxAccessible::wxCheckListBoxAccessible(wxCheckListBox* win)
-    : wxWindowAccessible(win)
-{}
-
-wxAccStatus wxCheckListBoxAccessible::GetRole(int childId, wxAccRole* role)
-{
-    wxCheckListBox* checkListBox = wxDynamicCast(GetWindow(), wxCheckListBox);
-    wxCHECK(checkListBox, wxACC_FAIL);
-
-    *role = (childId == wxACC_SELF) ? wxROLE_SYSTEM_LIST : wxROLE_SYSTEM_CHECKBUTTON;
-    return wxACC_OK;
-}
-
-// Returns a state constant.
-wxAccStatus wxCheckListBoxAccessible::GetState(int childId, long* state)
-{
-    wxCheckListBox* checkListBox = wxDynamicCast(GetWindow(), wxCheckListBox);
-    wxCHECK(checkListBox, wxACC_FAIL);
-
-    if (childId <= 0)
-        return wxACC_NOT_IMPLEMENTED; // Fall back to Windows default
-
-    long st = 0;
-    if (!checkListBox->IsEnabled())
-        st |= wxACC_STATE_SYSTEM_UNAVAILABLE;
-    if (!checkListBox->IsShown())
-        st |= wxACC_STATE_SYSTEM_INVISIBLE;
-
-    if (checkListBox->IsFocusable())
-        st |= wxACC_STATE_SYSTEM_FOCUSABLE;
-
-    // this needs to be returned such that a child below is recognized as focused
-    if (checkListBox->HasFocus())
-        st |= wxACC_STATE_SYSTEM_FOCUSED;
-    if (checkListBox->IsChecked(childId-1))
-        st |= wxACC_STATE_SYSTEM_CHECKED;
-    *state = st;
-    return wxACC_OK;
-}
-
 #endif // wxUSE_ACCESSIBILITY
 
 #endif // wxUSE_CHECKLISTBOX


### PR DESCRIPTION
The standard Windows ListBox class has no concept of checked/unchecked
state of items. WXWidgets obviously overcomes this with owner drawn
items so that the checked boxes can be drawn. But this info gets lost
when using the standard Windows IAccessible ListBox implementation
since said implementation has no concept of checked state for
individual items.

Fixes https://github.com/wxwidgets/wxwidgets/issues/25948
