### PR TITLE
Update generic wxTreeCtrl state images when DPI changes

### DIFF
--- a/include/wx/treectrl.h
+++ b/include/wx/treectrl.h
@@ -435,6 +435,10 @@ protected:
                                         int& flags) const = 0;
 
 
+    // override the base class version to take state images into account
+    virtual bool HasAnyImages() const override;
+
+
     // Usually we inherit from this class, rather than aggregating it, but we
     // need two different sets of images here, so we do both.
     wxWithImages m_imagesState;

--- a/include/wx/withimages.h
+++ b/include/wx/withimages.h
@@ -262,6 +262,15 @@ public:
     }
 
 protected:
+    // This is the same as HasImages() for all controls except for wxTreeCtrl
+    // which has a special "state image list" in addition to the normal one and
+    // this function takes it into account, unlike HasImages() itself, which
+    // doesn't and can't be modified to do so for compatibility reasons.
+    virtual bool HasAnyImages() const
+    {
+        return HasImages();
+    }
+
     // This function is called when the images associated with the control
     // change, due to either SetImages() or SetImageList() being called.
     //
@@ -274,7 +283,7 @@ protected:
     // and simply calls OnImagesChanged() to refresh the images when it happens.
     void WXHandleDPIChanged(wxDPIChangedEvent& event)
     {
-        if ( HasImages() )
+        if ( HasAnyImages() )
             OnImagesChanged();
 
         event.Skip();

--- a/src/common/treebase.cpp
+++ b/src/common/treebase.cpp
@@ -201,6 +201,11 @@ void wxTreeCtrlBase::SetItemState(const wxTreeItemId& item, int state)
     DoSetItemState(item, state);
 }
 
+bool wxTreeCtrlBase::HasAnyImages() const
+{
+    return HasImages() || m_imagesState.HasImages();
+}
+
 namespace
 {
 


### PR DESCRIPTION
Ensure that wxTreeCtrl using only state images, without the normal ones, is still updated correctly when the DPI changes: this didn't happen previously because OnImagesChanged() was only called for the control with normal images.

As changing HasImages() to return true if there are only state images is almost certainly a bad idea for compatibility reasons (existing code may assume that it can use normal images if it returns true), add a new HasAnyImages() function and override it in wxTreeCtrl to account for the state images too.

Closes #26059.