### PR TITLE
Support drag-and-drop autoscroll

### DIFF
--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -35,13 +35,13 @@ endif()
 wx_add_sample(dialogs ${SAMPLE_DIALOGS_SRC} DATA tips.txt)
 wx_add_sample(dialup nettest.cpp LIBRARIES wxnet DEPENDS wxUSE_DIALUP_MANAGER)
 wx_add_sample(display)
-wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP)
+wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP IMPORTANT)
 wx_add_sample(docview docview.cpp doc.cpp view.cpp docview.h doc.h view.h
-    RES docview.rc PLIST Info.plist.in LIBRARIES wxaui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE)
+    RES docview.rc PLIST Info.plist.in LIBRARIES wxaui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE IMPORTANT)
 wx_add_sample(dragimag dragimag.cpp dragimag.h RES dragimag.rc
     DATA backgrnd.png shape01.png shape02.png shape03.png
     DEPENDS wxUSE_DRAGIMAGE)
-wx_add_sample(drawing DATA pat4.bmp pat35.bmp pat36.bmp image.bmp mask.bmp NAME drawingsample)
+wx_add_sample(drawing DATA pat4.bmp pat35.bmp pat36.bmp image.bmp mask.bmp NAME drawingsample IMPORTANT)
 wx_add_sample(erase)
 wx_add_sample(event event.cpp gestures.cpp gestures.h chessboard.cpp chessboard.h)
 wx_add_sample(except DEPENDS wxUSE_EXCEPTIONS)

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -37,11 +37,11 @@ wx_add_sample(dialup nettest.cpp LIBRARIES wxnet DEPENDS wxUSE_DIALUP_MANAGER)
 wx_add_sample(display)
 wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP)
 wx_add_sample(docview docview.cpp doc.cpp view.cpp docview.h doc.h view.h
-    RES docview.rc PLIST Info.plist.in LIBRARIES wxaui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE IMPORTANT)
+    RES docview.rc PLIST Info.plist.in LIBRARIES wxaui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE)
 wx_add_sample(dragimag dragimag.cpp dragimag.h RES dragimag.rc
     DATA backgrnd.png shape01.png shape02.png shape03.png
     DEPENDS wxUSE_DRAGIMAGE)
-wx_add_sample(drawing DATA pat4.bmp pat35.bmp pat36.bmp image.bmp mask.bmp NAME drawingsample IMPORTANT)
+wx_add_sample(drawing DATA pat4.bmp pat35.bmp pat36.bmp image.bmp mask.bmp NAME drawingsample)
 wx_add_sample(erase)
 wx_add_sample(event event.cpp gestures.cpp gestures.h chessboard.cpp chessboard.h)
 wx_add_sample(except DEPENDS wxUSE_EXCEPTIONS)

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 wx_add_sample(dialogs ${SAMPLE_DIALOGS_SRC} DATA tips.txt)
 wx_add_sample(dialup nettest.cpp LIBRARIES wxnet DEPENDS wxUSE_DIALUP_MANAGER)
 wx_add_sample(display)
-wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP IMPORTANT)
+wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP)
 wx_add_sample(docview docview.cpp doc.cpp view.cpp docview.h doc.h view.h
     RES docview.rc PLIST Info.plist.in LIBRARIES wxaui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE IMPORTANT)
 wx_add_sample(dragimag dragimag.cpp dragimag.h RES dragimag.rc

--- a/include/wx/scrolwin.h
+++ b/include/wx/scrolwin.h
@@ -168,6 +168,18 @@ public:
                         wxEventType& evtHorzScroll,
                         wxEventType& evtVertScroll) const;
 
+    // wxWidgets <= 3.3.1 mostly restricted autoscroll to the
+    // window holding the mouse capture.  However, when dragging
+    // objects between windows, the destination window should be
+    // the window that is scrolling (to allow positioning the
+    // dragged object).  The intent is that a window will call
+    // EnableAutoscrollWithoutCapture() when processing a
+    // drag-enter, and DisableAutoscrollWithoutCapture() when
+    // processing a drag-exit or drag-drop.
+    bool GetAutoscrollWithoutCapture() const;
+    void EnableAutoscrollWithoutCapture();
+    void DisableAutoscrollWithoutCapture();
+
     // Set the x, y scrolling increments.
     void SetScrollRate( int xstep, int ystep );
 
@@ -366,6 +378,7 @@ protected:
     wxCoord               m_innerScrollWidth = 0;
     bool                  m_outerScrollEnabled = true;
     bool                  m_inAutoScrollRegion = false;
+    bool                  m_autoscrollWithoutCapture = false;
 
     double                m_scaleX;
     double                m_scaleY;

