### PR TITLE
Replace recently added wxFrame::Modality with wxWindowMode

### DIFF
--- a/include/wx/dialog.h
+++ b/include/wx/dialog.h
@@ -51,12 +51,15 @@ enum wxDialogLayoutAdaptationMode
     wxDIALOG_ADAPTATION_MODE_DISABLED = 2   // disable this dialog overriding global status
 };
 
-enum wxDialogModality
-{
-    wxDIALOG_MODALITY_NONE = 0,
-    wxDIALOG_MODALITY_WINDOW_MODAL = 1,
-    wxDIALOG_MODALITY_APP_MODAL = 2
-};
+// The following symbols are preserved only for compatibility.
+// Please use wxWindowMode directly in any new code instead.
+
+// Preview frame modality kind used with wxPreviewFrame::Initialize()
+using wxDialogModality = wxWindowMode;
+
+constexpr wxWindowMode wxDIALOG_MODALITY_NONE = wxWindowMode::Normal;
+constexpr wxWindowMode wxDIALOG_MODALITY_WINDOW_MODAL = wxWindowMode::WindowModal;
+constexpr wxWindowMode wxDIALOG_MODALITY_APP_MODAL = wxWindowMode::AppModal;
 
 extern WXDLLIMPEXP_DATA_CORE(const char) wxDialogNameStr[];
 
@@ -106,7 +109,7 @@ public:
     // This function always returns a valid top level window or nullptr.
     wxWindow *GetParentForModalDialog(wxWindow *parent, long style) const
     {
-        return DoGetParentForDialog(wxDIALOG_MODALITY_APP_MODAL, parent, style);
+        return DoGetParentForDialog(wxWindowMode::AppModal, parent, style);
     }
 
     // This overload can only be used for already initialized windows, i.e. not
@@ -123,7 +126,7 @@ public:
     // is only shown later, after showing the parent).
     wxWindow *GetParentForModelessDialog(wxWindow *parent, long style) const
     {
-        return DoGetParentForDialog(wxDIALOG_MODALITY_NONE, parent, style);
+        return DoGetParentForDialog(wxWindowMode::Normal, parent, style);
     }
 
 #if wxUSE_STATTEXT // && wxUSE_TEXTCTRL
@@ -203,7 +206,7 @@ public:
     static void EnableLayoutAdaptation(bool enable) { sm_layoutAdaptation = enable; }
 
     // modality kind
-    virtual wxDialogModality GetModality() const;
+    virtual wxWindowMode GetModality() const;
 protected:
     // emulate click of a button with the given id if it's present in the dialog
     //
@@ -256,13 +259,13 @@ protected:
 
 private:
     // Common implementation of GetParentFor{Modal,Modeless}Dialog().
