### PR TITLE
Add way to get generated SVG content from wxSVGFileDC

### DIFF
--- a/include/wx/dcsvg.h
+++ b/include/wx/dcsvg.h
@@ -35,8 +35,6 @@ enum wxSVGShapeRenderingMode
     wxSVG_SHAPE_RENDERING_OPTIMISE_SPEED = wxSVG_SHAPE_RENDERING_OPTIMIZE_SPEED
 };
 
-class WXDLLIMPEXP_FWD_BASE wxFileOutputStream;
-
 class WXDLLIMPEXP_FWD_CORE wxSVGFileDC;
 
 // Base class for bitmap handlers used by wxSVGFileDC, used by the standard
@@ -145,6 +143,8 @@ public:
     void SetBitmapHandler(wxSVGBitmapHandler* handler);
 
     void SetShapeRenderingMode(wxSVGShapeRenderingMode renderingMode);
+
+    wxString GetSVGDocument() const;
 
 private:
     virtual bool DoGetPixel(wxCoord WXUNUSED(x), wxCoord WXUNUSED(y),
@@ -276,7 +276,7 @@ private:
     bool                m_graphics_changed;  // set by Set{Brush,Pen}()
     int                 m_width, m_height;
     double              m_dpi;
-    std::unique_ptr<wxFileOutputStream> m_outfile;
+    wxString            m_svgDocument;
     std::unique_ptr<wxSVGBitmapHandler> m_bmp_handler; // class to handle bitmaps
     wxSVGShapeRenderingMode m_renderingMode;
 
@@ -322,6 +322,9 @@ public:
     void SetBitmapHandler(wxSVGBitmapHandler* handler);
 
     void SetShapeRenderingMode(wxSVGShapeRenderingMode renderingMode);
+
+    // Return the SVG document as a string.
+    wxString GetSVGDocument() const;
 
 private:
     wxDECLARE_ABSTRACT_CLASS(wxSVGFileDC);

--- a/interface/wx/dcsvg.h
+++ b/interface/wx/dcsvg.h
@@ -68,7 +68,8 @@ public:
         @a height at @a dpi resolution, and an optional @a title.
 
         The title provides a readable name for the SVG document.
-        The filename is allowed to be empty, in which case no SVG file will be written.
+        The filename is allowed to be empty, in which case no SVG file will be
+        written. Call GetSVGDocument() to retrieve the generated content.
     */
     wxSVGFileDC(const wxString& filename, int width = 320, int height = 240,
                 double dpi = wxSVG_DEFAULT_DPI, const wxString& title = wxString());
@@ -78,7 +79,8 @@ public:
         an optional @a title, and an optional @a dpi resolution.
 
         The title provides a readable name for the SVG document.
-        The filename is allowed to be empty, in which case no SVG file will be written.
+        The filename is allowed to be empty, in which case no SVG file will be
+        written. Call GetSVGDocument() to retrieve the generated content.
 
         @since 3.3.2
     */
@@ -122,6 +124,17 @@ public:
         @since 3.1.3
     */
     void SetShapeRenderingMode(wxSVGShapeRenderingMode renderingMode);
+
+    /**
+        Returns the SVG document as a string.
+
+        This can be used to retrieve the generated SVG content regardless of
+        whether it was also written to a file. This can be called after all
+        drawing commands to get the current SVG content.
+
+        @since 3.3.3
+    */
+    wxString GetSVGDocument() const;
 
     /**
         Destroys the current clipping region so that none of the DC is clipped.

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -1452,7 +1452,7 @@ void wxSVGFileDCImpl::DoDrawBitmap(const wxBitmap& bmp, wxCoord x, wxCoord y,
         m_bmp_handler.reset(new wxSVGBitmapFileHandler(m_filename));
 
     wxStringOutputStream stream(&m_svgDocument);
-    m_writeError = m_bmp_handler->ProcessBitmap(bmp, x, y, stream);
+    m_writeError = !m_bmp_handler->ProcessBitmap(bmp, x, y, stream);
 }
 
 void wxSVGFileDCImpl::write(const wxString& s)

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -20,9 +20,10 @@
 
 #include "wx/base64.h"
 #include "wx/dcsvg.h"
-#include "wx/wfstream.h"
+#include "wx/file.h"
 #include "wx/filename.h"
 #include "wx/mstream.h"
+#include "wx/sstream.h"
 #include "wx/scopedarray.h"
 #include "wx/private/rescale.h"
 
@@ -501,6 +502,11 @@ void wxSVGFileDC::SetShapeRenderingMode(wxSVGShapeRenderingMode renderingMode)
     ((wxSVGFileDCImpl*)GetImpl())->SetShapeRenderingMode(renderingMode);
 }
 
+wxString wxSVGFileDC::GetSVGDocument() const
+{
+    return ((wxSVGFileDCImpl*)GetImpl())->GetSVGDocument();
+}
+
 // ----------------------------------------------------------
 // wxSVGFileDCImpl
 // ----------------------------------------------------------
@@ -549,11 +555,6 @@ void wxSVGFileDCImpl::Init(const wxString& filename, int width, int height,
 
     m_bmp_handler.reset();
 
-    if ( m_filename.empty() )
-        m_outfile.reset();
-    else
-        m_outfile.reset(new wxFileOutputStream(m_filename));
-
     wxString s;
     s += wxS("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
     s += wxS("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n\n");
@@ -566,16 +567,27 @@ void wxSVGFileDCImpl::Init(const wxString& filename, int width, int height,
     write(s);
 }
 
-wxSVGFileDCImpl::~wxSVGFileDCImpl()
+wxString wxSVGFileDCImpl::GetSVGDocument() const
 {
-    wxString s;
+    wxString doc(m_svgDocument);
 
     // Close remaining clipping group elements
     for (size_t i = 0; i < m_clipUniqueId; i++)
-        s += wxS("</g>\n");
+        doc += wxS("</g>\n");
 
-    s += wxS("</g>\n</svg>\n");
-    write(s);
+    doc += wxS("</g>\n</svg>\n");
+
+    return doc;
+}
+
+wxSVGFileDCImpl::~wxSVGFileDCImpl()
+{
+    if ( !m_filename.empty() )
+    {
+        wxFile file(m_filename, wxFile::write);
+        if ( file.IsOpened() )
+            file.Write(GetSVGDocument(), wxConvUTF8);
+    }
 }
 
 void wxSVGFileDCImpl::DoGetSizeMM(int* width, int* height) const
@@ -1435,28 +1447,17 @@ void wxSVGFileDCImpl::DoDrawBitmap(const wxBitmap& bmp, wxCoord x, wxCoord y,
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
         CalcBoundingBox(x, y, x + bmp.GetWidth(), y + bmp.GetHeight());
 
-    if ( !m_outfile )
-        return;
-
     // If we don't have any bitmap handler yet, use the default one.
     if ( !m_bmp_handler )
         m_bmp_handler.reset(new wxSVGBitmapFileHandler(m_filename));
 
-    m_writeError = m_bmp_handler->ProcessBitmap(bmp, x, y, *m_outfile);
+    wxStringOutputStream stream(&m_svgDocument);
+    m_writeError = m_bmp_handler->ProcessBitmap(bmp, x, y, stream);
 }
 
 void wxSVGFileDCImpl::write(const wxString& s)
 {
-    if ( !m_outfile )
-        return;
-
-    if ( m_outfile->IsOk() )
-    {
-        const wxCharBuffer buf = s.utf8_str();
-        m_outfile->Write(buf, strlen((const char*)buf));
-    }
-
-    m_writeError = !m_outfile->IsOk();
+    m_svgDocument += s;
 }
 
 #endif // wxUSE_SVG


### PR DESCRIPTION
Currently, if you pass empty filename string to either of `wxSVGFileDC`'s CTORs then nothing happens. Now, the content will be stored in a buffer that you can get via the new `GetSVGDocument()` function (regardless of whether you save to a file or not).

I was wanting to do some post hoc editing on the content and save it myself. This is more elegant than writing to a temp file and doing surgery on that.

Also, fixes an issue with `IsOK()` being wrong if bitmaps were processed successfully.