### PR TITLE
Fix `wxPGMultiButton` bitmap appearance 

### DIFF
--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -511,7 +511,8 @@ void ButtonWidgetsPage::CreateButton()
         }
         else
         {
-          bbtn = new wxButton(this, ButtonPage_Button);
+          bbtn = new wxButton(this, ButtonPage_Button, wxEmptyString,
+                              wxDefaultPosition, wxDefaultSize, flags);
           bbtn->SetBitmapLabel(CreateBitmap(wxART_INFORMATION));
         }
         bbtn->SetBitmapMargins((wxCoord)m_imageMarginH, (wxCoord)m_imageMarginV);

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -112,7 +112,7 @@ protected:
     void CreateButton();
 
     // helper function: create a bitmap bundle for wxBitmapButton
-    wxBitmapBundle CreateBitmap(const wxString& label, const wxArtID& type);
+    wxBitmapBundle CreateBitmap(const wxArtID& type);
 
 
     // the controls
@@ -506,24 +506,24 @@ void ButtonWidgetsPage::CreateButton()
         if ( m_chkUseBitmapClass->GetValue() )
         {
           bbtn = new wxBitmapButton(this, ButtonPage_Button,
-                                    CreateBitmap("normal", wxART_INFORMATION),
+                                    CreateBitmap(wxART_INFORMATION),
                                     wxDefaultPosition, wxDefaultSize, flags);
         }
         else
         {
           bbtn = new wxButton(this, ButtonPage_Button);
-          bbtn->SetBitmapLabel(CreateBitmap("normal", wxART_INFORMATION));
+          bbtn->SetBitmapLabel(CreateBitmap(wxART_INFORMATION));
         }
         bbtn->SetBitmapMargins((wxCoord)m_imageMarginH, (wxCoord)m_imageMarginV);
 
         if ( m_chkUsePressed->GetValue() )
-            bbtn->SetBitmapPressed(CreateBitmap("pushed", wxART_HELP));
+            bbtn->SetBitmapPressed(CreateBitmap(wxART_HELP));
         if ( m_chkUseFocused->GetValue() )
-            bbtn->SetBitmapFocus(CreateBitmap("focused", wxART_ERROR));
+            bbtn->SetBitmapFocus(CreateBitmap(wxART_ERROR));
         if ( m_chkUseCurrent->GetValue() )
-            bbtn->SetBitmapCurrent(CreateBitmap("hover", wxART_WARNING));
+            bbtn->SetBitmapCurrent(CreateBitmap(wxART_WARNING));
         if ( m_chkUseDisabled->GetValue() )
-            bbtn->SetBitmapDisabled(CreateBitmap("disabled", wxART_MISSING_IMAGE));
+            bbtn->SetBitmapDisabled(CreateBitmap(wxART_MISSING_IMAGE));
         m_button = bbtn;
 #if wxUSE_COMMANDLINKBUTTON
         m_cmdLnkButton = nullptr;
@@ -692,20 +692,7 @@ void ButtonWidgetsPage::OnButton(wxCommandEvent& WXUNUSED(event))
 // ----------------------------------------------------------------------------
 
 wxBitmapBundle
-ButtonWidgetsPage::CreateBitmap(const wxString& label, const wxArtID& type)
+ButtonWidgetsPage::CreateBitmap(const wxArtID& type)
 {
-    wxBitmap bmp(FromDIP(wxSize(180, 70))); // shouldn't hardcode but it's simpler like this
-    wxMemoryDC dc;
-    dc.SelectObject(bmp);
-    dc.SetFont(GetFont());
-    dc.SetBackground(*wxCYAN_BRUSH);
-    dc.Clear();
-    dc.SetTextForeground(*wxBLACK);
-    dc.DrawLabel(wxStripMenuCodes(m_textLabel->GetValue()) + "\n"
-                    "(" + label + " state)",
-                 wxArtProvider::GetBitmap(type),
-                 wxRect(10, 10, bmp.GetWidth() - 20, bmp.GetHeight() - 20),
-                 wxALIGN_CENTRE);
-
-    return bmp;
+    return wxArtProvider::GetBitmapBundle(type, wxART_BUTTON);
 }

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -130,8 +130,7 @@ protected:
                *m_chkUseMarkup,
 #endif // wxUSE_MARKUP
                *m_chkDefault,
-               *m_chkUseBitmapClass,
-               *m_chkDisable;
+               *m_chkUseBitmapClass;
 
     // more checkboxes for wxBitmapButton only
     wxCheckBox *m_chkUsePressed,
