### PR TITLE
Fix the accessible label of checkboxes.

### DIFF
--- a/include/wx/msw/private/accessible.h
+++ b/include/wx/msw/private/accessible.h
@@ -53,21 +53,6 @@ public:
         return wxACC_OK;
     }
 
-    virtual wxAccStatus GetName(int childId, wxString* name) override
-    {
-        if ( childId != wxACC_SELF )
-            return wxACC_NOT_IMPLEMENTED;
-
-        TControl* const ctrl = wxStaticCast(GetWindow(), TControl);
-        wxCHECK(ctrl, wxACC_FAIL);
-
-        if ( !ctrl->MSWIsOwnerDrawn() )
-            return wxACC_NOT_IMPLEMENTED;
-
-        *name = ctrl->GetLabel();
-        return wxACC_OK;
-    }
-
     virtual wxAccStatus GetState(int childId, long* state) override
     {
         if ( childId != wxACC_SELF )

--- a/include/wx/msw/private/accessible.h
+++ b/include/wx/msw/private/accessible.h
@@ -53,6 +53,21 @@ public:
         return wxACC_OK;
     }
 
+    virtual wxAccStatus GetName(int childId, wxString* name) override
+    {
+        if ( childId != wxACC_SELF )
+            return wxACC_NOT_IMPLEMENTED;
+
+        TControl* const ctrl = wxStaticCast(GetWindow(), TControl);
+        wxCHECK(ctrl, wxACC_FAIL);
+
+        if ( !ctrl->MSWIsOwnerDrawn() )
+            return wxACC_NOT_IMPLEMENTED;
+
+        *name = ctrl->GetLabel();
+        return wxACC_OK;
+    }
+
     virtual wxAccStatus GetState(int childId, long* state) override
     {
         if ( childId != wxACC_SELF )

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3887,15 +3887,7 @@ wxAccStatus wxWindowAccessible::GetName(int childId, wxString* name)
     if (childId > 0)
         return wxACC_NOT_IMPLEMENTED;
 
-    // This will eventually be replaced by specialised
-    // accessible classes, one for each kind of wxWidgets
-    // control or window.
-#if wxUSE_BUTTON
-    if (wxDynamicCast(GetWindow(), wxButton))
-        title = ((wxButton*) GetWindow())->GetLabel();
-    else
-#endif
-        title = GetWindow()->GetName();
+    title = GetWindow()->GetLabel();
 
     if (!title.empty())
     {


### PR DESCRIPTION
I noticed an absolutely critical bug when updating to wxWidgets 3.3.2. All of my checkboxes now have their accessible labels replaced with "check"!
The problem: wxWindowAccessible::GetName() has a special case for wxButton -> GetLabel(), but falls through to GetWindow()->GetName() for everything else. GetName() returns the internal wx window name ("check"), not the user-visible label. Before, owner-drawn checkboxes fell back to Windows' own IAccessible which reads window text (the label) directly. Once CreateAccessible() was wired up, it started going through wxWindowAccessible::GetName() and returning the wrong thing. The fix adds GetName() to wxOwnerDrawnAccessible returning ctrl->GetLabel() when owner-drawn, and wxACC_NOT_IMPLEMENTED otherwise to pass through to the standard Windows accessible as before.
Is there a release policy for absolutely breaking bugs like this? wxWidgets 3.3.2 is utterly unusable for me because of this despite having many fixes I want. I get it if I have to wait for 3.3.3, but that would be unfortunate too.