### PR TITLE
Simplify clipboard operations in GTK

### DIFF
--- a/src/gtk/clipbrd.cpp
+++ b/src/gtk/clipbrd.cpp
@@ -646,8 +646,6 @@ bool wxClipboard::SetData( wxDataObject *data )
 
     wxCHECK_MSG( data, false, wxT("data is invalid") );
 
-    Clear();
-
     return AddData( data );
 }
 
@@ -658,7 +656,16 @@ bool wxClipboard::AddData( wxDataObject *data )
     wxCHECK_MSG( data, false, wxT("data is invalid") );
 
     // we can only store one wxDataObject so clear the old one
-    Clear();
+    if ( m_usePrimary )
+    {
+        delete m_dataPrimary;
+        m_dataPrimary = nullptr;
+    }
+    else
+    {
+        delete m_dataClipboard;
+        m_dataClipboard = nullptr;
+    }
 
     Data() = data;
 


### PR DESCRIPTION
When changing the clipboard contents the current code emits a lot of noise on the X11 connection, it clears the contents and verifies it's empty before settings the new content.

This non-atomic operation is problematic for desktop environments with clipboard managers that try to replace an empty clipboard. It becomes racey with us setting our new contents.

See #26265