### PR TITLE
Don't unconditionally set m_clipping to true in wxMSWDCImpl::SetHDC()

### DIFF
--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -117,17 +117,7 @@ public:
     }
 
     WXHDC GetHDC() const { return m_hDC; }
-    void SetHDC(WXHDC dc, bool bOwnsDC = false)
-    {
-        m_hDC = dc;
-        m_bOwnsDC = bOwnsDC;
-
-        // we might have a pre existing clipping region, make sure that we
-        // return it if asked -- but avoid calling ::GetClipBox() right now as
-        // it could be unnecessary wasteful
-        m_clipping = true;
-        m_isClipBoxValid = false;
-    }
+    void SetHDC(WXHDC dc, bool bOwnsDC = false);
 
     void* GetHandle() const override { return (void*)GetHDC(); }
 

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -339,6 +339,37 @@ void wxMSWDCImpl::SelectOldObjects(WXHDC dc)
     m_selectedBitmap = wxNullBitmap;
 }
 
+void wxMSWDCImpl::SetHDC(WXHDC dc, bool bOwnsDC)
+{
+    m_hDC = dc;
+    m_bOwnsDC = bOwnsDC;
+
+    m_isClipBoxValid = false;
+
+    if ( m_hDC != 0 )
+    {
+        // Notice that m_clipping is initialized to true only if there is
+        // an application-defined clipping region already set on the device.
+        // Quoting the MSDN:
+        //  "An application-defined clipping region is a clipping region
+        //   identified by the SelectClipRgn function. It is not a clipping
+        //   region created when the application calls the BeginPaint function."
+        //
+        HRGN hrgn;
+        int result = ::GetClipRgn((WXHDC)m_hDC, hrgn);
+        if ( result == -1 )
+        {
+            wxLogLastError("GetClipRgn");
+        }
+        else
+        {
+            // We might have a pre-existing clipping region; make sure that we
+            // return it if asked for.
+            m_clipping = result;
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // clipping
 // ---------------------------------------------------------------------------

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -355,7 +355,7 @@ void wxMSWDCImpl::SetHDC(WXHDC dc, bool bOwnsDC)
         //   identified by the SelectClipRgn function. It is not a clipping
         //   region created when the application calls the BeginPaint function."
         //
-        HRGN hrgn;
+        HRGN hrgn = 0;
         int result = ::GetClipRgn((WXHDC)m_hDC, hrgn);
         if ( result == -1 )
         {


### PR DESCRIPTION
Account for application-defined clipping regions only (those identified by the SelectClipRgn function) when setting m_clipping to true. IOW, clipping regions that are set by the system during BeginPaint are not considered.

Closes #26251