### PR TITLE
Fix for wxTextEntryDialog resizing in unexpected ways

### DIFF
--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -117,6 +117,15 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
 
     topsizer->Fit( this );
 
+    // Set minimum size to the fitted size so dialog can't shrink below content
+    SetMinSize(GetSize());
+
+    // For single-line entry, also constrain max height to prevent vertical expansion
+    if ( !(style & wxTE_MULTILINE) )
+    {
+        SetMaxSize(wxSize(-1, GetSize().GetHeight()));
+    }
+
     if ( style & wxCENTRE )
         Centre( wxBOTH );
 


### PR DESCRIPTION
Resizes width and height with multiline control, but doesn't go down to 0,0.
Single-line only resizes horizontally now.
Closes #25739