### PR TITLE
Add wxGLContext::GetProcAddress()

### DIFF
--- a/include/wx/glcanvas.h
+++ b/include/wx/glcanvas.h
@@ -182,6 +182,8 @@ public:
 // wxGLContextBase: OpenGL rendering context
 // ----------------------------------------------------------------------------
 
+using wxGLExtFunction = void (*)();
+
 class WXDLLIMPEXP_GL wxGLContextBase : public wxObject
 {
 public:
@@ -199,6 +201,20 @@ public:
     static void ClearCurrent();
 
     bool IsOK() const { return m_isOk; }
+
+    // Get pointer to OpenGL extension function, return nullptr if not found.
+    static wxGLExtFunction GetProcAddress(const wxString& name);
+
+    // Same as above, but returns the function of the specified type.
+    template <typename T>
+    static T GetProcAddress(const wxString& name)
+    {
+        wxGCC_WARNING_SUPPRESS_CAST_FUNCTION_TYPE()
+
+        return reinterpret_cast<T>(GetProcAddress(name));
+
+        wxGCC_WARNING_RESTORE_CAST_FUNCTION_TYPE()
+    }
 
 protected:
     bool m_isOk;

--- a/include/wx/unix/private/glcanvas.h
+++ b/include/wx/unix/private/glcanvas.h
@@ -137,6 +137,7 @@ public:
 
     // Static functions of wxGLContext and wxGLCanvas.
     virtual void ClearCurrentContext() = 0;
+    virtual wxGLExtFunction GetProcAddress(const wxString& name) = 0;
 
     virtual bool IsExtensionSupported(const char* extension) = 0;
 

--- a/include/wx/unix/private/glegl.h
+++ b/include/wx/unix/private/glegl.h
@@ -145,6 +145,7 @@ public:
     CreateCanvasImpl(wxGLCanvasUnix* canvas) override;
 
     void ClearCurrentContext() override;
+    wxGLExtFunction GetProcAddress(const wxString& name) override;
 
     bool IsExtensionSupported(const char* extension) override;
     bool IsDisplaySupported(const wxGLAttributes& dispAttrs) override;

--- a/include/wx/unix/private/glx11.h
+++ b/include/wx/unix/private/glx11.h
@@ -87,6 +87,7 @@ public:
     CreateCanvasImpl(wxGLCanvasUnix* canvas) override;
 
     void ClearCurrentContext() override;
+    wxGLExtFunction GetProcAddress(const wxString& name) override;
 
     bool IsExtensionSupported(const char* extension) override;
     bool IsDisplaySupported(const wxGLAttributes& dispAttrs) override;

--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -437,6 +437,15 @@ public:
 };
 
 /**
+    Return type of wxGLContext::GetProcAddress().
+
+    Generic OpenGL function pointer type.
+
+    @since 3.3.2
+ */
+using wxGLExtFunction = void (*)();
+
+/**
     @class wxGLContext
 
     An instance of a wxGLContext represents the state of an OpenGL state
@@ -548,6 +557,62 @@ public:
         @since 3.3.2
     */
     static void ClearCurrent();
