### PR TITLE
Show generic `wxTreeCtrl` in the sample and improve its colours under MSW

### DIFF
--- a/include/wx/rtti.h
+++ b/include/wx/rtti.h
@@ -226,6 +226,25 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
     wxObject* name::wxCreateObject()                                          \
         { return new name; }
 
+    // Template specialization with one base class.
+#define wxIMPLEMENT_DYNAMIC_TEMPLATE_SPECIALIZATION(name, arg, basename)      \
+    template <>                                                               \
+    wxObject* name<arg>::wxCreateObject() { return new name<arg>; }           \
+    template <>                                                               \
+    wxClassInfo                                                               \
+    name<arg>::ms_classInfo                                                   \
+        (                                                                     \
+            wxT(#name) L"<" wxT(#arg) L">",                                   \
+            &basename::ms_classInfo,                                          \
+            nullptr,                                                          \
+            static_cast<int>(sizeof(name<arg>)),                              \
+            name<arg>::wxCreateObject                                         \
+        );                                                                    \
+    template <>                                                               \
+    wxClassInfo* name<arg>::GetClassInfo() const { return &ms_classInfo; }
+
+
+
 // -----------------------------------
 // for abstract classes
 // -----------------------------------

--- a/interface/wx/object.h
+++ b/interface/wx/object.h
@@ -798,6 +798,36 @@ public:
 #define wxIMPLEMENT_DYNAMIC_CLASS2( className, baseClassName1, baseClassName2 )
 
 /**
+    Used in a C++ implementation file to complete the declaration of a class
+    that has run-time type information, and whose instances can be created
+    dynamically. Use this for template specializations.
+
+    Please note that @a arg must be the template parameter the primary template
+    @a templateName is being specialized for, e.g.
+
+    @code
+    template <typename T>
+    class MyWindow : public wxWindow
+    {
+    public:
+        MyWindow() = default; // Must have a default ctor for dynamic creation.
+
+    private:
+        T m_value;
+
+        wxDECLARE_DYNAMIC_CLASS(MyWindow);
+    };
+
+    wxIMPLEMENT_DYNAMIC_TEMPLATE_SPECIALIZATION(MyWindow, int, wxWindow);
+    @endcode
+
+    @header{wx/object.h}
+
+    @since 3.3.2
+*/
+#define wxIMPLEMENT_DYNAMIC_TEMPLATE_SPECIALIZATION( templateName, arg, baseClassName )
+
+/**
     Synonym for wxIMPLEMENT_ABSTRACT_CLASS().
 
     Please prefer to use the more clear, if longer,

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -109,7 +109,10 @@ enum wxSystemColour
     wxSYS_COLOUR_LISTBOXTEXT,
 
     /**
-        Text colour for the unfocused selection of list-like controls.
+        Text colour for the selected items in list-like controls.
+
+        This colour is supposed to have good contrast with the background drawn
+        by wxRendererNative::DrawItemSelectionRect().
 
         @since 2.9.1
      */

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -782,7 +782,7 @@ void MyFrame::OnSetFocus(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnInsertItem(wxCommandEvent& WXUNUSED(event))
 {
-    int image = wxGetApp().ShowImages() ? MyTreeCtrl::TreeCtrlIcon_File : -1;
+    int image = wxGetApp().ShowImages() ? TreeCtrlIcon_File : -1;
     m_treeCtrl->InsertItem(m_treeCtrl->GetRootItem(), image, "2nd item");
 }
 
@@ -795,7 +795,7 @@ void MyFrame::OnAddItem(wxCommandEvent& WXUNUSED(event))
 
     m_treeCtrl->AppendItem(m_treeCtrl->GetRootItem(),
                            text /*,
-                           MyTreeCtrl::TreeCtrlIcon_File */ );
+                           TreeCtrlIcon_File */ );
 }
 
 void MyFrame::OnAddManyItems(wxCommandEvent& WXUNUSED(event))
@@ -1191,7 +1191,7 @@ void MyTreeCtrl::AddItemsRecursively(const wxTreeItemId& idParent,
 void MyTreeCtrl::AddTestItemsToTree(size_t numChildren,
                                     size_t depth)
 {
-    int image = wxGetApp().ShowImages() ? MyTreeCtrl::TreeCtrlIcon_Folder : -1;
+    int image = wxGetApp().ShowImages() ? TreeCtrlIcon_Folder : -1;
     wxTreeItemId rootId = AddRoot("Root",
                                   image, image,
                                   new MyTreeItemData("Root item"));

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -89,6 +89,9 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     MENU_LINK(TogFullHighlight)
     MENU_LINK(SetFgColour)
     MENU_LINK(SetBgColour)
+#if wxUSE_ALT_GENERIC_TREECTRL
+    MENU_LINK(UseGeneric)
+#endif // wxUSE_ALT_GENERIC_TREECTRL
     MENU_LINK(ResetStyle)
 
     MENU_LINK(Highlight)
@@ -221,6 +224,10 @@ MyFrame::MyFrame()
     style_menu->AppendSeparator();
     style_menu->Append(TreeTest_SetFgColour, "Set &foreground colour...");
     style_menu->Append(TreeTest_SetBgColour, "Set &background colour...");
+#if wxUSE_ALT_GENERIC_TREECTRL
+    style_menu->AppendSeparator();
+    style_menu->AppendCheckItem(TreeTest_UseGeneric, "Use &generic tree control\tCtrl-G");
+#endif // wxUSE_ALT_GENERIC_TREECTRL
     style_menu->AppendSeparator();
     style_menu->Append(TreeTest_ResetStyle, "&Reset to default\tF10");
 
@@ -355,10 +362,26 @@ void MyFrame::CreateTreeWithDefStyle()
 
 void MyFrame::CreateTree(long style)
 {
-    m_treeCtrl = new MyTreeCtrl;
-    m_treeCtrl->Create(m_panel, TreeTest_Ctrl,
-                       wxDefaultPosition, wxDefaultSize,
-                       style);
+#if wxUSE_ALT_GENERIC_TREECTRL
+    if ( GetMenuBar()->IsChecked(TreeTest_UseGeneric) )
+    {
+        auto* const tree = new MyTreeCtrl<wxGenericTreeCtrl>;
+        tree->Create(m_panel, TreeTest_Ctrl,
+                     wxDefaultPosition, wxDefaultSize,
+                     style);
+        m_treeCtrlIface = tree;
+        m_treeCtrl = tree;
+    }
+    else
+#endif // wxUSE_ALT_GENERIC_TREECTRL
+    {
+        auto* const tree = new MyTreeCtrl<wxTreeCtrl>;
+        tree->Create(m_panel, TreeTest_Ctrl,
+                     wxDefaultPosition, wxDefaultSize,
+                     style);
+        m_treeCtrlIface = tree;
+        m_treeCtrl = tree;
+    }
 
     GetMenuBar()->Enable(TreeTest_SelectRoot, !(style & wxTR_HIDE_ROOT));
 
@@ -390,7 +413,7 @@ void MyFrame::OnIdle(wxIdleEvent& event)
         wxString status;
         if (idRoot.IsOk())
         {
-            wxTreeItemId idLast = m_treeCtrl->GetLastTreeITem();
+            wxTreeItemId idLast = m_treeCtrlIface->GetLastTreeITem();
             status = wxString::Format(
                 "Root/last item is %svisible/%svisible",
                 m_treeCtrl->IsVisible(idRoot) ? "" : "not ",
@@ -499,7 +522,7 @@ void MyFrame::DoSort(bool reverse)
 
     CHECK_ITEM( item );
 
-    m_treeCtrl->DoSortChildren(item, reverse);
+    m_treeCtrlIface->DoSortChildren(item, reverse);
 }
 
 void MyFrame::OnHighlight(wxCommandEvent& WXUNUSED(event))
@@ -528,7 +551,7 @@ void MyFrame::OnDump(wxCommandEvent& WXUNUSED(event))
 
     CHECK_ITEM( root );
 
-    m_treeCtrl->GetItemsRecursively(root);
+    m_treeCtrlIface->GetItemsRecursively(root);
 }
 
 #ifndef NO_MULTIPLE_SELECTION
@@ -636,7 +659,7 @@ void MyFrame::OnFreezeThaw(wxCommandEvent& event)
 void MyFrame::OnRecreate(wxCommandEvent& event)
 {
     OnDeleteAll(event);
-    m_treeCtrl->AddTestItemsToTree(NUM_CHILDREN_PER_LEVEL, NUM_LEVELS);
+    m_treeCtrlIface->AddTestItemsToTree(NUM_CHILDREN_PER_LEVEL, NUM_LEVELS);
 }
 
 void MyFrame::OnSetImageSize(wxCommandEvent& WXUNUSED(event))
@@ -644,11 +667,11 @@ void MyFrame::OnSetImageSize(wxCommandEvent& WXUNUSED(event))
     int size = wxGetNumberFromUser("Enter the size for the images to use",
                                     "Size: ",
                                     "TreeCtrl sample",
-                                    m_treeCtrl->ImageSize());
+                                    m_treeCtrlIface->ImageSize());
     if ( size == -1 )
         return;
 
-    m_treeCtrl->CreateImages(size);
+    m_treeCtrlIface->CreateImages(size);
     wxGetApp().SetShowImages(true);
 }
 
@@ -656,12 +679,12 @@ void MyFrame::OnToggleImages(wxCommandEvent& WXUNUSED(event))
 {
     if ( wxGetApp().ShowImages() )
     {
-        m_treeCtrl->CreateImages(-1);
+        m_treeCtrlIface->CreateImages(-1);
         wxGetApp().SetShowImages(false);
     }
     else
     {
-        m_treeCtrl->CreateImages(0);
+        m_treeCtrlIface->CreateImages(0);
         wxGetApp().SetShowImages(true);
     }
 }
@@ -675,7 +698,7 @@ void MyFrame::OnToggleStates(wxCommandEvent& WXUNUSED(event))
     }
     else
     {
-        m_treeCtrl->CreateStateImages();
+        m_treeCtrlIface->CreateStateImages();
         wxGetApp().SetShowStates(true);
     }
 }
