### PR TITLE
CMake: Automatically update outdated WebView2 package

### DIFF
--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -44,6 +44,8 @@ if(APPLE)
 elseif(WXMSW)
     if(wxUSE_WEBVIEW_EDGE)
         # Update the following variables if updating WebView2 SDK
+        # Also update this version and the _INTERFACE_DEFINED_ check in
+        # include/wx/msw/private/webview_edge.h and interface/wx/webview.h
         set(WEBVIEW2_VERSION "1.0.3485.44")
         set(WEBVIEW2_URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${WEBVIEW2_VERSION}")
         # When updating the above version of WebView2, download the nupkg from the above URL.

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -63,8 +63,22 @@ elseif(WXMSW)
                 ${WEBVIEW2_DEFAULT_PACKAGE_DIR}
         )
 
+        if (WEBVIEW2_PACKAGE_DIR)
+            get_filename_component(currentDir ${WEBVIEW2_PACKAGE_DIR} DIRECTORY)
+            get_filename_component(targetDir ${WEBVIEW2_DEFAULT_PACKAGE_DIR} DIRECTORY)
+            if (currentDir STREQUAL targetDir)
+                get_filename_component(currentVersion ${WEBVIEW2_PACKAGE_DIR} NAME)
+                string(SUBSTRING ${currentVersion} 23 -1 currentVersion)
+                if(${currentVersion} VERSION_LESS ${WEBVIEW2_VERSION})
+                    message(STATUS "Found outdated WebView2 SDK, downloading...")
+                    unset(WEBVIEW2_PACKAGE_DIR CACHE)
+                endif()
+            endif()
+        else()
+            message(STATUS "WebView2 SDK not found, downloading...")
+        endif()
+
         if (NOT WEBVIEW2_PACKAGE_DIR)
-            message(STATUS "WebView2 SDK not found locally, downloading...")
             set(WEBVIEW2_PACKAGE_DIR ${WEBVIEW2_DEFAULT_PACKAGE_DIR} CACHE PATH "WebView2 SDK PATH" FORCE)
             file(DOWNLOAD
                 ${WEBVIEW2_URL}

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -19,8 +19,8 @@
 
 #include <WebView2.h>
 
-#ifndef __ICoreWebView2Settings3_INTERFACE_DEFINED__
-    #error "WebView2 SDK version 1.0.1722.45 or newer is required"
+#ifndef __ICoreWebView2_22_INTERFACE_DEFINED__
+    #error "WebView2 SDK version 1.0.3485.44 or newer is required"
 #endif
 
 #ifndef __VISUALC__

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -842,7 +842,7 @@ public:
     This backend is enabled by default only when using CMake. To build it follow these steps:
     - When not using CMake:
         - Download the <a href="https://aka.ms/webviewnuget">WebView2 SDK</a>
-        NuGet package (Version 1.0.864.35 or newer)
+        NuGet package (Version 1.0.3485.44 or newer)
         - Extract the package (it's a zip archive) to @c WX_SRCDIR/3rdparty/webview2
         (you should have @c 3rdparty/webview2/build/native/include/WebView2.h
         file after unpacking it)


### PR DESCRIPTION
And update the versions numbers and compile-time version check to the required version.

See #26291