### PR TITLE
wxFindWindowAtPoint with specified window exclusion

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -744,6 +744,9 @@ protected:
     }
 
 private:
+    friend wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip);
+    bool m_hideFromFind;
+
     // common part of all ctors
     void Init();
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -744,7 +744,7 @@ protected:
     }
 
 private:
-    friend wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip);
+    friend WXDLLIMPEXP_CORE wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip);
     bool m_hideFromFind;
 
     // common part of all ctors

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -637,7 +637,9 @@ WXDLLIMPEXP_CORE int wxFindMenuItemId(wxFrame *frame, const wxString& menuString
 
 // Find the wxWindow at the given point. wxGenericFindWindowAtPoint
 // is always present but may be less reliable than a native version.
+WXDLLIMPEXP_CORE wxWindow* wxGenericFindWindowAtPoint(const wxPoint& pt, wxWindow* skip);
 WXDLLIMPEXP_CORE wxWindow* wxGenericFindWindowAtPoint(const wxPoint& pt);
+WXDLLIMPEXP_CORE wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip);
 WXDLLIMPEXP_CORE wxWindow* wxFindWindowAtPoint(const wxPoint& pt);
 
 // NB: this function is obsolete, use wxWindow::FindWindowByLabel() instead

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1291,7 +1291,7 @@ wxFindMenuItemId(wxFrame *frame,
 // within other controls, but are still siblings (e.g. buttons within
 // static boxes). Static boxes are likely to be created _before_ controls
 // that sit inside them.
-wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt)
+wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt, wxWindow* skip)
 {
     if (!win->IsShown())
         return nullptr;
@@ -1306,8 +1306,8 @@ wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt)
       if (sel >= 0)
       {
         wxWindow* child = nb->GetPage(sel);
-        wxWindow* foundWin = wxFindWindowAtPoint(child, pt);
-        if (foundWin)
+        wxWindow* foundWin = wxFindWindowAtPoint(child, pt, skip);
+        if (foundWin && foundWin != skip)
            return foundWin;
       }
     }
@@ -1317,8 +1317,8 @@ wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt)
     while (node)
     {
         wxWindow* child = node->GetData();
-        wxWindow* foundWin = wxFindWindowAtPoint(child, pt);
-        if (foundWin)
+        wxWindow* foundWin = wxFindWindowAtPoint(child, pt, skip);
+        if (foundWin && foundWin != skip)
           return foundWin;
         node = node->GetPrevious();
     }
@@ -1331,13 +1331,13 @@ wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt)
     }
 
     wxRect rect(pos, sz);
-    if (rect.Contains(pt))
+    if (win != skip && rect.Contains(pt))
         return win;
 
     return nullptr;
 }
 
-wxWindow* wxGenericFindWindowAtPoint(const wxPoint& pt)
+wxWindow* wxGenericFindWindowAtPoint(const wxPoint& pt, wxWindow* skip)
 {
     // Go backwards through the list since windows
     // on top are likely to have been appended most
@@ -1346,12 +1346,22 @@ wxWindow* wxGenericFindWindowAtPoint(const wxPoint& pt)
     while (node)
     {
         wxWindow* win = node->GetData();
-        wxWindow* found = wxFindWindowAtPoint(win, pt);
+        wxWindow* found = wxFindWindowAtPoint(win, pt, skip);
         if (found)
             return found;
         node = node->GetPrevious();
     }
     return nullptr;
+}
+
+wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt)
+{
+    return wxFindWindowAtPoint(win, pt, nullptr);
+}
+
+wxWindow* wxGenericFindWindowAtPoint(const wxPoint& pt)
+{
+    return wxGenericFindWindowAtPoint(pt, nullptr);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/dfb/window.cpp
+++ b/src/dfb/window.cpp
@@ -1039,6 +1039,12 @@ void wxWindowDFB::HandleKeyEvent(const wxDFBWindowEvent& event_)
     }
 }
 
