### PR TITLE
Disallow wxSplitterWindow to get the focus

### DIFF
--- a/include/wx/generic/splitter.h
+++ b/include/wx/generic/splitter.h
@@ -186,6 +186,9 @@ public:
     // minimum pane size is zero.
     virtual void OnDoubleClickSash(int x, int y);
 
+    // Do not allow wxSplitterWindow to get the focus as there is
+    // no keyboard handling anyways and the child windows should
+    // keep the focus
     bool AcceptsFocus() const override { return false; }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/include/wx/generic/splitter.h
+++ b/include/wx/generic/splitter.h
@@ -186,6 +186,8 @@ public:
     // minimum pane size is zero.
     virtual void OnDoubleClickSash(int x, int y);
 
+    bool AcceptsFocus() const override { return false; }
+
 ////////////////////////////////////////////////////////////////////////////
 // Implementation
 


### PR DESCRIPTION
Overrides AcceptsFocus() so that the child windows keeps the focus during a resize operation