### PR TITLE
Change return type of wxGetTranslation

### DIFF
--- a/include/wx/intl.h
+++ b/include/wx/intl.h
@@ -210,16 +210,16 @@ public:
     //
     // domains are searched in the last to first order, i.e. catalogs
     // added later override those added before.
-    const wxString& GetString(const wxString& origString,
-                              const wxString& domain = wxEmptyString) const
+    wxString GetString(const wxString& origString,
+                       const wxString& domain = wxEmptyString) const
     {
         return wxGetTranslation(origString, domain);
     }
     // plural form version of the same:
-    const wxString& GetString(const wxString& origString,
-                              const wxString& origString2,
-                              unsigned n,
-                              const wxString& domain = wxEmptyString) const
+    wxString GetString(const wxString& origString,
+                       const wxString& origString2,
+                       unsigned n,
+                       const wxString& domain = wxEmptyString) const
     {
         return wxGetTranslation(origString, origString2, n, domain);
     }

--- a/include/wx/msw/private/uilocale.h
+++ b/include/wx/msw/private/uilocale.h
@@ -10,6 +10,8 @@
 #ifndef _WX_MSW_PRIVATE_UILOCALE_H_
 #define _WX_MSW_PRIVATE_UILOCALE_H_
 
+#if wxUSE_INTL
+
 #include "wx/msw/private.h"     // Include <windows.h> to get LCID.
 
 #ifndef LOCALE_SNAME
@@ -22,5 +24,7 @@
 WXDLLIMPEXP_BASE wxString wxTranslateFromUnicodeFormat(const wxString& fmt);
 
 WXDLLIMPEXP_BASE wxString wxGetMSWDateTimeFormat(wxLocaleInfo index);
+
+#endif // wxUSE_INTL
 
 #endif // _WX_MSW_PRIVATE_UILOCALE_H_

--- a/include/wx/private/uilocale.h
+++ b/include/wx/private/uilocale.h
@@ -10,6 +10,8 @@
 #ifndef _WX_PRIVATE_UILOCALE_H_
 #define _WX_PRIVATE_UILOCALE_H_
 
+#if wxUSE_INTL
+
 #include "wx/localedefs.h"
 #include "wx/object.h"
 #include "wx/string.h"
@@ -144,5 +146,7 @@ public:
     static int GetMatchDistance(const wxString& desired, const wxString& supported);
     static bool SameRegionGroup(const wxString& language, const wxString& desiredRegion, const wxString& supportedRegion);
 };
+
+#endif // wxUSE_INTL
 
 #endif // _WX_PRIVATE_UILOCALE_H_

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -179,10 +179,11 @@ public:
     wxString GetHeaderValue(const wxString& header,
                             const wxString& domain = wxEmptyString) const;
 
-    // this is hack to work around a problem with wxGetTranslation() which
-    // returns const wxString& and not wxString, so when it returns untranslated
-    // string, it needs to have a copy of it somewhere
-    static const wxString& GetUntranslatedString(const wxString& str);
+
+    wxDEPRECATED_INLINE(
+        static const wxString& GetUntranslatedString(const wxString& str),
+        return str;
+    )
 
 private:
     enum class Translations
@@ -274,9 +275,9 @@ protected:
 // ----------------------------------------------------------------------------
 
 // get the translation of the string in the current locale
