### PR TITLE
wxRichTextCtrl: Fix selection jitter on macOS

### DIFF
--- a/include/wx/richtext/richtextbuffer.h
+++ b/include/wx/richtext/richtextbuffer.h
@@ -4765,10 +4765,7 @@ public:
     wxNODISCARD virtual wxRichTextObject* Clone() const override { return new wxRichTextPlainText(*this); }
 
 private:
-    bool DrawTabbedString(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect, wxString& str, wxCoord& x, wxCoord& y, bool selected);
-#ifdef __WXMAC__
-    bool DrawTabbedStringWithPartialSelection(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect, wxString& str, wxCoord& x, wxCoord& y, int selStart, int selEnd);
-#endif
+    void DrawTabbedString(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect, wxString& str, wxCoord& x, wxCoord& y, ssize_t selStart, ssize_t selEnd);
 
 protected:
     wxString    m_text;

--- a/include/wx/richtext/richtextbuffer.h
+++ b/include/wx/richtext/richtextbuffer.h
@@ -4766,6 +4766,9 @@ public:
 
 private:
     bool DrawTabbedString(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect, wxString& str, wxCoord& x, wxCoord& y, bool selected);
+#ifdef __WXMAC__
+    bool DrawTabbedStringWithPartialSelection(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect, wxString& str, wxCoord& x, wxCoord& y, int selStart, int selEnd);
+#endif
 
 protected:
     wxString    m_text;

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -6939,16 +6939,29 @@ bool wxRichTextPlainText::Draw(wxDC& dc, wxRichTextDrawingContext& context, cons
     // (a) All selected.
     if (allSelected)
     {
+#ifdef __WXMAC__
+        DrawTabbedStringWithPartialSelection(dc, textAttr, rect, stringChunk, x, y, 0, stringChunk.Len() - 1);
+#else
         DrawTabbedString(dc, textAttr, rect, stringChunk, x, y, true);
+#endif
     }
     // (b) None selected.
     else if (noneSelected)
     {
+#ifdef __WXMAC__
+        DrawTabbedStringWithPartialSelection(dc, textAttr, rect, stringChunk, x, y, -1, -1);
+#else
         // Draw all unselected
         DrawTabbedString(dc, textAttr, rect, stringChunk, x, y, false);
+#endif
     }
     else
     {
+#ifdef __WXMAC__
+        int selStart = wxMax(selectionRange.GetStart(), range.GetStart()) - range.GetStart();
+        int selEnd = wxMin(selectionRange.GetEnd(),   range.GetEnd()) - range.GetStart();
+        DrawTabbedStringWithPartialSelection(dc, textAttr, rect, stringChunk, x, y, selStart, selEnd);
+#else
         // (c) Part selected, part not
         // Let's draw unselected chunk, selected chunk, then unselected chunk.
 
@@ -7036,10 +7049,170 @@ bool wxRichTextPlainText::Draw(wxDC& dc, wxRichTextDrawingContext& context, cons
 
             DrawTabbedString(dc, textAttr, rect, stringFragment, x, y, false);
         }
+#endif
     }
 
     return true;
 }
