### PR TITLE
Enable macOS 26 Tahoe background

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1446,7 +1446,7 @@ wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
 #define wxCLIP_SIBLINGS         0x20000000
 
 /* Obsolete */
-#define wxTRANSPARENT_WINDOW    0x00000000
+#define wxTRANSPARENT_WINDOW    0x00100000
 
 /*  Add this style to a panel to get tab traversal working outside of dialogs */
 /*  (on by default for wxPanel, wxDialog, wxScrolledWindow) */

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1445,8 +1445,8 @@ wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
 /*  for subwindows/controls */
 #define wxCLIP_SIBLINGS         0x20000000
 
-/* This style is obsolete and doesn't do anything. */
-#define wxTRANSPARENT_WINDOW    0
+/* This style is re-used for semi-transparent backgrounds. */
+#define wxTRANSPARENT_WINDOW    0x00100000
 
 /*  Add this style to a panel to get tab traversal working outside of dialogs */
 /*  (on by default for wxPanel, wxDialog, wxScrolledWindow) */

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1445,8 +1445,8 @@ wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
 /*  for subwindows/controls */
 #define wxCLIP_SIBLINGS         0x20000000
 
-/* This style is re-used for semi-transparent backgrounds. */
-#define wxTRANSPARENT_WINDOW    0x00100000
+/* Obsolete */
+#define wxTRANSPARENT_WINDOW    0x00000000
 
 /*  Add this style to a panel to get tab traversal working outside of dialogs */
 /*  (on by default for wxPanel, wxDialog, wxScrolledWindow) */

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -3670,6 +3670,9 @@ public:
     // and call self->ProcessEvent() if a match was found.
     bool HandleEvent(wxEvent& event, wxEvtHandler *self);
 
+    // Search for handler of e.g. wxEVT_PAINT
+    bool HasHandleForEventType(wxEventType eventType);
+
     // Clear table
     void Clear();
 
@@ -3724,6 +3727,8 @@ public:
     void Unlink();
     bool IsUnlinked() const;
 
+    // Search for handler of e.g. wxEVT_PAINT
+    bool HasHandleForEventType(wxEventType eventType);
 
     // Global event filters
     // --------------------
@@ -4040,8 +4045,8 @@ public:
     void OnSinkDestroyed( wxEvtHandler *sink );
 
 
