### PR TITLE
CMake backports 02-2026

### DIFF
--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 
 # webkit extension plugin
 # we can't use (all of the) macros and functions because this library should
-# always be build as a shared libary, and not included in the monolithic build.
+# always be built as a shared library, and not included in the monolithic build.
 if(WXGTK AND wxUSE_WEBVIEW_WEBKIT2)
     wx_append_sources(WEBKIT2_EXT_FILES WEBVIEW_WEBKIT2_EXTENSION)
     add_library(wxwebkit2_ext SHARED ${WEBKIT2_EXT_FILES})

--- a/build/cmake/modules/FindGTK2.cmake
+++ b/build/cmake/modules/FindGTK2.cmake
@@ -1,0 +1,63 @@
+# - Try to find GTK+ 2
+# Once done, this will define
+#
+# GTK2_FOUND - system has GTK+ 2.
+# GTK2_INCLUDE_DIRS - the GTK+ 2. include directories
+# GTK2_LIBRARIES - link these to use GTK+ 2.
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+# Copyright (C) 2013 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+find_package(PkgConfig)
+pkg_check_modules(GTK2 QUIET gtk+-2.0)
+set(VERSION_OK TRUE)
+if (GTK2_VERSION)
+if (GTK2_FIND_VERSION_EXACT)
+if (NOT("${GTK2_FIND_VERSION}" VERSION_EQUAL "${GTK2_VERSION}"))
+set(VERSION_OK FALSE)
+endif ()
+else ()
+if ("${GTK2_VERSION}" VERSION_LESS "${GTK2_FIND_VERSION}")
+set(VERSION_OK FALSE)
+endif ()
+endif ()
+endif ()
+
+# silence output
+set(GTK2_FIND_QUIETLY_TEMP ${GTK2_FIND_QUIETLY})
+set(GTK2_FIND_QUIETLY TRUE)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GTK2 DEFAULT_MSG GTK2_INCLUDE_DIRS GTK2_LIBRARIES VERSION_OK)
+
+set(GTK2_FIND_QUIETLY ${GTK2_FIND_QUIETLY_TEMP})
+
+mark_as_advanced(GTK2_INCLUDE_DIRS GTK2_LIBRARIES)
+
+# not found using PkgConfig, use CMake's FindGTK2
+if(NOT GTK2_FOUND)
+    set(CMAKE_MODULE_PATH_TEMP ${CMAKE_MODULE_PATH})
+    set(CMAKE_MODULE_PATH "")
+    find_package(GTK2)
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_TEMP})
+endif()

--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -129,7 +129,7 @@ if(UNIX AND NOT WIN32 AND (WXX11 OR WXMOTIF OR WXGTK2 OR (WXGTK AND wxHAVE_GDK_X
 endif()
 
 if(WXQT)
-    find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+    find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
 
     if(QT_VERSION_MAJOR EQUAL 5)
         set(QT_COMPONENTS Core Widgets Gui OpenGL OpenGL Test)


### PR DESCRIPTION
Remove searching for Qt6 in CMake, as discussed in #26065.
And add the `FindGTK2` module that first uses PkgConfig to find GTK2 and if that fails, the built-in module.