### PR TITLE
Refactor wxBitmapBundleImplSVG

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,3 +45,4 @@
 [submodule "3rdparty/lunasvg"]
 	path = 3rdparty/lunasvg
 	url = https://github.com/wxWidgets/lunasvg.git
+	branch = wx

--- a/build/cmake/tests/base/CMakeLists.txt
+++ b/build/cmake/tests/base/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SRC
     arrays/arrays.cpp
     base64/base64.cpp
     cmdline/cmdlinetest.cpp
+    config/config.cpp
     config/fileconf.cpp
     config/regconf.cpp
     datetime/datetimetest.cpp
@@ -92,6 +93,7 @@ set(TEST_SRC
     weakref/evtconnection.cpp
     weakref/weakref.cpp
     xlocale/xlocale.cpp
+    xml/xmltest.cpp
 
     testprec.h
     testableframe.h

--- a/build/cmake/tests/gui/CMakeLists.txt
+++ b/build/cmake/tests/gui/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_GUI_SRC
     geometry/point.cpp
     geometry/region.cpp
     graphics/bitmap.cpp
+    graphics/bmpbundle.cpp
     graphics/colour.cpp
     graphics/ellipsization.cpp
     graphics/measuring.cpp
@@ -70,6 +71,7 @@ set(TEST_GUI_SRC
     controls/slidertest.cpp
     controls/spinctrldbltest.cpp
     controls/spinctrltest.cpp
+    controls/statbmptest.cpp
     controls/styledtextctrltest.cpp
     controls/textctrltest.cpp
     controls/textentrytest.cpp
@@ -83,6 +85,7 @@ set(TEST_GUI_SRC
     controls/windowtest.cpp
     controls/dialogtest.cpp
     events/clone.cpp
+    events/enterleave.cpp
     # Duplicate this file here to test GUI event loops too.
     events/evtlooptest.cpp
     events/propagation.cpp
@@ -104,6 +107,7 @@ set(TEST_GUI_SRC
     misc/garbage.cpp
     misc/safearrayconverttest.cpp
     misc/settings.cpp
+    misc/textwrap.cpp
     # This one is intentionally duplicated here (it is also part of
     # non-GUI test) as sockets behave differently in console and GUI
     # applications.

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -285,8 +285,8 @@ public:
             extra parameter explicitly specifying the length of the input data,
             @e must be used.
         @param sizeDef The default size to return from GetDefaultSize() for
-            this bundle. As SVG images usually don't have any natural
-            default size, it should be provided when creating the bundle.
+            this bundle. If an empty wxSize or wxDefaultSize is provided,
+            the size of the SVG will be the default size.
 
         @note Converting text objects to path objects will allow them to be
             rasterized as expected. This can be done in an SVG editor such as
@@ -322,7 +322,8 @@ public:
         @param path Path to the SVG file. Notice that it should a local file,
             not an URL.
         @param sizeDef The default size to return from GetDefaultSize() for
-            this bundle.
+            this bundle. If an empty wxSize or wxDefaultSize is provided,
+            the size of the SVG will be the default size.
      */
     static wxBitmapBundle FromSVGFile(const wxString& path, const wxSize& sizeDef);
 
@@ -335,7 +336,8 @@ public:
             On MacOS, it must be a file with an extension "svg" placed in
             the "Resources" subdirectory of the application bundle.
         @param sizeDef The default size to return from GetDefaultSize() for
-            this bundle.
+            this bundle. If an empty wxSize or wxDefaultSize is provided,
+            the size of the SVG will be the default size.
 
         @see FromResources(), FromSVGFile()
      */

--- a/samples/image/image.cpp
+++ b/samples/image/image.cpp
@@ -1359,9 +1359,7 @@ void MyFrame::OnNewSVGFrame(wxCommandEvent&)
     if ( filename.empty() )
         return;
 
-    // The default size here is completely arbitrary, as we don't know anything
-    // about the SVG being loaded.
-    wxBitmapBundle bb = wxBitmapBundle::FromSVGFile(filename, wxSize(200, 200));
+    wxBitmapBundle bb = wxBitmapBundle::FromSVGFile(filename, wxDefaultSize);
     if ( !bb.IsOk() )
         return;
 

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -80,10 +80,13 @@ public:
     }
 
     virtual bool IsOk() const = 0;
+    virtual wxSize GetSVGSize() const = 0;
     virtual wxBitmap DoRasterize(const wxSize& size) = 0;
 
     virtual wxSize GetDefaultSize() const override
     {
+        if ( m_sizeDef.IsEmpty() )
+            return GetSVGSize();
         return m_sizeDef;
     }
 
@@ -150,6 +153,13 @@ public:
     virtual bool IsOk() const override
     {
         return m_svgDocument != nullptr;
+    }
+
+    virtual wxSize GetSVGSize() const override
+    {
+        if ( IsOk() )
+            return wxSize(m_svgDocument->width(), m_svgDocument->height());
+        return wxDefaultSize;
     }
 
     virtual wxBitmap DoRasterize(const wxSize& size) override
@@ -306,6 +316,13 @@ public:
         // the data is not SVG at all, e.g. without this check creating a bundle
         // from any random file with FromSVGFile() would "work".
         return m_svgImage && m_svgImage->width != 0 && m_svgImage->height != 0 && m_svgImage->shapes;
+    }
+
+    virtual wxSize GetSVGSize() const override
+    {
+        if ( IsOk() )
+            return wxSize(m_svgImage->width, m_svgImage->height);
+        return wxDefaultSize;
     }
 
     virtual wxBitmap DoRasterize(const wxSize& size) override

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -19,13 +19,14 @@
 // for compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
-// This is required by NanoSVG headers. Include it before any wx headers to
-// avoid potential conflicts (see comments in nanosvg implementation section).
-#include <stdio.h>
-
 #ifdef wxHAS_SVG
 
 #include "wx/bmpbndl.h"
+
+#ifndef WX_PRECOMP
+    #include "wx/log.h"
+    #include "wx/utils.h"                   // Only for wxMin()
+#endif
 
 #if wxUSE_FFILE
     #include "wx/ffile.h"
@@ -36,10 +37,6 @@
 #endif
 
 #include "wx/rawbmp.h"
-#include "wx/private/bmpbndl.h"
-
-#include "wx/buffer.h"
-#include "wx/log.h"
 
 // ============================================================================
 // private helpers
@@ -69,17 +66,64 @@ static wxCharBuffer LoadSVGFile(const wxString& path)
     return wxCharBuffer();
 }
 
+
+// ============================================================================
+// wxBitmapBundleImplSVG implementation
+// ============================================================================
+
+class wxBitmapBundleImplSVG : public wxBitmapBundleImpl
+{
+public:
+    explicit wxBitmapBundleImplSVG(const wxSize& sizeDef)
+        : m_sizeDef(sizeDef)
+    {
+    }
+
+    virtual bool IsOk() const = 0;
+    virtual wxBitmap DoRasterize(const wxSize& size) = 0;
+
+    virtual wxSize GetDefaultSize() const override
+    {
+        return m_sizeDef;
+    }
+
+    wxSize GetPreferredBitmapSizeAtScale(double scale) const override
+    {
+        return GetDefaultSize() * scale;
+    }
+
+    wxBitmap GetBitmap(const wxSize& size) override
+    {
+        if ( !m_cachedBitmap.IsOk() || m_cachedBitmap.GetSize() != size )
+            m_cachedBitmap = DoRasterize(size);
+
+        return m_cachedBitmap;
+    }
+
+private:
+    const wxSize m_sizeDef;
+
+    // Cache the last used bitmap (may be invalid if not used yet).
+    //
+    // Note that we cache only the last bitmap and not all the bitmaps ever
+    // requested from GetBitmap() for the different sizes because there would
+    // be no way to clear such cache and its growth could be unbounded,
+    // resulting in too many bitmap objects being used in an application using
+    // SVG for all of its icons.
+    wxBitmap m_cachedBitmap;
+
+    wxDECLARE_NO_COPY_CLASS(wxBitmapBundleImplSVG);
+};
+
+
 #if wxUSE_LUNASVG
-
-#if !wxCHECK_CXX_STD(17)
-    #error wxUSE_LUNASVG requires C++17 or later
-#endif
-
 // ============================================================================
 // lunasvg implementation
 // ============================================================================
 
-#include <memory>
+#if !wxCHECK_CXX_STD(17)
+    #error wxUSE_LUNASVG requires C++17 or later
+#endif
 
 // Try to help people updating their sources from Git and forgetting to
 // initialize new submodules, if possible: if you get this error, it means that
@@ -94,106 +138,27 @@ static wxCharBuffer LoadSVGFile(const wxString& path)
 
 #include "../../3rdparty/lunasvg/include/lunasvg.h"
 
-class wxBitmapBundleImplSVG : public wxBitmapBundleImpl
+class wxBitmapBundleLunaSVG : public wxBitmapBundleImplSVG
 {
 public:
-    // data must be 0 terminated. wxBitmapBundleImplSVG doesn't take ownership
-    // so it can be deleted after the ctor is called.
-    wxBitmapBundleImplSVG(const char* data, const wxSize& sizeDef);
-
-    // data must be 0 terminated. wxBitmapBundleImplSVG doesn't take ownership
-    // so it can be deleted after the ctor is called.
-    wxBitmapBundleImplSVG(char* data, const wxSize& sizeDef);
-
-    // wxBitmapBundleImplSVG doesn't take ownership of data so it can be deleted
-    // after the ctor is called.
-    wxBitmapBundleImplSVG(const wxByte* data, size_t data_len, const wxSize& sizeDef);
-
-    virtual wxSize GetDefaultSize() const override;
-    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const override;
-
-    virtual wxBitmap GetBitmap(const wxSize& size) override;
-
-    bool IsOk() const;
-
-private:
-    wxBitmap DoRasterize(const wxSize& size);
-
-    std::unique_ptr<wxlunasvg::Document> m_svgDocument;
-
-    const wxSize m_sizeDef;
-
-    // Cache the last used bitmap (may be invalid if not used yet).
-    //
-    // Note that we cache only the last bitmap and not all the bitmaps ever
-    // requested from GetBitmap() for the different sizes because there would be
-    // no way to clear such cache and its growth could be unbounded, resulting
-    // in too many bitmap objects being used in an application using SVG for all
-    // of its icons.
-    wxBitmap m_cachedBitmap;
-
-    wxDECLARE_NO_COPY_CLASS(wxBitmapBundleImplSVG);
-};
-
-// ============================================================================
-// wxBitmapBundleImplSVG implementation
-// ============================================================================
-
-wxBitmapBundleImplSVG::wxBitmapBundleImplSVG(const char* data, const wxSize& sizeDef)
-    : m_sizeDef(sizeDef)
-{
-    wxCHECK_RET(data != nullptr, "null data");
-    wxCHECK_RET(sizeDef.GetWidth() > 0 && sizeDef.GetHeight() > 0, "invalid default size");
-
-    m_svgDocument = wxlunasvg::Document::loadFromData(data);
-}
-
-wxBitmapBundleImplSVG::wxBitmapBundleImplSVG(char* data, const wxSize& sizeDef)
-    : m_sizeDef(sizeDef)
-{
-    wxCHECK_RET(data != nullptr, "null data");
-    wxCHECK_RET(sizeDef.GetWidth() > 0 && sizeDef.GetHeight() > 0, "invalid default size");
-
-    m_svgDocument = wxlunasvg::Document::loadFromData(data);
-}
-
-wxBitmapBundleImplSVG::wxBitmapBundleImplSVG(const wxByte* data, size_t len, const wxSize& sizeDef)
-    : m_sizeDef(sizeDef)
-{
-    wxCHECK_RET(data != nullptr, "null data");
-    wxCHECK_RET(len > 0, "zero length");
-    wxCHECK_RET(sizeDef.GetWidth() > 0 && sizeDef.GetHeight() > 0, "invalid default size");
-
-    m_svgDocument = wxlunasvg::Document::loadFromData(reinterpret_cast<const char*>(data), len);
-}
-
-wxSize wxBitmapBundleImplSVG::GetDefaultSize() const
-{
-    return m_sizeDef;
-};
-
-wxSize wxBitmapBundleImplSVG::GetPreferredBitmapSizeAtScale(double scale) const
-{
-    return m_sizeDef * scale;
-}
-
-wxBitmap wxBitmapBundleImplSVG::GetBitmap(const wxSize& size)
-{
-    if ( !m_cachedBitmap.IsOk() || m_cachedBitmap.GetSize() != size )
-        m_cachedBitmap = DoRasterize(size);
-
-    return m_cachedBitmap;
-}
-
-bool wxBitmapBundleImplSVG::IsOk() const
-{
-    return m_svgDocument != nullptr;
-}
-
-wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize& size)
-{
-    if ( IsOk() )
+    wxBitmapBundleLunaSVG(char* data, const wxSize& sizeDef)
+        : wxBitmapBundleImplSVG(sizeDef)
+        , m_svgDocument(wxlunasvg::Document::loadFromData(data))
     {
+    }
+
+    virtual bool IsOk() const override
+    {
+        return m_svgDocument != nullptr;
+    }
+
+    virtual wxBitmap DoRasterize(const wxSize& size) override
+    {
+        wxBitmap bmp;
+
+        if ( !IsOk() )
+            return bmp;
+
         // conversion to wxBitmap is based on the code in
         // wxlunasvg::Bitmap::convert()
         const wxlunasvg::Bitmap lbmp = m_svgDocument->renderToBitmap(size.x, size.y);
@@ -205,7 +170,7 @@ wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize& size)
             const auto stride = lbmp.stride();
             auto rowData = lbmp.data();
 
-            wxBitmap bmp(width, height, 32);
+            bmp = wxBitmap(width, height, 32);
             wxAlphaPixelData bmpdata(bmp);
             wxAlphaPixelData::Iterator dst(bmpdata);
 
@@ -238,63 +203,26 @@ wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize& size)
 
                 rowData += stride;
             }
