### PR TITLE
Fix wxRibbonBar crashing under wxQt ( 5&6 )

### DIFF
--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -873,6 +873,8 @@ public:
 
         @note This method shouldn't be used with wxPaintDC as accessing the DC
         while drawing can result in unexpected results, notably in wxGTK.
+
+        @note This method can only be used with wxMemoryDC under wxQt.
     */
     bool GetPixel(wxCoord x, wxCoord y, wxColour* colour) const;
 

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -669,18 +669,19 @@ bool wxQtDCImpl::DoGetPixel(wxCoord x, wxCoord y, wxColour *col) const
 
     if ( col )
     {
-        wxCHECK_MSG( m_qtPixmap != nullptr, false, "This DC doesn't support GetPixel()" );
-        QPixmap pixmap1px = m_qtPixmap->copy( x, y, 1, 1 );
-        QImage image = pixmap1px.toImage();
-        QColor pixel = image.pixel( 0, 0 );
-        col->Set( pixel.red(), pixel.green(), pixel.blue(), pixel.alpha() );
+        if ( m_qtPixmap )
+        {
+            QPixmap pixmap1px = m_qtPixmap->copy( x, y, 1, 1 );
+            QImage image = pixmap1px.toImage();
+            QColor pixel = image.pixel( 0, 0 );
+            col->Set( pixel.red(), pixel.green(), pixel.blue(), pixel.alpha() );
 
-        return true;
+            return true;
+        }
+        // else: This DC doesn't support GetPixel()
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 void wxQtDCImpl::DoDrawPoint(wxCoord x, wxCoord y)

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -368,7 +368,21 @@ wxWindowQt::~wxWindowQt()
 
     DestroyChildren(); // This also destroys scrollbars
 
-    delete m_qtWindow;
+    auto* const p = m_qtWindow->parentWidget();
+
+    if ( p && p->isVisible() && m_qtWindow->testAttribute(Qt::WA_PendingResizeEvent) )
+    {
+        // To prevent a potential use-after-delete error, m_qtWindow should not be deleted
+        // until after the parent window's QShowEvent handler has fully completed. IOW,
+        // this occurs when a child window is destroyed while the parent is in the middle
+        // of showing its children in the QShowEvent handler.
+
+        m_qtWindow->deleteLater();
+    }
+    else
+    {
+        delete m_qtWindow;
+    }
 }
 
 