@@ -687,40 +710,68 @@ void MyFrame::OnToggleBell(wxCommandEvent& event)
 
 void MyFrame::OnToggleAlternateImages(wxCommandEvent& WXUNUSED(event))
 {
-    bool alternateImages = m_treeCtrl->AlternateImages();
+    bool alternateImages = m_treeCtrlIface->AlternateImages();
 
-    m_treeCtrl->SetAlternateImages(!alternateImages);
-    m_treeCtrl->CreateImages(0);
+    m_treeCtrlIface->SetAlternateImages(!alternateImages);
+    m_treeCtrlIface->CreateImages(0);
 }
 
 void MyFrame::OnToggleAlternateStates(wxCommandEvent& WXUNUSED(event))
 {
-    bool alternateStates = m_treeCtrl->AlternateStates();
+    bool alternateStates = m_treeCtrlIface->AlternateStates();
 
-    m_treeCtrl->SetAlternateStates(!alternateStates);
-    m_treeCtrl->CreateStateImages();
+    m_treeCtrlIface->SetAlternateStates(!alternateStates);
+    m_treeCtrlIface->CreateStateImages();
 
     // normal states < alternate states
     // so we must reset broken states
     if ( alternateStates )
-        m_treeCtrl->ResetBrokenStateImages();
+        m_treeCtrlIface->ResetBrokenStateImages();
 }
 
 void MyFrame::OnToggleButtons(wxCommandEvent& WXUNUSED(event))
 {
-#ifdef HAS_GENERIC_TREECTRL
+#if wxUSE_ALT_GENERIC_TREECTRL
+    if ( !GetMenuBar()->IsChecked(TreeTest_UseGeneric) )
+    {
+        wxLogError("Toggling buttons is currently only supported "
+                   "by the generic tree control.");
+        return;
+    }
+#endif // wxUSE_ALT_GENERIC_TREECTRL
+
+    auto* const treeCtrlGeneric = wxStaticCast(m_treeCtrl, wxGenericTreeCtrl);
+
     if ( wxGetApp().ShowButtons() )
     {
-        m_treeCtrl->CreateButtonsImageList(-1);
+        m_treeCtrlIface->CreateButtonsImageList(treeCtrlGeneric, -1);
         wxGetApp().SetShowButtons(false);
     }
     else
     {
-        m_treeCtrl->CreateButtonsImageList(15);
+        m_treeCtrlIface->CreateButtonsImageList(treeCtrlGeneric, 15);
         wxGetApp().SetShowButtons(true);
     }
-#endif
 }
+
+#if wxUSE_ALT_GENERIC_TREECTRL
+
+void MyFrame::OnUseGeneric(wxCommandEvent& WXUNUSED(event))
+{
+    // Get current style before destroying the tree
+    const long style = m_treeCtrl->GetWindowStyle();
+
+    // Destroy the old tree control
+    delete m_treeCtrl;
+    m_treeCtrlIface = nullptr;
+    m_treeCtrl = nullptr;
+
+    // Create tree control of different type (as check menu item state has been
+    // toggled) with the same style
+    CreateTree(style);
+}
+
+#endif // wxUSE_ALT_GENERIC_TREECTRL
 
 void MyFrame::OnCollapseAndReset(wxCommandEvent& WXUNUSED(event))
 {
@@ -730,7 +781,7 @@ void MyFrame::OnCollapseAndReset(wxCommandEvent& WXUNUSED(event))
 void MyFrame::OnEnsureVisible(wxCommandEvent& WXUNUSED(event))
 {
     const wxTreeItemId
-        idLast = m_treeCtrl->GetLastTreeITem();
+        idLast = m_treeCtrlIface->GetLastTreeITem();
     if ( idLast.IsOk() )
         m_treeCtrl->EnsureVisible(idLast);
     else
@@ -811,7 +862,7 @@ void MyFrame::OnToggleIcon(wxCommandEvent& WXUNUSED(event))
 
     CHECK_ITEM( item );
 
-    m_treeCtrl->DoToggleIcon(item);
+    m_treeCtrlIface->DoToggleIcon(item);
 }
 
 void MyFrame::OnToggleState(wxCommandEvent& WXUNUSED(event))
@@ -820,7 +871,7 @@ void MyFrame::OnToggleState(wxCommandEvent& WXUNUSED(event))
 
     CHECK_ITEM( item );
 
-    m_treeCtrl->DoToggleState(item);
+    m_treeCtrlIface->DoToggleState(item);
 }
 
 void MyFrame::DoShowFirstOrLast(TreeFunc0_t pfn, const wxString& label)
@@ -844,8 +895,8 @@ void MyFrame::DoShowRelativeItem(TreeFunc1_t pfn, const wxString& label)
 
     CHECK_ITEM( item );
 
