### PR TITLE
Fix wrong destruction of wxBitmap in wxMSW wxStaticBitmap

### DIFF
--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -239,6 +239,7 @@ TEST_GUI_OBJECTS =  \
 	test_gui_slidertest.o \
 	test_gui_spinctrldbltest.o \
 	test_gui_spinctrltest.o \
+	test_gui_statbmptest.o \
 	test_gui_styledtextctrltest.o \
 	test_gui_textctrltest.o \
 	test_gui_textentrytest.o \
@@ -1137,6 +1138,9 @@ test_gui_spinctrldbltest.o: $(srcdir)/controls/spinctrldbltest.cpp $(TEST_GUI_OD
 
 test_gui_spinctrltest.o: $(srcdir)/controls/spinctrltest.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/controls/spinctrltest.cpp
+
+test_gui_statbmptest.o: $(srcdir)/controls/statbmptest.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/controls/statbmptest.cpp
 
 test_gui_styledtextctrltest.o: $(srcdir)/controls/styledtextctrltest.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/controls/styledtextctrltest.cpp

--- a/tests/controls/statbmptest.cpp
+++ b/tests/controls/statbmptest.cpp
@@ -1,0 +1,89 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/controls/statbmptest.cpp
+// Purpose:     wxStaticBitmap unit test
+// Author:      Vadim Zeitlin
+// Created:     2026-01-22
+// Copyright:   (c) 2026 Vadim Zeitlin
+///////////////////////////////////////////////////////////////////////////////
+
+#include "testprec.h"
+
+#if wxUSE_STATBMP
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+#endif // WX_PRECOMP
+
+#include "wx/statbmp.h"
+
+#include "wx/dcmemory.h"
+
+#ifdef __WINDOWS__
+    #include "wx/msw/private/resource_usage.h"
+#endif // __WINDOWS__
+
+static void TestStaticBitmap(wxWindow* window, double scale)
+{
+    // Create the bitmaps using the window scale factor to make sure they
+    // are used directly by wxStaticBitmap instead, without any rescaling
+    // (which would create temporary bitmaps and hide the manifestation of
+    // the bug that this test was written to trigger, see #26106).
+    wxBitmap bmp1;
+    bmp1.CreateWithDIPSize(16, 16, scale);
+    wxBitmap bmp2;
+    bmp2.CreateWithDIPSize(32, 32, scale);
+
+    wxIcon icon;
+    icon.CopyFromBitmap(bmp1);
+
+    wxStaticBitmap statbmp(window, wxID_ANY, bmp1);
+    REQUIRE( statbmp.GetBitmap().IsOk() );
+
+    statbmp.SetBitmap(bmp2);
+    REQUIRE( statbmp.GetBitmap().IsOk() );
+
+    // Check that the bitmap is valid by selecting it into wxMemoryDC:
+    // unlike IsOk() check, this would fail if it had been destroyed.
+    REQUIRE_NOTHROW( wxMemoryDC(bmp1) );
+
+    statbmp.SetIcon(icon);
+    REQUIRE_NOTHROW( wxMemoryDC(bmp2) );
+
+    statbmp.SetBitmap(bmp2);
+    REQUIRE_NOTHROW( wxMemoryDC(bmp1) );
+}
+
+TEST_CASE("wxStaticBitmap::Set", "[wxStaticBitmap][bitmap]")
+{
+    auto* const window = wxTheApp->GetTopWindow();
+
+    TestStaticBitmap(window, window->GetDPIScaleFactor());
+}
+
+#ifdef __WINDOWS__
+
+TEST_CASE("wxStaticBitmap::ResourceLeak", "[wxStaticBitmap]")
+{
+    auto* const window = wxTheApp->GetTopWindow();
+    auto const scale = window->GetDPIScaleFactor();
+
+    wxGUIObjectUsage usageBefore;
+    for ( int n = 0; n < 100; ++n )
+    {
+        TestStaticBitmap(window, scale);
+
+        // First use of GDI allocates some resources, so consider the state
+        // after the first iteration as the baseline: if there are any leaks,
+        // we'll see them in the subsequent iterations too and the test below
+        // will fail.
+        if ( n == 0 )
+            usageBefore = wxGetCurrentlyUsedResources();
+    }
+
+    auto const usageAfter = wxGetCurrentlyUsedResources();
+    CHECK( usageAfter.numGDI == usageBefore.numGDI );
+}
+
+#endif // __WINDOWS__
+
+#endif // wxUSE_STATBMP

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -212,6 +212,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_slidertest.o \
 	$(OBJS)\test_gui_spinctrldbltest.o \
 	$(OBJS)\test_gui_spinctrltest.o \
+	$(OBJS)\test_gui_statbmptest.o \
 	$(OBJS)\test_gui_styledtextctrltest.o \
 	$(OBJS)\test_gui_textctrltest.o \
 	$(OBJS)\test_gui_textentrytest.o \
@@ -1083,6 +1084,9 @@ $(OBJS)\test_gui_spinctrldbltest.o: ./controls/spinctrldbltest.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_spinctrltest.o: ./controls/spinctrltest.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_statbmptest.o: ./controls/statbmptest.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_styledtextctrltest.o: ./controls/styledtextctrltest.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -227,6 +227,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_slidertest.obj \
 	$(OBJS)\test_gui_spinctrldbltest.obj \
 	$(OBJS)\test_gui_spinctrltest.obj \
+	$(OBJS)\test_gui_statbmptest.obj \
 	$(OBJS)\test_gui_styledtextctrltest.obj \
 	$(OBJS)\test_gui_textctrltest.obj \
 	$(OBJS)\test_gui_textentrytest.obj \
@@ -1383,6 +1384,9 @@ $(OBJS)\test_gui_spinctrldbltest.obj: .\controls\spinctrldbltest.cpp
 
 $(OBJS)\test_gui_spinctrltest.obj: .\controls\spinctrltest.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\controls\spinctrltest.cpp
+
+$(OBJS)\test_gui_statbmptest.obj: .\controls\statbmptest.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\controls\statbmptest.cpp
 
 $(OBJS)\test_gui_styledtextctrltest.obj: .\controls\styledtextctrltest.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\controls\styledtextctrltest.cpp

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -252,6 +252,7 @@
             controls/slidertest.cpp
             controls/spinctrldbltest.cpp
             controls/spinctrltest.cpp
+            controls/statbmptest.cpp
             controls/styledtextctrltest.cpp
             controls/textctrltest.cpp
             controls/textentrytest.cpp

--- a/tests/test_gui.vcxproj
+++ b/tests/test_gui.vcxproj
@@ -954,6 +954,7 @@
     <ClCompile Include="controls\slidertest.cpp" />
     <ClCompile Include="controls\spinctrldbltest.cpp" />
     <ClCompile Include="controls\spinctrltest.cpp" />
+    <ClCompile Include="controls\statbmptest.cpp" />
     <ClCompile Include="controls\styledtextctrltest.cpp" />
     <ClCompile Include="controls\textctrltest.cpp" />
     <ClCompile Include="controls\textentrytest.cpp" />

--- a/tests/test_gui.vcxproj.filters
+++ b/tests/test_gui.vcxproj.filters
@@ -248,6 +248,9 @@
     <ClCompile Include="controls\spinctrltest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="controls\statbmptest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="controls\styledtextctrltest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Due to a regression introduced in 3e32a9abe1 (Don't bother resetting wxStaticBitmap image when destroying it, 2025-06-12), which was part of #25518, the handle of wxBitmap passed to wxStaticBitmap::SetBitmap() was destroyed when another bitmap was passed to SetBitmap() later.

Fix this by ensuring that we don't overwrite the value of the current handle (to be deleted) prematurely in DoUpdateImage().

Add a simple unit test for wxStaticBitmap checking that the problem is really fixed and, under MSW, also that it doesn't leak bitmap handles.

Closes #26106.