-    wxWindow *DoGetParentForDialog(wxDialogModality modality,
+    wxWindow *DoGetParentForDialog(wxWindowMode modality,
                                    wxWindow *parent,
                                    long style) const;
 
     // helper of DoGetParentForDialog(): returns the passed in window if it
     // can be used as parent for this kind of dialog or nullptr if it can't
-    wxWindow *CheckIfCanBeUsedAsParent(wxDialogModality modality,
+    wxWindow *CheckIfCanBeUsedAsParent(wxWindowMode modality,
                                        wxWindow *parent) const;
 
     // Helper of OnCharHook() and OnCloseWindow(): find the appropriate button

--- a/include/wx/frame.h
+++ b/include/wx/frame.h
@@ -77,15 +77,8 @@ public:
     // frame modality
     // ------------------
 
-    enum class Modality
-    {
-        App,
-        Window,
-        None
-    };
-
     // Changing the frame modality after it has been shown has no effect
-    virtual void SetWindowModality(Modality modality);
+    virtual void SetWindowModality(wxWindowMode modality);
 
     // menu bar functions
     // ------------------
@@ -262,7 +255,7 @@ protected:
 #endif // wxUSE_TOOLBAR
 
     // The frame is not modal by default.
-    Modality m_modality = Modality::None;
+    wxWindowMode m_modality = wxWindowMode::Normal;
 
 #if wxUSE_MENUS
     wxDECLARE_EVENT_TABLE();

--- a/include/wx/osx/dialog.h
+++ b/include/wx/osx/dialog.h
@@ -70,7 +70,7 @@ public:
     // implementation
     // --------------
 
-    wxDialogModality GetModality() const override;
+    wxWindowMode GetModality() const override;
 
 #if wxOSX_USE_COCOA
     virtual void ModalFinishedCallback(void* WXUNUSED(panel), int WXUNUSED(returnCode)) {}
@@ -87,7 +87,7 @@ protected:
     virtual bool IsEscapeKey(const wxKeyEvent& event) override;
 
 
-    wxDialogModality m_modality;
+    wxWindowMode m_modality;
 
     wxModalEventLoop* m_eventLoop;
 

--- a/include/wx/prntbase.h
+++ b/include/wx/prntbase.h
@@ -55,22 +55,22 @@ enum wxPrinterError
 };
 
 // The following symbols are preserved only for compatibility.
-// Please use the new wxFrame::Modality instead in any new code.
+// Please use wxWindowMode directly instead in any new code.
 
 // Preview frame modality kind used with wxPreviewFrame::Initialize()
-using wxPreviewFrameModalityKind = wxFrameBase::Modality;
+using wxPreviewFrameModalityKind = wxWindowMode;
 
 // Disable all the other top level windows while the preview is shown.
 constexpr wxPreviewFrameModalityKind
-wxPreviewFrame_AppModal = wxFrameBase::Modality::App;
+wxPreviewFrame_AppModal = wxWindowMode::AppModal;
 
 // Disable only the parent window while the preview is shown.
 constexpr wxPreviewFrameModalityKind
-wxPreviewFrame_WindowModal = wxFrameBase::Modality::Window;
+wxPreviewFrame_WindowModal = wxWindowMode::WindowModal;
 
 // Don't disable any windows.
 constexpr wxPreviewFrameModalityKind
-wxPreviewFrame_NonModal = wxFrameBase::Modality::None;
+wxPreviewFrame_NonModal = wxWindowMode::Normal;
 
 //----------------------------------------------------------------------------
 // wxPrintFactory

--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -52,7 +52,7 @@ public:
 
     virtual void SetWindowStyleFlag( long style ) override;
 
-    virtual void SetWindowModality(Modality modality) override;
+    virtual void SetWindowModality(wxWindowMode modality) override;
 
     virtual void AddChild( wxWindowBase *child ) override;
     virtual void RemoveChild( wxWindowBase *child ) override;

--- a/include/wx/toplevel.h
+++ b/include/wx/toplevel.h
@@ -118,6 +118,20 @@ enum wxContentProtection
     wxCONTENT_PROTECTION_ENABLED
 };
 
+enum class wxWindowMode
+{
+    // Normal, not modal, window.
+    Normal,
+
+    // Modal in parent window scope, i.e. the user must close this window
+    // before being able to interact with the parent window again.
+    WindowModal,
+
+    // Modal in application scope, i.e. the user must close this window
+    // before being able to interact with any other window in the application.
+    AppModal
+};
+
 // ----------------------------------------------------------------------------
 // wxTopLevelWindow: a top level (as opposed to child) window
 // ----------------------------------------------------------------------------

--- a/interface/wx/frame.h
+++ b/interface/wx/frame.h
@@ -316,28 +316,17 @@ public:
     virtual wxPoint GetClientAreaOrigin() const;
 
     /**
-        Possible parameters for SetWindowModality().
-
-        @since 3.3.2
-    */
-    enum class Modality
-    {
-        App,    ///< Disable all the other TLWs while the frame is shown.
-        Window, ///< Disable only the parent window while the frame is shown.
-        None    ///< Show the frame non-modally, and this is the default.
-    };
-
-    /**
         Set the frame modality.
 
         Call this function before showing the frame to make it modal to the
-        application (Modality::App) or just to the parent window (Modality::Window).
+        application (wxWindowMode::AppModal) or just to the parent window
+        (wxWindowMode::WindowModal).
 
         @note Changing the frame modality after it has been shown has no effect
 
         @since 3.3.2
     */