-
-            return bmp;
         }
         else
             wxLogDebug("invalid wxlunasvg::Bitmap");
+
+        return bmp;
     }
 
-    return wxBitmap();
-}
+private:
+    std::unique_ptr<wxlunasvg::Document> m_svgDocument;
 
-/* static */
-wxBitmapBundle wxBitmapBundle::FromSVG(char* data, const wxSize& sizeDef)
-{
-    auto* impl = new wxBitmapBundleImplSVG(data, sizeDef);
-    if ( !impl->IsOk() )
-    {
-        delete impl;
-        return wxBitmapBundle();
-    }
-    return wxBitmapBundle::FromImpl(impl);
-}
+    wxDECLARE_NO_COPY_CLASS(wxBitmapBundleLunaSVG);
+};
 
-/* static */
-wxBitmapBundle wxBitmapBundle::FromSVG(const char* data, const wxSize& sizeDef)
-{
-    auto* impl = new wxBitmapBundleImplSVG(data, sizeDef);
-    if ( !impl->IsOk() )
-    {
-        delete impl;
-        return wxBitmapBundle();
-    }
-    return wxBitmapBundle::FromImpl(impl);
-}
+#endif // wxUSE_LUNASVG
 
-/* static */
-wxBitmapBundle wxBitmapBundle::FromSVG(const wxByte* data, size_t len, const wxSize& sizeDef)
-{
-    auto* impl = new wxBitmapBundleImplSVG(data, len, sizeDef);
-    if ( !impl->IsOk() )
-    {
-        delete impl;
-        return wxBitmapBundle();
-    }
-    return wxBitmapBundle::FromImpl(impl);
-}
 
