### PR TITLE
bugfix: wxWebRequestCURL: check for CURL error code when going through completed transfers

### DIFF
--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -1623,7 +1623,16 @@ void wxWebSessionCURL::CheckForCompletedTransfers()
             {
                 wxWebRequestCURL* request = it->second;
                 curl_multi_remove_handle(m_handle, curl);
-                request->HandleCompletion();
+                if ( msg->data.result != CURLE_OK )
+                {
+                    wxString errorMsg = wxString::Format("libcurl error: %s",
+                        curl_easy_strerror(msg->data.result));
+                    request->SetState(wxWebRequest::State_Failed, errorMsg);
+                }
+                else
+                {
+                    request->HandleCompletion();
+                }
                 m_activeTransfers.erase(it);
                 RemoveActiveSocket(curl);
             }


### PR DESCRIPTION
Hello!

I have encountered strange bug on Linux when `wxWebRequestEvent::GetState() == wxWebRequest::State_Completed`, but file is downloaded partially. This reproduces quickly if your internet connection is poor.

In application I now avoid this bug with check for `wxWebRequestEvent::GetResponse().GetContentLength() == wxWebRequestEvent::GetRequest().GetBytesReceived()`. If file is downloaded partially => condition is not true.

But expected result is `wxWebRequestEvent::GetState() == wxWebRequest::State_Failed`. Presumably, we need to check for data transfer error in `wxWebSessionCURL::CheckForCompletedTransfers()`.