### PR TITLE
Don't refresh wxAuiToolBar unnecessarily in wxEVT_SIZE handler

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2405,9 +2405,15 @@ void wxAuiToolBar::OnSize(wxSizeEvent& WXUNUSED(evt))
     m_sizer->SetDimension(0, 0, x, y);
 
     // We need to update the bitmap if the size has changed.
-    UpdateBackgroundBitmap(wxSize(x, y));
+    wxSize size(x, y);
+    if ( !m_backgroundBitmap.IsOk() || m_backgroundBitmap.GetSize() != size )
+    {
+        UpdateBackgroundBitmap(size);
 
-    Refresh(false);
+        // We need to refresh the entire window if the background bitmap has
+        // changed, not just the area affected by the resize.
+        Refresh(false);
+    }
 
     // idle events aren't sent while user is resizing frame (why?),
     // but resizing toolbar here causes havoc,


### PR DESCRIPTION
wxAuiToolBar gets wxEVT_SIZE events due to relayout done by wxAuiManager whenever any sash is being dragged, but this doesn't necessarily actually change its size, so avoid refreshing it in this case, as this results in very noticeable flicker, especially when the toolbar has any controls inside it.

This commit is best viewed ignoring whitespace-only changes.

Closes #26142.