### PR TITLE
Document that wxApp::OnExit() should be called from overrides.

### DIFF
--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -364,6 +364,9 @@ public:
 
         The return value of this function is currently ignored, return the same
         value as returned by the base class method if you override it.
+
+        NOTE: The base class method performs some cleanup - call it at the end
+        of your method if you override it.
     */
     virtual int OnExit();
 

--- a/samples/dialup/nettest.cpp
+++ b/samples/dialup/nettest.cpp
@@ -187,8 +187,7 @@ int MyApp::OnExit()
 {
     delete m_dial;
 
-    // exit code is 0, everything is ok
-    return 0;
+    return wxApp::OnExit();
 }
 
 void MyApp::OnConnected(wxDialUpEvent& event)

--- a/samples/dragimag/dragimag.cpp
+++ b/samples/dragimag/dragimag.cpp
@@ -403,11 +403,6 @@ bool MyApp::OnInit()
     return true;
 }
 
-int MyApp::OnExit()
-{
-    return 0;
-}
-
 bool MyApp::TileBitmap(const wxRect& rect, wxDC& dc, const wxBitmap& bitmap)
 {
     int w = bitmap.GetWidth();

--- a/samples/dragimag/dragimag.h
+++ b/samples/dragimag/dragimag.h
@@ -44,7 +44,6 @@ class MyApp: public wxApp
 public:
     MyApp();
     virtual bool OnInit() override;
-    virtual int OnExit() override;
 
 //// Operations
 

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -98,7 +98,7 @@ public:
     // return: if OnInit() returns false, the application terminates)
     virtual bool OnInit() override;
 
-    virtual int OnExit() override { DeleteBitmaps(); return 0; }
+    virtual int OnExit() override { DeleteBitmaps(); return wxApp::OnExit(); }
 
     // Get the menu ID corresponding to the initially selected appearance.
     int GetInitialAppearanceMenuId() const { return m_initialAppearanceMenuId; }

--- a/samples/help/demo.cpp
+++ b/samples/help/demo.cpp
@@ -374,7 +374,7 @@ int MyApp::OnExit()
     // clean up
     delete wxHelpProvider::Set(nullptr);
 
-    return 0;
+    return wxApp::OnExit();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/html/helpview/helpview.cpp
+++ b/samples/html/helpview/helpview.cpp
@@ -85,6 +85,6 @@ int MyApp::OnExit()
     delete help;
     delete wxConfig::Set(nullptr);
 
-    return 0;
+    return wxApp::OnExit();
 }
 

--- a/samples/ipc/baseclient.cpp
+++ b/samples/ipc/baseclient.cpp
@@ -131,7 +131,7 @@ int MyApp::OnExit()
 {
     delete m_client;
 
-    return 0;
+    return wxApp::OnExit();
 }
 
 void MyApp::OnIdle(wxIdleEvent& event)

--- a/samples/ipc/client.cpp
+++ b/samples/ipc/client.cpp
@@ -82,12 +82,6 @@ bool MyApp::OnInit()
     return true;
 }
 
-int MyApp::OnExit()
-{
-
-    return 0;
-}
-
 // Define my frame constructor
 MyFrame::MyFrame(wxFrame *frame, const wxString& title)
         : wxFrame(frame, wxID_ANY, title, wxDefaultPosition, wxSize(400, 300))

--- a/samples/ipc/client.h
+++ b/samples/ipc/client.h
@@ -29,7 +29,6 @@ class MyApp: public wxApp
 {
 public:
     virtual bool OnInit() override;
-    virtual int OnExit() override;
     MyFrame *GetFrame() { return m_frame; }
 
 protected:

--- a/samples/richtext/richtext.cpp
+++ b/samples/richtext/richtext.cpp
@@ -595,7 +595,7 @@ int MyApp::OnExit()
 #endif
     delete m_styleSheet;
 
-    return 0;
+    return wxApp::OnExit();
 }
 
 void MyApp::CreateStyles()

--- a/samples/sockets/baseclient.cpp
+++ b/samples/sockets/baseclient.cpp
@@ -301,7 +301,8 @@ Client::OnExit()
     for(EList::compatibility_iterator it = m_eventWorkers.GetFirst(); it ; it->GetNext()) {
         delete it->GetData();
     }
-    return 0;
+
+    return wxApp::OnExit();
 }
 
 // Create buffer to be sent by client. Buffer contains test indicator

--- a/samples/sockets/baseserver.cpp
+++ b/samples/sockets/baseserver.cpp
@@ -363,7 +363,8 @@ int Server::OnExit()
     m_threadWorkers.Clear();
     m_eventWorkers.Clear();
     m_listeningSocket->Destroy();
-    return 0;
+
+    return wxApp::OnExit();
 }
 
 void Server::OnSocketEvent(wxSocketEvent& pEvent)

--- a/samples/stc/stctest.cpp
+++ b/samples/stc/stctest.cpp
@@ -246,7 +246,7 @@ int App::OnExit () {
     if (g_pageSetupData) delete g_pageSetupData;
 #endif // wxUSE_PRINTING_ARCHITECTURE
 
-    return 0;
+    return wxApp::OnExit();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This was found while digging into #26172, but does not fix the issue of wxApp::OnExit() being called before windows are destroyed.