### PR TITLE
[msw/font] If the face name might be truncated, try to get the full face name

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -1041,6 +1041,16 @@ WXDLLIMPEXP_CORE wxFont wxCreateFontFromLogFont(const LOGFONT *logFont);
 WXDLLIMPEXP_CORE void wxGetCharSize(WXHWND wnd, int *x, int *y, const wxFont& the_font);
 WXDLLIMPEXP_CORE wxFontEncoding wxGetFontEncFromCharSet(int charset);
 
+// Helper function to check if the facename might be truncated: if it is,
+// wxGetMSWFaceNameFromHFONT() should be used to get the full name.
+inline bool wxIsFaceNamePossiblyTruncated(const wxString& facename)
+{
+    return facename.size() == LF_FACESIZE - 1;
+}
+
+// Get full face name (i.e. possibly longer than LF_FACESIZE) from an HFONT.
+wxString wxGetMSWFaceNameFromHFONT(HFONT hFont);
+
 inline void wxSetWindowFont(HWND hwnd, const wxFont& font)
 {
     ::SendMessage(hwnd, WM_SETFONT,
@@ -1210,12 +1220,6 @@ inline void *wxSetWindowUserData(HWND hwnd, void *data)
 {
     return (void *)(LONG_PTR)::SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)data);
 }
-
-// Helper function to get the non-truncated face name from an HFONT
-WXDLLIMPEXP_CORE wxString GetMSWFaceNameFromHFONT(HFONT hFont);
-
-// Helper function to known if the facename might be truncated or not
-WXDLLIMPEXP_CORE bool IsFullMSWFaceName(wxString facename);
 
 #endif // wxUSE_GUI && __WXMSW__
 

--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -1211,6 +1211,12 @@ inline void *wxSetWindowUserData(HWND hwnd, void *data)
     return (void *)(LONG_PTR)::SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)data);
 }
 
+// Helper function to get the non-truncated face name from an HFONT
+WXDLLIMPEXP_CORE wxString GetMSWFaceNameFromHFONT(HFONT hFont);
+
+// Helper function to known if the facename might be truncated or not
+WXDLLIMPEXP_CORE bool IsFullMSWFaceName(wxString facename);
+
 #endif // wxUSE_GUI && __WXMSW__
 
 #endif // _WX_PRIVATE_H_

--- a/src/msw/fontutil.cpp
+++ b/src/msw/fontutil.cpp
@@ -32,7 +32,6 @@
 #include "wx/encinfo.h"
 #include "wx/fontmap.h"
 #include "wx/tokenzr.h"
-#include "wx/scopeguard.h"
 
 // ============================================================================
 // implementation
@@ -279,49 +278,3 @@ wxFont wxCreateFontFromLogFont(const LOGFONT *logFont)
 }
 
 #endif // WXWIN_COMPATIBILITY_3_0
-
-// ----------------------------------------------------------------------------
-// Helper function to get the actual face name from an HFONT
-// ----------------------------------------------------------------------------
-
-wxString GetMSWFaceNameFromHFONT(HFONT hFont)
-{
-    ScreenHDC hdc;
-    SelectInHDC selectFont(hdc, hFont);
-
-    UINT otmSize = GetOutlineTextMetrics(hdc, 0, nullptr);
-    if ( !otmSize )
-    {
-        wxLogLastError("GetOutlineTextMetrics(nullptr)");
-        return wxString();
-    }
-
-    OUTLINETEXTMETRIC * const
-        otm = static_cast<OUTLINETEXTMETRIC *>(malloc(otmSize));
-    wxON_BLOCK_EXIT1( free, otm );
-
-    otm->otmSize = otmSize;
-    if ( !GetOutlineTextMetrics(hdc, otmSize, otm) )
-    {
-        wxLogLastError("GetOutlineTextMetrics()");
-        return wxString();
-    }
-
-    // in spite of its type, the otmpFamilyName field of OUTLINETEXTMETRIC
-    // gives an offset in _bytes_ of the face (not family!) name from the
-    // struct start while the name itself is an array of TCHARs
-    //
-    // FWIW otmpFaceName contains the same thing as otmpFamilyName followed
-    // by a possible " Italic" or " Bold" or something else suffix
-    return reinterpret_cast<wxChar *>(otm) +
-                wxPtrToUInt(otm->otmpFamilyName)/sizeof(wxChar);
-}
-
-// ----------------------------------------------------------------------------
-// Helper function to known if the facename might be truncated or not.
-// ----------------------------------------------------------------------------
-
-bool IsFullMSWFaceName(wxString facename)
-{
-    return facename.size() == (LF_FACESIZE - 1);
-}


### PR DESCRIPTION
Fix: https://github.com/wxWidgets/wxWidgets/issues/25333
LOGFONT.lfFaceName has a defined size (32). Because of that, the face name can be truncated (see the issue for a font with a family name longer then 31 characters). To avoid this problem, we can just call GetOutlineTextMetrics and use it's otmpFamilyName which is not truncated.

To test this, I used https://github.com/wxWidgets/wxWidgets/tree/1b582af60d99388b56b383fe240b647387a5e4b4/samples/font

In the issue, you mentionned I should just edit ``wxFontEnumerator``, but actually, I also needed to edit ``wxFontRefData`` because with the [sample](https://github.com/wxWidgets/wxWidgets/tree/1b582af60d99388b56b383fe240b647387a5e4b4/samples/font), if I use ``Select -> Select font``, the textbox will contain the truncated face name if I don't add a check with ``wxFontRefData``.