### PR TITLE
Backport wxNO_IMPLICIT_WXSTRING_CONV_TO_PTR to 3.2

### DIFF
--- a/docs/doxygen/overviews/string.h
+++ b/docs/doxygen/overviews/string.h
@@ -248,7 +248,7 @@ is not appropriate for the current software and platform. The macro @c
 wxNO_IMPLICIT_WXSTRING_ENCODING disables all implicit conversions, and
 forces the code to explicitly indicate the encoding of all C strings.
 
-Finally note that encodings, either implicitly or explicitly selected,
+Note that encodings, either implicitly or explicitly selected,
 may not be able to represent all the string's characters. The result
 in this case is undefined: the string may be empty, or the
 unrepresentable characters may be missing or wrong.
@@ -270,6 +270,12 @@ c = s.ToUTF8(); // Always compiles, encoding never fails
 c = s.utf8_str(); // Alias for the above
 c = s.mb_str(wxConvLibc); // Always compiles, explicit encoding
 @endcode
+
+Finally, please note that implicit conversion to both `const char*` (which
+is unsafe for the reasons explained above) and to `const wchar_t*` (which
+is safe from this point of view, but may still be considered dangerous, as
+any implicit conversion) may be entirely disabled by defining
+`wxNO_IMPLICIT_WXSTRING_CONV_TO_PTR` when building the application.
 
 @subsection overview_string_iterating Iterating wxString Characters
 

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1631,7 +1631,7 @@ public:
     // and not defining it in STL build also helps us to get more clear error
     // messages for the code which relies on implicit conversion to char* in
     // STL build
-#if !wxUSE_STD_STRING_CONV_IN_WXSTRING
+#if !wxUSE_STD_STRING_CONV_IN_WXSTRING && !defined(wxNO_IMPLICIT_WXSTRING_CONV_TO_PTR)
     operator const wchar_t*() const { return c_str(); }
 
 #if wxUSE_UNSAFE_WXSTRING_CONV && !defined(wxNO_UNSAFE_WXSTRING_CONV)
@@ -1642,7 +1642,7 @@ public:
     operator const void*() const { return c_str(); }
 #endif // wxUSE_UNSAFE_WXSTRING_CONV && !defined(wxNO_UNSAFE_WXSTRING_CONV)
 
-#endif // !wxUSE_STD_STRING_CONV_IN_WXSTRING
+#endif // !wxUSE_STD_STRING_CONV_IN_WXSTRING && !defined(wxNO_IMPLICIT_WXSTRING_CONV_TO_PTR)
 
     // identical to c_str(), for MFC compatibility
     const wxCStrData GetData() const { return c_str(); }


### PR DESCRIPTION
This PR backports `wxNO_IMPLICIT_WXSTRING_CONV_TO_PTR` from 889845fbc4a89e2fba62c96e04d26b0cf5639cd1 to the 3.2 branch, so that code that may need to be compiled against e.g. distro-provided wx packages can rely on its effect.

Also serves as a mitigation for https://github.com/wxWidgets/wxWidgets/pull/26306 