+
+    /**
+        Tries to load an OpenGL extension function with the given name.
+
+        This function uses the platform-specific mechanism for retrieving the
+        address of OpenGL extension functions, e.g. `wglGetProcAddress()` on
+        MSW and either `glXGetProcAddress()` or `eglGetProcAddress()` under
+        Unix systems.
+
+        When calling the template function, the type of the function must be
+        specified as the template parameter, e.g.
+
+        @code
+        typedef void (*glGenBuffers_t) (GLsizei n, GLuint *buffers);
+        auto glGenBuffers = wxGLContext::GetProcAddress<glGenBuffers_t>("glGenBuffers");
+        if ( glGenBuffers )
+        {
+            // glGenBuffers is supported, use it
+            ...
+        }
+        @endcode
+
+        If the type is omitted, the function returns a generic
+        ::wxGLExtFunction pointer that should be cast to the appropriate type
+        by the caller.
+
+        @note Under MSW the returned value may be specific to the currently
+            active context and thus may not be valid for other contexts. So, it
+            is recommended to call this function for each context separately
+            and not to share the returned function pointers between contexts.
+
+        @par
+
+        @note This function is currently not implemented under macOS and always
+            returns @NULL there.
+
+        @since 3.3.2
+     */
+    template <typename T = wxGLExtFunction>
+    static T GetProcAddress(const wxString& name);
+
+    /*
+        Documenting the function returning wxGLExtFunction directly results in
+        bogus Doxygen warnings:
+
+interface/wx/glcanvas.h:596: warning: no uniquely matching class member found for
+  returning a generic function wxGLContext::pointer
+Possible candidates:
+  'wxChar * wxString::pointer' at line 383 of file interface/wx/string.h
+  'value_type * wxVector< T >::pointer' at line 31 of file interface/wx/vector.h
+
+        So don't do it.
+
+        /// @overload
+        static wxGLExtFunction GetProcAddress(const wxString& name);
+    */
 };
 
 /**

--- a/samples/opengl/pyramid/oglpfuncs.cpp
+++ b/samples/opengl/pyramid/oglpfuncs.cpp
@@ -7,55 +7,18 @@
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
-#include "oglpfuncs.h"
+#include "wx/wxprec.h"
+
+#ifndef WX_PRECOMP
+    #include "wx/wx.h"
+#endif
+
+// This header needs to be included before GL/gl.h included by wx/glcanvas.h.
+#include "oglstuff.h"
+#include "wx/glcanvas.h"
 
 // Apple defines everything on his own
 #ifndef __APPLE__
-
-#if defined(_WIN32) || defined(__WIN32__)
-    #ifndef WIN32_LEAN_AND_MEAN
-        // Reduce a bit header VC++ compilation time
-        #define WIN32_LEAN_AND_MEAN 1
-        #define LE_ME_ISDEF
-    #endif
-
-    /*
-    APIENTRY is defined in oglpfuncs.h as well as by windows.h. Undefine
-    it to prevent a macro redefinition warning.
-    */
-    #undef APIENTRY
-    #include <windows.h> //For wglGetProcAddress
-    #ifdef LE_ME_ISDEF
-        #undef WIN32_LEAN_AND_MEAN
-        #undef LE_ME_ISDEF
-    #endif
-    // Our macro
-    #define MyGetProcAddress(name) wglGetProcAddress((LPCSTR)name)
-#else // Linux
-    // GLX_ARB_get_proc_address
-    // glXGetProcAddressARB is statically exported by all libGL implementations,
-    // while glXGetProcAddress may be not available.
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
-    extern void (*glXGetProcAddressARB(const GLubyte *procName))();
-    #ifdef __cplusplus
-        }
-    #endif
-    #define MyGetProcAddress(name) (*glXGetProcAddressARB)((const GLubyte*)name)
-#endif
-
-// The function to get the pointers
-void* MyGetGLFuncAddress(const char* fname)
-{
-    void* pret = (void*) MyGetProcAddress(fname);
-
-    // Some drivers return -apart from 0-, -1, 1, 2 or 3
-    if ( pret == (void*)-1 || pret == (void*)1 || pret == (void*)2 || pret == (void*)3 )
-        pret = nullptr;
-
-    return pret;
-}
 
 // Declare and initialize pointers
 PFNGLACTIVETEXTUREPROC my_glActiveTexture = nullptr;
@@ -96,7 +59,7 @@ PFNGLVERTEXATTRIBPOINTERPROC my_glVertexAttribPointer = nullptr;
 
 // Retrieve the pointers
 #define GETANDTEST(type, name)                       \
-    my_ ## name = (type) MyGetGLFuncAddress(#name);  \
+    my_ ## name = wxGLContext::GetProcAddress<type>(#name);  \
     if (name == nullptr)                                   \
         return false;
 

