### PR TITLE
Ensure windows are destroyed before wxApp::OnExit() is called

### DIFF
--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -482,6 +482,10 @@ public:
     // returns true for GUI wxApp subclasses
     virtual bool IsGUI() const { return false; }
 
+    // Perform the always needed cleanup before and after calling possibly
+    // overridden OnExit().
+    int CallOnExit();
+
 
     // command line arguments (public for backwards compatibility)
     int argc;
@@ -501,6 +505,13 @@ protected:
     //
     // called from ProcessPendingEvents()
     void DeletePendingObjects();
+
+    // Perform all delayed cleanup, including deleting the pending objects and
+    // anything else, e.g. the GUI version uses it to delete any remaining
+    // windows too.
+    //
+    // This function is safe to call multiple times.
+    virtual void DoDelayedCleanup();
 
     // the function which creates the traits object when GetTraits() needs it
     // for the first time
@@ -751,6 +762,9 @@ public:
     }
 
 protected:
+    // Override base class method to do the GUI-specific cleanup too.
+    virtual void DoDelayedCleanup() override;
+
     // override base class method to use GUI traits
     virtual wxAppTraits *CreateTraits() override;
 

--- a/include/wx/msw/mfc.h
+++ b/include/wx/msw/mfc.h
@@ -84,7 +84,7 @@ public:
         BaseApp::m_pMainWnd = nullptr;
 
         if ( wxTheApp )
-            wxTheApp->OnExit();
+            wxTheApp->CallOnExit();
 
         wxEntryCleanup();
 

--- a/src/common/appcmn.cpp
+++ b/src/common/appcmn.cpp
@@ -138,16 +138,19 @@ void wxAppBase::DeleteAllTLWs()
     }
 }
 
+void wxAppBase::DoDelayedCleanup()
+{
+    wxAppConsole::DoDelayedCleanup();
+
+    DeleteAllTLWs();
+}
+
 void wxAppBase::CleanUp()
 {
     // Clean up any still pending objects. Normally there shouldn't any as we
-    // already do this in OnExit(), but this could happen if the user code has
-    // somehow managed to create more of them since then or just forgot to call
-    // the base class OnExit().
-    DeletePendingObjects();
-
-    // and any remaining TLWs
-    DeleteAllTLWs();
+    // already do this in CallOnExit(), but this could happen if the user code
+    // has somehow managed to create more of them since then.
+    DoDelayedCleanup();
 
 #if wxUSE_LOG
     // flush the logged messages if any and don't use the current probably

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -26,7 +26,9 @@
 #endif
 
 #include "wx/init.h"
+
 #include "wx/atomic.h"
+#include "wx/scopeguard.h"
 
 #if defined(__WINDOWS__)
     #include "wx/msw/private.h"
@@ -106,15 +108,6 @@ public:
 private:
     wxAppConsole *m_app;
 };
-
-// ----------------------------------------------------------------------------
-// private functions
-// ----------------------------------------------------------------------------
-
-// suppress warnings about unused variables
-static inline void Use(void *) { }
-
-#define WX_SUPPRESS_UNUSED_WARN(x) Use(&x)
 
 // ----------------------------------------------------------------------------
 // initialization data
@@ -564,13 +557,7 @@ int wxEntryReal(int& argc, wxChar **argv)
         }
 
         // ensure that OnExit() is called if OnInit() had succeeded
-        class CallOnExit
-        {
-        public:
-            ~CallOnExit() { wxTheApp->OnExit(); }
-        } callOnExit;
-
-        WX_SUPPRESS_UNUSED_WARN(callOnExit);
+        wxON_BLOCK_EXIT_OBJ0(*wxTheApp, wxAppConsoleBase::CallOnExit);
 
         // app execution
         return wxTheApp->OnRun();

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -739,17 +739,10 @@ void wxApp::OnEndSession(wxCloseEvent& WXUNUSED(event))
     // WM_ENDSESSION handler or when we delete our last window, so make sure we
     // at least execute our cleanup code before
 
-    // Destroy all the remaining TLWs before calling OnExit() to have the same
-    // sequence of events in this case as in case of the normal shutdown,
-    // otherwise we could have many problems due to wxApp being already
-    // destroyed when window cleanup code (in close event handlers or dtor) is
-    // executed.
-    //
     // Note that we survive after this call only because we don't delete any
-    // windows at MSW level, see gs_gotEndSession check in wxWindow dtor.
-    DeleteAllTLWs();
-
-    const int rc = OnExit();
+    // windows at MSW level, see gs_gotEndSession check in wxWindow dtor, even
+    // though CallOnExit() deletes all C++ top level window objects.
+    const int rc = CallOnExit();
 
     // Skip unregistering windows classes: this is not really necessary and
     // would result in an error because we may still have an open window.


### PR DESCRIPTION
In some circumstances we could call wxApp::OnExit() before destroying the application windows, which violated the documented (and reasonably expected) behaviour.

Fix this by adding a wrapper CallOnExit() function which destroys all windows before calling OnExit() and, for good measure, then does it again in case the user-overridden version of this function created more windows when it was called.

This also has a nice side effect of freeing the user code from the need to call the base OnExit(), as it is now trivial and doesn't do anything any more.

Closes #26172.