### PR TITLE
wxPropertyGridInterface::SetPropertyImage incorrectly documented

### DIFF
--- a/interface/wx/propgrid/propgridiface.h
+++ b/interface/wx/propgrid/propgridiface.h
@@ -1026,7 +1026,7 @@ public:
         @remarks Bitmap will be scaled to a size returned by
                 wxPropertyGrid::GetImageSize();
     */
-    void SetPropertyImage( wxPGPropArg id, wxBitmapBundle& bmp );
+    void SetPropertyImage( wxPGPropArg id, const wxBitmapBundle& bmp );
 
     /**
         Sets maximum length of text in property text editor.


### PR DESCRIPTION
BitmapBundle argument is implemented as const