### PR TITLE
Cairo: Add support for Cygwin DLL

### DIFF
--- a/src/common/cairo.cpp
+++ b/src/common/cairo.cpp
@@ -330,6 +330,8 @@ wxCairo::wxCairo()
 
 #ifdef __WXMSW__
     wxString cairoDllStr("libcairo-2.dll");
+#elif defined(__CYGWIN__)
+    wxString cairoDllStr("cygcairo-2.dll");
 #elif defined(__WXOSX__)
     wxString cairoDllStr("libcairo.2.dylib");
 #else


### PR DESCRIPTION
This patch just adds the right name of the Cairo shared library on CYGWIN.

EDIT: I would like to backport this tiny patch to 3.2, what is the branch to use for this purpuse?