### PR TITLE
Make `wxGetLinuxDistributionInfo()` available on all Unices

### DIFF
--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -144,7 +144,7 @@ WXDLLIMPEXP_BASE wxString wxGetCpuArchitectureName();
 // Get native machine CPU architecture
 WXDLLIMPEXP_BASE wxString wxGetNativeCpuArchitectureName();
 
-#ifdef __LINUX__
+#ifdef __UNIX__
 // Get linux-distro information
 WXDLLIMPEXP_BASE wxLinuxDistributionInfo wxGetLinuxDistributionInfo();
 #endif

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -120,7 +120,8 @@ enum wxEndianness
 };
 
 /**
-    A structure containing information about a Linux distribution.
+    A structure containing information about a Linux distribution,
+    or another Unix-style operating system (FreeBSD).
 
     See wxGetLinuxDistributionInfo() or wxPlatformInfo::GetLinuxDistributionInfo()
     for more info.

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -1065,13 +1065,14 @@ wxString wxGetNativeCpuArchitectureName();
 
 /**
     Returns a structure containing information about the currently running
-    Linux distribution.
+    Linux distribution, or another Unix-style operating system (FreeBSD).
 
     In case such information cannot be obtained, this function will return
     a ::wxLinuxDistributionInfo structure containing empty strings.
 
-    This function is Linux-specific and is only available when the @c \__LINUX__
-    symbol is defined.
+    This function is Unix-specific and is only available when the
+    @c \__UNIX__ symbol is defined (since wxWidgets 3.3.2; in earlier
+    versions only when @c \__LINUX__ is defined).
 */
 wxLinuxDistributionInfo wxGetLinuxDistributionInfo();
 

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -216,7 +216,7 @@ void wxPlatformInfo::InitForCurrentPlatform()
     m_cpuArch = wxGetCpuArchitectureName();
     m_nativeCpuArch = wxGetNativeCpuArchitectureName();
 
-#ifdef __LINUX__
+#ifdef __UNIX__
     m_ldi = wxGetLinuxDistributionInfo();
 #endif
     // else: leave m_ldi empty

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1136,7 +1136,7 @@ wxString wxGetNativeCpuArchitectureName()
         return wxGetCpuArchitectureName();
 }
 
-#ifdef __LINUX__
+#ifdef __UNIX__
 
 static bool
 wxGetValuesFromOSRelease(const wxString& filename, wxLinuxDistributionInfo& ret)
@@ -1200,7 +1200,7 @@ wxLinuxDistributionInfo wxGetLinuxDistributionInfo()
 
     return ret;
 }
-#endif // __LINUX__
+#endif // __UNIX__
 
 // these functions are in src/osx/utils_base.mm for wxOSX.
 #ifndef __DARWIN__


### PR DESCRIPTION
Now that `wxGetLinuxDistributionInfo()` primarily obtains its data from `/etc/os-release`, there is nothing fundamentally Linux-specific about the implementation.

FreeBSD comes with `/etc/os-release` since FreeBSD 13.