### PR TITLE
Fix over-zealous exception catching on macOS.

### DIFF
--- a/src/osx/core/evtloop_cf.cpp
+++ b/src/osx/core/evtloop_cf.cpp
@@ -34,6 +34,8 @@
 #include "wx/osx/private.h"
 #include "wx/osx/core/cfref.h"
 #include "wx/thread.h"
+#include "wx/private/safecall.h"
+#include "wx/scopeguard.h"
 
 #if wxUSE_GUI
     #include "wx/nonownedwnd.h"
@@ -311,46 +313,40 @@ void wxCFEventLoop::OSXDoStop()
 // terminating when Exit() is called
 int wxCFEventLoop::DoRun()
 {
+    #if wxUSE_EXCEPTIONS
     // we must ensure that OnExit() is called even if an exception is thrown
     // from inside ProcessEvents() but we must call it from Exit() in normal
     // situations because it is supposed to be called synchronously,
-    // wxModalEventLoop depends on this (so we can't just use ON_BLOCK_EXIT or
-    // something similar here)
-#if wxUSE_EXCEPTIONS
-    for ( ;; )
-    {
-        try
-        {
-#endif // wxUSE_EXCEPTIONS
+    // wxModalEventLoop depends on this, so we can't just use ON_BLOCK_EXIT and
+    // need a named guard to be able to dismiss it if it was called normally
+    wxScopeGuard guardOnExit = wxMakeObjGuard(*this, &wxCFEventLoop::OnExit);
+    #endif // wxUSE_EXCEPTIONS
 
+    // This loop is only used when exceptions are used, but it should hopefully
+    // be optimized away completely when they are not, so use it in any case to
+    // make the code simpler.
+    for ( bool stop = false; !stop; )
+    {
+        wxSafeCall<void>([&, this]
+        {
             OSXDoRun();
 
-#if wxUSE_EXCEPTIONS
-            // exit the outer loop as well
-            break;
-        }
-        catch ( ... )
+            #if wxUSE_EXCEPTIONS
+            guardOnExit.Dismiss();
+            #endif // wxUSE_EXCEPTIONS
+
+            stop = true;
+        }, [&]()
         {
-            try
+            #if wxUSE_EXCEPTIONS
+            if ( !wxTheApp || !wxTheApp->OnExceptionInMainLoop() )
             {
-                if ( !wxTheApp || !wxTheApp->OnExceptionInMainLoop() )
-                {
-                    OnExit();
-                    break;
-                }
-                //else: continue running the event loop
+                stop = true;
             }
-            catch ( ... )
-            {
-                // OnException() throwed, possibly rethrowing the same
-                // exception again: very good, but we still need OnExit() to
-                // be called
-                OnExit();
-                throw;
-            }
-        }
+            //else: continue running the event loop
+            #endif // wxUSE_EXCEPTIONS
+        });
     }
-#endif // wxUSE_EXCEPTIONS
 
     return m_exitcode;
 }


### PR DESCRIPTION
I think this should have been done as part of ec12651b9b1, without it any exceptions thrown within the main loop when the exception handler is disabled appear to come from wxCFEventLoop::DoRun(), unfortunately this still doesn't get us all the way to the real exception source in a debugger because CFRunLoopInMode() installs a handler too, but this gets us one step closer at least.