### PR TITLE
Fix wxChoice::GetBestSize() on macOS 26

### DIFF
--- a/src/osx/choice_osx.cpp
+++ b/src/osx/choice_osx.cpp
@@ -19,6 +19,8 @@
 #endif
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
+
 
 wxChoice::~wxChoice()
 {
@@ -243,8 +245,13 @@ wxSize wxChoice::DoGetBestSize() const
     // computed by the base class method to account for the arrow.
     const int lbHeight = wxWindow::DoGetBestSize().y;
 
-    return wxSize(wxChoiceBase::DoGetBestSize().x + 4*GetCharWidth(),
-                  lbHeight);
+    int padding = 4 * GetCharWidth();
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_26_0
+    if (WX_IS_MACOS_AVAILABLE(26, 0))
+        padding += 2 * GetCharWidth() - 1;
+#endif
+
+    return wxSize(wxChoiceBase::DoGetBestSize().x + padding, lbHeight);
 }
 
 #endif // wxUSE_CHOICE


### PR DESCRIPTION
I either didn’t notice initially or this was adjusted in macOS 26.2, but `wxChoice` best size was not wide enough:
 
<img width="579" height="96" alt="CleanShot 2025-12-22 at 22 39 29@2x" src="https://github.com/user-attachments/assets/48c9131a-d162-4313-b945-2e1c6bceda0c" />

This updates the code to match native metrics exactly.