### PR TITLE
fix eglDestroySurface argument order

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -611,7 +611,7 @@ void wxGLCanvasEGL::OnRealized()
     {
         if ( m_surface != EGL_NO_SURFACE )
         {
-            eglDestroySurface(m_surface, m_display);
+            eglDestroySurface(m_display, m_surface);
             m_surface = EGL_NO_SURFACE;
         }
 


### PR DESCRIPTION
eglDestroySurface takes the display first and the surface second rather than the other way around. Since both EGLDisplay and EGLSurface are just typedef'd to void* this doesn't raise a compiler warning. This currently doesn't crash at runtime because Mesa validates the display pointer against a list of known good values and fails gracefully, but it still causes a resource leak.

I came across this while looking into #26340. This is not the cause, but it still seems worth fixing.