### PR TITLE
Allow running tests from MSVS in DLL configurations

### DIFF
--- a/tests/test.vcxproj
+++ b/tests/test.vcxproj
@@ -125,6 +125,7 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="..\build\msw\wx_setup.props" />
     <Import Project="..\build\msw\wx_local.props" Condition="Exists('..\build\msw\wx_local.props')" />
+    <Import Project="tests.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/tests/test_gui.vcxproj
+++ b/tests/test_gui.vcxproj
@@ -125,6 +125,7 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="..\build\msw\wx_setup.props" />
     <Import Project="..\build\msw\wx_local.props" Condition="Exists('..\build\msw\wx_local.props')" />
+    <Import Project="tests.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/tests/tests.props
+++ b/tests/tests.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Add the folder where wxWidgets DLL were built to MSVS PATH so that tests can be run
+    from MSVS in DLL builds.
+   -->
+  <PropertyGroup Condition="'$(Configuration)' == 'DLL Debug' or '$(Configuration)' == 'DLL Release'">
+    <LocalDebuggerEnvironment>PATH=.\..\lib\$(wxOutDirName);$(PATH)</LocalDebuggerEnvironment>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Create file tests/tests.props which adds the DLL build directory to MSVS PATH in <LocalDebuggerEnvironment> property and add the file to test.vcxproj and test_gui.vcxproj MSVC projects.

See also eba1064.