### PR TITLE
Fix `wxStyledTextCtrl::Get/SetUseAntiAliasing()`

### DIFF
--- a/interface/wx/stc/stc.h
+++ b/interface/wx/stc/stc.h
@@ -8026,15 +8026,22 @@ public:
     bool DoDropText(long x, long y, const wxString& data);
 
     /**
-       Specify whether anti-aliased fonts should be used.
+       Specify whether anti-aliasing should be used when rendering text.
 
-      This will have no effect on some platforms, but on some (wxMac for
-      example) can greatly improve performance.
+       If @p useAA is true, sets @ref SetFontQuality() "font quality" to @c wxSTC_EFF_QUALITY_DEFAULT.
+
+       If @p useAA is false, sets @ref SetFontQuality() "font quality" to @c wxSTC_EFF_QUALITY_NON_ANTIALIASED.
+
+       Prefer using @ref SetFontQuality() directly in new code.
     */
     void SetUseAntiAliasing(bool useAA);
 
     /**
-       Returns the current UseAntiAliasing setting.
+       Returns whether anti-aliasing is enabled by @ref SetFontQuality() "font quality" setting.
+
+       This function returns true if GetFontQuality() is something other than @c wxSTC_EFF_QUALITY_NON_ANTIALIASED.
+
+       Prefer using @ref GetFontQuality() directly in new code.
     */
     bool GetUseAntiAliasing();
 

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -264,7 +264,6 @@ void ScintillaWX::Initialise() {
     dropTarget->SetScintilla(this);
     stc->SetDropTarget(dropTarget);
 #endif // wxUSE_DRAG_AND_DROP
-    vs.extraFontFlag = true;   // UseAntiAliasing
 
     // Set up default OS X key mappings. Remember that SCI_CTRL stands for
     // "Cmd" key here, as elsewhere in wx API, while SCI_ALT is the "Option"
@@ -1325,15 +1324,6 @@ void ScintillaWX::ClipChildren(wxDC& WXUNUSED(dc), PRectangle WXUNUSED(rect))
 //     dc.SetClippingRegion(rgn);
 }
 
-
-void ScintillaWX::SetUseAntiAliasing(bool useAA) {
-    vs.extraFontFlag = useAA;
-    InvalidateStyleRedraw();
-}
-
-bool ScintillaWX::GetUseAntiAliasing() {
-    return vs.extraFontFlag != 0;
-}
 
 void ScintillaWX::DoMarkerDefineBitmap(int markerNumber, const wxBitmap& bmp) {
     if ( 0 <= markerNumber && markerNumber <= MARKER_MAX) {

--- a/src/stc/ScintillaWX.h
+++ b/src/stc/ScintillaWX.h
@@ -193,8 +193,6 @@ public:
     void DoScrollToLine(int line);
     void DoScrollToColumn(int column);
     void ClipChildren(wxDC& dc, PRectangle rect);
-    void SetUseAntiAliasing(bool useAA);
-    bool GetUseAntiAliasing();
     SurfaceData* GetSurfaceData() const {return m_surfaceData;}
     void SetPaintAbandoned(){paintState = paintAbandoned;}
     void DoMarkerDefineBitmap(int markerNumber, const wxBitmap& bmp);

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -5375,11 +5375,11 @@ bool wxStyledTextCtrl::DoDropText(long x, long y, const wxString& data) {
 
 
 void wxStyledTextCtrl::SetUseAntiAliasing(bool useAA) {
-    m_swx->SetUseAntiAliasing(useAA);
+    SetFontQuality(useAA ? wxSTC_EFF_QUALITY_DEFAULT : wxSTC_EFF_QUALITY_NON_ANTIALIASED);
 }
 
 bool wxStyledTextCtrl::GetUseAntiAliasing() {
-    return m_swx->GetUseAntiAliasing();
+    return GetFontQuality() != wxSTC_EFF_QUALITY_NON_ANTIALIASED;
 }
 
 void wxStyledTextCtrl::AnnotationClearLine(int line) {

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -567,11 +567,11 @@ bool wxStyledTextCtrl::DoDropText(long x, long y, const wxString& data) {
 
 
 void wxStyledTextCtrl::SetUseAntiAliasing(bool useAA) {
-    m_swx->SetUseAntiAliasing(useAA);
+    SetFontQuality(useAA ? wxSTC_EFF_QUALITY_DEFAULT : wxSTC_EFF_QUALITY_NON_ANTIALIASED);
 }
 
 bool wxStyledTextCtrl::GetUseAntiAliasing() {
-    return m_swx->GetUseAntiAliasing();
+    return GetFontQuality() != wxSTC_EFF_QUALITY_NON_ANTIALIASED;
 }
 
 void wxStyledTextCtrl::AnnotationClearLine(int line) {

--- a/src/stc/stc.interface.h.in
+++ b/src/stc/stc.interface.h.in
@@ -272,15 +272,22 @@ public:
     bool DoDropText(long x, long y, const wxString& data);
 
     /**
-       Specify whether anti-aliased fonts should be used.
+       Specify whether anti-aliasing should be used when rendering text.
 
-      This will have no effect on some platforms, but on some (wxMac for
-      example) can greatly improve performance.
+       If @p useAA is true, sets @ref SetFontQuality() "font quality" to @c wxSTC_EFF_QUALITY_DEFAULT.
+
+       If @p useAA is false, sets @ref SetFontQuality() "font quality" to @c wxSTC_EFF_QUALITY_NON_ANTIALIASED.
+
+       Prefer using @ref SetFontQuality() directly in new code.
     */
     void SetUseAntiAliasing(bool useAA);
 
     /**
-       Returns the current UseAntiAliasing setting.
+       Returns whether anti-aliasing is enabled by @ref SetFontQuality() "font quality" setting.
+
+       This function returns true if GetFontQuality() is something other than @c wxSTC_EFF_QUALITY_NON_ANTIALIASED.
+
+       Prefer using @ref GetFontQuality() directly in new code.
     */
     bool GetUseAntiAliasing();
 


### PR DESCRIPTION
Fixes #26339.

To be resolved before merging:
- [x] Improve documentation formatting
- [x] Decide on whether `SetUseAntiAliasing(true)` enables grayscale or subpixel antialiasing, or uses OS defaults (which might be no antialiasing)