### PR TITLE
wxQt: Suppress the selection changed event on the first display of th…

### DIFF
--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -453,7 +453,9 @@ public:
 
         const QModelIndex modelIndex = index(row, col);
 
-        if ( info.m_mask & wxLIST_MASK_STATE )
+        // For consistency with the other ports, don't generate wxEVT_LIST_ITEM_SELECTED
+        // event when the list control is shown for the first time.
+        if ( m_view->isVisible() && info.m_mask & wxLIST_MASK_STATE )
         {
             if ( (info.m_stateMask & wxLIST_STATE_FOCUSED) &&
                 (info.m_state & wxLIST_STATE_FOCUSED) )


### PR DESCRIPTION
…e wxListCtrl.

Since the `wxEVT_LIST_ITEM_SELECTED` event is not generated in the other ports when the `wxListCtrl` is shown for the first time, do not generate it under `wxQt` for consistency.

The `artprov` sample would assert here:

https://github.com/wxWidgets/wxWidgets/blob/4e4159836df134eb87d84e800ca11f45ed8e7d5e/src/common/artprov.cpp#L422-L428

because `m_client` were not initialized yet when this handler is executed:
https://github.com/wxWidgets/wxWidgets/blob/4e4159836df134eb87d84e800ca11f45ed8e7d5e/samples/artprov/artbrows.cpp#L241-L246

Initializing `m_client` before calling `SetItemState()` here
https://github.com/wxWidgets/wxWidgets/blob/4e4159836df134eb87d84e800ca11f45ed8e7d5e/samples/artprov/artbrows.cpp#L232-L236

fixes the problem, but will just hide the inconsistency of `wxQt` with the other ports.