### PR TITLE
Add check for config like in wxHtmlHelpController::ReadCustomization

### DIFF
--- a/include/wx/html/helpwnd.h
+++ b/include/wx/html/helpwnd.h
@@ -132,7 +132,8 @@ public:
         {
             m_Config = config;
             m_ConfigRoot = rootpath;
-            ReadCustomization(config, rootpath);
+            if (config)
+                ReadCustomization(config, rootpath);
         }
 
     // Saves custom settings into cfg config. it will use the path 'path'


### PR DESCRIPTION
This way the used config can be safely reset to `nullptr` as clearly the intention looking at wxHtmlHelpController.

Currently a segfault occurs when calling `wxHtmlHelpController::UseConfig(nullptr)` (or `wxHtmlHelpWindow::UseConfig(nullptr)` directly).