### PR TITLE
Some more RTL fixes

### DIFF
--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -2006,6 +2006,9 @@ public:
         @param y
             Receives the y position of the window on the screen if non-null.
 
+        @note Starting from wxWidgets 3.3.3, this function correctly returns the
+              upper-left corner of the window in RTL layout for child windows too.
+
         @see GetPosition()
     */
     void GetScreenPosition(int* x, int* y) const;

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -1082,6 +1082,17 @@ void wxWindowBase::DoGetScreenPosition(int *x, int *y) const
         *y = 0;
 
     ClientToScreen(x, y);
+
+    if ( x && GetLayoutDirection() == wxLayout_RightToLeft )
+    {
+        // In RTL layout, ClientToScreen(0, 0) correctly returns the upper-right corner
+        // of the window (for non TLWs). But the window position relative to the desktop
+        // surface should be expressed by its upper-left corner because position (0, 0)
+        // of the desktop surface is always at the upper-left even in RTL.
+        int width;
+        DoGetSize(&width, nullptr);
+        *x -= width;
+    }
 }
 
 void wxWindowBase::SendSizeEvent(int flags)

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -753,13 +753,15 @@ wxScrollHelperBase::AutoscrollTest(wxPoint clientPt,
     // can window can be scrolled in this direction?
     if ( m_win->HasScrollbar(wxHORIZONTAL) )
     {
+        const bool isRTL = m_win->GetLayoutDirection() == wxLayout_RightToLeft;
+
         if ( screenPt.x < inner.GetLeft() )
         {
-            evtHorzScroll = wxEVT_SCROLLWIN_LINEUP;
+            evtHorzScroll = isRTL ? wxEVT_SCROLLWIN_LINEDOWN : wxEVT_SCROLLWIN_LINEUP;
         }
         else if (screenPt.x >= inner.GetRight() )
         {
-            evtHorzScroll = wxEVT_SCROLLWIN_LINEDOWN;
+            evtHorzScroll = isRTL ? wxEVT_SCROLLWIN_LINEUP : wxEVT_SCROLLWIN_LINEDOWN;
         }
     }
 

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -1905,6 +1905,17 @@ wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, HDC hdc, wxDou
     : wxGraphicsContext(renderer)
     , m_layoutDir((::GetLayout(hdc) & LAYOUT_RTL) ? wxLayout_RightToLeft : wxLayout_LeftToRight)
 {
+    if ( m_layoutDir == wxLayout_RightToLeft )
+    {
+        // Mixing GDI+ with pure GDI calls on the same drawing may have
+        // unexpected results in RTL layout. i.e.: The final drawing may
+        // not be correctly mirrored on the destination DC. So we always
+        // perform drawing operations on an LTR HDC and a transformation
+        // matrix will be applied to this context to achieve the necessary
+        // mirroring effects.
+        ::SetLayout(hdc, 0);
+    }
+
     Init(new Graphics(hdc), width, height);
 }
 
@@ -1913,6 +1924,18 @@ wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, const wxDC& dc
     , m_layoutDir(dc.GetLayoutDirection())
 {
     HDC hdc = (HDC) dc.GetHDC();
+
+    if ( m_layoutDir == wxLayout_RightToLeft )
+    {
+        // Mixing GDI+ with pure GDI calls on the same drawing may have
+        // unexpected results in RTL layout. i.e.: The final drawing may
+        // not be correctly mirrored on the destination DC. So we always
+        // perform drawing operations on an LTR HDC and a transformation
+        // matrix will be applied to this context to achieve the necessary
+        // mirroring effects.
+        ::SetLayout(hdc, 0);
+    }
+
     wxSize sz = dc.GetSize();
 
     // We don't set HDC origin at MSW level in wxDC because this limits it to
@@ -1995,6 +2018,13 @@ void wxGDIPlusContext::Init(Graphics* graphics, int width, int height, const Mat
 
 wxGDIPlusContext::~wxGDIPlusContext()
 {
+    if ( m_layoutDir == wxLayout_RightToLeft )
+    {
+        WXHDC hdc = GetNativeHDC();
+        ::SetLayout((HDC)hdc, LAYOUT_RTL);
+        ReleaseNativeHDC(hdc);
+    }
+
     delete m_internalTransform;
     delete m_internalTransformInv;
     if ( m_context )

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -92,7 +92,7 @@ StringFormat* gs_drawTextStringFormat = nullptr;
 // Get the string format used for the text drawing and measuring functions:
 // notice that it must be the same one for all of them, otherwise the drawn
 // text might be of different size than what measuring it returned.
-inline StringFormat* GetDrawTextStringFormat(wxLayoutDirection dir = wxLayout_Default)
+inline StringFormat* GetDrawTextStringFormat(DWORD layoutDir = 0)
 {
     if ( !gs_drawTextStringFormat )
     {
@@ -103,7 +103,7 @@ inline StringFormat* GetDrawTextStringFormat(wxLayoutDirection dir = wxLayout_De
         auto flags = gs_drawTextStringFormat->GetFormatFlags()
                    | StringFormatFlagsMeasureTrailingSpaces;
 
-        if ( dir == wxLayout_RightToLeft )
+        if ( (layoutDir & LAYOUT_RTL) != 0 )
             flags |= StringFormatFlagsDirectionRightToLeft;
 
         gs_drawTextStringFormat->SetFormatFlags(flags);
@@ -483,7 +483,7 @@ public:
 
     Graphics* GetGraphics() const { return m_context; }
 
-    bool IsRTL() const { return m_layoutDir == wxLayout_RightToLeft; }
+    bool IsRTL() const { return (m_layoutDir & LAYOUT_RTL) != 0; }
 
     virtual WXHDC GetNativeHDC() override;
     virtual void ReleaseNativeHDC(WXHDC hdc) override;
@@ -505,7 +505,7 @@ private:
     GraphicsState m_state2;
     Matrix* m_internalTransform;
     Matrix* m_internalTransformInv;
-    wxLayoutDirection m_layoutDir = wxLayout_Default;
+    DWORD m_layoutDir = 0;
 
     wxDECLARE_NO_COPY_CLASS(wxGDIPlusContext);
 };
@@ -1903,9 +1903,9 @@ public :
 
 wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, HDC hdc, wxDouble width, wxDouble height   )
     : wxGraphicsContext(renderer)
-    , m_layoutDir((::GetLayout(hdc) & LAYOUT_RTL) ? wxLayout_RightToLeft : wxLayout_LeftToRight)
+    , m_layoutDir(::GetLayout(hdc))
 {
-    if ( m_layoutDir == wxLayout_RightToLeft )
+    if ( IsRTL() )
     {
         // Mixing GDI+ with pure GDI calls on the same drawing may have
         // unexpected results in RTL layout. i.e.: The final drawing may
@@ -1921,11 +1921,11 @@ wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, HDC hdc, wxDou
 
 wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, const wxDC& dc )
     : wxGraphicsContext(renderer, dc.GetWindow())
-    , m_layoutDir(dc.GetLayoutDirection())
+    , m_layoutDir(::GetLayout((HDC)dc.GetHandle()))
 {
     HDC hdc = (HDC) dc.GetHDC();
 
-    if ( m_layoutDir == wxLayout_RightToLeft )
+    if ( IsRTL() )
     {
         // Mixing GDI+ with pure GDI calls on the same drawing may have
         // unexpected results in RTL layout. i.e.: The final drawing may
@@ -1960,9 +1960,12 @@ wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer,
                                     HWND hwnd,
                                     wxWindow* window )
     : wxGraphicsContext(renderer, window)
-    , m_layoutDir((::GetWindowLong(hwnd, GWL_EXSTYLE) & WS_EX_LAYOUTRTL) ? wxLayout_RightToLeft
-                                                                         : wxLayout_LeftToRight)
 {
+    if ( (::GetWindowLong(hwnd, GWL_EXSTYLE) & WS_EX_LAYOUTRTL) != 0 )
+    {
+        m_layoutDir = LAYOUT_RTL;
+    }
+
     RECT rect = wxGetWindowRect(hwnd);
     Init(new Graphics(hwnd), rect.right - rect.left, rect.bottom - rect.top);
     m_enableOffset = true;
@@ -1991,7 +1994,7 @@ void wxGDIPlusContext::Init(Graphics* graphics, int width, int height, const Mat
     m_height = height;
     m_internalTransform = new Matrix();
 
-    if ( m_layoutDir == wxLayout_RightToLeft )
+    if ( IsRTL() )
     {
         m_context->ScaleTransform(-1, 1);
         m_context->TranslateTransform(-width, 0);
@@ -2018,10 +2021,10 @@ void wxGDIPlusContext::Init(Graphics* graphics, int width, int height, const Mat
 
 wxGDIPlusContext::~wxGDIPlusContext()
 {
-    if ( m_layoutDir == wxLayout_RightToLeft )
+    if ( IsRTL() )
     {
         WXHDC hdc = GetNativeHDC();
-        ::SetLayout((HDC)hdc, LAYOUT_RTL);
+        ::SetLayout((HDC)hdc, m_layoutDir);
         ReleaseNativeHDC(hdc);
     }
 


### PR DESCRIPTION
Rubberbanding is broken without these changes. Now, it's working correctly again under `wxMSW`, `wxGTK3` and `wxQt`

https://github.com/user-attachments/assets/11cf2948-8c5e-4a11-8ae8-82a495400315

