### PR TITLE
Fix silent wxString comparison breakage in C++20 with std::tuple etc.

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -49,6 +49,11 @@
     #endif
 #endif
 
+// Check if C++20 three-way-comparison operator is available
+#ifdef __cpp_impl_three_way_comparison
+    #include <compare>
+#endif
+
 #include "wx/afterstd.h"
 
 // by default we cache the mapping of the positions in UTF-8 string to the byte
@@ -2287,6 +2292,19 @@ public:
       { return s1.Cmp(s2) <= 0; }
   friend bool operator>=(const wxString& s1, const wxString& s2)
       { return s1.Cmp(s2) >= 0; }
+
+#ifdef __cpp_impl_three_way_comparison
+  friend auto operator<=>(const wxString& s1, const wxString& s2)
+  {
+      const int cmp = s1.Cmp(s2);
+      if (cmp < 0)
+          return std::strong_ordering::less;
+      else if (cmp > 0)
+          return std::strong_ordering::greater;
+      else
+          return std::strong_ordering::equal;
+  }
+#endif
 
   friend bool operator==(const wxString& s1, const wxCStrData& s2)
       { return s1 == s2.AsString(); }

--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -453,6 +453,21 @@ TEST_CASE("StringCompare", "[wxString]")
     CHECK( wxString("!").Cmp("z") < 0 );
 }
 
+#ifdef __cpp_lib_three_way_comparison
+TEST_CASE("StringCompareThreeWay", "[wxString]")
+{
+    // test that operator<=> works and compares by string contents
+
+    wxString a(wxT("bar"));
+    wxString b(wxT("bar"));
+    wxString c(wxT("baz"));
+
+    CHECK((a <=> b) == std::strong_ordering::equal);
+    CHECK((a <=> c) == std::strong_ordering::less);
+    CHECK((c <=> a) == std::strong_ordering::greater);
+}
+#endif // __cpp_lib_three_way_comparison
+
 TEST_CASE("StringCompareNoCase", "[wxString]")
 {
     wxString s1 = wxT("AHH");


### PR DESCRIPTION
This PR implements C++20’s spaceship operator for `wxString`.

This is not just nice-to-have, but prevents *silent* breakage of wxString comparison in user code compiled as C++20 using the *recommended* configuration of wx, with `wxNO_UNSAFE_WXSTRING_CONV` defined. Strings end up being compared by their `wchar_t*` pointer values, not string content. Hence the somewhat inflammatory title of the PR, even though the impact is limited to less commonly needed std containers.

How is this possible? The standard library implements comparison using `<=>` in C++20 if the operator is available. But `wxString` doesn’t have it, so it shouldn’t matter for it, right? Surprisingly, that’s not the case:

```cxx
// this assert, surprisingly, doesn’t fail
static_assert(std::three_way_comparable<wxString>);
```

Turns out, the spaceship operator is available *through implicit conversion to wchar_t pointers*:

- https://www.reddit.com/r/cpp/comments/ra5cpy/the_spacesship_operator_silently_broke_my_code/
- https://stackoverflow.com/questions/79736340/c20-tuple-compare-with-reference

Consequently, `std::tie`, `std::tuple`, `std::vector` (and who knows what else) comparison uses it for wxString content.

The behavior depends on the macros defined:

1. `wxNO_UNSAFE_WXSTRING_CONV` defined, as recommended by wx docs  →  fails silently
2. `wxNO_IMPLICIT_WXSTRING_CONV_TO_PTR` prevents the problem for self-evident reasons
3. Neither defined  → OK by a lucky break: there's *two* implicit conversions to pointers and the compiler can’t decide, ergo not three-way-comparable

This also makes it challenging to write a test for the suite — it doesn’t show with wx’s build-time settings, so merely putting the test in there would be a noop. I was using this for testing (and understanding the effect of the macros): 

```cxx
#define wxNO_UNSAFE_WXSTRING_CONV 1
#include <wx/string.h>

TEST_CASE("StringTupleCompare", "[wxString]")
{
    wxString a(wxT("bar"));
    wxString b(wxT("bar"));

    REQUIRE(a == b);
    REQUIRE(static_cast<const wchar_t*>(a) != static_cast<const wchar_t*>(b));

    CHECK_FALSE(std::tie(a) < std::tie(b));
    CHECK_FALSE(std::tie(b) < std::tie(a));
}
```

IMNSHO this fix needs to be backported to 3.2 too.