--- a/samples/dnd/dnd.cpp
+++ b/samples/dnd/dnd.cpp
@@ -773,7 +773,7 @@ public:
         m_frame->ProcessWindowEvent(event);
         return wxDropTarget::OnDragOver(x, y, def);
     }
-    virtual bool OnDrop(wxCoord x, wxCoord y)
+    virtual bool OnDrop(wxCoord x, wxCoord y) override
     {
         m_frame->DisableAutoscrollWithoutCapture();
         return wxDropTarget::OnDrop(x, y);

--- a/samples/dnd/dnd.cpp
+++ b/samples/dnd/dnd.cpp
@@ -702,7 +702,7 @@ private:
 // A frame for the shapes which can be drag-and-dropped between frames
 // ----------------------------------------------------------------------------
 
-class DnDShapeFrame : public wxFrame
+class DnDShapeFrame : public wxScrolled<wxFrame>
 {
 public:
     DnDShapeFrame(wxFrame *parent);
@@ -756,6 +756,7 @@ public:
 #if wxUSE_STATUSBAR
         m_frame->SetStatusText("Mouse entered the frame");
 #endif // wxUSE_STATUSBAR
+        m_frame->EnableAutoscrollWithoutCapture();
         return OnDragOver(x, y, def);
     }
     virtual void OnLeave() override
@@ -763,6 +764,19 @@ public:
 #if wxUSE_STATUSBAR
         m_frame->SetStatusText("Mouse left the frame");
 #endif // wxUSE_STATUSBAR
+        m_frame->DisableAutoscrollWithoutCapture();
+    }
+    virtual wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) override
+    {
+        wxMouseEvent event(wxEVT_MOTION);
+        event.SetPosition(wxPoint(x, y));
+        m_frame->ProcessWindowEvent(event);
+        return wxDropTarget::OnDragOver(x, y, def);
+    }
+    virtual bool OnDrop(wxCoord x, wxCoord y)
+    {
+        m_frame->DisableAutoscrollWithoutCapture();
+        return wxDropTarget::OnDrop(x, y);
     }
     virtual wxDragResult OnData(wxCoord x, wxCoord y, wxDragResult def) override
     {
@@ -1734,14 +1748,28 @@ void DnDShapeDialog::OnColour(wxCommandEvent& WXUNUSED(event))
 // DnDShapeFrame
 // ----------------------------------------------------------------------------
 
+bool wxCreateScrolled(wxFrame* self,
+                     wxWindow *parent, wxWindowID winid,
+                     const wxPoint& pos, const wxSize& size,
+                     long style, const wxString& name)
+{
+     return self->Create(parent, winid, name);
+}
+
 DnDShapeFrame *DnDShapeFrame::ms_lastDropTarget = nullptr;
 
 DnDShapeFrame::DnDShapeFrame(wxFrame *parent)
-             : wxFrame(parent, wxID_ANY, "Shape Frame")
+             : wxScrolled<wxFrame>(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxScrolledWindowStyle, "Shape Frame")
 {
 #if wxUSE_STATUSBAR
     CreateStatusBar();
 #endif // wxUSE_STATUSBAR
+
+    // this is completely arbitrary and is done just for illustration purposes
+    SetVirtualSize(1000, 1000);
+    SetScrollRate(20, 20);
+    EnableAutoScrollInside(20);
+    DisableAutoScrollOutside();
 
     wxMenu *menuShape = new wxMenu;
     menuShape->Append(Menu_Shape_New, "&New default shape\tCtrl-S");
@@ -1846,6 +1874,7 @@ void DnDShapeFrame::OnDrop(wxCoord x, wxCoord y, DnDShape *shape)
     ms_lastDropTarget = this;
 
     wxPoint pt(x, y);
+    pt = CalcUnscrolledPosition(pt);
 
 #if wxUSE_STATUSBAR
     wxString s;
@@ -1934,17 +1963,15 @@ void DnDShapeFrame::OnUpdateUIPaste(wxUpdateUIEvent& event)
     event.Enable( wxTheClipboard->IsSupported(wxDataFormat(ShapeFormatId())) );
 }
 
-void DnDShapeFrame::OnPaint(wxPaintEvent& event)
+void DnDShapeFrame::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
+    wxPaintDC dc(this);
+    DoPrepareDC(dc);
+    dc.Clear();
+
     if ( m_shape )
     {
-        wxPaintDC dc(this);
-
         m_shape->Draw(dc);
-    }
-    else
-    {
-        event.Skip();
     }
 }
 

--- a/samples/dnd/dnd.cpp
+++ b/samples/dnd/dnd.cpp
@@ -766,10 +766,6 @@ public:
 #endif // wxUSE_STATUSBAR
         m_frame->DisableAutoscrollWithoutCapture();
     }
