### PR TITLE
Avoid duplicate toolbar item IDs on macOS

### DIFF
--- a/include/wx/osx/toolbar.h
+++ b/include/wx/osx/toolbar.h
@@ -123,6 +123,11 @@ protected:
 #ifdef __WXOSX_IPHONE__
     WX_UIView m_macToolbar;
 #endif
+
+private:
+#if wxOSX_USE_NATIVE_TOOLBAR
+    wxString FormatToolId(const wxToolBarToolBase *tool);
+#endif
 };
 
 #endif // wxUSE_TOOLBAR


### PR DESCRIPTION
We use the `wxToolBarTool` address as the native toolbar item ID, which must be unique within the application (at least), not just within the toolbar, and triggers an assertion failure if a `wxToolbar` is destroyed and re-created with item(s) happening to land at the same memory addresses before the underlying `NSToolbar` is destroyed.

This commit changes the ID to include the `NSToolbar` address so that an ID won't be reused unless an `NSToolbar` has been fully destroyed and a new one created at the same address.

This may also hint at an (existing) bug since the `NSToolbar` object clearly exists for longer than the `wxToolBarTool`, and Cocoa _MIGHT_ ask us for the item after it has been deleted, but I'm not familiar enough with macOS to know whether or not this can happen.

Output of some tests which rapidly create/destroy a frame with a toolbar (with extra diagnostics in `wxToolbar::Realize()`) as a side effect demonstrating the issue:

