### PR TITLE
Take default style into account in wxMSW wxTextCtrl::SetValue()

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1301,7 +1301,24 @@ void wxTextCtrl::DoWriteText(const wxString& value, int flags)
         if ( !m_defaultStyle.IsDefault() )
         {
             long start, end;
-            GetSelection(&start, &end);
+
+            // For the selection style to be taken into account, we must use
+            // EM_REPLACESEL below, WM_SETTEXT ignores the style, so ensure
+            // that we do, selecting all the text if necessary to do the same
+            // thing as WM_SETTEXT would do.
+            if ( !selectionOnly )
+            {
+                start = 0;
+                end = GetLastPosition();
+                SetSelection(start, end); // Select everything.
+
+                selectionOnly = true;
+            }
+            else // We're already only overwriting the selection.
+            {
+                GetSelection(&start, &end);
+            }
+
             SetStyle(start, end, m_defaultStyle);
         }
     }


### PR DESCRIPTION
Previously this only worked for plain EDIT controls but not for the controls with wxTE_RICH[2] style because WM_SETTEXT ignores the current text style for the latter.

Work around this by using EM_REPLACESEL for them instead.

Closes #26320.