### PR TITLE
Wrap wxCHECK macro inside a do{}while construct to protect it

### DIFF
--- a/include/wx/debug.h
+++ b/include/wx/debug.h
@@ -354,6 +354,7 @@ extern void WXDLLIMPEXP_BASE wxAbort();
 // the generic macro: takes the condition to check, the statement to be executed
 // in case the condition is false and the message to pass to the assert handler
 #define wxCHECK2_MSG(cond, op, msg)                                       \
+    wxSTATEMENT_MACRO_BEGIN                                               \
     if ( cond )                                                           \
     {}                                                                    \
     else                                                                  \
@@ -361,7 +362,7 @@ extern void WXDLLIMPEXP_BASE wxAbort();
         wxFAIL_COND_MSG(#cond, msg);                                      \
         op;                                                               \
     }                                                                     \
-    struct wxMAKE_UNIQUE_NAME(wxDummyCheckStruct) /* to force a semicolon */
+    wxSTATEMENT_MACRO_END
 
 // check which returns with the specified return code if the condition fails
 #define wxCHECK_MSG(cond, rc, msg)   wxCHECK2_MSG(cond, return rc, msg)


### PR DESCRIPTION
Before, it is just a bare if statement, which could pose issues if used as the only statement in a single-line control flow construct, where the else clause could get associated with the wrong if statement, and the ending semicolon wrapper would get associated with the wrong nesting level.

We saw this get flagged in a Coverity scan check in KiCad when we had code like:
```
    if( !tmpPath.empty() )
        tmpPath.pop_back();
    else
        wxCHECK_MSG( false, /* void */, wxS( "Sheet paths must have a least one valid sheet." ) );
```
and Coverity then said that the macro `wxCHECK_MSG` had bad nesting level (the trailing semicolon would end up outside the if/else statement here).

It could also be problematic if someone tried the flow
```
if(something)
    wxCHECK_MSG( false, ...)
```
because then the `else` clause in the macro would actually bind to the wrong if statement (the one written by the user, not the one in the macro).

Also, this makes the `wxCHECK` implementations consistent with `wxFAIL_COND_MSG_AT` and `wxASSERT_MSG_AT`, which use this statement wrapper.