### PR TITLE
Fix accelerator characters shown in accessible label of controls

### DIFF
--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3891,7 +3891,11 @@ wxAccStatus wxWindowAccessible::GetName(int childId, wxString* name)
 
     if (!title.empty())
     {
+#if wxUSE_CONTROLS
+        *name = wxControl::GetLabelText(title);
+#else
         *name = title;
+#endif
         return wxACC_OK;
     }
     else

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3891,11 +3891,7 @@ wxAccStatus wxWindowAccessible::GetName(int childId, wxString* name)
 
     if (!title.empty())
     {
-#if wxUSE_CONTROLS
-        *name = wxControl::GetLabelText(title);
-#else
-        *name = title;
-#endif
+        *name = wxStripMenuCodes(title, wxStrip_Mnemonics);
         return wxACC_OK;
     }
     else


### PR DESCRIPTION
The fix in 85c436dcc4 (Fix accessible label of checkboxes broken by
recent changes, 2026-03-06) made wxWindowAccessible::GetName() return
GetLabel() for all controls. However, GetLabel() returns the raw label
including '&' accelerator markers (e.g. "&Minimize to system tray"),
causing screen readers to announce the literal ampersand.

Fix this by passing the label through wxControl::GetLabelText(), which
strips accelerator markers, guarded by wxUSE_CONTROLS for configurations
that don't include controls.

See #26270.