### PR TITLE
Don't generate any events after handling wxEVT_CHAR_HOOK

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -146,6 +146,11 @@ extern wxPopupWindow* wxCurrentPopupWindow;
 wxWindowMSW *wxWindowBeingErased = nullptr;
 #endif // wxUSE_UXTHEME
 
+// Set to the key code of the pressed key if we need to ignore it but couldn't
+// return 1 from the keyboard hook because we had to leave the IME edit this
+// event, see wxKeyboardHook() code.
+WPARAM wxVKBlockedByKeyboardHook = 0;
+
 namespace
 {
 
@@ -7342,6 +7347,13 @@ wxKeyboardHook(int nCode, WXWPARAM wParam, WXLPARAM lParam)
                             // Stop processing of this event.
                             return 1;
                         }
+
+                        // Because we don't stop processing of the event at
+                        // Windows level, we are going to get WM_KEYDOWN for
+                        // this key, but we need to ignore it as it's not
+                        // supposed to be generated if wxEVT_CHAR_HOOK handled
+                        // the event.
+                        wxVKBlockedByKeyboardHook = wParam;
                     }
                 }
             }


### PR DESCRIPTION
Restore the expected behaviour of wxEVT_CHAR_HOOK which was broken when IME was in use by 7b8195f5c4 (Don't hang handling wxEVT_CHAR_HOOK while IME is used in wxMSW, 2025-12-11).

Because we don't stop the event handling at Windows level in this case any more, we need to do it at wx level, so add an ad hoc check to ProcessMessage() to ensure that we block the unwanted events there.

See #22473, #26027.

Closes #26168.