### PR TITLE
Fix building non-GTK ports under Windows with Cairo >= 1.18

### DIFF
--- a/include/wx/private/cairo.h
+++ b/include/wx/private/cairo.h
@@ -1,0 +1,29 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/cairo.h
+// Purpose:     Wrapper for including cairo.h from wx code
+// Author:      Vadim Zeitlin
+// Created:     2026-02-23
+// Copyright:   (c) 2026 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_CAIRO_H_
+#define _WX_PRIVATE_CAIRO_H_
+
+// We want to prevent cairo.h from using dllimport attribute for the functions
+// it declares as we're loading them dynamically, but this is trickier than it
+// should be because older versions of cairo.h respected cairo_public being
+// defined before including it, but this was broken in 1.18, so we need to
+// define an alternative symbol and avoid defining cairo_public as this would
+// result in a warning about its redefinition.
+#include <cairo-version.h>
+
+#if CAIRO_VERSION_MAJOR > 1 || CAIRO_VERSION_MINOR >= 18
+#define CAIRO_WIN32_STATIC_BUILD
+#else
+#define cairo_public
+#endif
+
+#include <cairo.h>
+
+#endif // _WX_PRIVATE_CAIRO_H_

--- a/src/common/cairo.cpp
+++ b/src/common/cairo.cpp
@@ -14,11 +14,8 @@
 
 #if wxUSE_CAIRO && !defined(__WXGTK__)
 
-// keep cairo.h from defining dllimport as we're defining the symbols inside
-// the wx dll in order to load them dynamically.
-#define cairo_public
+#include "wx/private/cairo.h"
 
-#include <cairo.h>
 #include "wx/dynlib.h"
 
 #ifdef __WXMSW__

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -16,13 +16,8 @@
 
 #if wxUSE_CAIRO
 
-#ifndef __WXGTK__
-// keep cairo.h from defining dllimport as we're defining the symbols inside
-// the wx dll in order to load them dynamically.
-#define cairo_public
-#endif
+#include "wx/private/cairo.h"
 
-#include <cairo.h>
 #include <float.h>
 
 bool wxCairoInit();


### PR DESCRIPTION
Cairo 1.18 broke using cairo_public redefinition hack used before to avoid declaring Cairo functions as being dll-imported. Use the new way to prevent this from happening but still define cairo_public when using older versions.

Note that, unfortunately, we can't do it unconditionally because this results in a macro redefinition warning with newer versions which is impossible to disable using gcc.

Closes #26224.