### PR TITLE
Deprecate wxXmlInitResourceModule() and do nothing in it

### DIFF
--- a/include/wx/xrc/xmlres.h
+++ b/include/wx/xrc/xmlres.h
@@ -695,8 +695,10 @@ public:
        variable->Hide();
 
 
-// FIXME -- remove this $%^#$%#$@# as soon as Ron checks his changes in!!
-WXDLLIMPEXP_XRC void wxXmlInitResourceModule();
+// This function didn't do anything useful and is now preserved just to avoid
+// breaking compilation of the code using it.
+wxDEPRECATED_MSG("Simply remove the calls to this function from your code")
+inline void wxXmlInitResourceModule() { }
 
 
 // This class is used to create instances of XRC "object" nodes with "subclass"

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -3250,14 +3250,4 @@ public:
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxXmlResourceModule, wxModule);
 
-
-// When wxXml is loaded dynamically after the application is already running
-// then the built-in module system won't pick this one up.  Add it manually.
-void wxXmlInitResourceModule()
-{
-    wxModule* module = new wxXmlResourceModule;
-    wxModule::RegisterModule(module);
-    wxModule::InitializeModules();
-}
-
 #endif // wxUSE_XRC


### PR DESCRIPTION
This function seems to do more harm than good, so stop doing anything in it and deprecate it as it doesn't seem like calling it could ever be useful.

Closes #26039.