### PR TITLE
Make Linux distribution `wxGetOsDescription()`'s main output

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -843,7 +843,9 @@ bool wxGetUserName(char* buf, int sz);
 /**
     Returns the string containing the description of the current platform in a
     user-readable form. For example, this function may return strings like
-    "Windows 10 (build 10240), 64-bit edition" or "Linux 4.1.4 i386".
+    "Windows 10 (build 10240), 64-bit edition",
+    "AlmaLinux 10.1 (Heliotrope Lion), 6.12.0-55.9.1.el10_0.x86_64",
+    or "Linux 4.1.4 i386".
 
     @see wxGetOsVersion()
 

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -870,6 +870,9 @@ wxString wxGetOsDescription();
     numbers (as returned by the 'uname -r' command); e.g. "4", "1", and "4" if
     the machine is using kernel 4.1.4.
 
+    On Linux (@c __LINUX__ defined), if you are interested in the distribution
+    version rather than the kernel version, see wxGetLinuxDistributionInfo().
+
     For macOS systems (@c wxOS_MAC) the major and minor version integers are the
     natural version numbers associated with the OS; e.g. "10", "11" and "2" if
     the machine is using macOS El Capitan 10.11.2.
@@ -989,7 +992,7 @@ wxString wxGetOsDescription();
     See the <a href="https://learn.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version">Microsoft documentation</a>
     for more info about the values above.
 
-    @see wxGetOsDescription(), wxPlatformInfo
+    @see wxGetOsDescription(), wxGetLinuxDistributionInfo(), wxPlatformInfo
 
     @header{wx/utils.h}
 */
