### PR TITLE
Fix type of wxAuiDefaultToolBarArt::Get{Label,Tool}Size "dc" parameters

### DIFF
--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -874,13 +874,27 @@ public:
                 const wxRect& rect,
                 int state);
 
+    /**
+        Return the size of the label for the given item.
+
+        Note that the type of @a dc was wxDC until wxWidgets 3.3.0, where it
+        was changed to wxReadOnlyDC as this function doesn't modify the DC
+        contents.
+     */
     virtual wxSize GetLabelSize(
-                wxDC& dc,
+                wxReadOnlyDC& dc,
                 wxWindow* wnd,
                 const wxAuiToolBarItem& item);
 
+    /**
+        Return the size of the given item.
+
+        Note that the type of @a dc was wxDC until wxWidgets 3.3.0, where it
+        was changed to wxReadOnlyDC as this function doesn't modify the DC
+        contents.
+     */
     virtual wxSize GetToolSize(
-                wxDC& dc,
+                wxReadOnlyDC& dc,
                 wxWindow* wnd,
                 const wxAuiToolBarItem& item);
 


### PR DESCRIPTION
They are now wxReadOnlyDC and not wxDC.