### PR TITLE
Remove implementation details from `wxGetLinuxDistribution()` docs

### DIFF
--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -120,8 +120,7 @@ enum wxEndianness
 };
 
 /**
-    A structure containing information about a Linux distribution as returned
-    by the @c lsb_release utility.
+    A structure containing information about a Linux distribution.
 
     See wxGetLinuxDistributionInfo() or wxPlatformInfo::GetLinuxDistributionInfo()
     for more info.

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -1067,13 +1067,8 @@ wxString wxGetNativeCpuArchitectureName();
     Returns a structure containing information about the currently running
     Linux distribution.
 
-    This function uses the @c lsb_release utility which is part of the
-    <tt>Linux Standard Base Core</tt> specification
-    (see http://refspecs.linux-foundation.org/lsb.shtml) since the very first LSB
-    release 1.0 (released in 2001).
-    The @c lsb_release utility is very common on modern Linux distributions but in
-    case it's not available, then this function will return a ::wxLinuxDistributionInfo
-    structure containing empty strings.
+    In case such information cannot be obtained, this function will return
+    a ::wxLinuxDistributionInfo structure containing empty strings.
 
     This function is Linux-specific and is only available when the @c \__LINUX__
     symbol is defined.


### PR DESCRIPTION
An introduction to `lsb_release` is unnecessary, and saying it is very common on modern Linux distributions is an exaggeration, at least today.

And besides those, the details are not even accurate since aef7df6 (Read Linux distribution info from os-release file, 2023-07-14) (#23712), which made `lsb_release` the fallback method for obtaining information.

A candidate for backporting to 3.2.