### PR TITLE
Require CMake 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-cmake_minimum_required(VERSION 3.5...4.1)
+cmake_minimum_required(VERSION 3.10...4.1)
 
 if(NOT CMAKE_CONFIGURATION_TYPES)
     get_property(HAVE_MULTI_CONFIG_GENERATOR GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)


### PR DESCRIPTION
This is needed for the correct GLX detection by FindOpenGL which we use since 065e639a9d (Enable building wxGTK without GLX, 2026-02-02).

See #26146.