-inline const wxString& wxGetTranslation(const wxString& str,
-                                        const wxString& domain = wxString(),
-                                        const wxString& context = wxString())
+inline wxString wxGetTranslation(const wxString& str,
+                                 const wxString& domain = wxString(),
+                                 const wxString& context = wxString())
 {
     wxTranslations *trans = wxTranslations::Get();
     const wxString *transStr = trans ? trans->GetTranslatedString(str, domain, context)
@@ -284,16 +285,14 @@ inline const wxString& wxGetTranslation(const wxString& str,
     if ( transStr )
         return *transStr;
     else
-        // NB: this function returns reference to a string, so we have to keep
-        //     a copy of it somewhere
-        return wxTranslations::GetUntranslatedString(str);
+        return str;
 }
 
-inline const wxString& wxGetTranslation(const wxString& str1,
-                                        const wxString& str2,
-                                        unsigned n,
-                                        const wxString& domain = wxString(),
-                                        const wxString& context = wxString())
+inline wxString wxGetTranslation(const wxString& str1,
+                                 const wxString& str2,
+                                 unsigned n,
+                                 const wxString& domain = wxString(),
+                                 const wxString& context = wxString())
 {
     wxTranslations *trans = wxTranslations::Get();
     const wxString *transStr = trans ? trans->GetTranslatedString(str1, n, domain, context)
@@ -301,11 +300,7 @@ inline const wxString& wxGetTranslation(const wxString& str1,
     if ( transStr )
         return *transStr;
     else
-        // NB: this function returns reference to a string, so we have to keep
-        //     a copy of it somewhere
-        return n == 1
-               ? wxTranslations::GetUntranslatedString(str1)
-               : wxTranslations::GetUntranslatedString(str2);
+        return n == 1 ? str1 : str2;
 }
 
 #ifdef wxNO_IMPLICIT_WXSTRING_ENCODING
@@ -314,19 +309,20 @@ inline const wxString& wxGetTranslation(const wxString& str1,
  * It must always be possible to call wxGetTranslation() with const
  * char* arguments.
  */
-inline const wxString& wxGetTranslation(const char *str,
-                                        const char *domain = "",
-                                        const char *context = "") {
+
+inline wxString wxGetTranslation(const char *str,
+                                 const char *domain = "",
+                                 const char *context = "") {
     const wxMBConv &conv = wxConvWhateverWorks;
     return wxGetTranslation(wxString(str, conv), wxString(domain, conv),
                             wxString(context, conv));
 }
 
-inline const wxString& wxGetTranslation(const char *str1,
-                                        const char *str2,
-                                        unsigned n,
-                                        const char *domain = "",
-                                        const char *context = "") {
+inline wxString wxGetTranslation(const char *str1,
+                                 const char *str2,
+                                 unsigned n,
+                                 const char *domain = "",
+                                 const char *context = "") {
     const wxMBConv &conv = wxConvWhateverWorks;
     return wxGetTranslation(wxString(str1, conv), wxString(str2, conv), n,
                             wxString(domain, conv),
@@ -383,7 +379,7 @@ inline wxString wxTRANS_INPUT_STR(const wchar_t* s)
 */
 
 template<size_t N, typename T>
-const wxString& wxUnderscoreWrapper(const T (&msg)[N])
+wxString wxUnderscoreWrapper(const T (&msg)[N])
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg));
 }
@@ -396,9 +392,9 @@ wxString wxUnderscoreWrapper(T)
 }
 
 template<size_t M, size_t N, typename T>
-const wxString& wxPluralWrapper(const T (&msg)[M],
-                                const T (&plural)[N],
-                                int count)
+wxString wxPluralWrapper(const T (&msg)[M],
+                         const T (&plural)[N],
+                         int count)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
                             count);
@@ -412,8 +408,8 @@ wxString wxPluralWrapper(T, U, int)
 }
 
 template<size_t M, size_t N, typename T>
-const wxString& wxGettextInContextWrapper(const T (&ctx)[M],
-                                          const T (&msg)[N])
+wxString wxGettextInContextWrapper(const T (&ctx)[M],
+                                   const T (&msg)[N])
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxString(),
                             wxTRANS_INPUT_STR(ctx));
@@ -427,10 +423,10 @@ wxString wxGettextInContextWrapper(T, U)
 }
 
 template<size_t L, size_t M, size_t N, typename T>
-const wxString& wxGettextInContextPluralWrapper(const T (&ctx)[L],
-                                                const T (&msg)[M],
-                                                const T (&plural)[N],
-                                                int count)
+wxString wxGettextInContextPluralWrapper(const T (&ctx)[L],
+                                         const T (&msg)[M],
+                                         const T (&plural)[N],
+                                         int count)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
                             count, wxString(), wxTRANS_INPUT_STR(ctx));
@@ -447,30 +443,30 @@ wxString wxGettextInContextPluralWrapper(T, U, V, int)
 
 // Wrapper functions that accept both string literals and variables
 // as arguments.
-inline const wxString& wxUnderscoreWrapper(const char *msg)
+inline wxString wxUnderscoreWrapper(const char *msg)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg));
 }
 
-inline const wxString& wxPluralWrapper(const char *msg,
-                                       const char *plural,
-                                       int count)
+inline wxString wxPluralWrapper(const char *msg,
+                                const char *plural,
+                                int count)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
                             count);
 }
 
-inline const wxString& wxGettextInContextWrapper(const char *ctx,
-                                                 const char *msg)
+inline wxString wxGettextInContextWrapper(const char *ctx,
+                                          const char *msg)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxString(),
                             wxTRANS_INPUT_STR(ctx));
 }
 
-inline const wxString& wxGettextInContextPluralWrapper(const char *ctx,
-                                                       const char *msg,
-                                                       const char *plural,
-                                                       int count)
+inline wxString wxGettextInContextPluralWrapper(const char *ctx,
+                                                const char *msg,
+                                                const char *plural,
+                                                int count)
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
                             count, wxString(), wxTRANS_INPUT_STR(ctx));

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -494,15 +494,15 @@ public:
     /**
         Calls wxGetTranslation(const wxString&, const wxString&).
     */
