### PR TITLE
Improve sizer debugging

### DIFF
--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -374,7 +374,7 @@ public:
     float GetRatio() const
         { return m_ratio; }
 
-    virtual wxRect GetRect() { return m_rect; }
+    virtual wxRect GetRect() const { return m_rect; }
 
     // set a sizer item id (different from a window id, all sizer items,
     // including spacers, can have an associated id)

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1306,7 +1306,7 @@ public:
     /**
         Get the rectangle of the item on the parent window, excluding borders.
     */
-    virtual wxRect GetRect();
+    virtual wxRect GetRect() const;
 
     /**
         Get the current size of the item, as set in the last Layout.

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1909,11 +1909,17 @@ public:
         m_tabCtrlHeight = h;
     }
 
-    // As we don't have a valid HWND, the base class version doesn't work for
-    // this window, so override it to return the appropriate DPI.
+    // As we don't have a valid HWND, base class implementations of these
+    // functions don't work for this window, so override them to forward to the
+    // real window.
     wxSize GetDPI() const override
     {
         return m_tabs->GetDPI();
+    }
+
+    wxLayoutDirection GetLayoutDirection() const override
+    {
+        return m_tabs->GetLayoutDirection();
     }
 
 protected:

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3139,13 +3139,8 @@ static void DrawBorder(wxWindowBase *win, const wxRect& rect, bool fill, const w
 
 static void DrawSizer(wxWindowBase *win, wxSizer *sizer)
 {
-    const wxSizerItemList& items = sizer->GetChildren();
-    for ( wxSizerItemList::const_iterator i = items.begin(),
-                                        end = items.end();
-          i != end;
-          ++i )
+    for ( const wxSizerItem* item : sizer->GetChildren() )
     {
-        wxSizerItem *item = *i;
         if ( item->IsSizer() )
         {
             DrawBorder(win, item->GetRect().Deflate(2), false, wxRED_PEN);
@@ -3175,13 +3170,9 @@ static void DrawSizers(wxWindowBase *win)
     }
     else // no sizer, still recurse into the children
     {
-        const wxWindowList& children = win->GetChildren();
-        for ( wxWindowList::const_iterator i = children.begin(),
-                                         end = children.end();
-              i != end;
-              ++i )
+        for ( wxWindowBase* child : win->GetChildren() )
         {
-            DrawSizers(*i);
+            DrawSizers(child);
         }
 
         // show all kind of sizes of this window; see the "window sizing" topic

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3122,8 +3122,11 @@ bool wxWindowBase::WXSendContextMenuEvent(const wxPoint& posInScreenCoords)
 // that well and also because we don't want to leave it enabled in default
 // builds used for production
 #if wxDEBUG_LEVEL > 1
+    #define wxHAS_SIZER_DEBUG
+#endif
 
-static void DrawSizers(wxWindowBase *win);
+#ifdef wxHAS_SIZER_DEBUG
+static void DrawSizers(wxWindowBase *win, int level = 0);
 
 static void DrawBorder(wxWindowBase *win, const wxRect& rect, bool fill, const wxPen* pen)
 {
@@ -3203,21 +3206,21 @@ static void DrawSizers(wxWindowBase *win)
     }
 }
 
-#endif // wxDEBUG_LEVEL
+#endif // wxHAS_SIZER_DEBUG
 
 // process special middle clicks
 void wxWindowBase::OnMiddleClick( wxMouseEvent& event )
 {
     if ( event.ControlDown() && event.AltDown() )
     {
-#if wxDEBUG_LEVEL > 1
+#ifdef wxHAS_SIZER_DEBUG
         // Ctrl-Alt-Shift-mclick makes the sizers visible in debug builds
         if ( event.ShiftDown() )
         {
             DrawSizers(this);
         }
         else
-#endif // __WXDEBUG__
+#endif // wxHAS_SIZER_DEBUG
         {
 #if wxUSE_MSGDLG
             // just Ctrl-Alt-middle click shows information about wx version


### PR DESCRIPTION
Miscellaneous small changes to help with debugging sizer layout.

Visual indicators are not very useful, but debug output from that code and `wxDumpSizer()` are nice to have, at least.