### PR TITLE
Don't accumulate timer events when calling YieldFor() in wxMSW

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -48,7 +48,14 @@ enum wxEventCategory
     /// This category is for wxSocketEvent
     wxEVT_CATEGORY_SOCKET = 4,
 
-    /// This category is for wxTimerEvent
+    /**
+        This category is for wxTimerEvent.
+
+        @note Under wxMSW, if this category is not specified when calling
+        wxEventLoopBase::YieldFor, events from one-off timers may be lost,
+        so it's recommended to either pass this category to it or use
+        repeatedly firing timers instead.
+     */
     wxEVT_CATEGORY_TIMER = 8,
 
     /**

--- a/interface/wx/evtloop.h
+++ b/interface/wx/evtloop.h
@@ -262,6 +262,11 @@ public:
         wxWidgets events posted using wxEvtHandler::AddPendingEvent or
         wxEvtHandler::QueueEvent are instead selectively processed by all ports.
 
+        @note Under wxMSW, if @a eventsToProcess doesn't include
+        ::wxEVT_CATEGORY_TIMER, events from one-off timers may be lost,
+        so it's recommended to either include this category in the argument or
+        use repeatedly firing timers instead.
+
         @see wxEvent::GetEventCategory
     */
     bool YieldFor(long eventsToProcess);

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -27,11 +27,16 @@
     essentially be the same as this class.
 
     Note that you must be aware that wxProgressDialog internally calls
-    wxEventLoopBase::YieldFor with @c wxEVT_CATEGORY_UI and @c wxEVT_CATEGORY_USER_INPUT
+    wxEventLoopBase::YieldFor with ::wxEVT_CATEGORY_UI and ::wxEVT_CATEGORY_USER_INPUT
     and this may cause unwanted re-entrancies or the out-of-order processing
     of pending events (to help preventing the last problem if you're using
     wxProgressDialog in a multi-threaded application you should be sure to use
-    wxThreadEvent for your inter-threads communications).
+    wxThreadEvent for your inter-threads communications). Additionally because
+    events from one-off timers, i.e. those started with wxTimer::StartOnce(),
+    are discarded by wxEventLoopBase::YieldFor() when it's called with these
+    flags in wxMSW, any such timers firing while the progress dialog is shown
+    will not be processed at all, so it is recommended not to start such timers
+    before showing the progress dialog.
 
     Although wxProgressDialog is not really modal, it should be created on the
     stack, and not the heap, as other modal dialogs, e.g. use it like this:


### PR DESCRIPTION
Repeated calls to this function could result in unbounded input queue growth because timer events were synthesized for each call to it, put back into the queue if not processed, and then another event would be synthesized again during the next call.

Fix this by discarding timer events instead. This is not ideal when using one-off timers, but better than the alternative.

Document this limitation of wxMSW.

Closes #26192.