-    const wxString& GetString(const wxString& origString,
-                              const wxString& domain = wxEmptyString) const;
+    wxString GetString(const wxString& origString,
+                       const wxString& domain = wxEmptyString) const;
 
     /**
         Calls wxGetTranslation(const wxString&, const wxString&, unsigned, const wxString&).
     */
-    const wxString& GetString(const wxString& origString,
-                              const wxString& origString2, unsigned n,
-                              const wxString& domain = wxEmptyString) const;
+    wxString GetString(const wxString& origString,
+                       const wxString& origString2, unsigned n,
+                       const wxString& domain = wxEmptyString) const;
 
     /**
         Returns current platform-specific locale name as passed to setlocale().

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -612,9 +612,9 @@ public:
 
     @header{wx/intl.h}
 */
-const wxString& wxGetTranslation(const wxString& string,
-                                 const wxString& domain = wxEmptyString,
-                                 const wxString& context = wxEmptyString);
+wxString wxGetTranslation(const wxString& string,
+                          const wxString& domain = wxEmptyString,
+                          const wxString& context = wxEmptyString);
 
 /**
     This is an overloaded version of
@@ -638,10 +638,10 @@ const wxString& wxGetTranslation(const wxString& string,
 
     @header{wx/intl.h}
 */
-const wxString& wxGetTranslation(const wxString& string,
-                                 const wxString& plural, unsigned n,
-                                 const wxString& domain = wxEmptyString,
-                                 const wxString& context = wxEmptyString);
+wxString wxGetTranslation(const wxString& string,
+                          const wxString& plural, unsigned n,
+                          const wxString& domain = wxEmptyString,
+                          const wxString& context = wxEmptyString);
 
 /**
     Macro to be used around all literal strings that should be translated.

--- a/src/common/numformatter.cpp
+++ b/src/common/numformatter.cpp
@@ -173,6 +173,8 @@ void wxNumberFormatter::AddThousandsSeparators(wxString& s, int style)
         grouping = numForm.grouping;
         decimalSeparator = numForm.decimalSeparator;
     }
+#else
+    wxUnusedVar(style);
 #endif // wxUSE_INTL
 
     if (groupingSeparator.empty() )
@@ -320,8 +322,8 @@ void wxNumberFormatter::AddCurrency(wxString& s, int style)
         }
     }
 #else
-    wxUnused(s);
-    wxUnused(style);
+    wxUnusedVar(s);
+    wxUnusedVar(style);
 #endif // wxUSE_INTL
 }
 
@@ -372,7 +374,7 @@ wxString wxNumberFormatter::RemoveCurrencySymbolOrCode(wxString s, int style)
     }
     return s;
 #else
-    wxUnused(style);
+    wxUnusedVar(style);
     return s;
 #endif // wxUSE_INTL
 }

--- a/src/msw/datetimectrl.cpp
+++ b/src/msw/datetimectrl.cpp
@@ -80,6 +80,8 @@ wxDateTimePickerCtrl::MSWCreateDateTimePicker(wxWindow *parent,
     return true;
 }
 
+#if wxUSE_INTL
+
 void wxDateTimePickerCtrl::MSWSetTimeFormat(wxLocaleInfo index)
 {
     const wxString format = wxGetMSWDateTimeFormat(index);
@@ -89,6 +91,8 @@ void wxDateTimePickerCtrl::MSWSetTimeFormat(wxLocaleInfo index)
                            static_cast<const wchar_t*>(format.t_str()));
     }
 }
+
+#endif // wxUSE_INTL
 
 void wxDateTimePickerCtrl::SetValue(const wxDateTime& dt)
 {

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -98,6 +98,9 @@
 // For wxCmpNatural()
 #include <shlwapi.h>
 
+// For std::unique_ptr
+#include <memory>
+
 // In some distributions of MinGW32, this function is exported in the library,
 // but not declared in shlwapi.h. Therefore we declare it here.
 #if defined( __MINGW32_TOOLCHAIN__ )

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -264,7 +264,9 @@ public:
         m_dataPath = wxStandardPaths::Get().GetUserLocalDataDir();
 #ifdef __VISUALC__
         m_webViewEnvironmentOptions = Make<CoreWebView2EnvironmentOptions>().Get();
+#if wxUSE_INTL
         m_webViewEnvironmentOptions->put_Language(wxUILocale::GetCurrent().GetLocaleId().GetName().wc_str());
+#endif
 
         wxCOMPtr<ICoreWebView2EnvironmentOptions3> options3;
         if (SUCCEEDED(m_webViewEnvironmentOptions->QueryInterface(IID_PPV_ARGS(&options3))))


### PR DESCRIPTION
Change it from `const wxString&` to just `wxString` so there is no need to keep a copy around of untranslated strings.
This allows to remove `thread_local UntranslatedStringHolder` used by `GetUntranslatedString`, which causes many problems with MinGW.

Fixes https://github.com/wxWidgets/wxWidgets/issues/26195