### PR TITLE
Fix minimal MSW static-build

### DIFF
--- a/include/wx/colour.h
+++ b/include/wx/colour.h
@@ -13,6 +13,7 @@
 
 #include "wx/defs.h"
 #include "wx/gdiobj.h"
+#include "wx/string.h"
 #include "wx/variant.h"
 
 class WXDLLIMPEXP_FWD_CORE wxColour;

--- a/src/common/framecmn.cpp
+++ b/src/common/framecmn.cpp
@@ -172,12 +172,14 @@ wxFrameBase::wxFrameBase()
                 switch ( m_modality )
                 {
                     case wxWindowMode::AppModal:
+#if wxUSE_MENUS
                         if ( !gs_windowDisablers.empty() )
                         {
                             gs_windowDisablers.pop();
                             break;
 
                         }
+#endif
 
                         wxFAIL_MSG("Must have wxWindowDisabler if app modal");
                         break;
@@ -313,7 +315,9 @@ void wxFrameBase::SetWindowModality(wxWindowMode modality)
     {
         case wxWindowMode::AppModal:
             // Disable everything for this frame.
+#if wxUSE_MENUS
             gs_windowDisablers.emplace(wxWindowDisabler( this ));
+#endif
             isModal = true;
             break;
 

--- a/src/generic/msgdlgg.cpp
+++ b/src/generic/msgdlgg.cpp
@@ -39,6 +39,7 @@
     #include "wx/statline.h"
 #endif
 
+#if wxUSE_STATTEXT
 // ----------------------------------------------------------------------------
 // wxTitleTextWrapper: simple class to create wrapped text in "title font"
 // ----------------------------------------------------------------------------
@@ -61,6 +62,7 @@ protected:
         return win;
     }
 };
+#endif // wxUSE_STATTEXT
 
 // ----------------------------------------------------------------------------
 // icons
@@ -101,6 +103,7 @@ wxGenericMessageDialog::wxGenericMessageDialog( wxWindow *parent,
 wxGCC_WARNING_RESTORE(maybe-uninitialized)
 #endif
 
+#if wxUSE_BUTTON
 wxSizer *wxGenericMessageDialog::CreateMsgDlgButtonSizer()
 {
     if ( HasCustomLabels() )
@@ -165,6 +168,7 @@ wxSizer *wxGenericMessageDialog::CreateMsgDlgButtonSizer()
                                  wxNO_DEFAULT | wxCANCEL_DEFAULT)
            );
 }
+#endif // wxUSE_BUTTON
 
 void wxGenericMessageDialog::DoCreateMsgdialog()
 {
@@ -229,10 +233,12 @@ void wxGenericMessageDialog::DoCreateMsgdialog()
     AddMessageDialogCheckBox( topsizer );
     AddMessageDialogDetails( topsizer );
 
+#if wxUSE_BUTTON
     // 4) buttons
     wxSizer *sizerBtn = CreateMsgDlgButtonSizer();
     if ( sizerBtn )
         topsizer->Add(sizerBtn, 0, wxEXPAND | wxALL, 10 );
+#endif // wxUSE_BUTTON
 
     SetSizer( topsizer );
 

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -913,11 +913,13 @@ WXLRESULT wxFrame::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lPara
     WXLRESULT rc = 0;
     bool processed = false;
 
+#if wxUSE_MENUBAR
     if ( GetMenuBar() &&
           HandleMenuMessage(&rc, this, message, wParam, lParam) )
     {
         return rc;
     }
+#endif // wxUSE_MENUBAR
 
     switch ( message )
     {
@@ -949,6 +951,7 @@ WXLRESULT wxFrame::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lPara
             }
             break;
 
+#if wxUSE_MENUBAR
         case WM_INITMENUPOPUP:
         case WM_UNINITMENUPOPUP:
             // We get these messages from the menu bar even if the menu is
@@ -964,6 +967,7 @@ WXLRESULT wxFrame::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lPara
                 }
             }
             break;
+#endif // wxUSE_MENUBAR
 
         case WM_QUERYDRAGICON:
             {

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -121,10 +121,12 @@ wxMessageDialog::HookFunction(int code, WXWPARAM wParam, WXLPARAM lParam)
         // too big to fit the display
         wnd->ReplaceStaticWithEdit();
 
+#ifdef wxHAS_ANY_BUTTON
         // update the labels if necessary: we need to do it before centering
         // the dialog as this can change its size
         if ( wnd->HasCustomLabels() )
             wnd->AdjustButtonLabels();
+#endif // wxHAS_ANY_BUTTON
 
         // centre the message box on its parent if requested
         if ( wnd->GetMessageDialogStyle() & wxCENTER )
@@ -262,6 +264,7 @@ void wxMessageDialog::ReplaceStaticWithEdit()
     }
 }
 
