### PR TITLE
Build fix for wxGTK/Win

### DIFF
--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -338,8 +338,6 @@ bool wxGUIAppTraits::ShowAssertDialog(const wxString& msg)
     return wxAppTraitsBase::ShowAssertDialog(msg);
 }
 
-#endif // __UNIX__
-
 bool wxMoveToTrash(const wxString& path)
 {
     wxGtkError err;
@@ -354,3 +352,5 @@ bool wxMoveToTrash(const wxString& path)
 
     return ok;
 }
+
+#endif // __UNIX__


### PR DESCRIPTION
Build command
```
mkdir -p cmake_build-gtk3_ucrt64-shared_unicode
        cmake \
          -DwxBUILD_TOOLKIT="gtk3" \
          -S . \
          -B cmake_build-gtk3_ucrt64-shared_unicode
cmake --build cmake_build-gtk3_ucrt64-shared_unicode
```

error

```
[932/1153] Linking CXX shared library lib\gcc_x64_dll\wxgtk3333ud_core_gcc_x64_custom.dll
FAILED: [code=1] lib/gcc_x64_dll/wxgtk3333ud_core_gcc_x64_custom.dll lib/gcc_x64_dll/libwxgtk333ud_core.a
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\msys64\ucrt64\bin\c++.exe -g  -shared -o lib\gcc_x64_dll\wxgtk3333ud_core_gcc_x64_custom.dll -Wl,--out-implib,lib\gcc_x64_dll\libwxgtk333ud_core.a -Wl,--major-image-version,3,--minor-image-version,0 @CMakeFiles\wxcore.rsp && cd ."
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libs/core/CMakeFiles/wxcore.dir/__/__/__/__/src/msw/utilswin.cpp.obj: in function `wxMoveToTrash(wxString const&)':
C:/devel/repos/wxwidgets_libs/wxWidgets/src/msw/utilswin.cpp:184: multiple definition of `wxMoveToTrash(wxString const&)'; libs/core/CMakeFiles/wxcore.dir/__/__/__/__/src/gtk/utilsgtk.cpp.obj:C:/devel/repos/wxwidgets_libs/wxWidgets/src/gtk/utilsgtk.cpp:344: first defined here
```