### PR TITLE
Add missing null check in wxAffineMatrix2D::Get

### DIFF
--- a/interface/wx/affinematrix2d.h
+++ b/interface/wx/affinematrix2d.h
@@ -28,9 +28,11 @@ public:
     /**
         Get the component values of the matrix.
 
+        At least one of the parameters must be non-NULL.
+
         @param mat2D
-            The rotational components of the matrix (upper 2 x 2), must be
-            non-null.
+            The rotational components of the matrix (upper 2 x 2),
+            may be @NULL.
         @param tr
             The translational components of the matrix, may be @NULL.
     */

--- a/src/common/affinematrix2d.cpp
+++ b/src/common/affinematrix2d.cpp
@@ -29,10 +29,16 @@ void wxAffineMatrix2D::Set(const wxMatrix2D &mat2D, const wxPoint2DDouble &tr)
 // gets the component values of the matrix
 void wxAffineMatrix2D::Get(wxMatrix2D *mat2D, wxPoint2DDouble *tr) const
 {
-    mat2D->m_11 = m_11;
-    mat2D->m_12 = m_12;
-    mat2D->m_21 = m_21;
-    mat2D->m_22 = m_22;
+    wxASSERT_MSG( mat2D || tr,
+                  wxT("at least one parameter must be non-null") );
+
+    if( mat2D )
+    {
+        mat2D->m_11 = m_11;
+        mat2D->m_12 = m_12;
+        mat2D->m_21 = m_21;
+        mat2D->m_22 = m_22;
+    }
 
     if ( tr )
     {


### PR DESCRIPTION
Variable "mat2D" wasn't being checked for null, despite "tr" was checked for it.