### PR TITLE
Corrected wxTreeCtrl::DoGetBestSize(), added DoGetBestClientWidth

### DIFF
--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -355,6 +355,7 @@ protected:
 
     virtual wxSize DoGetBestSize() const override;
     virtual int DoGetBestClientWidth(int height) const override;
+    virtual wxSize DoGetBestClientSize() const override;
 
 private:
     void OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))

--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -354,7 +354,8 @@ protected:
     void DoDirtyProcessing();
 
     virtual wxSize DoGetBestSize() const override;
-
+    virtual int DoGetBestClientWidth(int height) const override;
+    
 private:
     void OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
     {

--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -355,7 +355,7 @@ protected:
 
     virtual wxSize DoGetBestSize() const override;
     virtual int DoGetBestClientWidth(int height) const override;
-    
+
 private:
     void OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
     {

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2491,18 +2491,26 @@ void wxGenericTreeCtrl::AssignButtonsImageList(wxImageList *imageList)
 // helpers
 // -----------------------------------------------------------------------------
 
+wxSize GetTotalAreaFromClientArea(wxSize size)
+{
+    int x = size.x + PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+    int y = size.y + PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+    return wxSize( x, y);
+}
+
 void wxGenericTreeCtrl::AdjustMyScrollbars()
 {
     if (m_anchor)
     {
         int x = 0, y = 0;
         m_anchor->GetSize( x, y, this );
-        y += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
-        x += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+        wxSize totalSize = GetTotalAreaFromClientArea( wxSize( x, y) );
         int x_pos = GetScrollPos( wxHORIZONTAL );
         int y_pos = GetScrollPos( wxVERTICAL );
-        SetScrollbars( PIXELS_PER_UNIT, PIXELS_PER_UNIT,
-                       x/PIXELS_PER_UNIT, y/PIXELS_PER_UNIT,
+        SetScrollbars( PIXELS_PER_UNIT, 
+                       PIXELS_PER_UNIT,
+                       totalSize.x/PIXELS_PER_UNIT, 
+                       totalSize.y/PIXELS_PER_UNIT,
                        x_pos, y_pos );
     }
     else
@@ -4189,7 +4197,7 @@ void wxGenericTreeCtrl::DoDirtyProcessing()
     AdjustMyScrollbars();
 }
 
-wxSize wxGenericTreeCtrl::DoGetBestSize() const
+wxSize wxGenericTreeCtrl::DoGetBestClientSize() const
 {
     // make sure all positions are calculated as normally this only done during
     // idle time but we need them for base class DoGetBestSize() to return the
@@ -4202,10 +4210,16 @@ wxSize wxGenericTreeCtrl::DoGetBestSize() const
     // will not have scrollbars
 
     // Use the calculation from AdjustMyScrollbars()
-    size.y += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
-    size.x += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+    size = GetTotalAreaFromClientArea( size );
     size.x = (size.x / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
     size.y = (size.y / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
+
+    return size;
+}
+
+wxSize wxGenericTreeCtrl::DoGetBestSize() const
+{
+    wxSize size = DoGetBestClientSize();
 
     // add the border
     const wxSize& borderSize = GetWindowBorderSize();
@@ -4217,21 +4231,7 @@ wxSize wxGenericTreeCtrl::DoGetBestSize() const
 
 int wxGenericTreeCtrl::DoGetBestClientWidth(int height) const
 {
-    // make sure all positions are calculated as normally this only done during
-    // idle time but we need them for base class DoGetBestSize() to return the
-    // correct result
-    wxConstCast(this, wxGenericTreeCtrl)->CalculatePositions();
-
-    wxSize size = wxTreeCtrlBase::DoGetBestSize();
-
-    // DoGetBestClientWidth calculates if a vertical scrollbar is
-    // needed based on the given height
-
-    // Use the calculation from AdjustMyScrollbars()
-    size.y += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
-    size.x += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
-    size.x = (size.x / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
-    size.y = (size.y / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
+    wxSize size = DoGetBestClientSize();
 
     if (height < size.y)
     {

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -4198,23 +4198,49 @@ wxSize wxGenericTreeCtrl::DoGetBestSize() const
 
     wxSize size = wxTreeCtrlBase::DoGetBestSize();
 
-    // there seems to be an implicit extra border around the items, although
-    // I'm not really sure where does it come from -- but without this, the
-    // scrollbars appear in a tree with default/best size
-    size.IncBy(4, 4);
+    // DoGetBestSize assumes we can stretch out completely and therefore
+    // will not have scrollbars
 
-    // and the border has to be rounded up to a multiple of PIXELS_PER_UNIT or
-    // scrollbars still appear
+    // Use the calculation from AdjustMyScrollbars()
+    size.y += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+    size.x += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+    size.x = (size.x / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
+    size.y = (size.y / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
+
+    // add the border 
     const wxSize& borderSize = GetWindowBorderSize();
-
-    int dx = (size.x - borderSize.x) % PIXELS_PER_UNIT;
-    if ( dx )
-        size.x += PIXELS_PER_UNIT - dx;
-    int dy = (size.y - borderSize.y) % PIXELS_PER_UNIT;
-    if ( dy )
-        size.y += PIXELS_PER_UNIT - dy;
+    size.x += borderSize.x;
+    size.y += borderSize.y;
 
     return size;
+}
+
+int wxGenericTreeCtrl::DoGetBestClientWidth(int height) const
+{ 
+    // make sure all positions are calculated as normally this only done during
+    // idle time but we need them for base class DoGetBestSize() to return the
+    // correct result
+    wxConstCast(this, wxGenericTreeCtrl)->CalculatePositions();
+
+    wxSize size = wxTreeCtrlBase::DoGetBestSize();
+
+    // DoGetBestClientWidth calculates if a vertical scrollbar is
+    // needed based on the given height
+
+    // Use the calculation from AdjustMyScrollbars()
+    size.y += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+    size.x += PIXELS_PER_UNIT+2; // one more scrollbar unit + 2 pixels
+    size.x = (size.x / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
+    size.y = (size.y / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
+
+    if (height < size.y) 
+    {
+        // Add space for vertical scrollbar
+        return size.x + wxSystemSettings::GetMetric( wxSYS_VSCROLL_X );
+    }
+
+    // No scrollbar needed
+    return size.x;
 }
 
 #endif // wxUSE_TREECTRL

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -4207,7 +4207,7 @@ wxSize wxGenericTreeCtrl::DoGetBestSize() const
     size.x = (size.x / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
     size.y = (size.y / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
 
-    // add the border 
+    // add the border
     const wxSize& borderSize = GetWindowBorderSize();
     size.x += borderSize.x;
     size.y += borderSize.y;
@@ -4216,7 +4216,7 @@ wxSize wxGenericTreeCtrl::DoGetBestSize() const
 }
 
 int wxGenericTreeCtrl::DoGetBestClientWidth(int height) const
-{ 
+{
     // make sure all positions are calculated as normally this only done during
     // idle time but we need them for base class DoGetBestSize() to return the
     // correct result
@@ -4233,7 +4233,7 @@ int wxGenericTreeCtrl::DoGetBestClientWidth(int height) const
     size.x = (size.x / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
     size.y = (size.y / PIXELS_PER_UNIT) * PIXELS_PER_UNIT;
 
-    if (height < size.y) 
+    if (height < size.y)
     {
         // Add space for vertical scrollbar
         return size.x + wxSystemSettings::GetMetric( wxSYS_VSCROLL_X );


### PR DESCRIPTION
For the generic wxTreeCtrl:
- Corrected ::DoGetBestSize(), added DoGetBestClientWidth
 - Adapted both to the same calculation of the required virtual size that is used in AdjustScrollbars() removing the need for adding magic 4
 - Now, importantly, wxTreeBook actually calls a real DoGetBestClientWidth() based on a known height and can correctly figure out if a vertical scrollbar is needed
  - This removes the ugly horizontal scrollbar in wxTreeBook when a the horizontal scrollbar appears.
  - Tested on macOS 26