### PR TITLE
wxQt: Fix window modality when using wxWindowDisabler

### DIFF
--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -681,6 +681,10 @@ public:
     // ctor disables all windows except the given one(s)
     explicit wxWindowDisabler(wxWindow *winToSkip, wxWindow *winToSkip2 = nullptr);
 
+    // ctor disables all windows except the given one. Or disables the parent
+    // window only if disableParentOnly is true.
+    explicit wxWindowDisabler(wxWindow *winToSkip, bool disableParentOnly);
+
     // dtor enables back all windows disabled by the ctor
     ~wxWindowDisabler();
 
@@ -696,6 +700,7 @@ private:
 #endif
     wxVector<wxWindow*> m_windowsToSkip;
     bool m_disabled;
+    bool m_disableParentOnly = false;
 
     wxDECLARE_NO_COPY_CLASS(wxWindowDisabler);
 };

--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -1760,21 +1760,8 @@ void wxPreviewFrame::OnCloseWindow(wxCloseEvent& WXUNUSED(event))
 {
     // Reenable any windows we disabled by undoing whatever we did in our
     // Initialize().
-    switch ( m_modalityKind )
-    {
-        case wxPreviewFrame_AppModal:
-            delete m_windowDisabler;
-            m_windowDisabler = nullptr;
-            break;
-
-        case wxPreviewFrame_WindowModal:
-            if ( GetParent() )
-                GetParent()->Enable();
-            break;
-
-        case wxPreviewFrame_NonModal:
-            break;
-    }
+    delete m_windowDisabler;
+    m_windowDisabler = nullptr;
 
     Destroy();
 }
@@ -1814,26 +1801,13 @@ void wxPreviewFrame::InitializeWithModality(wxPreviewFrameModalityKind kind)
     SetSizeHints(ClientToWindowSize(m_controlBar->GetBestSize()));
 
     m_modalityKind = kind;
-    switch ( m_modalityKind )
-    {
-        case wxPreviewFrame_AppModal:
-            // Disable everything.
-            m_windowDisabler = new wxWindowDisabler( this );
-            break;
-
-        case wxPreviewFrame_WindowModal:
-            // Disable our parent if we have one.
-            if ( GetParent() )
-                GetParent()->Disable();
-            break;
-
-        case wxPreviewFrame_NonModal:
-            // Nothing to do, we don't need to disable any windows.
-            break;
-    }
 
     if ( m_modalityKind != wxPreviewFrame_NonModal )
     {
+        const bool disableParentOnly = m_modalityKind == wxPreviewFrame_WindowModal;
+
+        m_windowDisabler = new wxWindowDisabler( this, disableParentOnly );
+
         // Behave like modal dialogs, don't show in taskbar. This implies
         // removing the minimize box, because minimizing windows without
         // taskbar entry is confusing.

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1518,6 +1518,7 @@ wxWindowDisabler::wxWindowDisabler(wxWindow *winToSkip, bool disableParentOnly)
 #endif
 }
 
+#if !defined(__WXQT__)
 void wxWindowDisabler::DoDisable()
 {
     if ( m_disableParentOnly )
@@ -1577,6 +1578,7 @@ wxWindowDisabler::~wxWindowDisabler()
         }
     }
 }
+#endif // !__WXQT__
 
 // Yield to other apps/messages and disable user input to all windows except
 // the given one


### PR DESCRIPTION
To see the problem:
- Run the printing sample
- Display the print preview window:  File->Print preview... or Ctrl+V
- The window is incorrectly in a disabled state (see the first image below)

<img width="600" height="741" alt="printdemo_bad" src="https://github.com/user-attachments/assets/7a06f820-afc6-43c8-8a3d-078e4613a2c5" />



and should look like this:

<img width="600" height="741" alt="printdemo_good" src="https://github.com/user-attachments/assets/9251d0a7-b1ef-495f-9b3e-1c89a39f894f" />

I'll update the documentation once these changes are approved.

TIA!
