### PR TITLE
Update wxFrame documentation for macOS style

### DIFF
--- a/interface/wx/frame.h
+++ b/interface/wx/frame.h
@@ -134,6 +134,7 @@
     @style{wxFRAME_EX_METAL}
            On macOS, frames with this style will be shown with a metallic
            look. This is an extra style.
+           Note that this is deprecated after macOS 10.12.
     @endExtraStyleTable
 
     @beginEventEmissionTable


### PR DESCRIPTION
Document deprecation of metallic look style on macOS.
Closes #26114