+
+#ifdef __WXMAC__
+bool wxRichTextPlainText::DrawTabbedStringWithPartialSelection(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect, wxString& str, wxCoord& x, wxCoord& y, int selStart, int selEnd)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // This function assumes str has uniform formatting (attr applies to the //
+    // entire string). The calling code should split text into style runs    //
+    // before calling this function.                                         //
+    ///////////////////////////////////////////////////////////////////////////
+
+    wxColour highlightBackgroundColor(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
+    wxColour standardTextColor = (attr.HasTextColour() && attr.GetTextColour().IsOk()) ? attr.GetTextColour() : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    wxCoord originx = x;
+    wxArrayInt startpos;  // Character starting positions
+    wxArrayInt endpos;    // Character ending positions (cumulative widths)
+    wxArrayInt tabstops;  // Array of tab stop positions
+    wxPen savedpen;
+
+    int strikethrough = (attr.HasTextEffects() && (attr.GetTextEffects() & wxTEXT_ATTR_EFFECT_STRIKETHROUGH)) ? 1 : 0;
+    int strikeheight = (int) (rect.y + rect.GetHeight()/2.0 + 0.5);  // Cast truncates; +0.5 forces rounding
+    int tabcount;
+    int effectivetabstop;
+    int posadjustment;
+    int printstart;
+    int i  = 0;  // initialization iterator
+    int si = 0;  // string iterator
+    int ti = 0;  // tabstop iterator
+    int pi = 0;  // position iterator
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    //                             Initial setup                             //
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (str.Len() == 0) return true; // Nonsensical but it's what the original does
+
+    // Get character ending positions
+    dc.GetPartialTextExtents(str, endpos);
+    startpos.SetCount(endpos.GetCount());
+
+    startpos[0] = originx;
+    for (i = 0; i < endpos.GetCount() - 1; i++) {
+        endpos[i] = originx + endpos[i];
+        startpos[i+1] = endpos[i];
+    }
+    endpos[i] = originx + endpos[i];
+
+    // Get all of the tabstops
+    tabstops = (attr.GetTabs().IsEmpty())  ?  wxRichTextParagraph::GetDefaultTabs()  :  attr.GetTabs();
+    tabcount = tabstops.GetCount();
+    for (i = 0; i < tabcount; i++)
+        tabstops[i] = originx + ConvertTenthsMMToPixels(dc, tabstops[i]);
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    //                     Tab stop position adjustments                     //
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Adjust horizontal positions to account for tab stops.
+    // Do this by looping through to find every tab character, calculate the appropriate tab stop for it, measure
+    // the horizontal space difference, and adjust the tab's ending position and the start/end positions of every
+    // character after it.
+    //
+    // TL;DR: Tab Char --> Tab Stop --> Pixel Adjustment --> New startpos/endpos
+    //
+    // NOTE: TODO: This almost certainly does not work for RTL languages unless wxDC has some real x-flipping magic.
+    for (si = 0; si < str.Len(); si++) {
+
+        if (str[si] == '\t') {
+            // We have a tab. Find the next tab stop AFTER this tab's start position.
+            while (ti < tabcount && tabstops[ti] <= startpos[si]) ti++;
+
+            if (ti < tabcount) {
+                // We have a valid tabstop in tabstops[ti] that is past startpos[si]
+                effectivetabstop = tabstops[ti];
+            } else {
+                // No more tabstops defined; use default tab width
+                effectivetabstop = startpos[si] + ConvertTenthsMMToPixels(dc, WIDTH_FOR_DEFAULT_TABS);
+            }
+
+            // Adjust position calculations accordingly
+            posadjustment = effectivetabstop - endpos[si];
+            endpos[si] += posadjustment;
+            for (pi = si + 1; pi < endpos.GetCount(); pi++) {
+                startpos[pi] += posadjustment;
+                endpos[pi] += posadjustment;
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    //                          Draw text background                         //
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Manually draw the text background. We do this rather than using wxDC's SetBackgroundMode(wxBRUSHSTYLE_SOLID)
+    // and SetTextBackground(standardBackgroundColor) because native macOS behavior is that the selection rectangle
+    // COMPLETELY overrides the background color. But text drawing happens after/on top of the selection rect, so the
+    // only other way to achieve native behavior is with separate DrawText() calls with with different background
+    // settings... but the separate DrawText() calls cause left-right jitter during selection because of aggressive
+    // kerning.
+    if (attr.HasBackgroundColour() && attr.GetBackgroundColour().IsOk()) {
+        wxCoord w, h;
+        int backgroundWidth = endpos[endpos.GetCount() - 1] - startpos[0] + 1; // Avoid kerning gaps
+        savedpen = dc.GetPen();
+        wxCheckSetBrush(dc, wxBrush(attr.GetBackgroundColour()));
+        wxCheckSetPen(dc, wxPen(attr.GetBackgroundColour()));
+        dc.GetTextExtent(str, &w, &h);  // Get actual text height
+        wxRect bgRect(startpos[0], y, backgroundWidth, h);
+        dc.DrawRectangle(bgRect);
+        wxCheckSetPen(dc, savedpen);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    //                        Draw selection rectangle                       //
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (selStart >=0 && selStart < endpos.GetCount()) {
+        if (selEnd >= selStart && selEnd < endpos.GetCount()) {
+            int selectionWidth = endpos[selEnd] - startpos[selStart] + 1; // Avoid kerning gaps
+            savedpen = dc.GetPen();
+            wxCheckSetBrush(dc, wxBrush(highlightBackgroundColor));
+            wxCheckSetPen(dc, wxPen(highlightBackgroundColor));
+            wxRect selRect(startpos[selStart], rect.y, selectionWidth, rect.GetHeight());
+            dc.DrawRectangle(selRect);
+            wxCheckSetPen(dc, savedpen);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    //                     Draw text (and strikethrough)                     //
+    ///////////////////////////////////////////////////////////////////////////
+
+    printstart = 0;
+    savedpen = dc.GetPen();
+    wxCheckSetPen(dc, wxPen(standardTextColor));
+    dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
+    dc.SetTextForeground(standardTextColor);
+    for (si = 0; si < str.Len(); si++) {
+        if (str[si] == '\t') {
+            if (si - printstart > 0) {
+                dc.DrawText(str.Mid(printstart, si-printstart), startpos[printstart], y);
+                if (strikethrough) dc.DrawLine(startpos[printstart], strikeheight, startpos[si], strikeheight);
+            }
+            if (selStart <= si && si <= selEnd && strikethrough) {
+                // Matching original behavior of only showing strikethrough on tabs when selected
+                dc.DrawLine(startpos[si], strikeheight, endpos[si], strikeheight);
+            }
+            printstart = si + 1;
+        }
+    }
+    if (printstart < str.Len()) {
+        dc.DrawText(str.Mid(printstart), startpos[printstart], y);
+        if (strikethrough) dc.DrawLine(startpos[printstart], strikeheight, endpos[endpos.GetCount()-1], strikeheight);
+    }
+    wxCheckSetPen(dc, savedpen);
+
+    return true;
+}
+#endif
 
 bool wxRichTextPlainText::DrawTabbedString(wxDC& dc, const wxRichTextAttr& attr, const wxRect& rect,wxString& str, wxCoord& x, wxCoord& y, bool selected)
 {


### PR DESCRIPTION
On macOS, selecting text in wxRichTextCtrl caused visible horizontal jitter as the text shifted left and right during selection. This was caused by splitting DrawText() calls at selection boundaries, which made each text chunk get shaped independently with different kerning.

This commit introduces DrawTabbedStringWithPartialSelection() for macOS, which renders text in a single pass (splitting only at tabs), eliminating the kerning discontinuities that caused jitter.

The implementation matches native macOS behavior where selected text maintains its original styling (like TextEdit in Rich Text mode), with the selection highlight drawn as a background rectangle that completely overrides any text background colors in the selected range.

See #22771 (unable to reproduce on Windows, but confirmed on macOS)

Selection in TextEdit:

<img width="809" height="545" alt="PR 915e340 TextEdit Selection" src="https://github.com/user-attachments/assets/163e91d1-dc03-4bc2-8fc1-d3ed52877e60" />

Selection in wxRichTextCtrl with this commit:

<img width="762" height="545" alt="PR 915e340 wxRTC Selection" src="https://github.com/user-attachments/assets/ce041382-52a7-4564-abde-ea81c22c7999" />

Demonstration of lack of left-right jitter:

https://github.com/user-attachments/assets/754bd6e8-ce9a-4b24-8ea9-72b5d38573cf