-    virtual void SetWindowModality(Modality modality);
+    virtual void SetWindowModality(wxWindowMode modality);
 
 
     /**

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -153,7 +153,7 @@ public:
     The elements of this enum can be used with wxPreviewFrame::Initialize() to
     indicate how should the preview frame be shown.
 
-    @note Since version 3.3.2, this is just an alias for wxFrame::Modality.
+    @note Since version 3.3.2, this is just an alias for wxWindowMode.
 
     @since 2.9.2
 */
@@ -162,7 +162,7 @@ enum wxPreviewFrameModalityKind
     /**
         Disable all the other top level windows while the preview frame is shown.
 
-        Same as wxFrame::Modality::App
+        Same as wxWindowMode::AppModal.
 
         This is the default behaviour.
      */
@@ -171,14 +171,14 @@ enum wxPreviewFrameModalityKind
     /**
         Disable only the parent window while the preview frame is shown.
 
-        Same as wxFrame::Modality::Window
+        Same as wxWindowMode::WindowModal.
      */
     wxPreviewFrame_WindowModal,
 
     /**
         Show the preview frame non-modally and don't disable any other windows.
 
-        Same as wxFrame::Modality::None
+        Same as wxWindowMode::Normal.
      */
     wxPreviewFrame_NonModal
 };

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -40,6 +40,18 @@ enum
                           wxFULLSCREEN_NOCAPTION
 };
 
+/**
+    Possible parameters for wxFrame::SetWindowModality().
+
+    @since 3.3.2
+*/
+enum class wxWindowMode
+{
+    Normal,      ///< Show the frame non-modally, and this is the default.
+    WindowModal, ///< Disable only the parent window while the frame is shown.
+    AppModal     ///< Disable all the other TLWs while the frame is shown.
+};
+
 #define wxDEFAULT_FRAME_STYLE (wxSYSTEM_MENU |          \
                                wxRESIZE_BORDER |        \
                                wxMINIMIZE_BOX |         \

--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -128,7 +128,7 @@ wxDialogBase::wxDialogBase()
 }
 
 wxWindow *
