### PR TITLE
Fix static build regression on GTK (wxMoveToTrash)

### DIFF
--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -440,7 +440,13 @@ WXDLLIMPEXP_BASE bool wxRemoveFile(const wxString& file);
     #define wxHAS_MOVE_TO_TRASH
 #endif
 
-WXDLLIMPEXP_BASE bool wxMoveToTrash(const wxString& path);
+#ifdef wxHAS_MOVE_TO_TRASH
+    #ifdef __WXGTK__
+        WXDLLIMPEXP_CORE bool wxMoveToTrash(const wxString& path);
+    #else
+        WXDLLIMPEXP_BASE bool wxMoveToTrash(const wxString& path);
+    #endif
+#endif // wxHAS_MOVE_TO_TRASH
 
 // Rename file
 WXDLLIMPEXP_BASE bool wxRenameFile(const wxString& oldpath, const wxString& newpath, bool overwrite = true);

--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -441,11 +441,7 @@ WXDLLIMPEXP_BASE bool wxRemoveFile(const wxString& file);
 #endif
 
 #ifdef wxHAS_MOVE_TO_TRASH
-    #ifdef __WXGTK__
-        WXDLLIMPEXP_CORE bool wxMoveToTrash(const wxString& path);
-    #else
-        WXDLLIMPEXP_BASE bool wxMoveToTrash(const wxString& path);
-    #endif
+    WXDLLIMPEXP_CORE bool wxMoveToTrash(const wxString& path);
 #endif // wxHAS_MOVE_TO_TRASH
 
 // Rename file

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -356,8 +356,7 @@ bool wxRemoveFile(const wxString& file);
     facility.
 
     Preprocessor symbol @c wxHAS_MOVE_TO_TRASH is defined if this function is
-    supported on the current platform. If it is not defined, the function still
-    exists but always returns @false without doing anything else.
+    available on the current platform.
 
     Implementation details:
     - Under Windows, this uses @c SHFileOperation with @c FOF_ALLOWUNDO.

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -641,15 +641,6 @@ bool wxRemoveFile(const wxString& file)
     return res == 0;
 }
 
-#ifndef wxHAS_MOVE_TO_TRASH
-
-bool wxMoveToTrash(const wxString& WXUNUSED(path))
-{
-    return false;
-}
-
-#endif // !wxHAS_MOVE_TO_TRASH
-
 bool wxMkdir(const wxString& dir, int perm)
 {
 #if defined(__WXMAC__) && !defined(__UNIX__)

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1715,35 +1715,6 @@ wxCreateHiddenWindow(LPCTSTR *pclassname, LPCTSTR classname, WNDPROC wndproc)
     return hwnd;
 }
 
-bool wxMoveToTrash(const wxString& path)
-{
-    // SHFileOperation needs double null termination string
-    // but without separator at the end of the path
-    wxString pathStr(path);
-    if ( pathStr.Last() == wxFILE_SEP_PATH )
-        pathStr.RemoveLast();
-    pathStr += wxT('\0');
-
-    SHFILEOPSTRUCT fileop;
-    wxZeroMemory(fileop);
-    fileop.wFunc = FO_DELETE;
-    fileop.pFrom = pathStr.t_str();
-    fileop.fFlags = FOF_ALLOWUNDO | FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI;
-
-    const int ret = SHFileOperation(&fileop);
-    if ( ret != 0 || fileop.fAnyOperationsAborted )
-    {
-        // Note that the return value from SHFileOperation() is not a standard
-        // Win32 error code, so we can't use wxLogSysError() here.
-        wxLogError(_("'%s' couldn't be moved to trash: error 0x%08x"),
-                   path,
-                   ret);
-        return false;
-    }
-
-    return true;
-}
-
 int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
 {
     return StrCmpLogicalW(s1.wc_str(), s2.wc_str());

--- a/src/msw/utilswin.cpp
+++ b/src/msw/utilswin.cpp
@@ -14,6 +14,7 @@
     #include "wx/utils.h"
 #endif //WX_PRECOMP
 
+#include "wx/filefn.h"
 #include "wx/private/launchbrowser.h"
 #include "wx/msw/private.h"     // includes <windows.h>
 #include "wx/msw/private/dpiaware.h"
@@ -177,4 +178,33 @@ bool wxMSWIsOnSecureScreen()
     // that is used for UAC prompts and sign-in screens and running at system
     // level.
     return wcscmp(name, L"Winlogon") == 0;
+}
+
+bool wxMoveToTrash(const wxString& path)
+{
+    // SHFileOperation needs double null termination string
+    // but without separator at the end of the path
+    wxString pathStr(path);
+    if ( pathStr.Last() == wxFILE_SEP_PATH )
+        pathStr.RemoveLast();
+    pathStr += wxT('\0');
+
+    SHFILEOPSTRUCT fileop;
+    wxZeroMemory(fileop);
+    fileop.wFunc = FO_DELETE;
+    fileop.pFrom = pathStr.t_str();
+    fileop.fFlags = FOF_ALLOWUNDO | FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI;
+
+    const int ret = SHFileOperation(&fileop);
+    if ( ret != 0 || fileop.fAnyOperationsAborted )
+    {
+        // Note that the return value from SHFileOperation() is not a standard
+        // Win32 error code, so we can't use wxLogSysError() here.
+        wxLogError(_("'%s' couldn't be moved to trash: error 0x%08x"),
+                   path,
+                   ret);
+        return false;
+    }
+
+    return true;
 }

