### PR TITLE
Changed wxWindowAccessible::GetParent to return wxACC_NOT_IMPLEMENTED when parentWindow->GetOrCreateAccessible() returns nullptr

### DIFF
--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3955,7 +3955,7 @@ wxAccStatus wxWindowAccessible::GetParent(wxAccessible** parent)
         if (*parent)
             return wxACC_OK;
         else
-            return wxACC_FAIL;
+            return wxACC_NOT_IMPLEMENTED;
     }
 }
 
@@ -4151,5 +4151,3 @@ wxWindowBase::AdjustForLayoutDirection(wxCoord x,
 
     return x;
 }
-
-


### PR DESCRIPTION
If a widget has a custom accessibility implementation derived from
wxWindowAccessible, there's no guarantee that the parent overrides the nullptr-returning base CreateAccessible.

Returning wxACC_NOT_IMPLEMENTED follows the pattern of other
accessibility methods to defer to the platform's default
implementation, and fixes wx WindowAccessible::GetParent when called on
custom accessibility implementations like wxCheckListBoxAccessible.

My search of the code indicates that only the Windows specific
accessibility layer currently defers to the default platform interface
when wxACC_NOT_IMPLEMENTED is returned.
