### PR TITLE
Backport: Fix wx/stc/stc.h compilation with wxNO_IMPLICIT_WXSTRING_ENCODING

### DIFF
--- a/include/wx/stc/stc.h
+++ b/include/wx/stc/stc.h
@@ -2890,7 +2890,7 @@ public:
     wxStyledTextCtrl(wxWindow *parent, wxWindowID id=wxID_ANY,
                      const wxPoint& pos = wxDefaultPosition,
                      const wxSize& size = wxDefaultSize, long style = 0,
-                     const wxString& name = wxSTCNameStr);
+                     const wxString& name = wxASCII_STR(wxSTCNameStr));
     wxStyledTextCtrl() { m_swx = NULL; }
     ~wxStyledTextCtrl();
 
@@ -2899,7 +2899,7 @@ public:
     bool Create(wxWindow *parent, wxWindowID id=wxID_ANY,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize, long style = 0,
-                const wxString& name = wxSTCNameStr);
+                const wxString& name = wxASCII_STR(wxSTCNameStr));
 
 
     //----------------------------------------------------------------------

--- a/include/wx/stc/stc.h
+++ b/include/wx/stc/stc.h
@@ -5392,7 +5392,7 @@ public:
         if ( pos == -1 )
             return -1;
 
-        if ( x >= LineLength(y) )
+        if ( x >= LineLength((int)y) )
             return -1;
 
         pos += x;
@@ -5405,7 +5405,7 @@ public:
         if ( l == -1 )
             return false;
 
-        int lx = pos - PositionFromLine(l);
+        long lx = pos - PositionFromLine(l);
         if ( lx >= LineLength(l) )
             return false;
 

--- a/src/stc/stc.h.in
+++ b/src/stc/stc.h.in
@@ -175,7 +175,7 @@ public:
     wxStyledTextCtrl(wxWindow *parent, wxWindowID id=wxID_ANY,
                      const wxPoint& pos = wxDefaultPosition,
                      const wxSize& size = wxDefaultSize, long style = 0,
-                     const wxString& name = wxSTCNameStr);
+                     const wxString& name = wxASCII_STR(wxSTCNameStr));
     wxStyledTextCtrl() { m_swx = NULL; }
     ~wxStyledTextCtrl();
 
@@ -184,7 +184,7 @@ public:
     bool Create(wxWindow *parent, wxWindowID id=wxID_ANY,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize, long style = 0,
-                const wxString& name = wxSTCNameStr);
+                const wxString& name = wxASCII_STR(wxSTCNameStr));
 
 
     //----------------------------------------------------------------------

--- a/src/stc/stc.h.in
+++ b/src/stc/stc.h.in
@@ -510,7 +510,7 @@ public:
         if ( pos == -1 )
             return -1;
 
-        if ( x >= LineLength(y) )
+        if ( x >= LineLength((int)y) )
             return -1;
 
         pos += x;
@@ -523,7 +523,7 @@ public:
         if ( l == -1 )
             return false;
 
-        int lx = pos - PositionFromLine(l);
+        long lx = pos - PositionFromLine(l);
         if ( lx >= LineLength(l) )
             return false;
 

--- a/tests/allheaders.h
+++ b/tests/allheaders.h
@@ -321,6 +321,7 @@
 #include <wx/statline.h>
 #include <wx/stattext.h>
 #include <wx/statusbr.h>
+#include <wx/stc/stc.h>
 #include <wx/stdpaths.h>
 #include <wx/stdstream.h>
 #include <wx/stockitem.h>


### PR DESCRIPTION
This backports the three commits made as fixes to #25047 to 3.2.