--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -261,4 +261,12 @@ void wxGLContextBase::ClearCurrent()
     [NSOpenGLContext clearCurrentContext];
 }
 
+/* static */
+wxGLExtFunction wxGLContextBase::GetProcAddress(const wxString& WXUNUSED(name))
+{
+    // TODO: we should probably use wxDynamicLibrary to load the function but
+    // it's not clear what is the shared library to load them from.
+    return nullptr;
+}
+
 #endif // wxUSE_GLCANVAS

--- a/src/unix/glcanvas.cpp
+++ b/src/unix/glcanvas.cpp
@@ -266,6 +266,12 @@ void wxGLContextBase::ClearCurrent()
     wxGLBackend::Get().ClearCurrentContext();
 }
 
+/* static */
+wxGLExtFunction wxGLContextBase::GetProcAddress(const wxString& name)
+{
+    return wxGLBackend::Get().GetProcAddress(name);
+}
+
 // ----------------------------------------------------------------------------
 // wxGLCanvasUnix
 // ----------------------------------------------------------------------------

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -342,6 +342,11 @@ void wxGLBackendEGL::ClearCurrentContext()
                    EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
+wxGLExtFunction wxGLBackendEGL::GetProcAddress(const wxString& name)
+{
+    return eglGetProcAddress(name.utf8_str());
+}
+
 // ============================================================================
 // wxGLCanvasEGL implementation
 // ============================================================================
@@ -378,13 +383,17 @@ EGLDisplay wxGLCanvasEGL::GetDisplay()
                 eglQueryString(nullptr, EGL_EXTENSIONS),
                 "EGL_EXT_platform_base") )
         {
-            s_eglGetPlatformDisplay = reinterpret_cast<GetPlatformDisplayFunc>(
-                    eglGetProcAddress("eglGetPlatformDisplay"));
+            s_eglGetPlatformDisplay =
+                wxGLContext::GetProcAddress<GetPlatformDisplayFunc>(
+                    "eglGetPlatformDisplay"
+                );
             if ( !s_eglGetPlatformDisplay )
             {
                 // Try the fallback if not available.
-                s_eglGetPlatformDisplay = reinterpret_cast<GetPlatformDisplayFunc>(
-                    eglGetProcAddress("eglGetPlatformDisplayEXT"));
+                s_eglGetPlatformDisplay =
+                    wxGLContext::GetProcAddress<GetPlatformDisplayFunc>(
+                        "eglGetPlatformDisplayEXT"
+                    );
             }
         }
     }
@@ -541,8 +550,10 @@ EGLSurface wxGLCanvasEGL::CallCreatePlatformWindowSurface(void *window) const
         static CreatePlatformWindowSurface s_eglCreatePlatformWindowSurface = nullptr;
         if ( !s_eglCreatePlatformWindowSurface )
         {
-            s_eglCreatePlatformWindowSurface = reinterpret_cast<CreatePlatformWindowSurface>(
-                eglGetProcAddress("eglCreatePlatformWindowSurface"));
+            s_eglCreatePlatformWindowSurface =
+                wxGLContext::GetProcAddress<CreatePlatformWindowSurface>(
+                    "eglCreatePlatformWindowSurface"
+                );
         }
 
         // This check is normally superfluous but avoid crashing just in case
@@ -564,8 +575,10 @@ EGLSurface wxGLCanvasEGL::CallCreatePlatformWindowSurface(void *window) const
 
         if ( wxGLBackendEGL_instance.IsExtensionSupported("EGL_EXT_platform_base") )
         {
-            s_eglCreatePlatformWindowSurfaceEXT = reinterpret_cast<CreatePlatformWindowSurface>(
-                eglGetProcAddress("eglCreatePlatformWindowSurfaceEXT"));
+            s_eglCreatePlatformWindowSurfaceEXT =
+                wxGLContext::GetProcAddress<CreatePlatformWindowSurface>(
+                    "eglCreatePlatformWindowSurfaceEXT"
+                );
         }
     }
 