@@ -998,6 +1001,9 @@ wxOperatingSystemId wxGetOsVersion(int* major = nullptr, int* minor = nullptr, i
 /**
     Returns @true if the version of the operating system on which the program
     is running under is the same or later than the given version.
+
+    For Unix-like systems (except macOS), this is the kernel version, not
+    the marketing/distribution version.
 
     @since 3.1.0
 

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1170,7 +1170,7 @@ wxGetSpecificValueFromOSRelease(const wxString& key)
         "/usr/lib/os-release"
     };
 
-    for ( int i = 0; i < WXSIZEOF(Filename); ++i )
+    for ( size_t i = 0; i < WXSIZEOF(Filename); ++i )
     {
         if ( wxFileName::Exists(Filename[i]) )
         {

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1159,6 +1159,31 @@ wxGetValuesFromOSRelease(const wxString& filename, wxLinuxDistributionInfo& ret)
 #endif
 }
 
+static wxString
+wxGetSpecificValueFromOSRelease(const wxString& key)
+{
+#if wxUSE_CONFIG
+    // Read /etc/os-release and fall back to /usr/lib/os-release per below
+    // https://www.freedesktop.org/software/systemd/man/os-release.html
+    const wxString Filename[] = {
+        "/etc/os-release",
+        "/usr/lib/os-release"
+    };
+
+    for ( int i = 0; i < WXSIZEOF(Filename); ++i )
+    {
+        if ( wxFileName::Exists(Filename[i]) )
+        {
+            wxFileConfig fc(wxEmptyString, wxEmptyString,
+                            wxEmptyString, Filename[i]);
+            // Default value suggested by the spec
+            return fc.Read(key, "Linux");
+        }
+    }
+#endif
+    return wxEmptyString;
+}
+
 static bool
 wxGetValueFromLSBRelease(const wxString& arg, const wxString& lhs, wxString* rhs)
 {
@@ -1257,6 +1282,47 @@ wxString wxGetOsDescription()
 {
 #ifdef __VMS
     return wxGetCommandOutput(wxT("uname -s -v -m"));
+#elif defined(__LINUX__)
+    wxString osDesc;
+
+    const wxString DistName = wxGetSpecificValueFromOSRelease("NAME");
+    const wxString Version = wxGetSpecificValueFromOSRelease("VERSION");
+
+    if ( !DistName.empty() )
+    {
+        osDesc += DistName;
+        if ( !Version.empty() )
+        {
+            osDesc += " " + Version;
+        }
+        osDesc += ",";
+    }
+
+    const wxString System = wxGetCommandOutput(wxT("uname -s"));
+    const wxString Release = wxGetCommandOutput(wxT("uname -r"));
+    const wxString Machine = wxGetCommandOutput(wxT("uname -m"));
+
+    // If any of the strings above is already present in the info
+    // read from os-release, avoid repeating the values to keep
+    // the description relatively short. Also do not repeat
+    // e.g. the machine type if it is already part of the kernel
+    // version number.
+
+    if ( osDesc.Find(System) == wxNOT_FOUND )
+    {
+        osDesc += " " + System;
+    }
+    if ( osDesc.Find(Release) == wxNOT_FOUND )
+    {
+        osDesc += " " + Release;
+    }
+    if ( osDesc.Find(Machine) == wxNOT_FOUND )
+    {
+        osDesc += " " + Machine;
+    }
+
+    osDesc.Trim(false);
+    return osDesc;
 #else
     return wxGetCommandOutput(wxT("uname -s -r -m"));
 #endif

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1165,17 +1165,17 @@ wxGetSpecificValueFromOSRelease(const wxString& key)
 #if wxUSE_CONFIG
     // Read /etc/os-release and fall back to /usr/lib/os-release per below
     // https://www.freedesktop.org/software/systemd/man/os-release.html
-    const wxString Filename[] = {
+    const wxString fileName[] = {
         "/etc/os-release",
         "/usr/lib/os-release"
     };
 
-    for ( size_t i = 0; i < WXSIZEOF(Filename); ++i )
+    for ( size_t i = 0; i < WXSIZEOF(fileName); ++i )
     {
-        if ( wxFileName::Exists(Filename[i]) )
+        if ( wxFileName::Exists(fileName[i]) )
         {
             wxFileConfig fc(wxEmptyString, wxEmptyString,
-                            wxEmptyString, Filename[i]);
+                            wxEmptyString, fileName[i]);
             // Default value suggested by the spec
             return fc.Read(key, "Linux");
         }
@@ -1285,22 +1285,22 @@ wxString wxGetOsDescription()
 #elif defined(__LINUX__)
     wxString osDesc;
 
-    const wxString DistName = wxGetSpecificValueFromOSRelease("NAME");
-    const wxString Version = wxGetSpecificValueFromOSRelease("VERSION");
+    const wxString distName = wxGetSpecificValueFromOSRelease("NAME");
+    const wxString version = wxGetSpecificValueFromOSRelease("VERSION");
 
-    if ( !DistName.empty() )
+    if ( !distName.empty() )
     {
-        osDesc += DistName;
-        if ( !Version.empty() )
+        osDesc += distName;
+        if ( !version.empty() )
         {
-            osDesc += " " + Version;
+            osDesc += " " + version;
         }
         osDesc += ",";
     }
 
-    const wxString System = wxGetCommandOutput(wxT("uname -s"));
-    const wxString Release = wxGetCommandOutput(wxT("uname -r"));
-    const wxString Machine = wxGetCommandOutput(wxT("uname -m"));
+    const wxString unSystem = wxGetCommandOutput(wxT("uname -s"));
+    const wxString unRelease = wxGetCommandOutput(wxT("uname -r"));
+    const wxString unMachine = wxGetCommandOutput(wxT("uname -m"));
 
     // If any of the strings above is already present in the info
     // read from os-release, avoid repeating the values to keep
@@ -1308,17 +1308,17 @@ wxString wxGetOsDescription()
     // e.g. the machine type if it is already part of the kernel
     // version number.
 
-    if ( osDesc.Find(System) == wxNOT_FOUND )
+    if ( osDesc.Find(unSystem) == wxNOT_FOUND )
     {
-        osDesc += " " + System;
+        osDesc += " " + unSystem;
     }
-    if ( osDesc.Find(Release) == wxNOT_FOUND )
+    if ( osDesc.Find(unRelease) == wxNOT_FOUND )
     {
-        osDesc += " " + Release;
+        osDesc += " " + unRelease;
     }
-    if ( osDesc.Find(Machine) == wxNOT_FOUND )
+    if ( osDesc.Find(unMachine) == wxNOT_FOUND )
     {
-        osDesc += " " + Machine;
+        osDesc += " " + unMachine;
     }
 
     osDesc.Trim(false);

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1159,31 +1159,6 @@ wxGetValuesFromOSRelease(const wxString& filename, wxLinuxDistributionInfo& ret)
 #endif
 }
 
-static wxString
-wxGetSpecificValueFromOSRelease(const wxString& key)
-{
-#if wxUSE_CONFIG
-    // Read /etc/os-release and fall back to /usr/lib/os-release per below
-    // https://www.freedesktop.org/software/systemd/man/os-release.html
-    const wxString fileName[] = {
-        "/etc/os-release",
-        "/usr/lib/os-release"
-    };
-
-    for ( size_t i = 0; i < WXSIZEOF(fileName); ++i )
-    {
-        if ( wxFileName::Exists(fileName[i]) )
-        {
-            wxFileConfig fc(wxEmptyString, wxEmptyString,
-                            wxEmptyString, fileName[i]);
-            // Default value suggested by the spec
-            return fc.Read(key, "Linux");
-        }
-    }
-#endif
-    return wxEmptyString;
-}
-
 static bool
 wxGetValueFromLSBRelease(const wxString& arg, const wxString& lhs, wxString* rhs)
 {
@@ -1278,52 +1253,81 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
     return wxPlatformInfo::GetOperatingSystemId(kernel);
 }
 
+static bool
+wxGetDescFromOSRelease(wxString* distName, wxString* version)
+{
+#if wxUSE_CONFIG
+    // Read /etc/os-release and fall back to /usr/lib/os-release per below
+    // https://www.freedesktop.org/software/systemd/man/os-release.html
+    static const char* const osReleasePaths[] =
+    {
+        "/etc/os-release",
+        "/usr/lib/os-release"
+    };
+
+    for ( const auto& fileName : osReleasePaths )
+    {
+        if ( wxFileName::Exists(fileName) )
+        {
+            // No app, no vendor, no global file path, just the local config
+            // file to read the values from.
+            wxFileConfig fc({}, {}, {}, fileName);
+
+            // Default value suggested by the spec
+            *distName = fc.Read("NAME", "Linux");
+
+            *version = fc.Read("VERSION");
+
+            return true;
+        }
+    }
+#endif // wxUSE_CONFIG
+
+    return false;
+}
+
 wxString wxGetOsDescription()
 {
 #ifdef __VMS
     return wxGetCommandOutput(wxT("uname -s -v -m"));
-#elif defined(__LINUX__)
-    wxString osDesc;
-
-    const wxString distName = wxGetSpecificValueFromOSRelease("NAME");
-    const wxString version = wxGetSpecificValueFromOSRelease("VERSION");
-
-    if ( !distName.empty() )
+#else
+    wxString distName, version;
+    if ( wxGetDescFromOSRelease(&distName, &version) )
     {
-        osDesc += distName;
+        wxString osDesc = distName;
         if ( !version.empty() )
         {
             osDesc += " " + version;
         }
         osDesc += ",";
+
+        const wxString unameSystem = wxGetCommandOutput(wxT("uname -s"));
+        const wxString unameRelease = wxGetCommandOutput(wxT("uname -r"));
+        const wxString unameMachine = wxGetCommandOutput(wxT("uname -m"));
+
+        // If any of the strings above is already present in the info
+        // read from os-release, avoid repeating the values to keep
+        // the description relatively short. Also do not repeat
+        // e.g. the machine type if it is already part of the kernel
+        // version number.
+
+        if ( osDesc.Find(unameSystem) == wxNOT_FOUND )
+        {
+            osDesc += " " + unameSystem;
+        }
+        if ( osDesc.Find(unameRelease) == wxNOT_FOUND )
+        {
+            osDesc += " " + unameRelease;
+        }
+        if ( osDesc.Find(unameMachine) == wxNOT_FOUND )
+        {
+            osDesc += " " + unameMachine;
+        }
+
+        osDesc.Trim(false);
+        return osDesc;
     }
 
-    const wxString unSystem = wxGetCommandOutput(wxT("uname -s"));
-    const wxString unRelease = wxGetCommandOutput(wxT("uname -r"));
-    const wxString unMachine = wxGetCommandOutput(wxT("uname -m"));
-
-    // If any of the strings above is already present in the info
-    // read from os-release, avoid repeating the values to keep
-    // the description relatively short. Also do not repeat
-    // e.g. the machine type if it is already part of the kernel
-    // version number.
-
-    if ( osDesc.Find(unSystem) == wxNOT_FOUND )
-    {
-        osDesc += " " + unSystem;
-    }
-    if ( osDesc.Find(unRelease) == wxNOT_FOUND )
-    {
-        osDesc += " " + unRelease;
-    }
-    if ( osDesc.Find(unMachine) == wxNOT_FOUND )
-    {
-        osDesc += " " + unMachine;
-    }
-
-    osDesc.Trim(false);
-    return osDesc;
-#else
     return wxGetCommandOutput(wxT("uname -s -r -m"));
 #endif
 }


### PR DESCRIPTION
When available, acquire the name and release of the Linux distribution and return it as `wxGetOsDescription()`'s output, followed by the near equivalent of the traditional `uname -srm` output.

The uname output, something like `Linux 6.19.0-5-generic x86_64`, is not the best description for a Linux system, since it leaves up to the reader to figure out what kind of a system this actually is.

The output changes significantly from what it was earlier, but the output was never meant to be machine-readable, nor was it consistent across different operating systems.