### PR TITLE
Document wxGLAttributes::Default no longer using multi-sampling

### DIFF
--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -259,7 +259,7 @@ public:
 
     /**
         wxWidgets defaults:
-        RGBA, Z-depth 16 bits, double buffering, 1 sample buffer, 4 samplers.
+        RGBA, Z-depth 16 bits, double buffering.
 
         @see PlatformDefaults()
     */


### PR DESCRIPTION
This was changed in 46857a73ba82bb09fcc6bb42d3d4c886354b9243.

---

Just a small fix I noticed when reading through the docs.