### PR TITLE
WebView Edge: ensure keyboard focus is inside the  webview document if the WebView window gets focus before MS Webview2 is fully initialized

### DIFF
--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -856,6 +856,14 @@ HRESULT wxWebViewEdgeImpl::OnWebViewCreated(HRESULT result, ICoreWebView2Control
     m_webViewController->put_IsVisible(true);
     m_ctrl->NotifyWebViewCreated();
 
+    // If focus moved to the WebView window before the Edge instance was fully
+    // created, we couldn't call m_webViewController->MoveFocus at that time. If focus is
+    // there now, call MoveFocus to ensure that focus is inside of the web
+    // content window. This helps screen readers, since they  use the focus
+    // window to influence their behavior.
+    if (m_ctrl && m_ctrl->HasFocus())
+        m_webViewController->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
+
     // Connect and handle the various WebView events
     m_webView->add_NavigationStarting(
         Callback<ICoreWebView2NavigationStartingEventHandler>(


### PR DESCRIPTION
If focus moved to the wxWebView window before the Edge instance was
fully created, we couldn't call m_webViewController->MoveFocus at that
time. If focus is on the wxWebview at the time we get the
wxWebViewEdgeImpl::OnWebViewCreated callback, we now call MoveFocus to
ensure that focus is inside of the web content window. This helps
screen readers, since they use the focus window to influence their
behavior.

Fixes https://github.com/wxWidgets/wxWidgets/issues/26155