```
[ RUN            ] LuaPluginLoader.SetCommentBitAligned
refTB = 0x600000e74b40 nsItemId = '105553119509248'
refTB = 0x600000e74b40 nsItemId = '105553119501568'
refTB = 0x600000e74b40 nsItemId = '105553119479296'
refTB = 0x600000e74b40 nsItemId = '105553119478272'
refTB = 0x600000e74b40 nsItemId = 'NSToolbarSpaceItem'
refTB = 0x600000e74b40 nsItemId = '105553119490816' <--- Note the ID (wxToolbarTool) here
refTB = 0x600000e74b40 nsItemId = '105553119477760'
[              OK ] LuaPluginLoader.SetCommentBitAligned (58 ms)
...
[ RUN            ] LuaPluginLoader.SetDataType
refTB = 0x600000e7fa20 nsItemId = '105553119501824'
refTB = 0x600000e7fa20 nsItemId = '105553119509504'
refTB = 0x600000e7fa20 nsItemId = '105553119507200'
refTB = 0x600000e7fa20 nsItemId = '105553119490816' <-- Newly allocated wxToolbarTool at same address, however assertion message references the earlier NSToolbar which clearly hasn't been destroyed yet.
2025-12-28 20:08:55.242843+0000 all-tests[38836:84190441] [general] *** Assertion failure in -[wxNSToolbar _insertNewItemWithItemIdentifier:atIndex:propertyListRepresentation:notifyFlags:], NSToolbar.m:1621
2025-12-28 20:08:55.246963+0000 all-tests[38836:84190441] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'NSToolbar 0x600000e74b40 already contains an item with the identifier 105553119490816. Duplicate items of this type are not allowed.'
*** First throw call stack:
(
	0      CoreFoundation                                            0x000000018c377ae0 __exceptionPreprocess + 176
	1      libobjc.A.dylib                                          0x000000018be3ab90 objc_exception_throw + 88
	2      Foundation                                                    0x000000018d987a78 -[NSCalendarDate initWithCoder:] + 0
	3      AppKit                                                            0x00000001902dfdac -[NSToolbar _insertNewItemWithItemIdentifier:atIndex:propertyListRepresentation:notifyFlags:] + 236
	4      AppKit                                                            0x0000000190cdb428 __51-[NSToolbar _notifyFamily_InsertedNewItem:atIndex:]_block_invoke + 196
	5      AppKit                                                            0x0000000190cdb058 _enumerateToolbarsInFamily + 260
	6      AppKit                                                            0x00000001902e0654 -[NSToolbar _insertItem:atIndex:notifyDelegate:no
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'NSToolbar 0x600000e74b40 already contains an item with the identifier 105553119490816. Duplicate items of this type are not allowed.'
*** First throw call stack:
(
	0      CoreFoundation                                            0x000000018c377ae0 __exceptionPreprocess + 176
	1      libobjc.A.dylib                                          0x000000018be3ab90 objc_exception_throw + 88
	2      Foundation                                                    0x000000018d987a78 -[NSCalendarDate initWithCoder:] + 0
	3      AppKit                                                            0x00000001902dfdac -[NSToolbar _insertNewItemWithItemIdentifier:atIndex:propertyListRepresentation:notifyFlags:] + 236
	4      AppKit                                                            0x0000000190cdb428 __51-[NSToolbar _notifyFamily_InsertedNewItem:atIndex:]_block_invoke + 196
	5      AppKit                                                            0x0000000190cdb058 _enumerateToolbarsInFamily + 260
	6      AppKit                                                            0x00000001902e0654 -[NSToolbar _insertItem:atIndex:notifyDelegate:notifyView:notifyFamilyAndUpdateDefaults:] + 736
	7      AppKit                                                            0x00000001902dfe38 -[NSToolbar _insertNewItemWithItemIdentifier:atIndex:propertyListRepresentation:notifyFlags:] + 376
	8      all-tests                                                      0x00000001009984a0 _ZN9wxToolBar7RealizeEv + 684
	9      all-tests                                                      0x00000001000efcf4 _ZN5REHex10MainWindowC2ERK6wxSize + 25652
	10    all-tests                                                      0x000000010063de88 _ZN32LuaPluginLoader_SetDataType_Test8TestBodyEv + 448
	11    all-tests                                                      0x0000000100010aa8 _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_8TestCaseEvEET0_PT_MS4_FS3_vEPKc + 116
	12    all-tests                                                      0x0000000100010984 _ZN7testing4Test3RunEv + 212
	13    all-tests                                                      0x0000000100011f38 _ZN7testing8TestInfo3RunEv + 240
	14    all-tests                                                      0x0000000100012860 _ZN7testing8TestCase3RunEv + 260
	15    all-tests                                                      0x000000010001e40c _ZN7testing8internal12UnitTestImpl11RunAllTestsEv + 800
	16    all-tests                                                      0x000000010001dfa0 _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc + 116
	17    all-tests                                                      0x000000010001def8 _ZN7testing8UnitTest3RunEv + 124
	18    all-tests                                                      0x0000000100644658 main + 1208
	19    dyld                                                                0x000000018be7ab98 start + 6076
)
2025-12-28 20:08:55.247107+0000 all-tests[38836:84190441] [General] An uncaught exception was raised
2025-12-28 20:08:55.247121+0000 all-tests[38836:84190441] [General] NSToolbar 0x600000e74b40 already contains an item with the identifier 105553119490816. Duplicate items of this type are not allowed.
2025-12-28 20:08:55.247169+0000 all-tests[38836:84190441] [General] (
	0      CoreFoundation                                            0x000000018c377ae0 __exceptionPreprocess + 176
	1      libobjc.A.dylib                                          0x000000018be3ab90 objc_exception_throw + 88
	2      Foundation                                                    0x000000018d987a78 -[NSCalendarDate initWithCoder:] + 0
	3      AppKit                                                            0x00000001902dfdac -[NSToolbar _insertNewItemWithItemIdentifier:atIndex:propertyListRepresentation:notifyFlags:] + 236
	4      AppKit                                                            0x0000000190cdb428 __51-[NSToolbar _notifyFamily_InsertedNewItem:atIndex:]_block_invoke + 196
	5      AppKit                                                            0x0000000190cdb058 _enumerateToolbarsInFamily + 260
	6      AppKit                                                            0x00000001902e0654 -[NSToolbar _insertItem:atIndex:notifyDelegate:notifyView:notifyFamilyAndUpdateDefaults:] + 736
	7      AppKit                                                            0x00000001902dfe38 -[NSToolbar _insertNewItemWithItemIdentifier:atIndex:propertyListRepresentation:notifyFlags:] + 376
	8      all-tests                                                      0x00000001009984a0 _ZN9wxToolBar7RealizeEv + 684
	9      all-tests                                                      0x00000001000efcf4 _ZN5REHex10MainWindowC2ERK6wxSize + 25652
	10    all-tests                                                      0x000000010063de88 _ZN32LuaPluginLoader_SetDataType_Test8TestBodyEv + 448
	11    all-tests                                                      0x0000000100010aa8 _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_8TestCaseEvEET0_PT_MS4_FS3_vEPKc + 116
	12    all-tests                                                      0x0000000100010984 _ZN7testing4Test3RunEv + 212
	13    all-tests                                                      0x0000000100011f38 _ZN7testing8TestInfo3RunEv + 240
	14    all-tests                                                      0x0000000100012860 _ZN7testing8TestCase3RunEv + 260
	15    all-tests                                                      0x000000010001e40c _ZN7testing8internal12UnitTestImpl11RunAllTestsEv + 800
	16    all-tests                                                      0x000000010001dfa0 _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc + 116
	17    all-tests                                                      0x000000010001def8 _ZN7testing8UnitTest3RunEv + 124
	18    all-tests                                                      0x0000000100644658 main + 1208
	19    dyld                                                                0x000000018be7ab98 start + 6076
)
2025-12-28 20:08:55.248056+0000 all-tests[38836:84190441] [HIExceptions] FAULT: NSInternalInconsistencyException: NSToolbar 0x600000e74b40 already contains an item with the identifier 105553119490816. Duplicate items of this type are not allowed.; {
        NSAssertFile = "NSToolbar.m";
        NSAssertLine = 1621;
}
libc++abi: terminating due to uncaught exception of type NSException
Process 38836 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
        frame #0: 0x000000018c1e2388 libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`__pthread_kill:
->  0x18c1e2388 <+8>:    b.lo      0x18c1e23a8        ; <+40>
       0x18c1e238c <+12>: pacibsp 
       0x18c1e2390 <+16>: stp        x29, x30, [sp, #-0x10]!
       0x18c1e2394 <+20>: mov        x29, sp
Target 0: (all-tests) stopped.
```

I've only done cursory testing of toolbars (i.e. they exist and clicking buttons works) with this patch applied on top of 3.2.8.1.