--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -12,6 +12,8 @@
 #ifndef WX_PRECOMP
 #include "wx/object.h"
 #include "wx/math.h"
+#include "wx/intl.h"
+#include "wx/log.h"
 #endif
 
 #if wxOSX_USE_COCOA_OR_CARBON

--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -694,4 +694,31 @@ wxOSXEffectiveAppearanceSetter::~wxOSXEffectiveAppearanceSetter()
 #endif
 }
 
+#ifdef __WXDARWIN_OSX__
+
+// Move file or directory to macOS Trash using NSFileManager.
+bool wxMoveToTrash(const wxString& path)
+{
+    wxCFStringRef cfPath(path);
+    NSURL *fileURL = [NSURL fileURLWithPath:cfPath.AsNSString()];
+    if ( fileURL == nil )
+        return false;
+
+    NSError *error = nil;
+    BOOL ok = [[NSFileManager defaultManager] trashItemAtURL:fileURL
+                                            resultingItemURL:nil
+                                                       error:&error];
+    if ( !ok )
+    {
+        wxLogError(_("'%s' couldn't be moved to trash: %s"),
+                   path,
+                   error ? wxCFStringRef::AsString([error localizedDescription])
+                         : _("unknown error"));
+    }
+
+    return ok;
+}
+
+#endif // __WXDARWIN_OSX__
+
 #endif

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -388,27 +388,4 @@ bool wxMacInitCocoa()
     return cocoaLoaded;
 }
 
-// Move file or directory to macOS Trash using NSFileManager.
-bool wxMoveToTrash(const wxString& path)
-{
-    wxCFStringRef cfPath(path);
-    NSURL *fileURL = [NSURL fileURLWithPath:cfPath.AsNSString()];
-    if ( fileURL == nil )
-        return false;
-
-    NSError *error = nil;
-    BOOL ok = [[NSFileManager defaultManager] trashItemAtURL:fileURL
-                                            resultingItemURL:nil
-                                                       error:&error];
-    if ( !ok )
-    {
-        wxLogError(_("'%s' couldn't be moved to trash: %s"),
-                   path,
-                   error ? wxCFStringRef::AsString([error localizedDescription])
-                         : _("unknown error"));
-    }
-
-    return ok;
-}
-
 #endif // __WXDARWIN_OSX__


### PR DESCRIPTION
Static builds on Linux (GTK), `wxMoveToTrash` will cause a link error because the stub version will be included in `wx::base` (because `__GTK__` isn't defined), but then the actual GTK implementation is built into `wx::core` (where `__GTK__` is defined; this is all because of the GIO dependency).

So we need to ensure that under GTK, only the actual GTK function is compiled (into `wx::core`) and the stub is left out. Under macOS and Windows, it continues to be built into `wx::base`.

This does mean that if `wxHAS_MOVE_TO_TRASH` is not defined, then this function will not be available now. IMO, that actually seems better than a stub function that silently fails.

P.S.
This behavior is likely by design because of https://github.com/wxWidgets/wxWidgets/issues/26043