### PR TITLE
Let wxAuiToolBars with stretchable elements stretch

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -636,6 +636,9 @@ public:
     // Override to call DoIdleUpdate().
     virtual void UpdateWindowUI(long flags = wxUPDATE_UI_NONE) override;
 
+    // This function is for internal use only, don't call it from your code.
+    bool CanStretch() const;
+
 protected:
     void Init();
 

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2207,6 +2207,17 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     return true;
 }
 
+bool wxAuiToolBar::CanStretch() const
+{
+    for (auto const& item : m_items)
+    {
+        if (item.m_proportion)
+            return true;
+    }
+
+    return false;
+}
+
 int wxAuiToolBar::GetOverflowState() const
 {
     return m_overflowState;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -2447,7 +2447,13 @@ void wxAuiManager::LayoutAddPane(wxSizer* cont,
         if (min_size == wxDefaultSize)
         {
             min_size = pane.best_size;
-            pane_proportion = 0;
+
+            // Toolbars may be fixed, i.e. non-resizable, but still need to
+            // stretch if they contain stretchable spacers, so we should avoid
+            // setting their proportion to 0 in this case.
+            auto* const toolbar = wxDynamicCast(pane.window, wxAuiToolBar);
+            if (!toolbar || !toolbar->CanStretch())
+                pane_proportion = 0;
         }
     }
 


### PR DESCRIPTION
Previously, all fixed panes without a minimum size were forced to have a proportion of 0 in wxAUI layout code, which meant that a wxAuiToolBar with stretchable elements (typically spaces, but labels and controls could be stretchable too) couldn't stretch unless its pane was given some non-default minimum size, even if it was just wxSize(-1,1).

This was completely undiscoverable and not intuitive at all, so let wxAuiToolBar stretch if it has any stretchable elements, regardless of its pane min size instead.

This required adding wxAuiToolBar::CanStretch() and using an ugly dynamic cast. We could probably avoid this by using some kind of heuristic based on e.g. comparing min and best size, but this is simple and guaranteed not to break anything else, so do it like this for now.

Closes #26249.