+wxWindow* wxFindWindowAtPoint(const wxPoint& WXUNUSED(pt), wxWindow* WXUNUSED(skip))
+{
+    wxFAIL_MSG( "wxFindWindowAtPoint not implemented" );
+    return nullptr;
+}
+
 wxWindow* wxFindWindowAtPoint(const wxPoint& WXUNUSED(pt))
 {
     wxFAIL_MSG( "wxFindWindowAtPoint not implemented" );

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -95,6 +95,11 @@ wxDisplayInfo wxGetDisplayInfo()
 
 #endif // __UNIX__
 
+wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip)
+{
+    return wxGenericFindWindowAtPoint(pt, skip);
+}
+
 wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
 {
     return wxGenericFindWindowAtPoint(pt);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -394,6 +394,7 @@ void wxWindowMSW::Init()
 {
     // MSW specific
     m_oldWndProc = nullptr;
+    m_hideFromFind = false;
     m_mouseInWindow = false;
     m_lastKeydownProcessed = false;
 
@@ -3937,6 +3938,10 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 WXLRESULT wxWindowMSW::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lParam)
 {
     WXLRESULT result;
+    if (m_hideFromFind && message == WM_NCHITTEST)
+    {
+        return HTTRANSPARENT;
+    }
     if ( !MSWHandleMessage(&result, message, wParam, lParam) )
     {
 #if wxDEBUG_LEVEL >= 2
@@ -7957,6 +7962,14 @@ wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
     }
 
     return wxGetWindowFromHWND((WXHWND)hWnd);
+}
+
+wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip)
+{
+    if (skip) skip->m_hideFromFind = true;
+    wxWindow* found = wxFindWindowAtPoint(pt);
+    if (skip) skip->m_hideFromFind = false;
+    return found;
 }
 
 #if wxUSE_HOTKEY

--- a/src/osx/utils_osx.cpp
+++ b/src/osx/utils_osx.cpp
@@ -120,7 +120,7 @@ wxEventLoopBase* wxGUIAppTraits::CreateEventLoop()
 
 wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt);
 
-wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
+wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip)
 {
     return wxGenericFindWindowAtPoint( pt, skip );
 }

--- a/src/osx/utils_osx.cpp
+++ b/src/osx/utils_osx.cpp
@@ -122,6 +122,11 @@ wxWindow* wxFindWindowAtPoint(wxWindow* win, const wxPoint& pt);
 
 wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
 {
+    return wxGenericFindWindowAtPoint( pt, skip );
+}
+
+wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
+{
     return wxGenericFindWindowAtPoint( pt );
 }
 

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -66,13 +66,18 @@ wxMouseState wxGetMouseState()
 #endif
 
 
-wxWindow *wxFindWindowAtPoint(const wxPoint& pt)
+wxWindow *wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip)
 {
     /* Another option is to use QApplication::topLevelAt()
      * but that gives the QWidget so the wxWindow list must
      * be traversed comparing with this, or use the pointer from
      * a wxQtWidget/wxQtFrame to the window, but they have
      * no standard interface to return that. */
+    return wxGenericFindWindowAtPoint( pt, skip );
+}
+
+wxWindow *wxFindWindowAtPoint(const wxPoint& pt)
+{
     return wxGenericFindWindowAtPoint( pt );
 }
 

--- a/src/x11/utils.cpp
+++ b/src/x11/utils.cpp
@@ -144,6 +144,11 @@ void wxGetMousePosition( int* x, int* y )
 #endif
 };
 
+wxWindow* wxFindWindowAtPoint(const wxPoint& pt, wxWindow* skip)
+{
+    return wxGenericFindWindowAtPoint(pt, skip);
+}
+
 wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
 {
     return wxGenericFindWindowAtPoint(pt);


### PR DESCRIPTION
Hi,

I added overloaded wxFindWindowAtPoint with extra parameter for dragged wxWindow to be excluded from the search.
On MSW it uses httransparent in nchittest temporarily during search. On other platforms it simply continue iterating windows.

regards, Martin