### PR TITLE
OS X, correct background of wxStaticText in a wxStaticBox

### DIFF
--- a/include/wx/osx/stattext.h
+++ b/include/wx/osx/stattext.h
@@ -50,6 +50,12 @@ protected :
 #endif // wxUSE_MARKUP && wxOSX_USE_COCOA
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxStaticText);
+    
+    void DoUpdateBackground();
+    void OnSysColourChanged(wxSysColourChangedEvent& event);
+
+private:
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/src/osx/stattext_osx.cpp
+++ b/src/osx/stattext_osx.cpp
@@ -19,11 +19,16 @@
     #include "wx/dc.h"
     #include "wx/dcclient.h"
     #include "wx/settings.h"
+    #include "wx/statbox.h"
 #endif // WX_PRECOMP
 
 #include "wx/osx/private.h"
 
 #include <stdio.h>
+
+wxBEGIN_EVENT_TABLE(wxStaticText, wxStaticTextBase)
+    EVT_SYS_COLOUR_CHANGED( wxStaticText::OnSysColourChanged )
+wxEND_EVENT_TABLE()
 
 
 bool wxStaticText::Create( wxWindow *parent,
@@ -52,7 +57,31 @@ bool wxStaticText::Create( wxWindow *parent,
         SetInitialSize(size);
     }
 
+    DoUpdateBackground();
+
     return true;
+}
+
+void wxStaticText::DoUpdateBackground()
+{
+#if wxOSX_USE_COCOA_OR_CARBON
+    if ((GetParent() != nullptr) && GetParent()->IsKindOf(wxCLASSINFO(wxStaticBox)))
+    {
+        if (wxSystemSettings::GetAppearance().IsDark())
+        {
+            SetBackgroundColour( wxColour( 37, 37, 37 ) );
+        }
+        else
+        {
+            SetBackgroundColour( wxColour( 247, 247, 247 ) );
+        }
+    }
+#endif
+}
+
+void wxStaticText::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
+{
+    DoUpdateBackground();
 }
 
 void wxStaticText::SetLabel(const wxString& label)


### PR DESCRIPTION

<img width="260" height="71" alt="background" src="https://github.com/user-attachments/assets/0b1e0956-eec4-40ff-ba2d-37807015e33d" />
<img width="1055" height="240" alt="background3" src="https://github.com/user-attachments/assets/c834fb44-a381-43b8-8161-d671000e46f3" />
  - Manually set background if static text is in static box
  - Problem is that static text is not transparent in its current implementation on OS X
  - Same problem applies to wxCheckBox, wxRadioButton and all items of wxRadioBox, possibly more
  - Better fix would be to find a way to make these labels truely transparent
  - NSTextField labelWithAttributedString might do this (?)
  - This is to start a debate - the patch works in dark and light mode

The attached first screenshot shows the wrong background colour, in this case in a wxRadioBox in dark mode. The second screenshot shows the corrected background colour of a wxStatictext in a wxStaticBox, but the uncorrected wrong colour of a wxCheckBox in the same wxStaticBox.

It also shows the macOS system settings dialog of macOS Tahoe 26.2 on the left, which clearly uses a different colour theme altogether, so the wxWidgets app uses some legacy rendering, which eventually we should get rid of (maybe due to overriding drawRect as has been suggested in a different patch).