### PR TITLE
Add `wxTextEntryDialog::SetHint()`

### DIFF
--- a/include/wx/generic/textdlgg.h
+++ b/include/wx/generic/textdlgg.h
@@ -63,6 +63,9 @@ public:
     void SetValue(const wxString& val);
     wxString GetValue() const { return m_value; }
 
+    void SetHint(const wxString &hint);
+    wxString GetHint() const;
+
     void SetMaxLength(unsigned long len);
 
     void ForceUpper();

--- a/include/wx/generic/textdlgg.h
+++ b/include/wx/generic/textdlgg.h
@@ -64,7 +64,6 @@ public:
     wxString GetValue() const { return m_value; }
 
     void SetHint(const wxString &hint);
-    wxString GetHint() const;
 
     void SetMaxLength(unsigned long len);
 

--- a/interface/wx/textdlg.h
+++ b/interface/wx/textdlg.h
@@ -179,6 +179,15 @@ public:
     void SetValue(const wxString& value);
 
     /**
+        Sets the hint shown in the empty text control.
+
+        @see wxTextEntry::SetHint()
+
+        @since 3.3.2
+    */
+    void SetHint(const wxString &hint);
+
+    /**
         Convert all text entered into the text control used by the dialog to upper case.
 
         Call this method to ensure that all text entered into the text control

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -1180,6 +1180,7 @@ void MyFrame::LineEntry(wxCommandEvent& WXUNUSED(event))
                              "Please enter a string",
                              "Default value",
                              wxOK | wxCANCEL);
+    dialog.SetHint("Enter your text here");
 
     if (dialog.ShowModal() == wxID_OK)
     {
@@ -1193,6 +1194,7 @@ void MyFrame::TextEntry(wxCommandEvent& WXUNUSED(event))
                              "Please enter some text",
                              "First line\nSecond one\nAnd another one too",
                              wxOK | wxCANCEL | wxTE_MULTILINE);
+    dialog.SetHint("Enter your text here");
 
     if (dialog.ShowModal() == wxID_OK)
     {

--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -178,18 +178,6 @@ void wxTextEntryDialog::SetHint(const wxString& hint)
     }
 }
 
-wxString wxTextEntryDialog::GetHint() const
-{
-    if ( m_textctrl )
-    {
-        return m_textctrl->GetHint();
-    }
-    else
-    {
-        return wxString();
-    }
-}
-
 void wxTextEntryDialog::ForceUpper()
 {
     if ( m_textctrl )

--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -170,6 +170,26 @@ void wxTextEntryDialog::SetValue(const wxString& val)
     }
 }
 
+void wxTextEntryDialog::SetHint(const wxString& hint)
+{
+    if ( m_textctrl )
+    {
+        m_textctrl->SetHint(hint);
+    }
+}
+
+wxString wxTextEntryDialog::GetHint() const
+{
+    if ( m_textctrl )
+    {
+        return m_textctrl->GetHint();
+    }
+    else
+    {
+        return wxString();
+    }
+}
+
 void wxTextEntryDialog::ForceUpper()
 {
     if ( m_textctrl )


### PR DESCRIPTION
Sets the hint text for the underlying `wxTextCtrl`.

Also add a corresponding, intentionally undocumented `GetHint()`.