### PR TITLE
wxRichTextCtrl: Enhance macOS key bindings

### DIFF
--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -1655,8 +1655,10 @@ Left:       left one character
 Right:      right one character
 Up:         up one line
 Down:       down one line
-Ctrl-Left:  left one word
-Ctrl-Right: right one word
+Ctrl-Left:  left one word (start of line on macOS)
+Ctrl-Right: right one word (end of line on macOS)
+Alt-Left:   left one word (macOS only)
+Alt-Right:  right one word (macOS only)
 Ctrl-Up:    previous paragraph start
 Ctrl-Down:  next start of paragraph
 Home:       start of line
@@ -1684,17 +1686,35 @@ bool wxRichTextCtrl::KeyboardNavigate(int keyCode, int flags)
 
     if (keyCode == WXK_RIGHT || keyCode == WXK_NUMPAD_RIGHT)
     {
+#ifdef __WXMAC__
+        if (flags & wxRICHTEXT_CTRL_DOWN)
+            success = MoveToLineEnd(flags);
+        else if (flags & wxRICHTEXT_ALT_DOWN)
+            success = WordRight(1, flags);
+        else
+            success = MoveRight(1, flags);
+#else
         if (flags & wxRICHTEXT_CTRL_DOWN)
             success = WordRight(1, flags);
         else
             success = MoveRight(1, flags);
+#endif
     }
     else if (keyCode == WXK_LEFT || keyCode == WXK_NUMPAD_LEFT)
     {
+#ifdef __WXMAC__
+        if (flags & wxRICHTEXT_CTRL_DOWN)
+            success = MoveToLineStart(flags);
+        else if (flags & wxRICHTEXT_ALT_DOWN)
+            success = WordLeft(1, flags);
+        else
+            success = MoveLeft(1, flags);
+#else
         if (flags & wxRICHTEXT_CTRL_DOWN)
             success = WordLeft(1, flags);
         else
             success = MoveLeft(1, flags);
+#endif
     }
     else if (keyCode == WXK_UP || keyCode == WXK_NUMPAD_UP)
     {


### PR DESCRIPTION
Updated key bindings for macOS to more closely match native behavior.

Currently, Cmd+Left goes to the left word boundary, and Cmd+Right goes
to the right word boundary, like on Windows (wxWidgets treats Cmd on
Mac as if it were Ctrl for keyboard modifier key purposes). Alt/Opt+
Left and Alt/Opt+Right do nothing. 

This change maps Cmd+Left to the start of the line, and Cmd+Right to
the end of the line.  It also maps Alt/Opt+Left to WordLeft() and Alt/
Opt+Right to WordRight(), which is conventional on native Cocoa
controls (including other wxWidgets controls that map directly to Cocoa
controls).