### PR TITLE
Incorrect use of @onlyfor in toplevel.h doc

### DIFF
--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -719,8 +719,6 @@ public:
         Only @c ::wxFULLSCREEN_NOTOOLBAR and @c ::wxFULLSCREEN_NOMENUBAR will be
         used when using the fullscreen API (other values are ignored).
 
-        @onlyfor{wxosx}
-
         @see ShowFullScreen(), wxFullScreenEvent
 
         @since 3.1.0


### PR DESCRIPTION
`wxTopLevelWindow::EnableFullScreenView` is incorrectly documented with @onlyfor{wxosx} as this method is  available for all platforms but only actually works on MacOS (as documented).