### PR TITLE
Fix flushing white background for check/radio buttons in dark mode

### DIFF
--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -578,7 +578,17 @@ bool wxMSWOwnerDrawnButtonBase::MSWDrawButton(WXDRAWITEMSTRUCT *item)
     }
 
     // Erase the background.
-    ::FillRect(hdc, &rect, m_win->MSWGetBgBrush(hdc));
+    HBRUSH hbr = m_win->MSWGetBgBrush(hdc);
+    if ( !hbr && wxMSWDarkMode::IsActive() )
+    {
+        // We always need to use custom background in dark mode, default
+        // behaviour is never correct.
+        auto const colBg = m_win->GetBackgroundColour();
+        wxBrush* brush = wxTheBrushList->FindOrCreateBrush(colBg);
+        hbr = (WXHBRUSH)brush->GetResourceHandle();
+    }
+
+    ::FillRect(hdc, &rect, hbr);
 
     // draw the button itself
     wxDCTemp dc(hdc);


### PR DESCRIPTION
Use correct background brush for erasing wxCheckBox and wxRadioButton background in dark mode even if no custom background brush is specified as we can't rely on the default behaviour, which uses white background brush, when using it.

This fixes incorrect flushes of white background when these controls were focused after the containing TLW got focus and before it got repainted again using a different code path which erased background correctly.

Closes #23380.