### PR TITLE
Generic wxListCtrl: Fix colors when system theme changes

### DIFF
--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -618,6 +618,8 @@ public:
 
     void OnPaint( wxPaintEvent &event );
 
+    void OnSysColourChanged( wxSysColourChangedEvent &event );
+
     void OnChildFocus(wxChildFocusEvent& event);
 
     void DrawImage( int index, wxDC *dc, int x, int y );

--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -356,6 +356,7 @@ public:
 
     void OnPaint( wxPaintEvent &event );
     void OnMouse( wxMouseEvent &event );
+    void OnSysColourChanged( wxSysColourChangedEvent &event );
 
     // needs refresh
     bool m_dirty;

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1529,6 +1529,7 @@ wxBEGIN_EVENT_TABLE(wxListMainWindow, wxWindow)
   EVT_KILL_FOCUS     (wxListMainWindow::OnKillFocus)
   EVT_SCROLLWIN      (wxListMainWindow::OnScroll)
   EVT_CHILD_FOCUS    (wxListMainWindow::OnChildFocus)
+  EVT_SYS_COLOUR_CHANGED(wxListMainWindow::OnSysColourChanged)
 wxEND_EVENT_TABLE()
 
 void wxListMainWindow::Init()
@@ -2205,6 +2206,26 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
             DrawFocusRect(this, dc, GetLineHighlightRect(m_current), flags);
     }
 #endif // !__WXMAC__
+}
+
+void wxListMainWindow::OnSysColourChanged( wxSysColourChangedEvent &event )
+{
+    SetOwnForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
+    SetOwnBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
+
+    if ( m_highlightBrush )
+    {
+        m_highlightBrush->SetColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
+    }
+
+    if ( m_highlightUnfocusedBrush )
+    {
+        m_highlightUnfocusedBrush->SetColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));
+    }
+
+    Refresh();
+
+    event.Skip();
 }
 
 void wxListMainWindow::HighlightAll( bool on )

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -905,6 +905,7 @@ void wxListLineData::ReverseHighlight( void )
 wxBEGIN_EVENT_TABLE(wxListHeaderWindow,wxWindow)
     EVT_PAINT         (wxListHeaderWindow::OnPaint)
     EVT_MOUSE_EVENTS  (wxListHeaderWindow::OnMouse)
+    EVT_SYS_COLOUR_CHANGED(wxListHeaderWindow::OnSysColourChanged)
 wxEND_EVENT_TABLE()
 
 void wxListHeaderWindow::Init()
@@ -1051,13 +1052,17 @@ void wxListHeaderWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
         if (i == 0)
            flags |= wxCONTROL_SPECIAL; // mark as first column
 
+        wxHeaderButtonParams headerBtnParams;
+        headerBtnParams.m_arrowColour = GetForegroundColour();
+
         wxRendererNative::Get().DrawHeaderButton
                                 (
                                     this,
                                     dc,
                                     wxRect(x, HEADER_OFFSET_Y, cw, ch),
                                     flags,
-                                    sortArrow
+                                    sortArrow,
+                                    &headerBtnParams
                                 );
 
         // see if we have enough space for the column label
@@ -1304,6 +1309,15 @@ void wxListHeaderWindow::OnMouse( wxMouseEvent &event )
                 SetCursor(*m_currentCursor);
         }
     }
+}
+
+void wxListHeaderWindow::OnSysColourChanged(wxSysColourChangedEvent &event) {
+    SetOwnForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    SetOwnBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+
+    Refresh();
+
+    event.Skip();
 }
 
 bool wxListHeaderWindow::SendListEvent(wxEventType type, const wxPoint& pos)


### PR DESCRIPTION
This PR addresses several issues when switching the system theme (e. g. light to dark mode) while using the generic `wxListCtrl` (default on GTK).

1. `wxListHeaderWindow`: Added `EVT_SYS_COLOUR_CHANGED` handler to update foreground/background colors and fixed the sort arrow color, which now uses the window's foreground color to ensure visibility on dark headers.
2. `wxListMainWindow`: Added `EVT_SYS_COLOUR_CHANGED` handler to update standard colors and the selection brushes (`m_highlightBrush`, `m_highlightUnfocusedBrush`).

#### Known Issue / Advice Wanted
While the content and headers now update perfectly, the border of the `wxGenericListCtrl` container does not update its color when the theme changes. It retains the color of the theme active at creation.

I tried many different approaches to force a refresh, but the underlying native GTK border does not seem to react to the system color change event. While I'm a long time user of wxWidgets, this is my first time working in the library internals, so I would appreciate any guidance on how to fix the border issue. Just point me in the right direction and I can give it a try. 