### PR TITLE
Fix for right/middle click handling in `wxAuiToolBar`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -52,8 +52,11 @@ f58ea625968953ca93585ea7f93dcc07ad032d8f
 # Remove trailing whitespace from several files, 2018-04-11
 496da2e550ce1f562f727230babc363da190530e
 
-# Remove all lines containing cvs/svn "$Id$" keyword.
+# Remove all lines containing cvs/svn "$Id$" keyword., 2013-07-26
 3f66f6a5b3583b02c34854556eb83e3a808524ce
+
+# Change variables naming convention in wxAUI code., 2011-10-30
+9a29fe70bc90b08b4f0bd4c23c1d12ad17cbbed2
 
 # No changes, just removed hard tabs and trailing white space., 2009-08-21
 03647350fc7cd141953c72e0284e928847d30f44

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -724,6 +724,9 @@ private:
     // Common part of OnLeaveWindow() and OnCaptureLost().
     void DoResetMouseState();
 
+    // Common part of On{Right,Middle}Up().
+    void DoRightOrMiddleUp(wxMouseEvent& evt, wxEventType eventType);
+
     wxSize RealizeHelper(wxReadOnlyDC& dc, wxOrientation orientation);
 
     void UpdateBackgroundBitmap(const wxSize& size);

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -716,6 +716,12 @@ public:
      */
     virtual void SetElementSize(int elementId, int size) = 0;
 
+    /**
+        Show a drop down menu with the given items.
+
+        @return ID of the item selected in the menu or -1 if the menu was
+            dismissed
+     */
     virtual int ShowDropDown(
                          wxWindow* wnd,
                          const wxAuiToolBarItemArray& items) = 0;

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1650,13 +1650,14 @@ void wxAuiToolBar::RefreshOverflowState()
 
 
     // find out the mouse's current position
-    wxPoint pt = ::wxGetMousePosition();
+    const wxMouseState mouseState = ::wxGetMouseState();
+    wxPoint pt = mouseState.GetPosition();
     pt = this->ScreenToClient(pt);
 
     // find out if the mouse cursor is inside the dropdown rectangle
     if (GetOverflowRect().Contains(pt))
     {
-        if (::wxGetMouseState().LeftIsDown())
+        if (mouseState.LeftIsDown())
             overflow_state = wxAUI_BUTTON_STATE_PRESSED;
         else
             overflow_state = wxAUI_BUTTON_STATE_HOVER;

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2873,25 +2873,23 @@ void wxAuiToolBar::OnRightUp(wxMouseEvent& evt)
     wxAuiToolBarItem* hitItem;
     hitItem = FindToolByPosition(evt.GetX(), evt.GetY());
 
+    int toolId;
     if (m_actionItem && hitItem == m_actionItem)
     {
-        wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_RIGHT_CLICK, m_actionItem->m_toolId);
-        e.SetEventObject(this);
-        e.SetToolId(m_actionItem->m_toolId);
-        e.SetClickPoint(m_actionPos);
-        GetEventHandler()->ProcessEvent(e);
-        DoIdleUpdate();
+        toolId = m_actionItem->m_toolId;
     }
     else
     {
         // right-clicked on the invalid area of the toolbar
-        wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_RIGHT_CLICK, -1);
-        e.SetEventObject(this);
-        e.SetToolId(-1);
-        e.SetClickPoint(m_actionPos);
-        GetEventHandler()->ProcessEvent(e);
-        DoIdleUpdate();
+        toolId = wxNOT_FOUND;
     }
+
+    wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_RIGHT_CLICK, toolId);
+    e.SetEventObject(this);
+    e.SetToolId(toolId);
+    e.SetClickPoint(m_actionPos);
+    GetEventHandler()->ProcessEvent(e);
+    DoIdleUpdate();
 
     // reset member variables
     m_actionPos = wxPoint(-1,-1);

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1648,15 +1648,13 @@ void wxAuiToolBar::RefreshOverflowState()
 
     int overflow_state = 0;
 
-    wxRect overflow_rect = GetOverflowRect();
-
 
     // find out the mouse's current position
     wxPoint pt = ::wxGetMousePosition();
     pt = this->ScreenToClient(pt);
 
     // find out if the mouse cursor is inside the dropdown rectangle
