### PR TITLE
Add debug logging to `wxWebRequest`

### DIFF
--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -170,6 +170,10 @@ private:
         return Fail(operation, ::GetLastError());
     }
 
+    // Log all the headers of the response if debug logging is enabled.
+    void LogResponseHeadersIfNecessary();
+
+
     // These functions can only be used for asynchronous requests.
     void SetFailed(const wxString& operation, DWORD errorCode)
     {

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -362,10 +362,21 @@ public:
 
     virtual bool EnablePersistentStorage(bool WXUNUSED(enable)) { return false; }
 
+    void SetDebugLogger(std::unique_ptr<wxWebRequestDebugLogger> logger)
+        { m_debugLogger = std::move(logger); }
+
+    // Return raw, non owning pointer to the debug logger (may be null).
+    wxWebRequestDebugLogger* GetDebugLogger() const
+        { return m_debugLogger.get(); }
+
 protected:
     explicit wxWebSessionImpl(Mode mode);
 
     bool IsAsync() const { return m_mode == Mode::Async; }
+
+
+    // If non-null, use it to log debug information.
+    std::unique_ptr<wxWebRequestDebugLogger> m_debugLogger;
 
 private:
     // Make it a friend to allow accessing our m_headers.

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -135,6 +135,37 @@ protected:
     wxWebResponseImplPtr m_impl;
 };
 
+// Base class for logging debug information from web requests.
+class wxWebRequestDebugLogger
+{
+public:
+    wxWebRequestDebugLogger() = default;
+    virtual ~wxWebRequestDebugLogger() = default;
+
+    // Informational message not directly corresponding to any data sent or
+    // received.
+    virtual void OnInfo(const wxString& info) = 0;
+
+    // Request sent to the server, e.g.  "GET /index.html HTTP/1.1".
+    virtual void OnRequestSent(const wxString& line) = 0;
+
+    // Response received from the server, e.g. "HTTP/1.1 200 OK".
+    virtual void OnResponseReceived(const wxString& line) = 0;
+
+    // Header sent to the server.
+    virtual void OnHeaderSent(const wxString& name, const wxString& value) = 0;
+
+    // Header received from the server.
+    virtual void OnHeaderReceived(const wxString& name, const wxString& value) = 0;
+
+    // Data sent to the server. This data may be binary and encrypted when
+    // using HTTPS, so it is typically not human-readable.
+    virtual void OnDataSent(const void* data, size_t size) = 0;
+
+    // Data received from the server. Same remarks as for OnDataSent() apply.
+    virtual void OnDataReceived(const void* data, size_t size) = 0;
+};
+
 class WXDLLIMPEXP_NET wxWebRequestBase
 {
 public:
@@ -394,6 +425,8 @@ public:
     void Close();
 
     bool EnablePersistentStorage(bool enable = true);
+
+    void SetDebugLogger(std::unique_ptr<wxWebRequestDebugLogger> logger);
 
     wxWebSessionHandle GetNativeHandle() const;
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -1236,6 +1236,14 @@ bool wxWebSessionBase::EnablePersistentStorage(bool enable)
     return m_impl->EnablePersistentStorage(enable);
 }
 
+void
+wxWebSessionBase::SetDebugLogger(std::unique_ptr<wxWebRequestDebugLogger> logger)
+{
+    wxCHECK_IMPL_VOID();
+
+    m_impl->SetDebugLogger(std::move(logger));
+}
+
 // ----------------------------------------------------------------------------
 // Module ensuring all global/singleton objects are destroyed on shutdown.
 // ----------------------------------------------------------------------------

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -578,7 +578,7 @@ private:
 class SchemeHandler : public CefResourceHandler
 {
 public:
-    SchemeHandler(const wxSharedPtr<wxWebViewHandler>& handler) : m_handler(handler), m_offset(0) {}
+    SchemeHandler(const wxSharedPtr<wxWebViewHandler>& handler) : m_handler(handler) {}
 
     // CefResourceHandler methods
     virtual bool ProcessRequest(CefRefPtr<CefRequest> request,
@@ -603,7 +603,6 @@ private:
 
     std::string m_data;
     std::string m_mime_type;
-    size_t m_offset;
 
     IMPLEMENT_REFCOUNTING(SchemeHandler);
     base::Lock m_lock;


### PR DESCRIPTION
This is a draft as there is no documentation yet and I'd also like to log at least something (even though I don't think we can information at the same level of details as libcurl provides) for the WinHTTP backend.

I'd welcome comments about the API, notably I don't know if it really makes sense to allocate a new logger for each request, but if we want to reuse the same one, we probably need to pass the request to it?