-/* static */
-wxBitmapBundle wxBitmapBundle::FromSVGFile(const wxString& path, const wxSize& sizeDef)
-{
-    wxCharBuffer buf = LoadSVGFile(path);
-    if ( buf.data() )
-        return wxBitmapBundle::FromSVG(buf.data(), sizeDef);
-
-    return wxBitmapBundle();
-}
-
-#else // !wxUSE_LUNASVG
+#if wxUSE_NANOSVG
+// ============================================================================
+// nanosvg implementation
+// ============================================================================
 
 #if !wxUSE_NANOSVG_EXTERNAL
 
@@ -310,10 +238,6 @@ wxBitmapBundle wxBitmapBundle::FromSVGFile(const wxString& path, const wxSize& s
 #endif // __has_include
 
 #endif // !wxUSE_NANOSVG_EXTERNAL
-
-// ============================================================================
-// nanosvg implementation
-// ============================================================================
 
 // Note that we have to include NanoSVG headers before including any of wx
 // headers, notably wx/unichar.h which defines global operator==() overloads
@@ -359,158 +283,124 @@ wxGCC_WARNING_RESTORE(cast-qual)
     #pragma warning(pop)
 #endif
 
-#ifndef WX_PRECOMP
-    #include "wx/utils.h"                   // Only for wxMin()
-#endif // WX_PRECOMP
 
-// ============================================================================
-// nanosvg implementation
-// ============================================================================
-
-namespace
-{
-
-class wxBitmapBundleImplSVG : public wxBitmapBundleImpl
+class wxBitmapBundleNanoSVG : public wxBitmapBundleImplSVG
 {
 public:
-    // Ctor must be passed a valid NSVGimage and takes ownership of it.
-    wxBitmapBundleImplSVG(NSVGimage* svgImage, const wxSize& sizeDef)
-        : m_svgImage(svgImage),
-          m_svgRasterizer(nsvgCreateRasterizer()),
-          m_sizeDef(sizeDef)
+    wxBitmapBundleNanoSVG(char* data, const wxSize& sizeDef)
+        : wxBitmapBundleImplSVG(sizeDef)
+        , m_svgImage(nsvgParse(data, "px", 96))
+        , m_svgRasterizer(nsvgCreateRasterizer())
     {
     }
 
-    ~wxBitmapBundleImplSVG()
+    ~wxBitmapBundleNanoSVG()
     {
         nsvgDeleteRasterizer(m_svgRasterizer);
         nsvgDelete(m_svgImage);
     }
 
-    virtual wxSize GetDefaultSize() const override;
-    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const override;
-    virtual wxBitmap GetBitmap(const wxSize& size) override;
+    virtual bool IsOk() const override
+    {
+        // Somewhat unexpectedly, a non-null but empty image is returned even if
+        // the data is not SVG at all, e.g. without this check creating a bundle
+        // from any random file with FromSVGFile() would "work".
+        return m_svgImage && m_svgImage->width != 0 && m_svgImage->height != 0 && m_svgImage->shapes;
+    }
+
+    virtual wxBitmap DoRasterize(const wxSize& size) override
+    {
+        wxBitmap bmp;
+
+        if ( !IsOk() )
+            return bmp;
+
+        wxVector<unsigned char> buffer(size.x*size.y*4);
+        nsvgRasterize
+        (
+            m_svgRasterizer,
+            m_svgImage,
+            0.0, 0.0,           // no offset
+            wxMin
+            (
+                size.x/m_svgImage->width,
+                size.y/m_svgImage->height
+            ),                  // scale
+            &buffer[0],
+            size.x, size.y,
+            size.x*4            // stride -- we have no gaps between lines
+        );
+
+        bmp = wxBitmap(size, 32);
+        wxAlphaPixelData bmpdata(bmp);
+        wxAlphaPixelData::Iterator dst(bmpdata);
+
+        const unsigned char* src = &buffer[0];
+        for ( int y = 0; y < size.y; ++y )
+        {
+            dst.MoveTo(bmpdata, 0, y);
+            for ( int x = 0; x < size.x; ++x )
+            {
+                const unsigned char a = src[3];
+#ifdef wxHAS_PREMULTIPLIED_ALPHA
+                // Some platforms require premultiplication by alpha.
+                dst.Red()   = src[0] * a / 255;
+                dst.Green() = src[1] * a / 255;
+                dst.Blue()  = src[2] * a / 255;
+                dst.Alpha() = a;
+#else
+                // Other platforms store bitmaps with straight alpha.
+                dst.Alpha() = a;
+                if ( a )
+                {
+                    dst.Red()   = src[0];
+                    dst.Green() = src[1];
+                    dst.Blue()  = src[2];
+                }
+                else
+                    // A more canonical form for completely transparent pixels.
+                    dst.Red() = dst.Green() = dst.Blue() = 0;
+#endif
+                ++dst;
+                src += 4;
+            }
+        }
+
+        return bmp;
+    }
 
 private:
-    wxBitmap DoRasterize(const wxSize& size);
-
     NSVGimage* const m_svgImage;
     NSVGrasterizer* const m_svgRasterizer;
 
-    const wxSize m_sizeDef;
-
-    // Cache the last used bitmap (may be invalid if not used yet).
-    //
-    // Note that we cache only the last bitmap and not all the bitmaps ever
-    // requested from GetBitmap() for the different sizes because there would
-    // be no way to clear such cache and its growth could be unbounded,
-    // resulting in too many bitmap objects being used in an application using
-    // SVG for all of its icons.
-    wxBitmap m_cachedBitmap;
-
-    wxDECLARE_NO_COPY_CLASS(wxBitmapBundleImplSVG);
+    wxDECLARE_NO_COPY_CLASS(wxBitmapBundleNanoSVG);
 };
 
-} // anonymous namespace
-
-// ============================================================================
-// wxBitmapBundleImplSVG implementation
-// ============================================================================
-
-wxSize wxBitmapBundleImplSVG::GetDefaultSize() const
-{
-    return m_sizeDef;
-}
-
-wxSize wxBitmapBundleImplSVG::GetPreferredBitmapSizeAtScale(double scale) const
-{
-    // We consider that we can render at any scale.
-    return m_sizeDef*scale;
-}
-
-wxBitmap wxBitmapBundleImplSVG::GetBitmap(const wxSize& size)
-{
-    if ( !m_cachedBitmap.IsOk() || m_cachedBitmap.GetSize() != size )
-    {
-        m_cachedBitmap = DoRasterize(size);
-    }
-
-    return m_cachedBitmap;
-}
-
-wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize& size)
-{
-    wxVector<unsigned char> buffer(size.x*size.y*4);
-    nsvgRasterize
-    (
-        m_svgRasterizer,
-        m_svgImage,
-        0.0, 0.0,           // no offset
-        wxMin
-        (
-            size.x/m_svgImage->width,
-            size.y/m_svgImage->height
-        ),                  // scale
-        &buffer[0],
-        size.x, size.y,
-        size.x*4            // stride -- we have no gaps between lines
-    );
-
-    wxBitmap bitmap(size, 32);
-    wxAlphaPixelData bmpdata(bitmap);
-    wxAlphaPixelData::Iterator dst(bmpdata);
-
-    const unsigned char* src = &buffer[0];
-    for ( int y = 0; y < size.y; ++y )
-    {
-        dst.MoveTo(bmpdata, 0, y);
-        for ( int x = 0; x < size.x; ++x )
-        {
-            const unsigned char a = src[3];
-#ifdef wxHAS_PREMULTIPLIED_ALPHA
-            // Some platforms require premultiplication by alpha.
-            dst.Red()   = src[0] * a / 255;
-            dst.Green() = src[1] * a / 255;
-            dst.Blue()  = src[2] * a / 255;
-            dst.Alpha() = a;
-#else
-            // Other platforms store bitmaps with straight alpha.
-            dst.Alpha() = a;
-            if ( a )
-            {
-                dst.Red()   = src[0];
-                dst.Green() = src[1];
-                dst.Blue()  = src[2];
-            }
-            else
-                // A more canonical form for completely transparent pixels.
-                dst.Red() = dst.Green() = dst.Blue() = 0;
 #endif
-            ++dst;
-            src += 4;
-        }
-    }
 
-    return bitmap;
-}
+
+// ============================================================================
+// wxBitmapBundle implementation
+// ============================================================================
 
 /* static */
 wxBitmapBundle wxBitmapBundle::FromSVG(char* data, const wxSize& sizeDef)
 {
-    NSVGimage* const svgImage = nsvgParse(data, "px", 96);
-    if ( !svgImage )
-        return wxBitmapBundle();
+    // data must be 0 terminated. wxBitmapBundleImplSVG doesn't take ownership
+    // so it can be deleted after the ctor is called.
 
-    // Somewhat unexpectedly, a non-null but empty image is returned even if
-    // the data is not SVG at all, e.g. without this check creating a bundle
-    // from any random file with FromSVGFile() would "work".
-    if ( svgImage->width == 0 && svgImage->height == 0 && !svgImage->shapes )
-    {
-        nsvgDelete(svgImage);
-        return wxBitmapBundle();
-    }
+    wxBitmapBundleImplSVG* svgImpl = nullptr;
+#if wxUSE_NANOSVG
+    svgImpl = new wxBitmapBundleNanoSVG(data, sizeDef);
+#elif wxUSE_LUNASVG
+    svgImpl = new wxBitmapBundleLunaSVG(data, sizeDef);
+#endif
+    wxBitmapBundle result(svgImpl);
 
-    return wxBitmapBundle(new wxBitmapBundleImplSVG(svgImage, sizeDef));
+    if ( svgImpl && !svgImpl->IsOk() )
+        result.Clear();
+
+    return result;
 }
 
 /* static */