-    if ((pfn == (TreeFunc1_t) &wxTreeCtrl::GetPrevVisible
-         || pfn == (TreeFunc1_t) &wxTreeCtrl::GetNextVisible)
+    if ((pfn == (TreeFunc1_t) &wxTreeCtrlBase::GetPrevVisible
+         || pfn == (TreeFunc1_t) &wxTreeCtrlBase::GetNextVisible)
         && !m_treeCtrl->IsVisible(item))
     {
         wxLogMessage("The selected item must be visible.");
@@ -878,7 +929,7 @@ void MyFrame::OnScrollTo(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnSelectLast(wxCommandEvent& WXUNUSED(event))
 {
-    wxTreeItemId item = m_treeCtrl->GetLastTreeITem();
+    wxTreeItemId item = m_treeCtrlIface->GetLastTreeITem();
 
     CHECK_ITEM( item );
 
@@ -900,18 +951,18 @@ void MyFrame::OnSetBgColour(wxCommandEvent& WXUNUSED(event))
 }
 
 // MyTreeCtrl implementation
-#if USE_GENERIC_TREECTRL
-wxIMPLEMENT_DYNAMIC_CLASS(MyTreeCtrl, wxGenericTreeCtrl);
-#else
-wxIMPLEMENT_DYNAMIC_CLASS(MyTreeCtrl, wxTreeCtrl);
-#endif
+#if wxUSE_ALT_GENERIC_TREECTRL
+wxIMPLEMENT_DYNAMIC_TEMPLATE_SPECIALIZATION(MyTreeCtrl, wxGenericTreeCtrl, wxGenericTreeCtrl);
+#endif // wxUSE_ALT_GENERIC_TREECTRL
+wxIMPLEMENT_DYNAMIC_TEMPLATE_SPECIALIZATION(MyTreeCtrl, wxTreeCtrl, wxTreeCtrl);
 
+template <class TreeCtrlBase>
 bool
-MyTreeCtrl::Create(wxWindow *parent, const wxWindowID id,
-                   const wxPoint& pos, const wxSize& size,
-                   long style)
+MyTreeCtrl<TreeCtrlBase>::Create(wxWindow *parent, const wxWindowID id,
+                                 const wxPoint& pos, const wxSize& size,
+                                 long style)
 {
-    if ( !wxTreeCtrl::Create(parent, id, pos, size, style) )
+    if ( !TreeCtrlBase::Create(parent, id, pos, size, style) )
         return false;
 
     CreateImages(16);
@@ -921,39 +972,39 @@ MyTreeCtrl::Create(wxWindow *parent, const wxWindowID id,
     AddTestItemsToTree(NUM_CHILDREN_PER_LEVEL, NUM_LEVELS);
 
     // Bind the event handlers.
-    Bind(wxEVT_TREE_BEGIN_DRAG, &MyTreeCtrl::OnBeginDrag, this);
-    Bind(wxEVT_TREE_BEGIN_DRAG, &MyTreeCtrl::OnBeginRDrag, this);
-    Bind(wxEVT_TREE_END_DRAG, &MyTreeCtrl::OnEndDrag, this);
-    Bind(wxEVT_TREE_BEGIN_LABEL_EDIT, &MyTreeCtrl::OnBeginLabelEdit, this);
-    Bind(wxEVT_TREE_END_LABEL_EDIT, &MyTreeCtrl::OnEndLabelEdit, this);
-    Bind(wxEVT_TREE_DELETE_ITEM, &MyTreeCtrl::OnDeleteItem, this);
+    this->Bind(wxEVT_TREE_BEGIN_DRAG, &MyTreeCtrl::OnBeginDrag, this);
+    this->Bind(wxEVT_TREE_BEGIN_DRAG, &MyTreeCtrl::OnBeginRDrag, this);
+    this->Bind(wxEVT_TREE_END_DRAG, &MyTreeCtrl::OnEndDrag, this);
+    this->Bind(wxEVT_TREE_BEGIN_LABEL_EDIT, &MyTreeCtrl::OnBeginLabelEdit, this);
+    this->Bind(wxEVT_TREE_END_LABEL_EDIT, &MyTreeCtrl::OnEndLabelEdit, this);
+    this->Bind(wxEVT_TREE_DELETE_ITEM, &MyTreeCtrl::OnDeleteItem, this);
 
 #if 0       // there are so many of those that logging them causes flicker
-    Bind(wxEVT_TREE_GET_INFO, &MyTreeCtrl::OnGetInfo, this);
+    this->Bind(wxEVT_TREE_GET_INFO, &MyTreeCtrl::OnGetInfo, this);
 #endif
-    Bind(wxEVT_TREE_SET_INFO, &MyTreeCtrl::OnSetInfo, this);
-    Bind(wxEVT_TREE_ITEM_EXPANDED, &MyTreeCtrl::OnItemExpanded, this);
-    Bind(wxEVT_TREE_ITEM_EXPANDING, &MyTreeCtrl::OnItemExpanding, this);
-    Bind(wxEVT_TREE_ITEM_COLLAPSED, &MyTreeCtrl::OnItemCollapsed, this);
-    Bind(wxEVT_TREE_ITEM_COLLAPSING, &MyTreeCtrl::OnItemCollapsing, this);
+    this->Bind(wxEVT_TREE_SET_INFO, &MyTreeCtrl::OnSetInfo, this);
+    this->Bind(wxEVT_TREE_ITEM_EXPANDED, &MyTreeCtrl::OnItemExpanded, this);
+    this->Bind(wxEVT_TREE_ITEM_EXPANDING, &MyTreeCtrl::OnItemExpanding, this);
+    this->Bind(wxEVT_TREE_ITEM_COLLAPSED, &MyTreeCtrl::OnItemCollapsed, this);
+    this->Bind(wxEVT_TREE_ITEM_COLLAPSING, &MyTreeCtrl::OnItemCollapsing, this);
 
-    Bind(wxEVT_TREE_SEL_CHANGED, &MyTreeCtrl::OnSelChanged, this);
-    Bind(wxEVT_TREE_SEL_CHANGING, &MyTreeCtrl::OnSelChanging, this);
-    Bind(wxEVT_TREE_KEY_DOWN, &MyTreeCtrl::OnTreeKeyDown, this);
-    Bind(wxEVT_TREE_ITEM_ACTIVATED, &MyTreeCtrl::OnItemActivated, this);
-    Bind(wxEVT_TREE_STATE_IMAGE_CLICK, &MyTreeCtrl::OnItemStateClick, this);
+    this->Bind(wxEVT_TREE_SEL_CHANGED, &MyTreeCtrl::OnSelChanged, this);
+    this->Bind(wxEVT_TREE_SEL_CHANGING, &MyTreeCtrl::OnSelChanging, this);
+    this->Bind(wxEVT_TREE_KEY_DOWN, &MyTreeCtrl::OnTreeKeyDown, this);
+    this->Bind(wxEVT_TREE_ITEM_ACTIVATED, &MyTreeCtrl::OnItemActivated, this);
+    this->Bind(wxEVT_TREE_STATE_IMAGE_CLICK, &MyTreeCtrl::OnItemStateClick, this);
 
     // so many different ways to handle right mouse button clicks...
-    Bind(wxEVT_CONTEXT_MENU, &MyTreeCtrl::OnContextMenu, this);
+    this->Bind(wxEVT_CONTEXT_MENU, &MyTreeCtrl::OnContextMenu, this);
     // wxEVT_TREE_ITEM_MENU is the preferred event for creating context menus
     // on a tree control, because it includes the point of the click or item,
     // meaning that no additional placement calculations are required.
-    Bind(wxEVT_TREE_ITEM_MENU, &MyTreeCtrl::OnItemMenu, this);
-    Bind(wxEVT_TREE_ITEM_RIGHT_CLICK, &MyTreeCtrl::OnItemRClick, this);
+    this->Bind(wxEVT_TREE_ITEM_MENU, &MyTreeCtrl::OnItemMenu, this);
+    this->Bind(wxEVT_TREE_ITEM_RIGHT_CLICK, &MyTreeCtrl::OnItemRClick, this);
 
-    Bind(wxEVT_RIGHT_DOWN, &MyTreeCtrl::OnRMouseDown, this);
-    Bind(wxEVT_RIGHT_UP, &MyTreeCtrl::OnRMouseUp, this);
-    Bind(wxEVT_RIGHT_DCLICK, &MyTreeCtrl::OnRMouseDClick, this);
+    this->Bind(wxEVT_RIGHT_DOWN, &MyTreeCtrl::OnRMouseDown, this);
+    this->Bind(wxEVT_RIGHT_UP, &MyTreeCtrl::OnRMouseUp, this);
+    this->Bind(wxEVT_RIGHT_DCLICK, &MyTreeCtrl::OnRMouseDClick, this);
 
     return true;
 }
@@ -1001,11 +1052,12 @@ namespace
     };
 } // anonymous namespace
 
-void MyTreeCtrl::CreateImages(int size)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::CreateImages(int size)
 {
     if ( size == -1 )
     {
-        SetImageList(nullptr);
+        this->SetImageList(nullptr);
         return;
     }
     if ( size == 0 )
@@ -1045,10 +1097,11 @@ void MyTreeCtrl::CreateImages(int size)
         images.push_back(wxBitmapBundle::FromImpl(new FixedSizeImpl(iconSize, icons[i])));
     }
 
-    SetImages(images);
+    this->SetImages(images);
 }
 
-void MyTreeCtrl::CreateStateImages()
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::CreateStateImages()
 {
     std::vector<wxBitmapBundle> images;
 
@@ -1079,15 +1132,14 @@ void MyTreeCtrl::CreateStateImages()
         }
     }
 