-private:
-    void DoBind(int winid,
+protected:
+    virtual void DoBind(int winid,
                    int lastId,
                    wxEventType eventType,
                    wxEventFunctor *func,
@@ -4053,6 +4058,7 @@ private:
                       const wxEventFunctor& func,
                       wxObject *userData = nullptr);
 
+private:
     static const wxEventTableEntry sm_eventTableEntries[];
 
 protected:

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -515,7 +515,8 @@ public:
     enum wxOSXSkipOverrides {
         wxOSXSKIP_NONE = 0x0,
         wxOSXSKIP_DRAW = 0x1,
-        wxOSXSKIP_DND = 0x2
+        wxOSXSKIP_DND = 0x2,
+        wxOSXSKIP_DND_AND_DRAW = wxOSXSKIP_DND|wxOSXSKIP_DRAW,
     };
 
     void WXDLLIMPEXP_CORE wxOSXCocoaClassAddWXMethods(Class c, wxOSXSkipOverrides skipFlags = wxOSXSKIP_NONE);

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -234,6 +234,8 @@ public :
 
     virtual void                ApplyScrollViewBorderType() override;
 
+    virtual void                PaintHandlerAdded() override;
+
 protected:
     WXWidget m_osxView;
     WXWidget m_osxClipView;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -397,6 +397,9 @@ public :
     // should be called to enable appropriate borders for native controls with scrollview superviews
     virtual void        ApplyScrollViewBorderType() { }
 
+    // Give the peer a change to override NSView's drawRect
+    virtual void        PaintHandlerAdded() {}
+
     // Mechanism used to keep track of whether a change should send an event
     // Do SendEvents(false) when starting actions that would trigger programmatic events
     // and SendEvents(true) at the end of the block.

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -151,6 +151,13 @@ public:
     // event handlers
     // --------------
 
+    // override this to catch binding to wxEVT_PAINT
+    virtual void DoBind(int winid,
+                   int lastId,
+                   wxEventType eventType,
+                   wxEventFunctor *func,
+                   wxObject* userData = nullptr) override;
+
     void OnMouseEvent( wxMouseEvent &event );
 
     void MacOnScroll( wxScrollEvent&event );

--- a/samples/notebook/notebook.cpp
+++ b/samples/notebook/notebook.cpp
@@ -63,7 +63,7 @@ bool MyApp::OnInit()
 
 wxPanel *CreateUserCreatedPage(wxBookCtrlBase *parent)
 {
-    wxPanel *panel = new wxPanel(parent);
+    wxPanel *panel = new wxPanel(parent, -1, wxDefaultPosition, wxDefaultSize, wxTRANSPARENT_WINDOW);
 
 #if wxUSE_HELP
     panel->SetHelpText("Panel with a Button");
@@ -77,7 +77,7 @@ wxPanel *CreateUserCreatedPage(wxBookCtrlBase *parent)
 
 wxPanel *CreateRadioButtonsPage(wxBookCtrlBase *parent)
 {
-    wxPanel *panel = new wxPanel(parent);
+    wxPanel *panel = new wxPanel(parent, -1, wxDefaultPosition, wxDefaultSize, wxTRANSPARENT_WINDOW);
 
 #if wxUSE_HELP
     panel->SetHelpText("Panel with some Radio Buttons");
@@ -108,7 +108,7 @@ wxPanel *CreateRadioButtonsPage(wxBookCtrlBase *parent)
 
 wxPanel *CreateVetoPage(wxBookCtrlBase *parent)
 {
-    wxPanel *panel = new wxPanel(parent);
+    wxPanel *panel = new wxPanel(parent, -1, wxDefaultPosition, wxDefaultSize, wxTRANSPARENT_WINDOW);
 
 #if wxUSE_HELP
     panel->SetHelpText("An empty panel");
@@ -138,7 +138,7 @@ wxWindow *CreateFullPageText(wxBookCtrlBase *parent)
 
 wxPanel *CreateInsertPage(wxBookCtrlBase *parent)
 {
-    wxPanel *panel = new wxPanel(parent);
+    wxPanel *panel = new wxPanel(parent, -1, wxDefaultPosition, wxDefaultSize, wxTRANSPARENT_WINDOW);
 
 #if wxUSE_HELP
     panel->SetHelpText("Maroon panel");
@@ -405,7 +405,7 @@ MyFrame::MyFrame()
     m_images.push_back(wxArtProvider::GetBitmapBundle(wxART_WARNING, wxART_OTHER, imageSize));
     m_images.push_back(wxArtProvider::GetBitmapBundle(wxART_ERROR, wxART_OTHER, imageSize));
 
-    m_panel = new wxPanel(this);
+    m_panel = new wxPanel(this, -1, wxDefaultPosition, wxDefaultSize, wxTRANSPARENT_WINDOW );
 
 #if USE_LOG
     m_text = new wxTextCtrl(m_panel, wxID_ANY, wxEmptyString,

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -1079,6 +1079,21 @@ bool wxEventHashTable::HandleEvent(wxEvent &event, wxEvtHandler *self)
     return false;
 }
 
+bool wxEventHashTable::HasHandleForEventType(wxEventType eventType)
+{
+    if (m_rebuildHash)
+    {
+        InitHashTable();
+        m_rebuildHash = false;
+    }
+
+    if (!m_eventTypeTable)
+        return false;
+
+    const EventTypeTablePointer eTTnode = m_eventTypeTable[eventType % m_size];
+    return (eTTnode && eTTnode->eventType == eventType);
+}
+
 void wxEventHashTable::InitHashTable()
 {
     // Loop over the event tables and all its base tables.
@@ -1639,6 +1654,11 @@ bool wxEvtHandler::DoTryChain(wxEvent& event)
     }
 
     return false;
+}
+
+bool wxEvtHandler::HasHandleForEventType(wxEventType eventType)
+{
+    return GetEventHashTable().HasHandleForEventType(eventType);
 }
 
 bool wxEvtHandler::TryHereOnly(wxEvent& event)

--- a/src/osx/cocoa/button.mm
+++ b/src/osx/cocoa/button.mm
@@ -33,7 +33,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/choice.mm
+++ b/src/osx/cocoa/choice.mm
@@ -34,7 +34,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/combobox.mm
+++ b/src/osx/cocoa/combobox.mm
@@ -43,7 +43,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1549,7 +1549,7 @@ outlineView:(NSOutlineView*)outlineView
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DND);
+        wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DND);  // |wxOSXSKIP_DRAW as well?
     }
 }
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1549,7 +1549,7 @@ outlineView:(NSOutlineView*)outlineView
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DND);  // |wxOSXSKIP_DRAW as well?
+        wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DND_AND_DRAW );
     }
 }
 

