### PR TITLE
wxPopupTransientWindow:  don't destroy twice

### DIFF
--- a/include/wx/tipwin.h
+++ b/include/wx/tipwin.h
@@ -34,7 +34,7 @@ public:
     //
     // Note that this is not a wxWeakRef<> because this is set to nullptr when
     // wxTipWindow is closed, which may be "long" before wxTipWindow is
-    // destroyed, bug wxWeakRef<> is set to nullptr on object destruction
+    // destroyed, but wxWeakRef<> is set to nullptr on object destruction
     class WXDLLIMPEXP_CORE Ref
     {
     public:

--- a/src/msw/popupwin.cpp
+++ b/src/msw/popupwin.cpp
@@ -22,6 +22,7 @@
 #if wxUSE_POPUPWIN
 
 #ifndef WX_PRECOMP
+    #include "wx/app.h"
 #endif //WX_PRECOMP
 
 #include "wx/popupwin.h"
@@ -238,14 +239,17 @@ wxPopupTransientWindow::MSWHandleMessage(WXLRESULT *result,
         case WM_ACTIVATE:
             if ( wParam == WA_INACTIVE )
             {
-                // We need to dismiss this window, however doing it directly
-                // from here seems to confuse ::ShowWindow(), which ends up
-                // calling this handler, and may result in losing activation
-                // entirely, so postpone it slightly.
-                //
-                // Also note that the active window hasn't changed yet, so we
-                // postpone calling it until DismissOnDeactivate() is executed.
-                CallAfter(&wxPopupTransientWindow::DismissOnDeactivate);
+                if (!wxTheApp->IsScheduledForDestruction(this))
+                {
+                    // We need to dismiss this window, however doing it directly
+                    // from here seems to confuse ::ShowWindow(), which ends up
+                    // calling this handler, and may result in losing activation
+                    // entirely, so postpone it slightly.
+                    //
+                    // Also note that the active window hasn't changed yet, so we
+                    // postpone calling it until DismissOnDeactivate() is executed.
+                    CallAfter(&wxPopupTransientWindow::DismissOnDeactivate);
+                }
             }
             break;
     }


### PR DESCRIPTION
On wxMSW, if the dialogs sample with this [tipwin-dismiss-race.patch](https://github.com/user-attachments/files/24519934/tipwin-dismiss-race.patch) runs in debug mode, then wxWidgets will soon `wxASSERT()` due to destroying a `wxTipWindow` instance twice.

To fix this problem, do not destroy an already-destroyed `wxPopupTransientWindow` .