### PR TITLE
Add wxMoveToTrash function

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -204,6 +204,9 @@ Currently the following symbols exist:
 @itemdef{wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG, Defined if the <code>long
     long</code> and <code>long</code> types are different. This can be useful
     to decide whether some function should be overloaded for both types or not.}
+@itemdef{wxHAS_MOVE_TO_TRASH, Defined if wxMoveToTrash() is supported on the
+    current platform. This is currently the case for MSW, macOS, and GTK.
+    This constant is available since wxWidgets 3.3.3}
 @itemdef{wxHAS_MULTIPLE_FILEDLG_FILTERS, Defined if wxFileDialog supports multiple ('|'-separated) filters.}
 @itemdef{wxHAS_NATIVE_ANIMATIONCTRL, Defined if native wxAnimationCtrl class is being used (this symbol only exists in wxWidgets 3.1.4 and later).}
 @itemdef{wxHAS_NATIVE_DATAVIEWCTRL, Defined if native wxDataViewCtrl class is being used (this symbol only exists in wxWidgets 3.1.4 and later).}

--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -435,6 +435,9 @@ WXDLLIMPEXP_BASE bool wxCopyFile(const wxString& src, const wxString& dest,
 // Remove file
 WXDLLIMPEXP_BASE bool wxRemoveFile(const wxString& file);
 
+// Move file or directory to trash/recycle bin
+WXDLLIMPEXP_BASE bool wxMoveToTrash(const wxString& path);
+
 // Rename file
 WXDLLIMPEXP_BASE bool wxRenameFile(const wxString& oldpath, const wxString& newpath, bool overwrite = true);
 

--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -436,6 +436,10 @@ WXDLLIMPEXP_BASE bool wxCopyFile(const wxString& src, const wxString& dest,
 WXDLLIMPEXP_BASE bool wxRemoveFile(const wxString& file);
 
 // Move file or directory to trash/recycle bin
+#if defined(__WINDOWS__) || defined(__WXMAC__) || defined(__WXGTK__)
+    #define wxHAS_MOVE_TO_TRASH
+#endif
+
 WXDLLIMPEXP_BASE bool wxMoveToTrash(const wxString& path);
 
 // Rename file

--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -436,7 +436,7 @@ WXDLLIMPEXP_BASE bool wxCopyFile(const wxString& src, const wxString& dest,
 WXDLLIMPEXP_BASE bool wxRemoveFile(const wxString& file);
 
 // Move file or directory to trash/recycle bin
-#if defined(__WINDOWS__) || defined(__WXMAC__) || defined(__WXGTK__)
+#if defined(__WINDOWS__) || defined(__WXDARWIN_OSX__) || defined(__WXGTK__)
     #define wxHAS_MOVE_TO_TRASH
 #endif
 

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -217,7 +217,7 @@ void wxSplitPath(const wxString& fullname,
 /**
     Returns time of last modification of given file.
 
-    The function returns <tt>(time_t)-1</tt> if an error occurred (e.g. file
+    The function returns <tt>(time_t)-1</tt> if an error occurred (e.g., file
     not found).
 
     @header{wx/filefn.h}
@@ -362,7 +362,7 @@ bool wxRemoveFile(const wxString& file);
     <a href="https://specifications.freedesktop.org/trash/latest/">FreeDesktop
     Trash specification</a> directly.
 
-    @note On Unix, moving files across filesystem boundaries (e.g. from an
+    @note On Unix, moving files across filesystem boundaries (e.g., from an
     external drive) is not supported and will return @false.
 
     @since 3.3.3

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -349,6 +349,29 @@ bool wxConcatFiles(const wxString& src1,
 bool wxRemoveFile(const wxString& file);
 
 /**
+    Moves @a path to the system trash or recycle bin, returning @true if
+    successful.
+
+    This works for both files and directories. The item is not permanently
+    deleted and can be restored by the user from the platform's trash
+    facility.
+
+    Under Windows, this uses the shell file operation with @c FOF_ALLOWUNDO.
+    Under macOS, this uses @c NSFileManager's @c trashItemAtURL method.
+    Under Unix systems (including Linux and BSD), this implements the
+    <a href="https://specifications.freedesktop.org/trash/latest/">FreeDesktop
+    Trash specification</a> directly.
+
+    @note On Unix, moving files across filesystem boundaries (e.g. from an
+    external drive) is not supported and will return @false.
+
+    @since 3.3.3
+
+    @header{wx/filefn.h}
+*/
+bool wxMoveToTrash(const wxString& path);
+
+/**
     File permission bit names.
 
     We define these constants in wxWidgets because S_IREAD &c are not standard.

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -363,7 +363,7 @@ bool wxRemoveFile(const wxString& file);
     @note On Unix, moving files across filesystem boundaries (e.g., from an
     external drive) is not supported and will return @false.
 
-    @availability{wxHAS_MOVE_TO_TRASH}
+    Requires @c wxHAS_MOVE_TO_TRASH.
 
     @since 3.3.3
 

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -363,6 +363,8 @@ bool wxRemoveFile(const wxString& file);
     @note On Unix, moving files across filesystem boundaries (e.g., from an
     external drive) is not supported and will return @false.
 
+    @availability{wxHAS_MOVE_TO_TRASH}
+
     @since 3.3.3
 
     @header{wx/filefn.h}

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -363,8 +363,6 @@ bool wxRemoveFile(const wxString& file);
     @note On Unix, moving files across filesystem boundaries (e.g., from an
     external drive) is not supported and will return @false.
 
-    Requires @c wxHAS_MOVE_TO_TRASH.
-
     @since 3.3.3
 
     @header{wx/filefn.h}

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -356,11 +356,9 @@ bool wxRemoveFile(const wxString& file);
     deleted and can be restored by the user from the platform's trash
     facility.
 
-    Under Windows, this uses the shell file operation with @c FOF_ALLOWUNDO.
+    Under Windows, this uses @c SHFileOperation with @c FOF_ALLOWUNDO.
     Under macOS, this uses @c NSFileManager's @c trashItemAtURL method.
-    Under Unix systems (including Linux and BSD), this implements the
-    <a href="https://specifications.freedesktop.org/trash/latest/">FreeDesktop
-    Trash specification</a> directly.
+    Under Unix systems (including Linux and BSD), this uses @c g_file_trash.
 
     @note On Unix, moving files across filesystem boundaries (e.g., from an
     external drive) is not supported and will return @false.

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -360,9 +360,6 @@ bool wxRemoveFile(const wxString& file);
     Under macOS, this uses @c NSFileManager's @c trashItemAtURL method.
     Under Unix systems (including Linux and BSD), this uses @c g_file_trash.
 
-    @note On Unix, moving files across filesystem boundaries (e.g., from an
-    external drive) is not supported and will return @false.
-
     @since 3.3.3
 
     @header{wx/filefn.h}

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -681,7 +681,7 @@ bool wxMoveToTrash(const wxString& path)
 {
     if ( !wxFileExists(path) && !wxDirExists(path) )
     {
-        wxLogError(_("'%s' doesn't exist and can't be moved to trash"), path);
+        wxLogError(_("'%s' doesn't exist and can't be moved to trash."), path);
         return false;
     }
 

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -641,70 +641,14 @@ bool wxRemoveFile(const wxString& file)
     return res == 0;
 }
 
-#if defined(__WXMAC__)
-extern bool wxMoveToTrashOSX(const wxString& path);
-#endif
+#ifndef wxHAS_MOVE_TO_TRASH
 
-#if defined(__WXGTK__)
-#include <gio/gio.h>
-#endif
-
-bool wxMoveToTrash(const wxString& path)
+bool wxMoveToTrash(const wxString& WXUNUSED(path))
 {
-    if ( !wxFileExists(path) && !wxDirExists(path) )
-    {
-        wxLogError(_("'%s' doesn't exist and can't be moved to trash."), path);
-        return false;
-    }
-
-#if defined(__WINDOWS__)
-    // SHFileOperation needs double null termination string
-    // but without separator at the end of the path
-    wxString pathStr(path);
-    if ( pathStr.Last() == wxFILE_SEP_PATH )
-        pathStr.RemoveLast();
-    pathStr += wxT('\0');
-
-    SHFILEOPSTRUCT fileop;
-    wxZeroMemory(fileop);
-    fileop.wFunc = FO_DELETE;
-    fileop.pFrom = pathStr.t_str();
-    fileop.fFlags = FOF_ALLOWUNDO | FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI;
-
-    int ret = SHFileOperation(&fileop);
-    if ( ret != 0 || fileop.fAnyOperationsAborted )
-    {
-        wxLogDebug(wxS("SHFileOperation(FO_DELETE with FOF_ALLOWUNDO) failed: error 0x%08x"),
-                   ret);
-        return false;
-    }
-
-    return true;
-
-#elif defined(__WXMAC__)
-    return wxMoveToTrashOSX(path);
-
-#elif defined(__WXGTK__)
-    GError* err = nullptr;
-    GFile* file = g_file_new_for_path(path.fn_str());
-
-    bool ok = g_file_trash(file, nullptr, &err);
-    if ( !ok )
-    {
-        wxLogError(_("'%s' couldn't be moved to trash: %s"),
-                   path, err ? err->message : _("unknown error"));
-    }
-
-    g_clear_error(&err);
-    g_object_unref(file);
-
-    return ok;
-
-#else
-    wxLogError(_("Moving to trash is not supported on this platform"));
     return false;
-#endif
 }
+
+#endif // !wxHAS_MOVE_TO_TRASH
 
 bool wxMkdir(const wxString& dir, int perm)
 {

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -692,7 +692,7 @@ bool wxMoveToTrash(const wxString& path)
     if ( !ok )
     {
         wxLogError(_("'%s' couldn't be moved to trash: %s"),
-                   path, err ? err->message : "unknown error");
+                   path, err ? err->message : _("unknown error"));
     }
 
     g_clear_error(&err);

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -770,7 +770,10 @@ bool wxMoveToTrash(const wxString& path)
 
         wxString encodedPath = wxTrashUrlEncodePath(fullPath);
         wxString info = wxString::Format(
-            "[Trash Info]\nPath=%s\nDeletionDate=%s\n",
+R"[Trash Info]
+Path=%s
+DeletionDate=%s
+",
             encodedPath,
             wxDateTime::Now().FormatISOCombined()
         );

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -645,37 +645,9 @@ bool wxRemoveFile(const wxString& file)
 extern bool wxMoveToTrashOSX(const wxString& path);
 #endif
 
-#if defined(__UNIX__) && !defined(__WXMAC__)
-#include <fcntl.h>
-
-// Percent-encode a file path per RFC 2396 for the FreeDesktop Trash spec.
-static wxString wxTrashUrlEncodePath(const wxString& path)
-{
-    const wxScopedCharBuffer utf8 = path.utf8_str();
-    const char* cur = utf8;
-    wxString result;
-
-    while ( *cur )
-    {
-        const unsigned char ch = static_cast<unsigned char>(*cur);
-        // Unreserved characters per RFC 2396: A-Z a-z 0-9 - _ . ~ /
-        if ( (ch >= 'A' && ch <= 'Z') ||
-             (ch >= 'a' && ch <= 'z') ||
-             (ch >= '0' && ch <= '9') ||
-             ch == '-' || ch == '_' || ch == '.' || ch == '~' || ch == '/' )
-        {
-            result += static_cast<char>(ch);
-        }
-        else
-        {
-            result += wxString::Format("%%%02X", ch);
-        }
-        ++cur;
-    }
-
-    return result;
-}
-#endif // __UNIX__ && !__WXMAC__
+#if defined(__WXGTK__)
+#include <gio/gio.h>
+#endif
 
 bool wxMoveToTrash(const wxString& path)
 {
@@ -712,85 +684,21 @@ bool wxMoveToTrash(const wxString& path)
 #elif defined(__WXMAC__)
     return wxMoveToTrashOSX(path);
 
-#elif defined(__UNIX__)
-    wxString xdgData;
-    if ( !wxGetEnv("XDG_DATA_HOME", &xdgData) || xdgData.empty() )
-        xdgData = wxFileName::GetHomeDir() + "/.local/share";
+#elif defined(__WXGTK__)
+    GError* err = nullptr;
+    GFile* file = g_file_new_for_path(path.fn_str());
 
-    wxString trashFiles = xdgData + "/Trash/files";
-    wxString trashInfo  = xdgData + "/Trash/info";
-
-    if ( !wxFileName::Mkdir(trashFiles, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL) )
-        return false;
-    if ( !wxFileName::Mkdir(trashInfo, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL) )
-        return false;
-
-    // Resolve the full absolute path
-    wxFileName fileName(path);
-    fileName.MakeAbsolute();
-    wxString fullPath = fileName.GetFullPath();
-
-    // Pick a unique trash name atomically using O_EXCL per the spec
-    wxString baseName = fileName.GetFullName();
-    wxString trashName = baseName;
-    wxString infoPath;
-
-    for ( int attempt = 2; ; ++attempt )
+    bool ok = g_file_trash(file, nullptr, &err);
+    if ( !ok )
     {
-        infoPath = trashInfo + "/" + trashName + ".trashinfo";
-
-        int infoFd = open(infoPath.utf8_str(), O_WRONLY | O_CREAT | O_EXCL, 0600);
-        if ( infoFd >= 0 )
-        {
-            close(infoFd);
-            break;
-        }
-        if ( errno != EEXIST )
-        {
-            wxLogSysError(_("'%s' couldn't be moved to trash"), path);
-            return false;
-        }
-
-        // Name collision, try next: "file.2.txt", "file.3.txt", ...
-        wxString name = fileName.GetName();
-        wxString ext  = fileName.GetExt();
-        trashName = wxString::Format("%s.%d", name, attempt);
-        if ( !ext.empty() )
-            trashName += "." + ext;
+        wxLogError(_("'%s' couldn't be moved to trash: %s"),
+                   path, err ? err->message : "unknown error");
     }
 
-    // Write the .trashinfo file
-    {
-        wxFile infoFile;
-        if ( !infoFile.Open(infoPath, wxFile::write) )
-        {
-            wxRemoveFile(infoPath);
-            return false;
-        }
+    g_clear_error(&err);
+    g_object_unref(file);
 
-        wxString encodedPath = wxTrashUrlEncodePath(fullPath);
-        wxString info = wxString::Format(
-R"[Trash Info]
-Path=%s
-DeletionDate=%s
-",
-            encodedPath,
-            wxDateTime::Now().FormatISOCombined()
-        );
-        infoFile.Write(info);
-    }
-
-    // Move the file or directory into Trash/files/
-    wxString destPath = trashFiles + "/" + trashName;
-    if ( wxRename(fullPath, destPath) != 0 )
-    {
-        // Move failed (e.g. cross-device) — clean up the .trashinfo
-        wxRemoveFile(infoPath);
-        wxLogSysError(_("'%s' couldn't be moved to trash"), path);
-        return false;
-    }
-
-    return true;
+    return ok;
 
 #else
     wxLogError(_("Moving to trash is not supported on this platform"));

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -26,6 +26,10 @@
 
 #include "wx/gtk/private/wrapgdk.h"
 #include "wx/gtk/private/backend.h"
+#include "wx/gtk/private/error.h"
+#include "wx/gtk/private/object.h"
+
+#include <gio/gio.h>
 
 #if wxDEBUG_LEVEL
     #include "wx/gtk/assertdlg_gtk.h"
@@ -335,3 +339,18 @@ bool wxGUIAppTraits::ShowAssertDialog(const wxString& msg)
 }
 
 #endif // __UNIX__
+
+bool wxMoveToTrash(const wxString& path)
+{
+    wxGtkError err;
+    wxGtkObject<GFile> file(g_file_new_for_path(path.utf8_str()));
+
+    bool ok = g_file_trash(file, nullptr, err.Out());
+    if ( !ok )
+    {
+        wxLogError(_("'%s' couldn't be moved to trash: %s"),
+                   path, err ? err.GetMessage() : _("unknown error"));
+    }
+
+    return ok;
+}

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1733,7 +1733,8 @@ bool wxMoveToTrash(const wxString& path)
     int ret = SHFileOperation(&fileop);
     if ( ret != 0 || fileop.fAnyOperationsAborted )
     {
-        wxLogError(wxS("SHFileOperation(FO_DELETE with FOF_ALLOWUNDO) failed: error 0x%08x"),
+        wxLogError(_("'%s' couldn't be moved to trash: error 0x%08x"),
+                   path,
                    ret);
         return false;
     }

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1715,6 +1715,32 @@ wxCreateHiddenWindow(LPCTSTR *pclassname, LPCTSTR classname, WNDPROC wndproc)
     return hwnd;
 }
 
+bool wxMoveToTrash(const wxString& path)
+{
+    // SHFileOperation needs double null termination string
+    // but without separator at the end of the path
+    wxString pathStr(path);
+    if ( pathStr.Last() == wxFILE_SEP_PATH )
+        pathStr.RemoveLast();
+    pathStr += wxT('\0');
+
+    SHFILEOPSTRUCT fileop;
+    wxZeroMemory(fileop);
+    fileop.wFunc = FO_DELETE;
+    fileop.pFrom = pathStr.t_str();
+    fileop.fFlags = FOF_ALLOWUNDO | FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI;
+
+    int ret = SHFileOperation(&fileop);
+    if ( ret != 0 || fileop.fAnyOperationsAborted )
+    {
+        wxLogDebug(wxS("SHFileOperation(FO_DELETE with FOF_ALLOWUNDO) failed: error 0x%08x"),
+                   ret);
+        return false;
+    }
+
+    return true;
+}
+
 int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
 {
     return StrCmpLogicalW(s1.wc_str(), s2.wc_str());

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1733,7 +1733,7 @@ bool wxMoveToTrash(const wxString& path)
     int ret = SHFileOperation(&fileop);
     if ( ret != 0 || fileop.fAnyOperationsAborted )
     {
-        wxLogDebug(wxS("SHFileOperation(FO_DELETE with FOF_ALLOWUNDO) failed: error 0x%08x"),
+        wxLogError(wxS("SHFileOperation(FO_DELETE with FOF_ALLOWUNDO) failed: error 0x%08x"),
                    ret);
         return false;
     }

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -389,3 +389,32 @@ bool wxMacInitCocoa()
 }
 
 #endif // __WXDARWIN_OSX__
+
+// Move file or directory to macOS Trash using NSFileManager.
+// Called from wxMoveToTrash() in src/common/filefn.cpp.
+bool wxMoveToTrashOSX(const wxString& path)
+{
+    wxCFStringRef cfPath(path);
+    NSURL *fileURL = [NSURL fileURLWithPath:cfPath.AsNSString()];
+    if ( fileURL == nil )
+        return false;
+
+    NSError *error = nil;
+    BOOL ok = [[NSFileManager defaultManager] trashItemAtURL:fileURL
+                                            resultingItemURL:nil
+                                                       error:&error];
+    if ( !ok )
+    {
+        if ( error )
+        {
+            wxLogDebug("NSFileManager trashItemAtURL failed: %s",
+                       wxCFStringRef::AsString([error localizedDescription]));
+        }
+        else
+        {
+            wxLogDebug("NSFileManager trashItemAtURL failed (unknown error)");
+        }
+    }
+
+    return ok;
+}

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -405,15 +405,10 @@ bool wxMoveToTrashOSX(const wxString& path)
                                                        error:&error];
     if ( !ok )
     {
-        if ( error )
-        {
-            wxLogDebug("NSFileManager trashItemAtURL failed: %s",
-                       wxCFStringRef::AsString([error localizedDescription]));
-        }
-        else
-        {
-            wxLogDebug("NSFileManager trashItemAtURL failed (unknown error)");
-        }
+        wxLogError(_("'%s' couldn't be moved to trash: %s"),
+                   path,
+                   error ? wxCFStringRef::AsString([error localizedDescription])
+                         : wxString("unknown error"));
     }
 
     return ok;

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -388,8 +388,6 @@ bool wxMacInitCocoa()
     return cocoaLoaded;
 }
 
-#endif // __WXDARWIN_OSX__
-
 // Move file or directory to macOS Trash using NSFileManager.
 bool wxMoveToTrash(const wxString& path)
 {
@@ -412,3 +410,5 @@ bool wxMoveToTrash(const wxString& path)
 
     return ok;
 }
+
+#endif // __WXDARWIN_OSX__

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -405,7 +405,7 @@ bool wxMoveToTrash(const wxString& path)
         wxLogError(_("'%s' couldn't be moved to trash: %s"),
                    path,
                    error ? wxCFStringRef::AsString([error localizedDescription])
-                         : wxString("unknown error"));
+                         : _("unknown error"));
     }
 
     return ok;

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -391,8 +391,7 @@ bool wxMacInitCocoa()
 #endif // __WXDARWIN_OSX__
 
 // Move file or directory to macOS Trash using NSFileManager.
-// Called from wxMoveToTrash() in src/common/filefn.cpp.
-bool wxMoveToTrashOSX(const wxString& path)
+bool wxMoveToTrash(const wxString& path)
 {
     wxCFStringRef cfPath(path);
     NSURL *fileURL = [NSURL fileURLWithPath:cfPath.AsNSString()];


### PR DESCRIPTION
Moves a file or directory (recursively) into the trash/recycle bin. If it fails, then returns `false` and leaves the file alone; I thought calling `wxRemoveFile` as an alternative path upon failure would be too aggressive and arbitrary.

I added implementation details in the docs; we seem to do that with system-level functions like this.

Tested on:

- Windows 11
- Linux Mint
- macOS Catalina