@@ -222,7 +221,6 @@ ButtonWidgetsPage::ButtonWidgetsPage(WidgetsBookCtrl *book,
 #endif // wxUSE_MARKUP
     m_chkDefault =
     m_chkUseBitmapClass =
-    m_chkDisable =
     m_chkUsePressed =
     m_chkUseFocused =
     m_chkUseCurrent =
@@ -267,8 +265,6 @@ void ButtonWidgetsPage::CreateContent()
     m_chkUseBitmapClass = CreateCheckBoxAndAddToSizer(sizerLeft,
         "Use wxBitmapButton", wxID_ANY, sizerLeftBox);
     m_chkUseBitmapClass->SetValue(true);
-
-    m_chkDisable = CreateCheckBoxAndAddToSizer(sizerLeft, "Disable", wxID_ANY, sizerLeftBox);
 
     sizerLeft->AddSpacer(5);
 
@@ -410,7 +406,6 @@ void ButtonWidgetsPage::Reset()
     m_chkUseMarkup->SetValue(false);
 #endif // wxUSE_MARKUP
     m_chkUseBitmapClass->SetValue(true);
-    m_chkDisable->SetValue(false);
 
     m_chkUsePressed->SetValue(true);
     m_chkUseFocused->SetValue(true);
@@ -609,8 +604,6 @@ void ButtonWidgetsPage::CreateButton()
 
     if ( m_chkDefault->GetValue() )
         m_button->SetDefault();
-
-    m_button->Enable(!m_chkDisable->IsChecked());
 
     m_sizerButton->AddStretchSpacer();
     m_sizerButton->Add(m_button, wxSizerFlags().Centre().Border());

--- a/src/gtk/button.cpp
+++ b/src/gtk/button.cpp
@@ -135,7 +135,7 @@ bool wxButton::Create(wxWindow *parent,
     if (style & wxNO_BORDER)
        gtk_button_set_relief( GTK_BUTTON(m_widget), GTK_RELIEF_NONE );
 
-    if ( useLabel && (style & wxBU_EXACTFIT) )
+    if (style & wxBU_EXACTFIT)
     {
 #ifdef __WXGTK3__
         GTKApplyCssStyle("* { padding:0 }");

--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -2208,92 +2208,12 @@ void wxPGMultiButton::Finalize( wxPropertyGrid* WXUNUSED(propGrid),
 
 #if wxUSE_BMPBUTTON
 
-#if defined(__WXGTK__)
-// Dedicated wxBitmapButton with reduced internal borders
-#include "wx/gtk/private.h"
-
-class wxPGEditorBitmapButton : public wxBitmapButton
-{
-public:
-    wxPGEditorBitmapButton(wxWindow *parent, wxWindowID id,
-                     const wxBitmap& bitmap, const wxPoint& pos,
-                     const wxSize& size, long style = 0)
-        : wxBitmapButton(parent, id, bitmap, pos, size, style)
-    {
-#if defined(__WXGTK3__)
-        GTKApplyCssStyle("*{ padding:0 }");
-#else
-        // Define a special button style without inner border
-        // if it's not yet done.
-        if ( !m_exactFitStyleDefined )
-        {
-            gtk_rc_parse_string(
-              "style \"wxPGEditorBitmapButton_style\"\n"
-              "{ GtkButton::inner-border = { 0, 0, 0, 0 } }\n"
-              "widget \"*wxPGEditorBitmapButton*\" style \"wxPGEditorBitmapButton_style\"\n"
-            );
-            m_exactFitStyleDefined = true;
-        }
-
-        // Assign the button to the GTK style without inner border.
-        gtk_widget_set_name(m_widget, "wxPGEditorBitmapButton");
-#endif
-    }
-
-    virtual ~wxPGEditorBitmapButton() = default;
-
-private:
-#ifndef __WXGTK3__
-    // To mark if special GTK style was already defined.
-    static bool m_exactFitStyleDefined;
-#endif // !__WXGTK3__
-};
-
-#ifndef __WXGTK3__
-bool wxPGEditorBitmapButton::m_exactFitStyleDefined = false;
-#endif // !__WXGTK3__
-
-#else // !__WXGTK__
-
-typedef wxBitmapButton wxPGEditorBitmapButton;
-
-#endif // __WXGTK__ / !__WXGTK__
-
 void wxPGMultiButton::Add( const wxBitmapBundle& bitmap, int itemid )
 {
     wxSize sz = GetSize();
-
-    // Internal margins around the bitmap inside the button
-    const int margins =
-#if defined(__WXMSW__)
-            2*4;
-#elif defined(__WXGTK3__)
-            2*2;
-#elif defined(__WXGTK__)
-            2*6;
-#elif defined(__WXOSX__)
-            2*3;
-#else
-            0;
-#endif
-    // Maximal heigth of the bitmap
-    const int hMax = wxMax(4, sz.y - margins);
-
-    wxBitmap bmp = bitmap.GetBitmapFor(this);
-    wxBitmap scaledBmp;
-    // Scale bitmap down if necessary
-    if ( bmp.GetHeight() > hMax )
-    {
-        double scale = (double)hMax / bmp.GetHeight();
-        scaledBmp = wxPropertyGrid::RescaleBitmap(bmp, scale, scale);
-    }
-    else
-    {
-        scaledBmp = bmp;
-    }
-
-    wxBitmapButton* button = new wxPGEditorBitmapButton(this, itemid, scaledBmp,
-                           wxPoint(sz.x, 0), wxSize(wxDefaultCoord, sz.y));
+    wxBitmapButton* button = new wxBitmapButton(this, itemid, bitmap,
+                           wxPoint(sz.x, 0), wxSize(wxDefaultCoord, sz.y),
+                           wxBU_EXACTFIT);
     // If button is narrow make it a square
     wxSize szBtn = button->GetSize();
     if ( szBtn.x < szBtn.y )


### PR DESCRIPTION
Unless I'm missing something, there is just no reason at all to have all this code in `wxPGMultiButton` as simply using `wxButton` with `wxBU_EXACTFIT` works just as well — and, in fact, significantly better because the bitmap in the sample is not completely ugly due to rescaling (at least in 200% DPI) any more.

Compare the old and new appearance of the buttons in the sample for GTK:

before: <img width="204" height="76" alt="pg-gtk-old" src="https://github.com/user-attachments/assets/3ca79d1e-b6bf-4f75-a67f-f349525e992f" /> and now: <img width="182" height="68" alt="pg-gtk-new" src="https://github.com/user-attachments/assets/6bb8dae4-9f00-4007-872d-55bcf37b026f" />

and MSW:

before: <img width="174" height="56" alt="pg-msw-old" src="https://github.com/user-attachments/assets/7733b555-49f3-42ac-8ba1-0f1c8262fbd4" /> and now: <img width="156" height="52" alt="pg-msw-new" src="https://github.com/user-attachments/assets/243fe985-874e-4f69-a581-f8a657819386" />