### PR TITLE
Add forgotten support for %T to our own wxDateTime::Format() code

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -634,6 +634,10 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
                     res += wxString::Format(fmt, tm.sec);
                     break;
 
+                case wxT('T'):       // time as %H:%M:%S
+                    res += wxString::Format(wxT("%02d:%02d:%02d"), tm.hour, tm.min, tm.sec);
+                    break;
+
                 case wxT('U'):       // week number in the year (Sunday 1st week day)
                     res += wxString::Format(fmt, GetWeekOfYear(Sunday_First, tz));
                     break;

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -796,6 +796,10 @@ TEST_CASE("wxDateTime::Format", "[datetime]")
     }
 
     CHECK(wxDateTime::Now().Format("%%") == "%");
+
+
+    wxDateTime dt(29, wxDateTime::May, 1976, 18, 30, 15, 678);
+    CHECK( dt.Format("%F %T.%l") == "1976-05-29 18:30:15.678" );
 }
 
 TEST_CASE("wxDateTime::ParseFormat", "[datetime]")


### PR DESCRIPTION
"%T" was only handled when strftime() could be used but not by our own implementation, resulting in failing to handle it for format string including both "%T" and one of the specifiers not supported by the standard function, such as "%l" or several others when using MinGW.

Closes #26179.