### PR DESCRIPTION
```
wxWidgets/build_qt/samples/ribbon$ valgrind --tool=memcheck --malloc-fill=0xFE --free-fill=0xFE ./ribbon                         
==9599== Memcheck, a memory error detector
==9599== Copyright (C) 2002-2017, and GNU GPL''d, by Julian Seward et al.
==9599== Using Valgrind-3.14.0.GIT and LibVEX; rerun with -h for copyright info
==9599== Command: ./ribbon
==9599== 
==9599== Invalid read of size 4
==9599==    at 0x5C05E10: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05D80: QWidgetPrivate::show_recursive() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05E4F: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C09328: QWidget::setVisible(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05CCF: QWidget::show() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05EA3: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C09328: QWidget::setVisible(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x4C82719: wxWindow::Show(bool) (window.cpp:514)
==9599==    by 0x4C7B1FC: wxTopLevelWindowQt::Show(bool) (toplevel.cpp:51)
==9599==  Address 0xe8e65d4 is 4 bytes inside a block of size 32 free''d
==9599==    at 0x48316AC: operator delete(void*) (vg_replace_malloc.c:576)
==9599==    by 0x56AB6E7: operator delete(void*, unsigned int) (in /usr/lib/i386-linux-gnu/libstdc++.so.6.0.25)
==9599==    by 0x4C8D9EC: wxQtWidget::~wxQtWidget() (window.cpp:68)
==9599==    by 0x4C81B8B: wxWindow::~wxWindow() (window.cpp:371)
==9599==    by 0x4CF2909: wxControlBase::~wxControlBase() (ctrlcmn.cpp:44)
==9599==    by 0x48BBE32: wxControl::~wxControl() (control.h:11)
==9599==    by 0x48BC5A3: wxRibbonControl::~wxRibbonControl() (control.h:23)
==9599==    by 0x48D274C: wxRibbonPageScrollButton::~wxRibbonPageScrollButton() (page.cpp:86)
==9599==    by 0x48D2770: wxRibbonPageScrollButton::~wxRibbonPageScrollButton() (page.cpp:88)
==9599==    by 0x4E0CF0B: wxWindowBase::Destroy() (wincmn.cpp:570)
==9599==    by 0x48D5422: wxRibbonPage::ShowScrollButtons() (page.cpp:883)
==9599==    by 0x48D4EAD: wxRibbonPage::HideScrollButtons() (page.cpp:787)
==9599==  Block was alloc''d at
==9599==    at 0x483083A: operator new(unsigned int) (vg_replace_malloc.c:328)
==9599==    by 0x4C81D3A: wxWindow::Create(wxWindow*, int, wxPoint const&, wxSize const&, long, wxString const&) (window.cpp:395)
==9599==    by 0x4BF2F76: wxControl::Create(wxWindow*, int, wxPoint const&, wxSize const&, long, wxValidator const&, wxString const&) (control.cpp:37)
==9599==    by 0x48CD017: wxRibbonControl::Create(wxWindow*, int, wxPoint const&, wxSize const&, long, wxValidator const&, wxString const&) (control.cpp:33)
==9599==    by 0x48BBF11: wxRibbonControl::wxRibbonControl(wxWindow*, int, wxPoint const&, wxSize const&, long, wxValidator const&, wxString const&) (control.h:36)
==9599==    by 0x48D2670: wxRibbonPageScrollButton::wxRibbonPageScrollButton(wxRibbonPage*, int, wxPoint const&, wxSize const&, long) (page.cpp:79)
==9599==    by 0x48D539F: wxRibbonPage::ShowScrollButtons() (page.cpp:871)
==9599==    by 0x48D4D62: wxRibbonPage::DoActualLayout() (page.cpp:764)
==9599==    by 0x48D43B1: wxRibbonPage::Realize() (page.cpp:617)
==9599==    by 0x48B5AF3: wxRibbonBar::Realize() (bar.cpp:167)
==9599==    by 0x11BC2E: MyFrame::MyFrame() (ribbondemo.cpp:505)
==9599==    by 0x1170B7: MyApp::OnInit() (ribbondemo.cpp:193)
==9599== 
==9599== Invalid read of size 1
==9599==    at 0x5C05E13: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05D80: QWidgetPrivate::show_recursive() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05E4F: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C09328: QWidget::setVisible(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05CCF: QWidget::show() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05EA3: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C09328: QWidget::setVisible(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x4C82719: wxWindow::Show(bool) (window.cpp:514)
==9599==    by 0x4C7B1FC: wxTopLevelWindowQt::Show(bool) (toplevel.cpp:51)
==9599==  Address 0xfefeff0e is not stack''d, malloc''d or (recently) free''d
==9599== 
==9599== 
==9599== Process terminating with default action of signal 11 (SIGSEGV)
==9599==  Access not within mapped region at address 0xFEFEFF0E
==9599==    at 0x5C05E13: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05D80: QWidgetPrivate::show_recursive() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05E4F: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C09328: QWidget::setVisible(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05CCF: QWidget::show() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05EA3: QWidgetPrivate::showChildren(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C05F7C: QWidgetPrivate::show_helper() (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x5C09328: QWidget::setVisible(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.9.5)
==9599==    by 0x4C82719: wxWindow::Show(bool) (window.cpp:514)
==9599==    by 0x4C7B1FC: wxTopLevelWindowQt::Show(bool) (toplevel.cpp:51)
==9599==  If you believe this happened as a result of a stack
==9599==  overflow in your program''s main thread (unlikely but
==9599==  possible), you can try to increase the size of the
==9599==  main thread stack using the --main-stacksize= flag.
==9599==  The main thread stack size used in this run was 8388608.
==9599== 
==9599== HEAP SUMMARY:
==9599==     in use at exit: 6,152,503 bytes in 83,422 blocks
==9599==   total heap usage: 372,689 allocs, 289,267 frees, 39,832,077 bytes allocated
==9599== 
==9599== LEAK SUMMARY:
==9599==    definitely lost: 2,432 bytes in 19 blocks
==9599==    indirectly lost: 1,228 bytes in 79 blocks
==9599==      possibly lost: 1,008,406 bytes in 4,206 blocks
==9599==    still reachable: 5,140,437 bytes in 79,118 blocks
==9599==                       of which reachable via heuristic:
==9599==                         newarray           : 880 bytes in 19 blocks
==9599==         suppressed: 0 bytes in 0 blocks
==9599== Rerun with --leak-check=full to see details of leaked memory
==9599== 
==9599== For counts of detected and suppressed errors, rerun with: -v
==9599== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
Segmentation fault (core dumped)

```