-    if (overflow_rect.Contains(pt.x, pt.y))
+    if (GetOverflowRect().Contains(pt))
     {
         if (::wxGetMouseState().LeftIsDown())
             overflow_state = wxAUI_BUTTON_STATE_PRESSED;
@@ -2649,7 +2647,7 @@ void wxAuiToolBar::OnLeftDown(wxMouseEvent& evt)
     if (m_gripperSizerItem)
     {
         wxRect gripper_rect = m_gripperSizerItem->GetRect();
-        if (gripper_rect.Contains(evt.GetX(), evt.GetY()))
+        if (gripper_rect.Contains(evt.GetPosition()))
         {
             // find aui manager
             wxAuiManager* manager = wxAuiManager::GetManager(this);
@@ -2667,9 +2665,7 @@ void wxAuiToolBar::OnLeftDown(wxMouseEvent& evt)
 
     if (m_overflowSizerItem && m_overflowVisible && m_art)
     {
-        wxRect overflow_rect = GetOverflowRect();
-
-        if (overflow_rect.Contains(evt.m_x, evt.m_y))
+        if (GetOverflowRect().Contains(evt.GetPosition()))
         {
             wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_OVERFLOW_CLICK, -1);
             e.SetEventObject(this);
@@ -2845,14 +2841,13 @@ void wxAuiToolBar::OnRightDown(wxMouseEvent& evt)
 
     if (m_gripperSizerItem)
     {
-        wxRect gripper_rect = m_gripperSizerItem->GetRect();
-        if (gripper_rect.Contains(evt.GetX(), evt.GetY()))
+        if (m_gripperSizerItem->GetRect().Contains(evt.GetPosition()))
             return;
     }
 
     if (m_overflowSizerItem && m_overflowVisible && m_art)
     {
-        if (GetOverflowRect().Contains(evt.GetX(), evt.GetY()))
+        if (GetOverflowRect().Contains(evt.GetPosition()))
             return;
     }
 
@@ -2911,14 +2906,13 @@ void wxAuiToolBar::OnMiddleDown(wxMouseEvent& evt)
 
     if (m_gripperSizerItem)
     {
-        wxRect gripper_rect = m_gripperSizerItem->GetRect();
-        if (gripper_rect.Contains(evt.GetX(), evt.GetY()))
+        if (m_gripperSizerItem->GetRect().Contains(evt.GetPosition()))
             return;
     }
 
     if (m_overflowSizerItem && m_overflowVisible && m_art)
     {
-        if (GetOverflowRect().Contains(evt.GetX(), evt.GetY()))
+        if (GetOverflowRect().Contains(evt.GetPosition()))
             return;
     }
 
@@ -3071,8 +3065,7 @@ void wxAuiToolBar::OnSetCursor(wxSetCursorEvent& evt)
 
     if (m_gripperSizerItem)
     {
-        wxRect gripper_rect = m_gripperSizerItem->GetRect();
-        if (gripper_rect.Contains(evt.GetX(), evt.GetY()))
+        if (m_gripperSizerItem->GetRect().Contains(evt.GetPosition()))
         {
             cursor = wxCursor(wxCURSOR_SIZING);
         }

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2244,23 +2244,23 @@ int wxAuiToolBar::GetOverflowState() const
 
 wxRect wxAuiToolBar::GetOverflowRect() const
 {
-    wxRect cli_rect(wxPoint(0,0), GetClientSize());
-    wxRect overflow_rect = m_overflowSizerItem->GetRect();
+    const wxSize cli_size = GetClientSize();
+    wxRect overflow_rect;
     int overflow_size = m_art->GetElementSizeForWindow(wxAUI_TBART_OVERFLOW_SIZE, this);
 
     if (m_orientation == wxVERTICAL)
     {
-        overflow_rect.y = cli_rect.height - overflow_size;
+        overflow_rect.y = cli_size.y - overflow_size;
         overflow_rect.x = 0;
-        overflow_rect.width = cli_rect.width;
+        overflow_rect.width = cli_size.x;
         overflow_rect.height = overflow_size;
     }
     else
     {
-        overflow_rect.x = cli_rect.width - overflow_size;
+        overflow_rect.x = cli_size.x - overflow_size;
         overflow_rect.y = 0;
         overflow_rect.width = overflow_size;
-        overflow_rect.height = cli_rect.height;
+        overflow_rect.height = cli_size.y;
     }
 
     return overflow_rect;

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2906,18 +2906,23 @@ void wxAuiToolBar::OnMiddleUp(wxMouseEvent& evt)
     wxAuiToolBarItem* hitItem;
     hitItem = FindToolByPosition(evt.GetX(), evt.GetY());
 
+    int toolId;
     if (m_actionItem && hitItem == m_actionItem)
     {
-        if (hitItem->m_kind == wxITEM_NORMAL)
-        {
-            wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_MIDDLE_CLICK, m_actionItem->m_toolId);
-            e.SetEventObject(this);
-            e.SetToolId(m_actionItem->m_toolId);
-            e.SetClickPoint(m_actionPos);
-            GetEventHandler()->ProcessEvent(e);
-            DoIdleUpdate();
-        }
+        toolId = m_actionItem->m_toolId;
     }
+    else
+    {
+        // middle-clicked on the invalid area of the toolbar
+        toolId = wxNOT_FOUND;
+    }
+
+    wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_MIDDLE_CLICK, toolId);
+    e.SetEventObject(this);
+    e.SetToolId(toolId);
+    e.SetClickPoint(m_actionPos);
+    GetEventHandler()->ProcessEvent(e);
+    DoIdleUpdate();
 
     // reset member variables
     m_actionPos = wxPoint(-1,-1);

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2850,16 +2850,10 @@ void wxAuiToolBar::OnRightDown(wxMouseEvent& evt)
             return;
     }
 
-    if (m_overflowSizerItem && m_art)
+    if (m_overflowSizerItem && m_overflowVisible && m_art)
     {
-        int overflowSize = m_art->GetElementSizeForWindow(wxAUI_TBART_OVERFLOW_SIZE, this);
-        if (overflowSize > 0 &&
-            evt.m_x > cli_rect.width - overflowSize &&
-            evt.m_y >= 0 &&
-            evt.m_y < cli_rect.height)
-        {
+        if (GetOverflowRect().Contains(evt.GetX(), evt.GetY()))
             return;
-        }
     }
 
     m_actionPos = wxPoint(evt.GetX(), evt.GetY());
@@ -2922,16 +2916,10 @@ void wxAuiToolBar::OnMiddleDown(wxMouseEvent& evt)
             return;
     }
 
-    if (m_overflowSizerItem && m_art)
+    if (m_overflowSizerItem && m_overflowVisible && m_art)
     {
-        int overflowSize = m_art->GetElementSizeForWindow(wxAUI_TBART_OVERFLOW_SIZE, this);
-        if (overflowSize > 0 &&
-            evt.m_x > cli_rect.width - overflowSize &&
-            evt.m_y >= 0 &&
-            evt.m_y < cli_rect.height)
-        {
+        if (GetOverflowRect().Contains(evt.GetX(), evt.GetY()))
             return;
-        }
     }
 
     m_actionPos = wxPoint(evt.GetX(), evt.GetY());

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2838,8 +2838,6 @@ void wxAuiToolBar::OnRightDown(wxMouseEvent& evt)
     if (HasCapture())
         return;
 
-    wxRect cli_rect(wxPoint(0,0), GetClientSize());
-
     if (m_gripperSizerItem)
     {
         if (m_gripperSizerItem->GetRect().Contains(evt.GetPosition()))
@@ -2900,8 +2898,6 @@ void wxAuiToolBar::OnMiddleDown(wxMouseEvent& evt)
 {
     if (HasCapture())
         return;
-
-    wxRect cli_rect(wxPoint(0,0), GetClientSize());
 
     if (m_gripperSizerItem)
     {

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2551,7 +2551,7 @@ void wxAuiToolBar::UpdateBackgroundBitmap(const wxSize& size)
 void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
     wxAutoBufferedPaintDC dc(this);
-    wxRect cli_rect(wxPoint(0,0), GetClientSize());
+    const wxSize cli_size = GetClientSize();
 
 
     bool horizontal = m_orientation == wxHORIZONTAL;
@@ -2575,9 +2575,9 @@ void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
     // calculated how far we can draw items
     int last_extent;
     if (horizontal)
-        last_extent = cli_rect.width;
+        last_extent = cli_size.x;
     else
-        last_extent = cli_rect.height;
+        last_extent = cli_size.y;
     if (m_overflowVisible)
         last_extent -= overflowSize;
 

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2834,7 +2834,7 @@ void wxAuiToolBar::OnRightDown(wxMouseEvent& evt)
     UnsetToolTip();
 }
 
-void wxAuiToolBar::OnRightUp(wxMouseEvent& evt)
+void wxAuiToolBar::DoRightOrMiddleUp(wxMouseEvent& evt, wxEventType eventType)
 {
     if (HasCapture())
         return;
@@ -2853,7 +2853,7 @@ void wxAuiToolBar::OnRightUp(wxMouseEvent& evt)
         toolId = wxNOT_FOUND;
     }
 
-    wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_RIGHT_CLICK, toolId);
+    wxAuiToolBarEvent e(eventType, toolId);
     e.SetEventObject(this);
     e.SetToolId(toolId);
     e.SetClickPoint(m_actionPos);
@@ -2863,6 +2863,11 @@ void wxAuiToolBar::OnRightUp(wxMouseEvent& evt)
     // reset member variables
     m_actionPos = wxPoint(-1,-1);
     m_actionItem = nullptr;
+}
+
+void wxAuiToolBar::OnRightUp(wxMouseEvent& evt)
+{
+    DoRightOrMiddleUp(evt, wxEVT_AUITOOLBAR_RIGHT_CLICK);
 }
 
 void wxAuiToolBar::OnMiddleDown(wxMouseEvent& evt)
@@ -2900,33 +2905,7 @@ void wxAuiToolBar::OnMiddleDown(wxMouseEvent& evt)
 
 void wxAuiToolBar::OnMiddleUp(wxMouseEvent& evt)
 {
-    if (HasCapture())
-        return;
-
-    wxAuiToolBarItem* hitItem;
-    hitItem = FindToolByPosition(evt.GetX(), evt.GetY());
-
-    int toolId;
-    if (m_actionItem && hitItem == m_actionItem)
-    {
-        toolId = m_actionItem->m_toolId;
-    }
-    else
-    {
-        // middle-clicked on the invalid area of the toolbar
-        toolId = wxNOT_FOUND;
-    }
-
-    wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_MIDDLE_CLICK, toolId);
-    e.SetEventObject(this);
-    e.SetToolId(toolId);
-    e.SetClickPoint(m_actionPos);
-    GetEventHandler()->ProcessEvent(e);
-    DoIdleUpdate();
-
-    // reset member variables
-    m_actionPos = wxPoint(-1,-1);
-    m_actionItem = nullptr;
+    DoRightOrMiddleUp(evt, wxEVT_AUITOOLBAR_MIDDLE_CLICK);
 }
 
 void wxAuiToolBar::OnMotion(wxMouseEvent& evt)

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -86,31 +86,6 @@ static bool IsThemeDark()
 
 
 
-class ToolbarCommandCapture : public wxEvtHandler
-{
-public:
-
-    ToolbarCommandCapture() { m_lastId = 0; }
-    int GetCommandId() const { return m_lastId; }
-
-    bool ProcessEvent(wxEvent& evt) override
-    {
-        if (evt.GetEventType() == wxEVT_MENU)
-        {
-            m_lastId = evt.GetId();
-            return true;
-        }
-
-        if (GetNextHandler())
-            return GetNextHandler()->ProcessEvent(evt);
-
-        return false;
-    }
-
-private:
-    int m_lastId;
-};
-
 wxBitmap wxAuiToolBarItem::GetCurrentBitmapFor(wxWindow* wnd) const
 {
     // We suppose that we don't have disabled bitmap if we don't have the
@@ -869,13 +844,9 @@ int wxAuiGenericToolBarArt::ShowDropDown(wxWindow* wnd,
     wxRect cli_rect = wnd->GetClientRect();
     pt.y = cli_rect.y + cli_rect.height;
 
-    ToolbarCommandCapture* cc = new ToolbarCommandCapture;
-    wnd->PushEventHandler(cc);
-    wnd->PopupMenu(&menuPopup, pt);
-    int command = cc->GetCommandId();
-    wnd->PopEventHandler(true);
+    const int command = wnd->GetPopupMenuSelectionFromUser(menuPopup, pt);
 
-    return command;
+    return command == wxID_NONE ? -1 : command;
 }
 
 


### PR DESCRIPTION
This started as a fix for #26242 (which is just the first commit, which will also need to be backported to 3.2) but I've also done some (ok, a lot of) cleanup.