@@ -533,16 +423,11 @@ wxBitmapBundle wxBitmapBundle::FromSVG(const wxByte* data, size_t len, const wxS
 /* static */
 wxBitmapBundle wxBitmapBundle::FromSVGFile(const wxString& path, const wxSize& sizeDef)
 {
-    // There is nsvgParseFromFile(), but it doesn't work with Unicode filenames
-    // under MSW and does exactly the same thing that we do here in any case,
-    // so it seems better to use our code.
     wxCharBuffer buf = LoadSVGFile(path);
     if ( buf.data() )
         return wxBitmapBundle::FromSVG(buf.data(), sizeDef);
 
     return wxBitmapBundle();
 }
-
-#endif // !wxUSE_LUNASVG
 
 #endif // wxHAS_SVG

--- a/tests/controls/statbmptest.cpp
+++ b/tests/controls/statbmptest.cpp
@@ -18,9 +18,9 @@
 
 #include "wx/dcmemory.h"
 
-#ifdef __WINDOWS__
+#ifdef __WXMSW__
     #include "wx/msw/private/resource_usage.h"
-#endif // __WINDOWS__
+#endif // __WXMSW__
 
 static void TestStaticBitmap(wxWindow* window, double scale)
 {
@@ -60,7 +60,7 @@ TEST_CASE("wxStaticBitmap::Set", "[wxStaticBitmap][bitmap]")
     TestStaticBitmap(window, window->GetDPIScaleFactor());
 }
 
-#ifdef __WINDOWS__
+#ifdef __WXMSW__
 
 TEST_CASE("wxStaticBitmap::ResourceLeak", "[wxStaticBitmap]")
 {
@@ -84,6 +84,6 @@ TEST_CASE("wxStaticBitmap::ResourceLeak", "[wxStaticBitmap]")
     CHECK( usageAfter.numGDI == usageBefore.numGDI );
 }
 
-#endif // __WINDOWS__
+#endif // __WXMSW__
 
 #endif // wxUSE_STATBMP

--- a/tests/events/enterleave.cpp
+++ b/tests/events/enterleave.cpp
@@ -60,7 +60,7 @@ TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
     SECTION("Without mouse capture")
     {
         sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
-        wxYield();
+        YieldForAWhile();
 
         CHECK( enter.GetCount() == 1 );
         CHECK( leave.GetCount() == 0 );
@@ -68,7 +68,7 @@ TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
         enter.Clear();
 
         sim.MouseMove(button->GetScreenPosition() + wxPoint(5, 5));
-        wxYield();
+        YieldForAWhile();
 
         // The parent window (panel) should receive wxEVT_LEAVE_WINDOW event
         // when mouse enters the child window (button)
@@ -78,7 +78,7 @@ TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
         leave.Clear();
 
         sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
-        wxYield();
+        YieldForAWhile();
 
         // Now it (panel) should receive wxEVT_ENTER_WINDOW event when
         // the mouse leaves the button and enters the panel again.
@@ -92,10 +92,10 @@ TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
         EventCounter clicked(button, wxEVT_BUTTON);
 
         sim.MouseMove(button->GetScreenPosition() + wxPoint(5, 5));
-        wxYield();
+        YieldForAWhile();
 
         sim.MouseClick();
-        wxYield();
+        YieldForAWhile();
 
         CHECK( clicked.GetCount() == 1 );
 
@@ -103,7 +103,7 @@ TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
         leave.Clear();
 
         sim.MouseDown();
-        wxYield();
+        YieldForAWhile();
 
 #if defined(__WXGTK__) && !defined(__WXGTK3__)
         if ( IsAutomaticTest() )
@@ -113,7 +113,7 @@ TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
         }
 #endif
         sim.MouseMove(button->GetScreenPosition() + wxPoint(10, 5));
-        wxYield();
+        YieldForAWhile();
 
         // Holding the mouse button down (initiated on the button) and then
         // hovering over the panel should not generate any events (enter/leave)
@@ -121,25 +121,25 @@ TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
         // mouse is still held down should also not generate any events.
 
         sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
-        wxYield();
+        YieldForAWhile();
 
         CHECK( enter.GetCount() == 0 );
         CHECK( leave.GetCount() == 0 );
 
         sim.MouseMove(textctrl->GetScreenPosition() + wxPoint(5, 5));
-        wxYield();
+        YieldForAWhile();
 
         CHECK( enter.GetCount() == 0 );
         CHECK( leave.GetCount() == 0 );
 
         sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
-        wxYield();
+        YieldForAWhile();
 
         CHECK( enter.GetCount() == 0 );
         CHECK( leave.GetCount() == 0 );
 
         sim.MouseUp();
-        wxYield();
+        YieldForAWhile();
 
         // wxGTK behaves differently here, as it does not generate a
         // wxEVT_ENTER_WINDOW event when we release the mouse button.

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -18,9 +18,9 @@
 #include "wx/dcmemory.h"
 #include "wx/imaglist.h"
 
-#ifdef __WINDOWS__
+#ifdef __WXMSW__
     #include "wx/msw/private/resource_usage.h"
-#endif // __WINDOWS__
+#endif // __WXMSW__
 
 #include "asserthelper.h"
 
@@ -77,7 +77,7 @@ TEST_CASE("BitmapBundle::GetBitmap", "[bmpbundle]")
     CHECK( b.GetBitmap(wxSize(48, 48)).GetSize() == wxSize(48, 48) );
 }
 
-#ifdef __WINDOWS__
+#ifdef __WXMSW__
 
 namespace
 {
@@ -134,7 +134,7 @@ TEST_CASE("BitmapBundle::ResourceLeak", "[bmpbundle]")
     CHECK( usageAfter.numGDI - usageBefore.numGDI < 10 );
 }
 
-#endif // __WINDOWS__
+#endif // __WXMSW__
 
 // Helper functions for the test below.
 namespace


### PR DESCRIPTION
Reduce code duplication by adding `wxBitmapBundleLunaSVG` and `wxBitmapBundleNanoSVG` that implement `DoRasterize()`.

Allow to use SVG size in `wxBitmapBundle::FromSVG()`.
If no default size is provided, get the size from the SVG.