-    SetStateImages(images);
+    this->SetStateImages(images);
 }
 
-void MyTreeCtrl::CreateButtonsImageList(int size)
+void MyTreeCtrlInterface::CreateButtonsImageList(wxGenericTreeCtrl* treectrl, int size)
 {
-#ifdef HAS_GENERIC_TREECTRL
     if ( size == -1 )
     {
-        SetButtonsImageList(nullptr);
+        treectrl->SetButtonsImageList(nullptr);
         return;
     }
 
@@ -1128,27 +1180,26 @@ void MyTreeCtrl::CreateButtonsImageList(int size)
         }
     }
 
-    AssignButtonsImageList(images);
-#else
-    wxUnusedVar(size);
-#endif
+    treectrl->AssignButtonsImageList(images);
 }
 
-int MyTreeCtrl::OnCompareItems(const wxTreeItemId& item1,
-                               const wxTreeItemId& item2)
+template <class TreeCtrlBase>
+int MyTreeCtrl<TreeCtrlBase>::OnCompareItems(const wxTreeItemId& item1,
+                                             const wxTreeItemId& item2)
 {
     if ( m_reverseSort )
     {
         // just exchange 1st and 2nd items
-        return wxTreeCtrl::OnCompareItems(item2, item1);
+        return TreeCtrlBase::OnCompareItems(item2, item1);
     }
     else
     {
-        return wxTreeCtrl::OnCompareItems(item1, item2);
+        return TreeCtrlBase::OnCompareItems(item1, item2);
     }
 }
 