-wxDialogBase::CheckIfCanBeUsedAsParent(wxDialogModality modality,
+wxDialogBase::CheckIfCanBeUsedAsParent(wxWindowMode modality,
                                        wxWindow *parent) const
 {
     if ( !parent )
@@ -153,11 +153,11 @@ wxDialogBase::CheckIfCanBeUsedAsParent(wxDialogModality modality,
     // be created before their parent is shown and only shown later.
     switch ( modality )
     {
-        case wxDIALOG_MODALITY_NONE:
+        case wxWindowMode::Normal:
             break;
 
-        case wxDIALOG_MODALITY_APP_MODAL:
-        case wxDIALOG_MODALITY_WINDOW_MODAL:
+        case wxWindowMode::AppModal:
+        case wxWindowMode::WindowModal:
             if ( !parent->IsShownOnScreen() )
             {
                 // using hidden parent won't work correctly either
@@ -177,7 +177,7 @@ wxDialogBase::CheckIfCanBeUsedAsParent(wxDialogModality modality,
 }
 
 wxWindow *
-wxDialogBase::DoGetParentForDialog(wxDialogModality modality,
+wxDialogBase::DoGetParentForDialog(wxWindowMode modality,
                                    wxWindow *parent,
                                    long style) const
 {
@@ -513,9 +513,9 @@ void wxDialogBase::SendWindowModalDialogEvent ( wxEventType type )
 }
 
 
-wxDialogModality wxDialogBase::GetModality() const
+wxWindowMode wxDialogBase::GetModality() const
 {
-    return IsModal() ? wxDIALOG_MODALITY_APP_MODAL : wxDIALOG_MODALITY_NONE;
+    return IsModal() ? wxWindowMode::AppModal : wxWindowMode::Normal;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -156,7 +156,7 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
     while ( keyWindow && keyWindow != tlw )
     {
         wxDialog *dlg = wxDynamicCast(keyWindow, wxDialog);
-        if ( dlg && dlg->GetModality() == wxDIALOG_MODALITY_WINDOW_MODAL )
+        if ( dlg && dlg->GetModality() == wxWindowMode::WindowModal )
             keyWindow = dlg->GetParent();
         else
             break;

--- a/src/osx/cocoa/dirdlg.mm
+++ b/src/osx/cocoa/dirdlg.mm
@@ -104,7 +104,7 @@ void wxDirDialog::ShowWindowModal()
 
     wxCHECK_RET(parentWindow, "Window modal display requires parent.");
 
-    m_modality = wxDIALOG_MODALITY_WINDOW_MODAL;
+    m_modality = wxWindowMode::WindowModal;
 
     NSOpenPanel *oPanel = OSXCreatePanel();
 
@@ -162,7 +162,7 @@ void wxDirDialog::ModalFinishedCallback(void* panel, int returnCode)
     }
     SetReturnCode(result);
 
-    if (GetModality() == wxDIALOG_MODALITY_WINDOW_MODAL)
+    if (GetModality() == wxWindowMode::WindowModal)
         SendWindowModalDialogEvent ( wxEVT_WINDOW_MODAL_DIALOG_CLOSED  );
 }
 

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -249,7 +249,7 @@ void wxFileDialog::ShowWindowModal()
 {
     wxNonOwnedWindow* parentWindow = nullptr;
 
-    m_modality = wxDIALOG_MODALITY_WINDOW_MODAL;
+    m_modality = wxWindowMode::WindowModal;
 
     if (GetParent())
         parentWindow = dynamic_cast<wxNonOwnedWindow*>(wxGetTopLevelParent(GetParent()));
@@ -689,7 +689,7 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
     if ( m_isNativeWindowWrapper )
         UnsubclassWin();
 
-    if (GetModality() == wxDIALOG_MODALITY_WINDOW_MODAL)
+    if (GetModality() == wxWindowMode::WindowModal)
         SendWindowModalDialogEvent ( wxEVT_WINDOW_MODAL_DIALOG_CLOSED  );
 
     [sPanel setAccessoryView:nil];

--- a/src/osx/cocoa/msgdlg.mm
+++ b/src/osx/cocoa/msgdlg.mm
@@ -170,7 +170,7 @@ void wxMessageDialog::ShowWindowModal()
 {
     wxNonOwnedWindow* parentWindow = nullptr;
 
-    m_modality = wxDIALOG_MODALITY_WINDOW_MODAL;
+    m_modality = wxWindowMode::WindowModal;
 
     if (GetParent())
         parentWindow = dynamic_cast<wxNonOwnedWindow*>(wxGetTopLevelParent(GetParent()));
@@ -204,7 +204,7 @@ void wxMessageDialog::ModalFinishedCallback(void* WXUNUSED(panel), int resultCod
     }
     SetReturnCode(resultbutton);
 
-    if (GetModality() == wxDIALOG_MODALITY_WINDOW_MODAL)
+    if (GetModality() == wxWindowMode::WindowModal)
         SendWindowModalDialogEvent ( wxEVT_WINDOW_MODAL_DIALOG_CLOSED  );
 }
 

--- a/src/osx/dialog_osx.cpp
+++ b/src/osx/dialog_osx.cpp
@@ -59,7 +59,7 @@ void wxDialog::OSXEndModalDialog()
 
 void wxDialog::Init()
 {
-    m_modality = wxDIALOG_MODALITY_NONE;
+    m_modality = wxWindowMode::Normal;
     m_eventLoop = nullptr;
 }
 
@@ -105,12 +105,12 @@ bool wxDialog::IsEscapeKey(const wxKeyEvent& event)
 
 bool wxDialog::IsModal() const
 {
-    return m_modality != wxDIALOG_MODALITY_NONE;
+    return m_modality != wxWindowMode::Normal;
 }
 
 bool wxDialog::Show(bool show)
 {
-    if ( m_modality == wxDIALOG_MODALITY_WINDOW_MODAL )
+    if ( m_modality == wxWindowMode::WindowModal )
     {
         if ( !wxWindow::Show(show) )
             // nothing to do
@@ -132,14 +132,14 @@ bool wxDialog::Show(bool show)
 
     if ( !show )
     {
-        const int modalityOrig = m_modality;
+        const wxWindowMode modalityOrig = m_modality;
 
         // complete the 'hiding' before we send the event
-        m_modality = wxDIALOG_MODALITY_NONE;
+        m_modality = wxWindowMode::Normal;
 
         switch ( modalityOrig )
         {
-            case wxDIALOG_MODALITY_WINDOW_MODAL:
+            case wxWindowMode::WindowModal:
                 EndWindowModal(); // OS X implementation method for cleanup
                 SendWindowModalDialogEvent ( wxEVT_WINDOW_MODAL_DIALOG_CLOSED  );
                 break;
@@ -156,7 +156,7 @@ int wxDialog::ShowModal()
 {
     WX_HOOK_MODAL_DIALOG();
 
-    m_modality = wxDIALOG_MODALITY_APP_MODAL;
+    m_modality = wxWindowMode::AppModal;
 
     Show();
 
@@ -174,14 +174,14 @@ int wxDialog::ShowModal()
 
 void wxDialog::ShowWindowModal()
 {
-    m_modality = wxDIALOG_MODALITY_WINDOW_MODAL;
+    m_modality = wxWindowMode::WindowModal;
 
     Show();
 
     DoShowWindowModal();
 }
 
-wxDialogModality wxDialog::GetModality() const
+wxWindowMode wxDialog::GetModality() const
 {
     return m_modality;
 }

--- a/src/osx/iphone/dialog.mm
+++ b/src/osx/iphone/dialog.mm
@@ -24,7 +24,7 @@ extern wxList wxModalDialogs;
 
 void wxDialog::DoShowWindowModal()
 {
-    m_modality = wxDIALOG_MODALITY_APP_MODAL;
+    m_modality = wxWindowMode::AppModal;
     ShowModal();
     SendWindowModalDialogEvent ( wxEVT_WINDOW_MODAL_DIALOG_CLOSED  );
 }

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -207,7 +207,7 @@ void wxFrame::SetWindowStyleFlag( long style )
     GetQMainWindow()->setWindowFlags(qtFlags);
 }
 
-void wxFrame::SetWindowModality(Modality modality)
+void wxFrame::SetWindowModality(wxWindowMode modality)
 {
     wxCHECK_RET( !IsShown(),
                  "SetWindowModality() must be called before showing the window" );
@@ -216,15 +216,15 @@ void wxFrame::SetWindowModality(Modality modality)
 
     switch ( modality )
     {
-        case Modality::App:
+        case wxWindowMode::AppModal:
             qtModality = Qt::ApplicationModal;
             break;
 
-        case Modality::Window:
+        case wxWindowMode::WindowModal:
             qtModality = Qt::WindowModal;
             break;
 
-        case Modality::None:
+        case wxWindowMode::Normal:
             qtModality = Qt::NonModal;
             break;
     }


### PR DESCRIPTION
Don't make the modality enum wxFrame-specific as a very similar enum was also used with wxDialog.

Replace both of them with wxWindowMode defined in the common header.

Also use "Normal" instead of "None" to avoid conflict with a symbol defined in X11 headers.

See #26147.

Closes #26183.