--- a/src/osx/cocoa/datetimectrl.mm
+++ b/src/osx/cocoa/datetimectrl.mm
@@ -54,7 +54,7 @@ using namespace wxOSXImpl;
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/gauge.mm
+++ b/src/osx/cocoa/gauge.mm
@@ -29,7 +29,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/listbox.mm
+++ b/src/osx/cocoa/listbox.mm
@@ -291,7 +291,7 @@ protected:
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/notebook.mm
+++ b/src/osx/cocoa/notebook.mm
@@ -99,7 +99,7 @@
         else
 #endif
         {
-            wxOSXCocoaClassAddWXMethods(self);
+            wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DRAW);
         }
     }
 }

--- a/src/osx/cocoa/radiobut.mm
+++ b/src/osx/cocoa/radiobut.mm
@@ -40,7 +40,7 @@ extern void wxOSX_controlAction(NSView* self, SEL _cmd, id sender);
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
         for ( int i = 1 ; i <= maxAlternateActions ; i++ )
         {
             class_addMethod(self, NSSelectorFromString([NSString stringWithFormat: alternateActionsSelector, i]), (IMP) wxOSX_controlAction, "v@:@" );

--- a/src/osx/cocoa/scrolbar.mm
+++ b/src/osx/cocoa/scrolbar.mm
@@ -33,7 +33,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods(self);
+        wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DRAW);
     }
 }
 

--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -123,6 +123,15 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
             sysColor = [NSColor controlColor];
         break;
     case wxSYS_COLOUR_LISTBOX:
+        if ( WX_IS_MACOS_AVAILABLE(26, 0) )
+        {
+            // macOS Tahoe does not have single value anymore but
+            // these are used for opaque backgrounds
+            if (wxSystemSettings::GetAppearance().IsDark())
+                return wxColour( 42, 48, 50 );
+            else
+                return wxColour(247,247,247);
+        } 
         sysColor = [NSColor controlBackgroundColor];
         break;
     case wxSYS_COLOUR_BTNSHADOW:

--- a/src/osx/cocoa/slider.mm
+++ b/src/osx/cocoa/slider.mm
@@ -27,7 +27,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods(self);
+        wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DRAW);
     }
 }
 

--- a/src/osx/cocoa/spinbutt.mm
+++ b/src/osx/cocoa/spinbutt.mm
@@ -27,7 +27,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods(self);
+        wxOSXCocoaClassAddWXMethods(self, wxOSXSKIP_DRAW);
     }
 }
 

--- a/src/osx/cocoa/srchctrl.mm
+++ b/src/osx/cocoa/srchctrl.mm
@@ -32,7 +32,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/statbmp.mm
+++ b/src/osx/cocoa/statbmp.mm
@@ -42,7 +42,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/statbox.mm
+++ b/src/osx/cocoa/statbox.mm
@@ -37,7 +37,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/stattext.mm
+++ b/src/osx/cocoa/stattext.mm
@@ -43,7 +43,7 @@
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -227,7 +227,7 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 
@@ -365,7 +365,7 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 
@@ -475,7 +475,7 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 
@@ -594,7 +594,7 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     if (!initialized)
     {
         initialized = YES;
-        wxOSXCocoaClassAddWXMethods( self );
+        wxOSXCocoaClassAddWXMethods( self, wxOSXSKIP_DRAW );
     }
 }
 
@@ -1906,6 +1906,10 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
         wxNSTextFieldControl* t = new wxNSTextFieldControl( wxpeer, wxpeer, v );
         c = t;
 