-void MyTreeCtrl::AddItemsRecursively(const wxTreeItemId& idParent,
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::AddItemsRecursively(const wxTreeItemId& idParent,
                                      size_t numChildren,
                                      size_t depth,
                                      size_t folder)
@@ -1178,17 +1229,17 @@ void MyTreeCtrl::AddItemsRecursively(const wxTreeItemId& idParent,
             {
                 image = imageSel = -1;
             }
-            wxTreeItemId id = AppendItem(idParent, str, image, imageSel,
-                                         new MyTreeItemData(str));
+            wxTreeItemId id = this->AppendItem(idParent, str, image, imageSel,
+                                               new MyTreeItemData(str));
 
             if ( wxGetApp().ShowStates() )
-                SetItemState(id, 0);
+                this->SetItemState(id, 0);
 
             // and now we also set the expanded one (only for the folders)
             if ( hasChildren && wxGetApp().ShowImages() )
             {
-                SetItemImage(id, TreeCtrlIcon_FolderOpened,
-                             wxTreeItemIcon_Expanded);
+                this->SetItemImage(id, TreeCtrlIcon_FolderOpened,
+                                   wxTreeItemIcon_Expanded);
             }
 
             AddItemsRecursively(id, numChildren, depth - 1, n + 1);
@@ -1197,44 +1248,46 @@ void MyTreeCtrl::AddItemsRecursively(const wxTreeItemId& idParent,
     //else: done!
 }
 
-void MyTreeCtrl::AddTestItemsToTree(size_t numChildren,
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::AddTestItemsToTree(size_t numChildren,
                                     size_t depth)
 {
     int image = wxGetApp().ShowImages() ? TreeCtrlIcon_Folder : -1;
-    wxTreeItemId rootId = AddRoot("Root",
-                                  image, image,
-                                  new MyTreeItemData("Root item"));
-    if ( !HasFlag(wxTR_HIDE_ROOT) && image != -1 )
+    wxTreeItemId rootId = this->AddRoot("Root",
+                                        image, image,
+                                        new MyTreeItemData("Root item"));
+    if ( !this->HasFlag(wxTR_HIDE_ROOT) && image != -1 )
     {
-        SetItemImage(rootId, TreeCtrlIcon_FolderOpened, wxTreeItemIcon_Expanded);
+        this->SetItemImage(rootId, TreeCtrlIcon_FolderOpened, wxTreeItemIcon_Expanded);
     }
 
     AddItemsRecursively(rootId, numChildren, depth, 0);
 
     // set some colours/fonts for testing
-    if ( !HasFlag(wxTR_HIDE_ROOT) )
-        SetItemFont(rootId, *wxITALIC_FONT);
+    if ( !this->HasFlag(wxTR_HIDE_ROOT) )
+        this->SetItemFont(rootId, *wxITALIC_FONT);
 
     wxTreeItemIdValue cookie;
-    wxTreeItemId id = GetFirstChild(rootId, cookie);
-    SetItemTextColour(id, *wxBLUE);
+    wxTreeItemId id = this->GetFirstChild(rootId, cookie);
+    this->SetItemTextColour(id, *wxBLUE);
 
-    id = GetNextChild(rootId, cookie);
+    id = this->GetNextChild(rootId, cookie);
     if ( id )
-        id = GetNextChild(rootId, cookie);
+        id = this->GetNextChild(rootId, cookie);
     if ( id )
     {
-        SetItemTextColour(id, *wxRED);
-        SetItemBackgroundColour(id, *wxLIGHT_GREY);
+        this->SetItemTextColour(id, *wxRED);
+        this->SetItemBackgroundColour(id, *wxLIGHT_GREY);
     }
 }
 
-wxTreeItemId MyTreeCtrl::GetLastTreeITem() const
+template <class TreeCtrlBase>
+wxTreeItemId MyTreeCtrl<TreeCtrlBase>::GetLastTreeITem() const
 {
-    wxTreeItemId item = GetRootItem();
+    wxTreeItemId item = this->GetRootItem();
     for ( ;; )
     {
-        wxTreeItemId itemChild = GetLastChild(item);
+        wxTreeItemId itemChild = this->GetLastChild(item);
         if ( !itemChild.IsOk() )
             break;
 
@@ -1244,92 +1297,97 @@ wxTreeItemId MyTreeCtrl::GetLastTreeITem() const
     return item;
 }
 
-void MyTreeCtrl::GetItemsRecursively(const wxTreeItemId& idParent,
-                                     wxTreeItemIdValue cookie)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::GetItemsRecursively(const wxTreeItemId& idParent,
+                                                   wxTreeItemIdValue cookie)
 {
     wxTreeItemId id;
 
     if ( !cookie )
-        id = GetFirstChild(idParent, cookie);
+        id = this->GetFirstChild(idParent, cookie);
     else
-        id = GetNextChild(idParent, cookie);
+        id = this->GetNextChild(idParent, cookie);
 
     if ( !id.IsOk() )
         return;
 
-    wxString text = GetItemText(id);
+    wxString text = this->GetItemText(id);
     wxLogMessage(text);
 
-    if (ItemHasChildren(id))
-        GetItemsRecursively(id);
+    if ( this->ItemHasChildren(id) )
+        this->GetItemsRecursively(id);
 
-    GetItemsRecursively(idParent, cookie);
+    this->GetItemsRecursively(idParent, cookie);
 }
 
-void MyTreeCtrl::DoToggleIcon(const wxTreeItemId& item)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::DoToggleIcon(const wxTreeItemId& item)
 {
-    int image = GetItemImage(item) == TreeCtrlIcon_Folder
+    int image = this->GetItemImage(item) == TreeCtrlIcon_Folder
                     ? TreeCtrlIcon_File
                     : TreeCtrlIcon_Folder;
-    SetItemImage(item, image, wxTreeItemIcon_Normal);
+    this->SetItemImage(item, image, wxTreeItemIcon_Normal);
 
-    image = GetItemImage(item, wxTreeItemIcon_Selected) == TreeCtrlIcon_FolderSelected
+    image = this->GetItemImage(item, wxTreeItemIcon_Selected) == TreeCtrlIcon_FolderSelected
                     ? TreeCtrlIcon_FileSelected
                     : TreeCtrlIcon_FolderSelected;
-    SetItemImage(item, image, wxTreeItemIcon_Selected);
+    this->SetItemImage(item, image, wxTreeItemIcon_Selected);
 }
 
-void MyTreeCtrl::DoToggleState(const wxTreeItemId& item)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::DoToggleState(const wxTreeItemId& item)
 {
     if ( m_alternateStates )
     {
         // sets random state unlike current
-        int state = GetItemState(item);
+        int state = this->GetItemState(item);
         int nState;
 
         srand (time(nullptr));
         do {
-            nState = rand() % GetStateImageCount();
+            nState = rand() % this->GetStateImageCount();
         } while (nState == state);
 
-        SetItemState(item, nState);
+        this->SetItemState(item, nState);
     }
     else
     {
         // we have only 2 checkbox states, so next state will be reversed
-        SetItemState(item, wxTREE_ITEMSTATE_NEXT);
+        this->SetItemState(item, wxTREE_ITEMSTATE_NEXT);
     }
 }
 
-void MyTreeCtrl::DoResetBrokenStateImages(const wxTreeItemId& idParent,
-                                          wxTreeItemIdValue cookie, int state)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::DoResetBrokenStateImages(const wxTreeItemId& idParent,
+                                                        wxTreeItemIdValue cookie, int state)
 {
     wxTreeItemId id;
 
     if ( !cookie )
-        id = GetFirstChild(idParent, cookie);
+        id = this->GetFirstChild(idParent, cookie);
     else
-        id = GetNextChild(idParent, cookie);
+        id = this->GetNextChild(idParent, cookie);
 
     if ( !id.IsOk() )
         return;
 
-    int curState = GetItemState(id);
+    int curState = this->GetItemState(id);
     if ( curState != wxTREE_ITEMSTATE_NONE && curState > state )
-        SetItemState(id, state);
+        this->SetItemState(id, state);
 
-    if (ItemHasChildren(id))
+    if (this->ItemHasChildren(id))
         DoResetBrokenStateImages(id, nullptr, state);
 
     DoResetBrokenStateImages(idParent, cookie, state);
 }
 
-void MyTreeCtrl::LogEvent(const wxString& name, const wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::LogEvent(const wxString& name, const wxTreeEvent& event)
 {
     wxTreeItemId item = event.GetItem();
     wxString text;
     if ( item.IsOk() )
-        text << '"' << GetItemText(item).c_str() << '"';
+        text << '"' << this->GetItemText(item).c_str() << '"';
     else
         text = "invalid item";
     wxLogMessage("%s(%s)", name, text);
@@ -1337,9 +1395,10 @@ void MyTreeCtrl::LogEvent(const wxString& name, const wxTreeEvent& event)
 
 // avoid repetition
 #define TREE_EVENT_HANDLER(name)                                 \
-void MyTreeCtrl::name(wxTreeEvent& event)                        \
+template <class TreeCtrlBase>                                    \
+void MyTreeCtrl<TreeCtrlBase>::name(wxTreeEvent& event)          \
 {                                                                \
-    LogEvent(#name, event);                                  \
+    LogEvent(#name, event);                                      \
     event.Skip();                                                \
 }
 
@@ -1499,25 +1558,27 @@ void LogKeyEvent(const wxString& name, const wxKeyEvent& event)
                   event.MetaDown() ? 'M' : '-');
 }
 
-void MyTreeCtrl::OnTreeKeyDown(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnTreeKeyDown(wxTreeEvent& event)
 {
     LogKeyEvent("Tree key down ", event.GetKeyEvent());
 
     event.Skip();
 }
 
-void MyTreeCtrl::OnBeginDrag(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnBeginDrag(wxTreeEvent& event)
 {
     // need to explicitly allow drag
-    if ( event.GetItem() != GetRootItem() )
+    if ( event.GetItem() != this->GetRootItem() )
     {
         m_draggedItem = event.GetItem();
 
         wxPoint clientpt = event.GetPoint();
-        wxPoint screenpt = ClientToScreen(clientpt);
+        wxPoint screenpt = this->ClientToScreen(clientpt);
 
         wxLogMessage("OnBeginDrag: started dragging %s at screen coords (%i,%i)",
-                     GetItemText(m_draggedItem),
+                     this->GetItemText(m_draggedItem),
                      screenpt.x, screenpt.y);
 
         event.Allow();
@@ -1528,17 +1589,18 @@ void MyTreeCtrl::OnBeginDrag(wxTreeEvent& event)
     }
 }
 
-void MyTreeCtrl::OnEndDrag(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnEndDrag(wxTreeEvent& event)
 {
     wxTreeItemId itemSrc = m_draggedItem,
                  itemDst = event.GetItem();
     m_draggedItem = nullptr;
 
     // where to copy the item?
-    if ( itemDst.IsOk() && !ItemHasChildren(itemDst) )
+    if ( itemDst.IsOk() && !this->ItemHasChildren(itemDst) )
     {
         // copy to the parent then
-        itemDst = GetItemParent(itemDst);
+        itemDst = this->GetItemParent(itemDst);
     }
 
     if ( !itemDst.IsOk() )
@@ -1548,9 +1610,9 @@ void MyTreeCtrl::OnEndDrag(wxTreeEvent& event)
         return;
     }
 
-    wxString text = GetItemText(itemSrc);
+    wxString text = this->GetItemText(itemSrc);
     wxLogMessage("OnEndDrag: '%s' copied to '%s'.",
-                 text, GetItemText(itemDst));
+                 text, this->GetItemText(itemDst));
 
     // just do append here - we could also insert it just before/after the item
     // on which it was dropped, but this requires slightly more work... we also
@@ -1560,13 +1622,14 @@ void MyTreeCtrl::OnEndDrag(wxTreeEvent& event)
     // Finally, we only copy one item here but we might copy the entire tree if
     // we were dragging a folder.
     int image = wxGetApp().ShowImages() ? TreeCtrlIcon_File : -1;
-    wxTreeItemId id = AppendItem(itemDst, text, image);
+    wxTreeItemId id = this->AppendItem(itemDst, text, image);
 
     if ( wxGetApp().ShowStates() )
-        SetItemState(id, GetItemState(itemSrc));
+        this->SetItemState(id, this->GetItemState(itemSrc));
 }
 
-void MyTreeCtrl::OnBeginLabelEdit(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnBeginLabelEdit(wxTreeEvent& event)
 {
     wxLogMessage("OnBeginLabelEdit");
 
@@ -1578,14 +1641,15 @@ void MyTreeCtrl::OnBeginLabelEdit(wxTreeEvent& event)
 
         event.Veto();
     }
-    else if ( itemId == GetRootItem() )
+    else if ( itemId == this->GetRootItem() )
     {
         // test that it is possible to change the text of the item being edited
-        SetItemText(itemId, "Editing root item");
+        this->SetItemText(itemId, "Editing root item");
     }
 }
 
-void MyTreeCtrl::OnEndLabelEdit(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnEndLabelEdit(wxTreeEvent& event)
 {
     wxLogMessage("OnEndLabelEdit");
 
@@ -1598,7 +1662,8 @@ void MyTreeCtrl::OnEndLabelEdit(wxTreeEvent& event)
     }
 }
 
-void MyTreeCtrl::OnItemCollapsing(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnItemCollapsing(wxTreeEvent& event)
 {
     wxLogMessage("OnItemCollapsing");
 
@@ -1612,11 +1677,12 @@ void MyTreeCtrl::OnItemCollapsing(wxTreeEvent& event)
     }
 }
 
-void MyTreeCtrl::OnItemActivated(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnItemActivated(wxTreeEvent& event)
 {
     // show some info about this item
     wxTreeItemId itemId = event.GetItem();
-    MyTreeItemData *item = (MyTreeItemData *)GetItemData(itemId);
+    MyTreeItemData *item = (MyTreeItemData *)this->GetItemData(itemId);
 
     if ( item != nullptr )
     {
@@ -1626,24 +1692,26 @@ void MyTreeCtrl::OnItemActivated(wxTreeEvent& event)
     wxLogMessage("OnItemActivated");
 }
 
-void MyTreeCtrl::OnItemStateClick(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnItemStateClick(wxTreeEvent& event)
 {
     // toggle item state
     wxTreeItemId itemId = event.GetItem();
     DoToggleState(itemId);
 
     wxLogMessage("Item \"%s\" state changed to %d",
-                 GetItemText(itemId), GetItemState(itemId));
+                 this->GetItemText(itemId), this->GetItemState(itemId));
 }
 
-void MyTreeCtrl::OnItemMenu(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnItemMenu(wxTreeEvent& event)
 {
     wxTreeItemId itemId = event.GetItem();
     wxCHECK_RET( itemId.IsOk(), "should have a valid item" );
 
-    MyTreeItemData *item = (MyTreeItemData *)GetItemData(itemId);
+    MyTreeItemData *item = (MyTreeItemData *)this->GetItemData(itemId);
     wxPoint clientpt = event.GetPoint();
-    wxPoint screenpt = ClientToScreen(clientpt);
+    wxPoint screenpt = this->ClientToScreen(clientpt);
 
     wxLogMessage("OnItemMenu for item \"%s\" at screen coords (%i, %i)",
                  item ? item->GetDesc() : wxString("unknown"), screenpt.x, screenpt.y);
@@ -1652,7 +1720,8 @@ void MyTreeCtrl::OnItemMenu(wxTreeEvent& event)
     event.Skip();
 }
 
-void MyTreeCtrl::OnContextMenu(wxContextMenuEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnContextMenu(wxContextMenuEvent& event)
 {
     wxPoint pt = event.GetPosition();
 
@@ -1661,12 +1730,13 @@ void MyTreeCtrl::OnContextMenu(wxContextMenuEvent& event)
     event.Skip();
 }
 
-void MyTreeCtrl::ShowMenu(wxTreeItemId id, const wxPoint& pt)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::ShowMenu(wxTreeItemId id, const wxPoint& pt)
 {
     wxString title;
     if ( id.IsOk() )
     {
-        title << "Menu for " << GetItemText(id);
+        title << "Menu for " << this->GetItemText(id);
     }
     else
     {
@@ -1680,46 +1750,50 @@ void MyTreeCtrl::ShowMenu(wxTreeItemId id, const wxPoint& pt)
     menu.Append(TreeTest_Highlight, "&Highlight item");
     menu.Append(TreeTest_Dump, "&Dump");
 
-    PopupMenu(&menu, pt);
+    this->PopupMenu(&menu, pt);
 #endif // wxUSE_MENUS
 }
 
-void MyTreeCtrl::OnItemRClick(wxTreeEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnItemRClick(wxTreeEvent& event)
 {
     wxTreeItemId itemId = event.GetItem();
     wxCHECK_RET( itemId.IsOk(), "should have a valid item" );
 
-    MyTreeItemData *item = (MyTreeItemData *)GetItemData(itemId);
+    MyTreeItemData *item = (MyTreeItemData *)this->GetItemData(itemId);
 
     wxLogMessage("Item \"%s\" right clicked", item ? item->GetDesc() : wxString("unknown"));
 
     event.Skip();
 }
 
-void MyTreeCtrl::OnRMouseDown(wxMouseEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnRMouseDown(wxMouseEvent& event)
 {
     wxLogMessage("Right mouse button down");
 
     event.Skip();
 }
 
-void MyTreeCtrl::OnRMouseUp(wxMouseEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnRMouseUp(wxMouseEvent& event)
 {
     wxLogMessage("Right mouse button up");
 
     event.Skip();
 }
 
-void MyTreeCtrl::OnRMouseDClick(wxMouseEvent& event)
+template <class TreeCtrlBase>
+void MyTreeCtrl<TreeCtrlBase>::OnRMouseDClick(wxMouseEvent& event)
 {
-    wxTreeItemId id = HitTest(event.GetPosition());
+    wxTreeItemId id = this->HitTest(event.GetPosition());
     if ( !id )
     {
         wxLogMessage("No item under mouse");
     }
     else
     {
-        MyTreeItemData *item = (MyTreeItemData *)GetItemData(id);
+        MyTreeItemData *item = (MyTreeItemData *)this->GetItemData(id);
         if ( item )
         {
             wxLogMessage("Item '%s' under mouse", item->GetDesc());
@@ -1734,7 +1808,7 @@ static inline const wxString Bool2String(bool b)
     return b ? "" : "not ";
 }
 
-void MyTreeItemData::ShowInfo(wxTreeCtrl *tree)
+void MyTreeItemData::ShowInfo(wxTreeCtrlBase *tree)
 {
     wxLogMessage("Item '%s': %sselected, %sexpanded, %sbold,\n"
                  "%u children (%u immediately under this item).",

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -214,10 +214,6 @@ bool MyApp::OnInit()
 MyFrame::MyFrame()
        : wxFrame(nullptr, wxID_ANY, "wxTreeCtrl test",
                  wxDefaultPosition, FromDIP(wxSize(450, 600), nullptr)),
-         m_treeCtrl(nullptr)
-#if wxUSE_LOG
-         , m_textCtrl(nullptr)
-#endif // wxUSE_LOG
 {
     // This reduces flicker effects - even better would be to define
     // OnEraseBackground to do nothing. When the tree control's scrollbars are

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -150,45 +150,6 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
 
 wxEND_EVENT_TABLE()
 
-#if USE_GENERIC_TREECTRL
-wxBEGIN_EVENT_TABLE(MyTreeCtrl, wxGenericTreeCtrl)
-#else
-wxBEGIN_EVENT_TABLE(MyTreeCtrl, wxTreeCtrl)
-#endif
-    EVT_TREE_BEGIN_DRAG(TreeTest_Ctrl, MyTreeCtrl::OnBeginDrag)
-    EVT_TREE_BEGIN_RDRAG(TreeTest_Ctrl, MyTreeCtrl::OnBeginRDrag)
-    EVT_TREE_END_DRAG(TreeTest_Ctrl, MyTreeCtrl::OnEndDrag)
-    EVT_TREE_BEGIN_LABEL_EDIT(TreeTest_Ctrl, MyTreeCtrl::OnBeginLabelEdit)
-    EVT_TREE_END_LABEL_EDIT(TreeTest_Ctrl, MyTreeCtrl::OnEndLabelEdit)
-    EVT_TREE_DELETE_ITEM(TreeTest_Ctrl, MyTreeCtrl::OnDeleteItem)
-#if 0       // there are so many of those that logging them causes flicker
-    EVT_TREE_GET_INFO(TreeTest_Ctrl, MyTreeCtrl::OnGetInfo)
-#endif
-    EVT_TREE_SET_INFO(TreeTest_Ctrl, MyTreeCtrl::OnSetInfo)
-    EVT_TREE_ITEM_EXPANDED(TreeTest_Ctrl, MyTreeCtrl::OnItemExpanded)
-    EVT_TREE_ITEM_EXPANDING(TreeTest_Ctrl, MyTreeCtrl::OnItemExpanding)
-    EVT_TREE_ITEM_COLLAPSED(TreeTest_Ctrl, MyTreeCtrl::OnItemCollapsed)
-    EVT_TREE_ITEM_COLLAPSING(TreeTest_Ctrl, MyTreeCtrl::OnItemCollapsing)
-
-    EVT_TREE_SEL_CHANGED(TreeTest_Ctrl, MyTreeCtrl::OnSelChanged)
-    EVT_TREE_SEL_CHANGING(TreeTest_Ctrl, MyTreeCtrl::OnSelChanging)
-    EVT_TREE_KEY_DOWN(TreeTest_Ctrl, MyTreeCtrl::OnTreeKeyDown)
-    EVT_TREE_ITEM_ACTIVATED(TreeTest_Ctrl, MyTreeCtrl::OnItemActivated)
-    EVT_TREE_STATE_IMAGE_CLICK(TreeTest_Ctrl, MyTreeCtrl::OnItemStateClick)
-
-    // so many different ways to handle right mouse button clicks...
-    EVT_CONTEXT_MENU(MyTreeCtrl::OnContextMenu)
-    // EVT_TREE_ITEM_MENU is the preferred event for creating context menus
-    // on a tree control, because it includes the point of the click or item,
-    // meaning that no additional placement calculations are required.
-    EVT_TREE_ITEM_MENU(TreeTest_Ctrl, MyTreeCtrl::OnItemMenu)
-    EVT_TREE_ITEM_RIGHT_CLICK(TreeTest_Ctrl, MyTreeCtrl::OnItemRClick)
-
-    EVT_RIGHT_DOWN(MyTreeCtrl::OnRMouseDown)
-    EVT_RIGHT_UP(MyTreeCtrl::OnRMouseUp)
-    EVT_RIGHT_DCLICK(MyTreeCtrl::OnRMouseDClick)
-wxEND_EVENT_TABLE()
-
 wxIMPLEMENT_APP(MyApp);
 
 bool MyApp::OnInit()
@@ -394,9 +355,10 @@ void MyFrame::CreateTreeWithDefStyle()
 
 void MyFrame::CreateTree(long style)
 {
-    m_treeCtrl = new MyTreeCtrl(m_panel, TreeTest_Ctrl,
-                                wxDefaultPosition, wxDefaultSize,
-                                style);
+    m_treeCtrl = new MyTreeCtrl;
+    m_treeCtrl->Create(m_panel, TreeTest_Ctrl,
+                       wxDefaultPosition, wxDefaultSize,
+                       style);
 
     GetMenuBar()->Enable(TreeTest_SelectRoot, !(style & wxTR_HIDE_ROOT));
 
@@ -944,16 +906,63 @@ wxIMPLEMENT_DYNAMIC_CLASS(MyTreeCtrl, wxGenericTreeCtrl);
 wxIMPLEMENT_DYNAMIC_CLASS(MyTreeCtrl, wxTreeCtrl);
 #endif
 
-MyTreeCtrl::MyTreeCtrl(wxWindow *parent, const wxWindowID id,
-                       const wxPoint& pos, const wxSize& size,
-                       long style)
-          : wxTreeCtrl(parent, id, pos, size, style)
+bool
+MyTreeCtrl::Create(wxWindow *parent, const wxWindowID id,
+                   const wxPoint& pos, const wxSize& size,
+                   long style)
 {
+    if ( !wxTreeCtrl::Create(parent, id, pos, size, style) )
+        return false;
+
     CreateImages(16);
     CreateStateImages();
 
     // Add some items to the tree
     AddTestItemsToTree(NUM_CHILDREN_PER_LEVEL, NUM_LEVELS);
+
+    // Bind the event handlers.
+    Bind(wxEVT_TREE_BEGIN_DRAG, &MyTreeCtrl::OnBeginDrag, this);
+    Bind(wxEVT_TREE_BEGIN_DRAG, &MyTreeCtrl::OnBeginRDrag, this);
+    Bind(wxEVT_TREE_END_DRAG, &MyTreeCtrl::OnEndDrag, this);
+    Bind(wxEVT_TREE_BEGIN_LABEL_EDIT, &MyTreeCtrl::OnBeginLabelEdit, this);
+    Bind(wxEVT_TREE_END_LABEL_EDIT, &MyTreeCtrl::OnEndLabelEdit, this);
+    Bind(wxEVT_TREE_DELETE_ITEM, &MyTreeCtrl::OnDeleteItem, this);
+
+#if 0       // there are so many of those that logging them causes flicker
+    Bind(wxEVT_TREE_GET_INFO, &MyTreeCtrl::OnGetInfo, this);
+#endif
+    Bind(wxEVT_TREE_SET_INFO, &MyTreeCtrl::OnSetInfo, this);
+    Bind(wxEVT_TREE_ITEM_EXPANDED, &MyTreeCtrl::OnItemExpanded, this);
+    Bind(wxEVT_TREE_ITEM_EXPANDING, &MyTreeCtrl::OnItemExpanding, this);
+    Bind(wxEVT_TREE_ITEM_COLLAPSED, &MyTreeCtrl::OnItemCollapsed, this);
+    Bind(wxEVT_TREE_ITEM_COLLAPSING, &MyTreeCtrl::OnItemCollapsing, this);
+
+    Bind(wxEVT_TREE_SEL_CHANGED, &MyTreeCtrl::OnSelChanged, this);
+    Bind(wxEVT_TREE_SEL_CHANGING, &MyTreeCtrl::OnSelChanging, this);
+    Bind(wxEVT_TREE_KEY_DOWN, &MyTreeCtrl::OnTreeKeyDown, this);
+    Bind(wxEVT_TREE_ITEM_ACTIVATED, &MyTreeCtrl::OnItemActivated, this);
+    Bind(wxEVT_TREE_STATE_IMAGE_CLICK, &MyTreeCtrl::OnItemStateClick, this);
+
+    // so many different ways to handle right mouse button clicks...
+    Bind(wxEVT_CONTEXT_MENU, &MyTreeCtrl::OnContextMenu, this);
+    // wxEVT_TREE_ITEM_MENU is the preferred event for creating context menus
+    // on a tree control, because it includes the point of the click or item,
+    // meaning that no additional placement calculations are required.
+    Bind(wxEVT_TREE_ITEM_MENU, &MyTreeCtrl::OnItemMenu, this);
+    Bind(wxEVT_TREE_ITEM_RIGHT_CLICK, &MyTreeCtrl::OnItemRClick, this);
+
+    Bind(wxEVT_RIGHT_DOWN, &MyTreeCtrl::OnRMouseDown, this);
+    Bind(wxEVT_RIGHT_UP, &MyTreeCtrl::OnRMouseUp, this);
+    Bind(wxEVT_RIGHT_DCLICK, &MyTreeCtrl::OnRMouseDClick, this);
+
+    return true;
+}
+
+template <class TreeCtrlBase>
+MyTreeCtrl<TreeCtrlBase>::~MyTreeCtrl()
+{
+    // Avoid messages about items being deleted during destruction.
+    this->Unbind(wxEVT_TREE_DELETE_ITEM, &MyTreeCtrl::OnDeleteItem, this);
 }
 
 namespace

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -213,7 +213,7 @@ bool MyApp::OnInit()
 // My frame constructor
 MyFrame::MyFrame()
        : wxFrame(nullptr, wxID_ANY, "wxTreeCtrl test",
-                 wxDefaultPosition, FromDIP(wxSize(450, 600), nullptr)),
+                 wxDefaultPosition, FromDIP(wxSize(450, 600), nullptr))
 {
     // This reduces flicker effects - even better would be to define
     // OnEraseBackground to do nothing. When the tree control's scrollbars are
@@ -947,12 +947,8 @@ wxIMPLEMENT_DYNAMIC_CLASS(MyTreeCtrl, wxTreeCtrl);
 MyTreeCtrl::MyTreeCtrl(wxWindow *parent, const wxWindowID id,
                        const wxPoint& pos, const wxSize& size,
                        long style)
-          : wxTreeCtrl(parent, id, pos, size, style),
-            m_alternateImages(false),
-            m_alternateStates(false)
+          : wxTreeCtrl(parent, id, pos, size, style)
 {
-    m_reverseSort = false;
-
     CreateImages(16);
     CreateStateImages();
 

--- a/samples/treectrl/treetest.h
+++ b/samples/treectrl/treetest.h
@@ -71,7 +71,7 @@ public:
         TreeCtrlIcon_FolderOpened
     };
 
-    MyTreeCtrl() { m_alternateImages = false; m_alternateStates = false; }
+    MyTreeCtrl() = default;
     MyTreeCtrl(wxWindow *parent, const wxWindowID id,
                const wxPoint& pos, const wxSize& size,
                long style);
@@ -163,10 +163,10 @@ private:
     void LogEvent(const wxString& name, const wxTreeEvent& event);
 
     int          m_imageSize;               // current size of images
-    bool         m_reverseSort;             // flag for OnCompareItems
+    bool m_reverseSort = false;             // flag for OnCompareItems
     wxTreeItemId m_draggedItem;             // item being dragged right now
-    bool         m_alternateImages;
-    bool         m_alternateStates;
+    bool         m_alternateImages = false;
+    bool         m_alternateStates = false;
 
     // NB: due to an ugly wxMSW hack you _must_ use wxDECLARE_DYNAMIC_CLASS();
     //     if you want your overloaded OnCompareItems() to be called.

--- a/samples/treectrl/treetest.h
+++ b/samples/treectrl/treetest.h
@@ -308,10 +308,10 @@ private:
     void DoShowRelativeItem(TreeFunc1_t pfn, const wxString& label);
 
 
-    wxPanel *m_panel;
-    MyTreeCtrl *m_treeCtrl;
+    wxPanel *m_panel = nullptr;
+    MyTreeCtrl *m_treeCtrl = nullptr;
 #if wxUSE_LOG
-    wxTextCtrl *m_textCtrl;
+    wxTextCtrl *m_textCtrl = nullptr;
 #endif // wxUSE_LOG
 
     void DoSetBold(bool bold = true);

--- a/samples/treectrl/treetest.h
+++ b/samples/treectrl/treetest.h
@@ -59,18 +59,18 @@ private:
     wxString m_desc;
 };
 
+enum
+{
+    TreeCtrlIcon_File,
+    TreeCtrlIcon_FileSelected,
+    TreeCtrlIcon_Folder,
+    TreeCtrlIcon_FolderSelected,
+    TreeCtrlIcon_FolderOpened
+};
+
 class MyTreeCtrl : public wxTreeCtrl
 {
 public:
-    enum
-    {
-        TreeCtrlIcon_File,
-        TreeCtrlIcon_FileSelected,
-        TreeCtrlIcon_Folder,
-        TreeCtrlIcon_FolderSelected,
-        TreeCtrlIcon_FolderOpened
-    };
-
     MyTreeCtrl() = default;
     MyTreeCtrl(wxWindow *parent, const wxWindowID id,
                const wxPoint& pos, const wxSize& size,

--- a/samples/treectrl/treetest.h
+++ b/samples/treectrl/treetest.h
@@ -72,10 +72,11 @@ class MyTreeCtrl : public wxTreeCtrl
 {
 public:
     MyTreeCtrl() = default;
-    MyTreeCtrl(wxWindow *parent, const wxWindowID id,
-               const wxPoint& pos, const wxSize& size,
-               long style);
-    virtual ~MyTreeCtrl(){}
+    bool Create(wxWindow *parent, const wxWindowID id,
+                const wxPoint& pos, const wxSize& size,
+                long style);
+
+    virtual ~MyTreeCtrl();
 
     void OnBeginDrag(wxTreeEvent& event);
     void OnBeginRDrag(wxTreeEvent& event);
@@ -173,7 +174,6 @@ private:
     //     OTOH, if you don't want it you may omit the next line - this will
     //     make default (alphabetical) sorting much faster under wxMSW.
     wxDECLARE_DYNAMIC_CLASS(MyTreeCtrl);
-    wxDECLARE_EVENT_TABLE();
 };
 
 // Define a new frame type

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -658,10 +658,7 @@ void wxListLineData::ApplyAttributes(wxDC *dc,
         else
             colText = *wxBLACK;
 #else
-        if ( hasFocus )
-            colText = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
-        else
-            colText = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT);
+        colText = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT);
 #endif
     }
     else if ( attr && attr->HasTextColour() )

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2796,10 +2796,7 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
             if (m_hasFocus)
                colText = *wxWHITE;
 #else
-            if (m_hasFocus)
-                colText = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
-            else
-                colText = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT);
+            colText = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT);
 #endif
         }
         else

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -929,7 +929,7 @@ wxRendererXP::DrawItemSelectionRect(wxWindow *win,
                                     const wxRect& rect,
                                     int flags)
 {
-    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW;LISTVIEW");
+    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW;LISTVIEW", L"DarkMode::LISTVIEW");
 
     const int itemState = GetListItemState(flags);
 

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -119,7 +119,7 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
     else if ( index == wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT)
     {
         // there is no standard colour with this index, map to another one
-        index = wxSYS_COLOUR_HIGHLIGHTTEXT;
+        index = wxSYS_COLOUR_LISTBOXTEXT;
     }
     else if ( index == wxSYS_COLOUR_LISTBOX )
     {


### PR DESCRIPTION
This addresses #26118 (also for generic list control) and also slightly improves the generic control appearance in dark mode, even though it is still not at all the same as Explorer, unfortunately.