### PR TITLE
Cache the Go installer in AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ environment:
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 cache:
-  - '%GOPATH%\go%GOVERSION%.windows-amd64.msi'
+  - '%USERPROFILE%\go%GOVERSION%.windows-amd64.msi'
 
 clone_depth: 1
 
@@ -84,7 +84,7 @@ before_test:
     echo Getting and launching httpbin.
     rmdir %GOROOT% /s /q
     mkdir %GOROOT%
-    cd %GOPATH%
+    cd %USERPROFILE%
     set go_exe=go%GOVERSION%.windows-amd64.msi
     if not exist "%go_exe%" (
         appveyor DownloadFile https://go.dev/dl/%go_exe%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,8 +51,7 @@ environment:
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 cache:
-  - %GOPATH%\go%GOVERSION%.windows-amd64.msi
-
+  - '%GOPATH%\go%GOVERSION%.windows-amd64.msi'
 
 clone_depth: 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,9 +86,7 @@ before_test:
     mkdir %GOROOT%
     cd %USERPROFILE%
     set go_exe=go%GOVERSION%.windows-amd64.msi
-    if not exist "%go_exe%" (
-        appveyor DownloadFile https://go.dev/dl/%go_exe%
-    )
+    if not exist "%go_exe%" appveyor DownloadFile https://go.dev/dl/%go_exe%
     msiexec /i %go_exe% INSTALLDIR="%GOROOT%" /q
     go version
     go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,10 @@ environment:
     CONFIGURATION: Release
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
+cache:
+  - %GOPATH%\go%GOVERSION%.windows-amd64.msi
+
+
 clone_depth: 1
 
 install: git submodule update --init
@@ -81,8 +85,12 @@ before_test:
     echo Getting and launching httpbin.
     rmdir %GOROOT% /s /q
     mkdir %GOROOT%
-    appveyor DownloadFile https://go.dev/dl/go%GOVERSION%.windows-amd64.msi
-    msiexec /i go%GOVERSION%.windows-amd64.msi INSTALLDIR="%GOROOT%" /q
+    cd %GOPATH%
+    set go_exe=go%GOVERSION%.windows-amd64.msi
+    if not exist "%go_exe%" (
+        appveyor DownloadFile https://go.dev/dl/%go_exe%
+    )
+    msiexec /i %go_exe% INSTALLDIR="%GOROOT%" /q
     go version
     go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@v2
     set PATH=%PATH%;%GOPATH%\bin


### PR DESCRIPTION
There were some issues downloading the Go installer in AppVeyor CI, see https://github.com/wxWidgets/wxWidgets/pull/26116#issuecomment-3808313208

Try to cache it.