-    virtual wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) override
-    {
-        return wxDropTarget::OnDragOver(x, y, def);
-    }
     virtual bool OnDrop(wxCoord x, wxCoord y) override
     {
         m_frame->DisableAutoscrollWithoutCapture();

--- a/samples/dnd/dnd.cpp
+++ b/samples/dnd/dnd.cpp
@@ -768,9 +768,6 @@ public:
     }
     virtual wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) override
     {
-        wxMouseEvent event(wxEVT_MOTION);
-        event.SetPosition(wxPoint(x, y));
-        m_frame->ProcessWindowEvent(event);
         return wxDropTarget::OnDragOver(x, y, def);
     }
     virtual bool OnDrop(wxCoord x, wxCoord y) override

--- a/samples/dnd/dnd.cpp
+++ b/samples/dnd/dnd.cpp
@@ -1750,8 +1750,8 @@ void DnDShapeDialog::OnColour(wxCommandEvent& WXUNUSED(event))
 
 bool wxCreateScrolled(wxFrame* self,
                      wxWindow *parent, wxWindowID winid,
-                     const wxPoint& pos, const wxSize& size,
-                     long style, const wxString& name)
+                     const wxPoint& WXUNUSED(pos), const wxSize& WXUNUSED(size),
+                     long WXUNUSED(style), const wxString& name)
 {
      return self->Create(parent, winid, name);
 }

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -106,7 +106,9 @@ wxAutoScrollTimer::wxAutoScrollTimer(wxWindow *winToScroll,
 void wxAutoScrollTimer::Notify()
 {
     // only do all this as long as the window is capturing the mouse
-    if ( wxWindow::GetCapture() != m_win )
+    // or in withoutCapture mode
+    if ( wxWindow::GetCapture() != m_win &&
+         !m_scrollHelper->GetAutoscrollWithoutCapture() )
     {
         Stop();
     }
@@ -120,7 +122,11 @@ void wxAutoScrollTimer::Notify()
         // if no event needed, stop auto-scroll
         if ( !m_scrollHelper->AutoscrollTest(pt, horizontalEvent, verticalEvent) )
         {
-            Stop();
+            // if withoutCapture mode, continue watching mouse
+            if ( !m_scrollHelper->GetAutoscrollWithoutCapture() )
+            {
+                Stop();
+            }
             return;
         }
 
@@ -773,6 +779,23 @@ wxScrollHelperBase::AutoscrollTest(wxPoint clientPt,
     return true;
 }
 
+bool wxScrollHelperBase::GetAutoscrollWithoutCapture() const
+{
+    return m_autoscrollWithoutCapture;
+}
+
+void wxScrollHelperBase::EnableAutoscrollWithoutCapture()
+{
+    m_autoscrollWithoutCapture = true;
+    OnEnterAutoScrollRegion();
+}
+
+void wxScrollHelperBase::DisableAutoscrollWithoutCapture()
+{
+    m_autoscrollWithoutCapture = false;
+    OnLeaveAutoScrollRegion();
+}
+
 void wxScrollHelperBase::SetScrollRate( int xstep, int ystep )
 {
     int old_x = m_xScrollPixelsPerLine * m_xScrollPosition;
@@ -1057,7 +1080,9 @@ void wxScrollHelperBase::OnMotion(wxMouseEvent& event)
     event.Skip();
 
     // if not dragging, no autoscroll
-    if ( wxWindow::GetCapture() != m_targetWindow )
+    // (unless in withoutCapture mode)
+    if ( wxWindow::GetCapture() != m_targetWindow &&
+         !GetAutoscrollWithoutCapture() )
     {
         return;
     }


### PR DESCRIPTION
As stated in https://github.com/wxWidgets/wxWidgets/pull/25978#discussion_r2595800569, I want to implement autoscroll for drag-and-drop operations, and https://github.com/wxWidgets/wxWidgets/blob/61300d78d215e576576e7dc951f3147ef1785db2/samples/dnd/d_and_d.txt#L163 implies that I'm not the only one who wants this feature.

Now that the `wxScrolled<>` autoscroll region is configurable, this PR is a suggestion for another `wxScrolled<>` extension to support autoscrolling during drag-and-drop.  Commit 905430223af2482eb0e7ac00eb2ce9a6ab6ca551 implements the support, and commit e2439c10f4ac8a30cd93d51e717a44877ef92bed modifies the `dnd` sample to demonstrate dragging a `DnDShape` from one `DnDShapeFrame` to another `DnDShapeFrame` with the destination `DnDShapeFrame` autoscrolling.

I realize that commit e2439c10f4ac8a30cd93d51e717a44877ef92bed leaves the sample with some imperfections, but I think the current form is sufficient to demonstrate the API.  If the API is approved, then I will go back and refine the sample.