--- a/src/unix/glx11.cpp
+++ b/src/unix/glx11.cpp
@@ -503,8 +503,10 @@ wxGLContextX11::wxGLContextX11(wxGLCanvas *win,
     PFNGLXCREATECONTEXTATTRIBSARBPROC wx_glXCreateContextAttribsARB = 0;
     if (fbc)
     {
-        wx_glXCreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC)
-            glXGetProcAddress(reinterpret_cast<const GLubyte*>("glXCreateContextAttribsARB"));
+        wx_glXCreateContextAttribsARB =
+            wxGLContext::GetProcAddress<PFNGLXCREATECONTEXTATTRIBSARBPROC>(
+                "glXCreateContextAttribsARB"
+            );
     }
 
     glXDestroyContext( dpy, tempContext );
@@ -811,8 +813,10 @@ wxGLSetSwapInterval(Display* dpy, GLXDrawable drawable, int interval)
         static bool s_glXSwapIntervalEXTInit = false;
         if ( !s_glXSwapIntervalEXTInit )
         {
-            s_glXSwapIntervalEXT = (PFNGLXSWAPINTERVALEXTPROC)
-                glXGetProcAddress((const GLubyte*)"glXSwapIntervalEXT");
+            s_glXSwapIntervalEXT =
+                wxGLContext::GetProcAddress<PFNGLXSWAPINTERVALEXTPROC>(
+                    "glXSwapIntervalEXT"
+                );
 
             s_glXSwapIntervalEXTInit = true;
 
@@ -828,8 +832,10 @@ wxGLSetSwapInterval(Display* dpy, GLXDrawable drawable, int interval)
         static bool s_glXSwapIntervalMESAInit = false;
         if ( !s_glXSwapIntervalMESAInit )
         {
-            s_glXSwapIntervalMESA = (PFNGLXSWAPINTERVALMESAPROC)
-                glXGetProcAddress((const GLubyte*)"glXSwapIntervalMESA");
+            s_glXSwapIntervalMESA =
+                wxGLContext::GetProcAddress<PFNGLXSWAPINTERVALMESAPROC>(
+                    "glXSwapIntervalMESA"
+                );
 
             s_glXSwapIntervalMESAInit = true;
 
@@ -900,8 +906,10 @@ int wxMESAGetSwapInterval()
         static bool s_glXGetSwapIntervalMESAInit = false;
         if ( !s_glXGetSwapIntervalMESAInit )
         {
-            s_glXGetSwapIntervalMESA = (PFNGLXGETSWAPINTERVALMESAPROC)
-                glXGetProcAddress((const GLubyte*)"glXGetSwapIntervalMESA");
+            s_glXGetSwapIntervalMESA =
+                wxGLContext::GetProcAddress<PFNGLXGETSWAPINTERVALMESAPROC>(
+                    "glXGetSwapIntervalMESA"
+                );
 
             s_glXGetSwapIntervalMESAInit = true;
 
@@ -1009,6 +1017,13 @@ wxGLBackendX11::CreateCanvasImpl(wxGLCanvasUnix* canvas)
 void wxGLBackendX11::ClearCurrentContext()
 {
     MakeCurrent(None, nullptr);
+}
+
+wxGLExtFunction wxGLBackendX11::GetProcAddress(const wxString& name)
+{
+    return glXGetProcAddressARB(reinterpret_cast<const GLubyte*>(
+            static_cast<const char*>(name.utf8_str())
+        ));
 }
 
 #endif // wxUSE_GLCANVAS


### PR DESCRIPTION
Implement this function as a trivial wrapper for wglGetProcAddress(), glXGetProcAddressARB() or eglGetProcAddress() depending on the platform (currently not implemented for macOS).

Account for the known bug in some Windows OpenGL drivers by checking for manifestly invalid return values and handling them as null.

Use the new function in wxGL code itself and in the pyramid sample.

Closes #9215.