### PR TITLE
Some wxQt fixes

### DIFF
--- a/src/qt/checkbox.cpp
+++ b/src/qt/checkbox.cpp
@@ -62,9 +62,6 @@ bool wxCheckBox::Create(wxWindow *parent, wxWindowID id, const wxString& label,
 
     GetQCheckBox()->setText( wxQtConvertString( label ) );
 
-    // Do the initialization here as WXValidateStyle may fail in unit tests
-    bool ok = wxCheckBoxBase::Create( parent, id, pos, size, style, validator, name );
-
     WXValidateStyle(&style);
 
     if ( style & wxCHK_2STATE )
@@ -74,7 +71,7 @@ bool wxCheckBox::Create(wxWindow *parent, wxWindowID id, const wxString& label,
     if ( style & wxALIGN_RIGHT )
         GetQCheckBox()->setLayoutDirection( Qt::RightToLeft );
 
-    return ok;
+    return wxCheckBoxBase::Create( parent, id, pos, size, style, validator, name );
 }
 
 QCheckBox* wxCheckBox::GetQCheckBox() const

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1278,13 +1278,11 @@ void wxWindowQt::DoSetClientSize(int width, int height)
     QWidget *qtWidget = QtGetClientWidget();
     wxCHECK_RET( qtWidget, "window must be created" );
 
-    if ( qtWidget != GetHandle() )
-    {
-        int x, y;
-        DoGetPosition(&x, &y);
-        // Ensure that this window is correctly positioned in RTL layout.
-        DoMoveWindow(x, y, width, height);
-    }
+    int x, y;
+    DoGetPosition(&x, &y);
+    DoMoveWindow(x, y, width, height);
+
+    // Ensure that this window is correctly positioned in RTL layout.
 
     QRect geometry = qtWidget->geometry();
     const int dx = width - geometry.width();


### PR DESCRIPTION
The 1st [commit](6062bda2ee1e11ae3742a85a6b50d9d11e4aaf3b) fixes a problem that can be seen in the **dialogs** samples:
The `wxRearrangeDialog` has invalid client size (press `Ctrl+R`):

**Before:**
<img width="712" height="617" alt="Screenshot from 2026-02-26 00-09-37" src="https://github.com/user-attachments/assets/f25268c6-f1ba-46e4-8ca4-491f434bf770" />

**After:**
<img width="356" height="341" alt="Screenshot from 2026-02-26 00-06-53" src="https://github.com/user-attachments/assets/a354df94-dfe5-470a-9bb4-d4699c105eea" />

The last one is how the dialog looks like under `wxMSW` and `wxGTK`.