### PR TITLE
Make wxXmlInitResourceModule() safer to use

### DIFF
--- a/include/wx/module.h
+++ b/include/wx/module.h
@@ -54,6 +54,10 @@ public:
 
     static void UnregisterModule(wxModule *module);
 
+    // Initialize the module with the given type information if it's not
+    // already initialized. This is for internal use only currently.
+    static void AddModuleIfNecessary(const wxClassInfo *classInfo);
+
 protected:
     static wxModuleList ms_modules;
 

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -3255,9 +3255,17 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxXmlResourceModule, wxModule);
 // then the built-in module system won't pick this one up.  Add it manually.
 void wxXmlInitResourceModule()
 {
-    wxModule* module = new wxXmlResourceModule;
-    wxModule::RegisterModule(module);
-    wxModule::InitializeModules();
+    // Only add the module if the module system is already initialized,
+    // otherwise it will be added automatically when it is done as it will be
+    // known to the module system at that time (this happens as soon as the
+    // code containing this function is loaded from a shared library and if
+    // this function is running, it must have been already loaded!).
+    if ( wxModule::AreInitialized() )
+    {
+        // Still check that this module is not already registered, as could
+        // happen if this function is called multiple times, for example.
+        wxModule::AddModuleIfNecessary(wxCLASSINFO(wxXmlResourceModule));
+    }
 }
 
 #endif // wxUSE_XRC


### PR DESCRIPTION
This function unconditionally added a new wxXmlResourceModule object to the modules list which could result in problems if it had been already initialized.

Ensure that we do this only if necessary by calling the new function added to wxModule which checks if the module is already known and adds and initializes only this module if it is not.

See #26039.