### PR TITLE
Document WebKitGTK rendering issue and workaround

### DIFF
--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -918,6 +918,13 @@ public:
     The predefined @c wxWebViewBackendWebKit constant contains the name of this
     backend.
 
+    @note WebKitGTK 2.42+ may fail to render content due to 
+    DMA-BUF hardware acceleration issues. This can be resolved by calling
+    @code
+    wxSetEnv("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    @endcode
+    before creating a @c wxWebView instance.
+
     @subsection wxWEBVIEW_WEBKIT_MACOS wxWEBVIEW_WEBKIT (macOS)
 
     The macOS WebKit backend uses Apple's

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -918,7 +918,7 @@ public:
     The predefined @c wxWebViewBackendWebKit constant contains the name of this
     backend.
 
-    @note WebKitGTK 2.42+ may fail to render content due to 
+    @note WebKitGTK 2.42+ may fail to render content due to
     DMA-BUF hardware acceleration issues. This can be resolved by calling
     @code
     wxSetEnv("WEBKIT_DISABLE_DMABUF_RENDERER", "1");


### PR DESCRIPTION
This is an experience I encounter with an older NVIDIA card + X11 + Linux Mint. Running this:

```
wxSetEnv("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
```
fixes it and appears to be a common recommendation:

https://forums.developer.nvidia.com/t/webkit-tauri-application-white-screen-on-dgx-spark-gpupermission-issues/348741

https://stackoverflow.com/questions/78358584/problematic-frame-c-libwebkit2gtk-4-0-so-370xd4f568