+#ifdef wxHAS_ANY_BUTTON
 void wxMessageDialog::AdjustButtonLabels()
 {
     // changing the button labels is the easy part but we also need to ensure
@@ -371,6 +374,7 @@ void wxMessageDialog::AdjustButtonLabels()
         rcBtn.right += wBtnNew + MARGIN_INNER;
     }
 }
+#endif // wxHAS_ANY_BUTTON
 
 /* static */
 wxFont wxMessageDialog::GetMessageFont()

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -306,6 +306,7 @@ WXLRESULT wxTopLevelWindowMSW::MSWWindowProc(WXUINT message, WXWPARAM wParam, WX
                 }
 
 #ifndef __WXUNIVERSAL__
+#if wxUSE_MENUS
                 // We need to generate events for the custom items added to the
                 // system menu if it had been created (and presumably modified).
                 // As SC_SIZE is the first of the system-defined commands, we
@@ -316,6 +317,7 @@ WXLRESULT wxTopLevelWindowMSW::MSWWindowProc(WXUINT message, WXWPARAM wParam, WX
                     if ( m_menuSystem->MSWCommand(0 /* unused anyhow */, id) )
                         processed = true;
                 }
+#endif // wxUSE_MENUS
 #endif // #ifndef __WXUNIVERSAL__
             }
             break;
@@ -517,7 +519,9 @@ bool wxTopLevelWindowMSW::Create(wxWindow *parent,
 
 wxTopLevelWindowMSW::~wxTopLevelWindowMSW()
 {
+#if wxUSE_MENUS
     delete m_menuSystem;
+#endif // wxUSE_MENUS
 
     SendDestroyEvent();
 }
@@ -1221,6 +1225,7 @@ void wxTopLevelWindowMSW::RequestUserAttention(int flags)
 wxMenu *wxTopLevelWindowMSW::MSWGetSystemMenu() const
 {
 #ifndef __WXUNIVERSAL__
+#if wxUSE_MENUS
     if ( !m_menuSystem )
     {
         HMENU hmenu = ::GetSystemMenu(GetHwnd(), FALSE);
@@ -1246,6 +1251,7 @@ wxMenu *wxTopLevelWindowMSW::MSWGetSystemMenu() const
         // correct but doesn't seem to have any serious drawbacks.
         m_menuSystem->SetInvokingWindow(self);
     }
+#endif // wxUSE_MENUS
 #endif // #ifndef __WXUNIVERSAL__
 
     return m_menuSystem;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -93,6 +93,10 @@
     #include "wx/caret.h"
 #endif // wxUSE_CARET
 
+#if wxUSE_CONTROLS
+    #include "wx/control.h"
+#endif // wxUSE_CONTROLS
+
 #if wxUSE_SPINCTRL
     #include "wx/spinctrl.h"
 #endif // wxUSE_SPINCTRL


### PR DESCRIPTION
I needed these changes to be able to build WxWidgets with these commands in a MSYS2 MinGW64 window:
```sh
$ mkdir build-debug
$ cd build-debug
$ ../configure --enable-debug --disable-shared --disable-pic --enable-threads --enable-exceptions --without-subdirs --disable-tests --disable-all-features --disable-accessibility --enable-intl --enable-file --enable-log --enable-msgdlg --enable-wxdib --disable-unsafe_conv_in_wxstring --enable-regkey --enable-image --enable-uxtheme --enable-controls
$ make -j4
```

then build the following minimal program in a sibling directory of WxWidgets with this command: `g++ $(../wxWidgets/build-debug/wx-config --cxxflags) test.cpp $(../wxWidgets/build-debug/wx-config --libs) && ./a.exe`
```cpp
#include <wx/frame.h>
#include <wx/app.h>

class MyFrame : public wxFrame
{
  public:
    MyFrame(const wxString & title)
        : wxFrame(NULL, wxID_ANY, title)
    {}

  private:
    wxDECLARE_EVENT_TABLE();
};

wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
wxEND_EVENT_TABLE()

class MyApp : public wxApp
{
  public:
    bool OnInit() override
    {
        (new MyFrame("My first WxWidgets App"))->Show(true);
        return true;
    }
};

wxDECLARE_APP(MyApp);
wxIMPLEMENT_APP(MyApp);
```