### PR TITLE
MSW: Refresh tabs after changing tabs programmatically in dark mode

### DIFF
--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -354,8 +354,8 @@ int wxNotebook::SetSelection(size_t nPage)
 
             (void)TabCtrl_SetCurSel(GetHwnd(), nPage);
 
-            /// MSW does not redraw the tab in darkmode
-            if (wxSystemSettings::GetAppearance().IsDark())
+            /// MSW does not redraw the tab in dark mode
+            if ( wxMSWDarkMode::IsActive() )
                 Refresh();
 
             SendPageChangedEvent(selectionOld, nPage);
@@ -405,7 +405,7 @@ int wxNotebook::ChangeSelection(size_t nPage)
         (void)TabCtrl_SetCurSel(GetHwnd(), nPage);
 
         /// MSW does not redraw the tab in darkmode
-        if (wxSystemSettings::GetAppearance().IsDark())
+        if ( wxMSWDarkMode::IsActive() )
             Refresh();
 
         UpdateSelection(nPage);

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -354,6 +354,10 @@ int wxNotebook::SetSelection(size_t nPage)
 
             (void)TabCtrl_SetCurSel(GetHwnd(), nPage);
 
+            /// MSW does not redraw the tab in darkmode
+            if (wxSystemSettings::GetAppearance().IsDark())
+                Refresh();
+
             SendPageChangedEvent(selectionOld, nPage);
         }
     }
@@ -399,6 +403,10 @@ int wxNotebook::ChangeSelection(size_t nPage)
     if ( m_selection == wxNOT_FOUND || nPage != (size_t)m_selection )
     {
         (void)TabCtrl_SetCurSel(GetHwnd(), nPage);
+
+        /// MSW does not redraw the tab in darkmode
+        if (wxSystemSettings::GetAppearance().IsDark())
+            Refresh();
 
         UpdateSelection(nPage);
     }


### PR DESCRIPTION
  - This did not occur in dark mode, leaving the tabs a wrong state
  - Fixes #26281