### PR TITLE
Use custom configuration name in object folder name also with MSBuild

### DIFF
--- a/build/msw/wx_setup.props
+++ b/build/msw/wx_setup.props
@@ -65,16 +65,16 @@
     <wxOutDir>..\..\lib\$(wxOutDirName)\</wxOutDir>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='DLL Debug'">
-    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)dll\</wxIntRootDir>
+    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)dll$(wxCfg)\</wxIntRootDir>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='DLL Release'">
-    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)dll\</wxIntRootDir>
+    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)dll$(wxCfg)\</wxIntRootDir>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='Debug'">
-    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)\</wxIntRootDir>
+    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)$(wxCfg)\</wxIntRootDir>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='Release'">
-    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)\</wxIntRootDir>
+    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)$(wxCfg)\</wxIntRootDir>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros">
     <wxIncSubDir>$(wxToolkitPrefix)u$(wxSuffixDebug)</wxIncSubDir>


### PR DESCRIPTION
When using MSBuild, use the custom configuration name (property wxCfg) in the object files folder name (property wxIntRootDir), just as it is done in the NMake makefile.

Closes #26135.