### PR TITLE
OSX add explicit transparency where missing

### DIFF
--- a/include/wx/osx/radiobox.h
+++ b/include/wx/osx/radiobox.h
@@ -73,6 +73,8 @@ public:
     virtual wxString GetString(unsigned int item) const override;
     virtual void SetString(unsigned int item, const wxString& label) override;
 
+    virtual bool HasTransparentBackground() override { return true; }
+
     // protect native font of box
     virtual bool SetFont( const wxFont &font ) override;
 // Other external functions

--- a/include/wx/osx/radiobut.h
+++ b/include/wx/osx/radiobut.h
@@ -37,6 +37,8 @@ public:
     virtual void SetValue(bool val) override;
     virtual bool GetValue() const override;
 
+    virtual bool HasTransparentBackground() override { return true; }
+
     // implementation
 
     void Command(wxCommandEvent& event) override;

--- a/include/wx/osx/slider.h
+++ b/include/wx/osx/slider.h
@@ -68,6 +68,8 @@ public:
     int GetThumbLength() const override;
     void SetTick(int tickPos) override;
 
+    virtual bool HasTransparentBackground() override { return true; }
+
     void Command(wxCommandEvent& event) override;
     // osx specific event handling common for all osx-ports
 


### PR DESCRIPTION
some controls were missing the info, and #26090 does not get traction