### PR TITLE
Fix rendering of non-BMP chars in wxD2DContext in UTF-8 build

### DIFF
--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -3322,16 +3322,24 @@ wxCOMPtr<IDWriteTextLayout> wxD2DFontData::CreateTextLayout(const wxString& text
 
     wxCOMPtr<IDWriteTextLayout> textLayout;
 
+#if wxUSE_UNICODE_WCHAR
+    const wchar_t* const wstr = text.c_str();
+    const size_t wlen = text.length();
+#else // wxUSE_UNICODE_UTF8
+    const wxWCharBuffer wstr = text.wc_str();
+    const size_t wlen = wstr.length();
+#endif
+
     hr = wxDWriteFactory()->CreateTextLayout(
-        text.c_str(),
-        text.length(),
+        wstr,
+        wlen,
         m_textFormat,
         MAX_WIDTH,
         MAX_HEIGHT,
         &textLayout);
     wxCHECK2_HRESULT_RET(hr, wxCOMPtr<IDWriteTextLayout>(nullptr));
 
-    DWRITE_TEXT_RANGE textRange = { 0, (UINT32) text.length() };
+    DWRITE_TEXT_RANGE textRange = { 0, (UINT32) wlen };
 
     if (m_underlined)
     {


### PR DESCRIPTION
We need the length of the wide character string, but wxString::length() (correctly) returns the number of Unicode characters in the string in UTF-8 build and not the number of UTF-16 code units, which is actually needed by IDWriteFactory::CreateTextLayout(), so the buffer contents was truncated when it contained any characters outside of the BMP, such as emojis.

Fix this by using UTF-16 buffer length.

Closes #26259.