+/*
+        Setting NO_BORDER on macOS 26 Tahoe triggers legacy rendering with
+        brown background
+
         if ( (style & wxNO_BORDER) || (style & wxSIMPLE_BORDER) )
         {
             // under 10.7 the textcontrol can draw its own focus
@@ -1915,6 +1919,7 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
             [v setBordered:NO];
         }
         else
+*/
         {
             // use native border
             c->SetNeedsFrame(false);

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -4373,16 +4373,16 @@ void wxWidgetCocoaImpl::ClipsToBounds(bool clip)
 
 wxWidgetImpl* wxWidgetImpl::CreateUserPane( wxWindowMac* wxpeer, wxWindowMac* WXUNUSED(parent),
     wxWindowID WXUNUSED(id), const wxPoint& pos, const wxSize& size,
-    long WXUNUSED(style), long WXUNUSED(extraStyle))
+    long style, long WXUNUSED(extraStyle))
 {
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
 
     wxWidgetCocoaImpl* c = nullptr;
 
-    //  Avoid macOS 26 Tahoe triggers legacy rendering with
-    //  brown background
+    //  Avoid macOS 26 Tahoe triggers legacy rendering with brown background
     if (wxpeer->IsKindOf(wxCLASSINFO(wxSpinCtrl))
-      || wxpeer->IsKindOf(wxCLASSINFO(wxSpinCtrlDouble)))
+      || wxpeer->IsKindOf(wxCLASSINFO(wxSpinCtrlDouble)) 
+      || ((style & wxTRANSPARENT_WINDOW) != 0))
     {
         wxNSView* v = [[wxNSView alloc] initWithFrame:r];
         c = new wxWidgetCocoaImpl( wxpeer, v, Widget_IsUserPane );
@@ -4391,20 +4391,6 @@ wxWidgetImpl* wxWidgetImpl::CreateUserPane( wxWindowMac* wxpeer, wxWindowMac* WX
     {
         wxNSViewWithDrawing* v = [[wxNSViewWithDrawing alloc] initWithFrame:r];
         c = new wxWidgetCocoaImpl( wxpeer, v, Widget_IsUserPane );
-
-        // This overrides user background colour and does not try to
-        // query the background colour, so it is wrong.
-        if (wxSystemSettings::GetAppearance().IsDark())
-            wxpeer->SetBackgroundColour( wxColour( 42, 48, 50 ) );
-        else
-            wxpeer->SetBackgroundColour( wxColour(247,247,247) );
-
-        wxpeer->Bind( wxEVT_SYS_COLOUR_CHANGED, [wxpeer] (wxSysColourChangedEvent&) {
-            if (wxSystemSettings::GetAppearance().IsDark())
-                wxpeer->SetBackgroundColour( wxColour( 42, 48, 50 ) );
-            else
-                wxpeer->SetBackgroundColour( wxColour(247,247,247) );
-        });
     }
     return c;
 }

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -184,6 +184,22 @@ void wxWidgetCocoaImpl::ApplyScrollViewBorderType()
 
 @end // wxNSViewWithDrawing
 
+@interface wxNSViewWithDrawing(TextInput) <NSTextInputClient>
+
+- (void)insertText:(id)aString replacementRange:(NSRange)replacementRange;
+- (void)doCommandBySelector:(SEL)aSelector;
+- (void)setMarkedText:(id)aString selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange;
+- (void)unmarkText;
+- (NSRange)selectedRange;
+- (NSRange)markedRange;
+- (BOOL)hasMarkedText;
+- (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange;
+- (NSArray*)validAttributesForMarkedText;
+- (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange;
+- (NSUInteger)characterIndexForPoint:(NSPoint)aPoint;
+
+@end
+
 @interface wxNSView : NSView
 {
 }
@@ -1011,6 +1027,81 @@ static void SetDrawingEnabledIfFrozenRecursive(wxWidgetCocoaImpl *impl, bool ena
 #endif
 
 @end // wxNSView
+
+
+// Not very elegant to have the same - almost empty - interface for 
+// wxNSViewWithDrawing and wxNSView, but we don't get any wxCHAR_EVENTs
+// otherwise
+
+@implementation wxNSViewWithDrawing(TextInput)
+
+void wxOSX_insertText(NSView* self, SEL _cmd, NSString* text);
+
+- (void)doCommandBySelector:(SEL)aSelector
+{
+    wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
+    if (impl)
+        impl->doCommandBySelector(aSelector, self, _cmd);
+}
+
+- (void)insertText:(id)aString replacementRange:(NSRange)replacementRange
+{
+    wxUnusedVar(replacementRange);
+    wxOSX_insertText(self, @selector(insertText:), aString);
+}
+
+- (void)setMarkedText:(id)aString selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange
+{
+    wxUnusedVar(aString);
+    wxUnusedVar(selectedRange);
+    wxUnusedVar(replacementRange);
+}
+
+- (void)unmarkText
+{
+}
+
+- (NSRange)selectedRange
+{
+    return NSMakeRange(NSNotFound, 0);
+}
+
+- (NSRange)markedRange
+{
+    return NSMakeRange(NSNotFound, 0);
+}
+
+- (BOOL)hasMarkedText
+{
+    return NO;
+}
+
+- (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
+{
+    wxUnusedVar(aRange);
+    wxUnusedVar(actualRange);
+    return nil;
+}
+
+- (NSArray*)validAttributesForMarkedText
+{
+    return nil;
+}
+
+- (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
+{
+    wxUnusedVar(aRange);
+    wxUnusedVar(actualRange);
+    return NSMakeRect(0, 0, 0, 0);
+}
+- (NSUInteger)characterIndexForPoint:(NSPoint)aPoint
+{
+    wxUnusedVar(aPoint);
+    return NSNotFound;
+}
+
+@end // wxNSViewWithDrawing(TextInput)
+
 
 // We need to adopt NSTextInputClient protocol in order to interpretKeyEvents: to work.
 // Currently, only insertText:(replacementRange:) is

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -28,8 +28,8 @@
 #include "wx/private/bmpbndl.h"
 
 #include "wx/evtloop.h"
-#include "wx/panel.h"
 #include "wx/spinctrl.h"
+#include "wx/settings.h"
 
 #if wxUSE_CARET
     #include "wx/caret.h"
@@ -4381,8 +4381,7 @@ wxWidgetImpl* wxWidgetImpl::CreateUserPane( wxWindowMac* wxpeer, wxWindowMac* WX
 
     //  Avoid macOS 26 Tahoe triggers legacy rendering with
     //  brown background
-    if (wxpeer->IsKindOf(wxCLASSINFO(wxPanel)) 
-      || wxpeer->IsKindOf(wxCLASSINFO(wxSpinCtrl))
+    if (wxpeer->IsKindOf(wxCLASSINFO(wxSpinCtrl))
       || wxpeer->IsKindOf(wxCLASSINFO(wxSpinCtrlDouble)))
     {
         wxNSView* v = [[wxNSView alloc] initWithFrame:r];
@@ -4392,6 +4391,20 @@ wxWidgetImpl* wxWidgetImpl::CreateUserPane( wxWindowMac* wxpeer, wxWindowMac* WX
     {
         wxNSViewWithDrawing* v = [[wxNSViewWithDrawing alloc] initWithFrame:r];
         c = new wxWidgetCocoaImpl( wxpeer, v, Widget_IsUserPane );
+
+        // This overrides user background colour and does not try to
+        // query the background colour, so it is wrong.
+        if (wxSystemSettings::GetAppearance().IsDark())
+            wxpeer->SetBackgroundColour( wxColour( 42, 48, 50 ) );
+        else
+            wxpeer->SetBackgroundColour( wxColour(247,247,247) );
+
+        wxpeer->Bind( wxEVT_SYS_COLOUR_CHANGED, [wxpeer] (wxSysColourChangedEvent&) {
+            if (wxSystemSettings::GetAppearance().IsDark())
+                wxpeer->SetBackgroundColour( wxColour( 42, 48, 50 ) );
+            else
+                wxpeer->SetBackgroundColour( wxColour(247,247,247) );
+        });
     }
     return c;
 }

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2334,6 +2334,17 @@ long wxWindowMac::MacRemoveBordersFromStyle( long style )
     return style & ~wxBORDER_MASK ;
 }
 
+void wxWindowMac::DoBind(int winid, int lastId, wxEventType eventType,
+                   wxEventFunctor *func, wxObject* userData )
+{
+    wxEvtHandler::DoBind( winid, lastId, eventType, func, userData );
+    if (eventType == wxEVT_PAINT)
+    {
+        // Give the peer a change to override NSView's drawRect
+        GetPeer()->PaintHandlerAdded();
+    }
+}
+
 void wxWindowMac::OnMouseEvent( wxMouseEvent &event )
 {
     if ( event.GetEventType() == wxEVT_RIGHT_DOWN )


### PR DESCRIPTION
  - Don't override drawRect (and as such disable user code drawing in all native controls) to avoid legacy rendering
  - Catch binding to wxEVT_PAINT in static tables and dynamically and add overriding of drawRect only then
  - Disable wxSIMPLE_BORDER and NO_BORDER in wxTextCtrl to avoid legacy rendering
  - Multi-line wxTextCtrl still uses brown background
  - Adapt system colour wxCOLOUR_LISTBOX to report the correct opaque colours in light and dark mode under Tahoe

