### PR TITLE
Fix wxGTK gesture handling

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -3612,6 +3612,8 @@ rotate_gesture_begin_callback(GtkGesture* gesture, GdkEventSequence* WXUNUSED(se
     event.SetPosition(wxPoint(wxRound(x), wxRound(y)));
     event.SetGestureStart();
 
+    data->m_lastAngleDelta = 0;
+
     // Save this point because the point obtained through gtk_gesture_get_bounding_box_center()
     // in the "end" signal is not a rotation center
     data->m_lastGesturePoint = wxPoint(wxRound(x), wxRound(y));

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -428,7 +428,7 @@ static double gs_lastOffset = 0;
 static gdouble gs_lastScale = 1.0;
 
 // This is used to set the angle when rotate gesture ends.
-static gdouble gs_lastAngle = 0;
+static gdouble gs_lastAngleDelta = 0;
 
 // Last Zoom/Rotate gesture point
 static wxPoint gs_lastGesturePoint;
@@ -3616,7 +3616,7 @@ rotate_gesture_begin_callback(GtkGesture* gesture, GdkEventSequence* WXUNUSED(se
 
 extern "C" {
 static void
-rotate_gesture_callback(GtkGesture* gesture, gdouble WXUNUSED(angle_delta), gdouble angle, wxWindowGTK* win)
+rotate_gesture_callback(GtkGesture* gesture, gdouble WXUNUSED(angle), gdouble angle_delta, wxWindowGTK* win)
 {
     gdouble x, y;
 
@@ -3629,11 +3629,11 @@ rotate_gesture_callback(GtkGesture* gesture, gdouble WXUNUSED(angle_delta), gdou
 
     event.SetEventObject(win);
     event.SetPosition(wxPoint(wxRound(x), wxRound(y)));
-
-    event.SetRotationAngle(angle);
+    // angle is the absolute orientation of the two fingers, angle_delta is the angle relative to when the gesure started
+    event.SetRotationAngle(angle_delta);
 
     // Save the angle to set it when the gesture ends.
-    gs_lastAngle = angle;
+    gs_lastAngleDelta = angle_delta;
 
     // Save this point because the point obtained through gtk_gesture_get_bounding_box_center()
     // in the "end" signal is not a rotation center
@@ -3652,7 +3652,7 @@ rotate_gesture_end_callback(GtkGesture* WXUNUSED(gesture), GdkEventSequence* WXU
     event.SetEventObject(win);
     event.SetPosition(gs_lastGesturePoint);
     event.SetGestureEnd();
-    event.SetRotationAngle(gs_lastAngle);
+    event.SetRotationAngle(gs_lastAngleDelta);
 
     win->GTKProcessEvent(event);
 }


### PR DESCRIPTION
This PR fixes several issues with gesture handling in wxGTK. The most severe issue is #26211, which is that gesture cancellation can result in spurious gesture end events. Another issue is that gesture handling used several global variables, even though there can be multiple independent gestures of the same type active in different windows.

I have tested the changes with both a touchpad and a touchscreen and everything seems to work perfectly. Since I don't have an actual touchscreen, I did the testing by configuring my system to recognize my touchpad as a touchscreen. I have tested:
- GNOME Wayland and XWayland with touchpad and touchscreen
- Weston Wayland and XWayland with touchscreen (Weston doesn't seem to support touchpad gestures)
- Xorg with touchpad and touchscreen

I was able to trigger two pan gestures at once in Weston by modifying the sample to open two windows, and using a touchscreen in one window and a mouse in the other. The existing code was horribly broken in this scenario, this PR fixes it.