### PR TITLE
Ensure that `wxDC::DeviceToLogical{X,Y}()` and `DeviceToLogical()` etc are always consistent

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -414,14 +414,45 @@ public:
 
     // coordinates conversions and transforms
 
-    virtual wxCoord DeviceToLogicalX(wxCoord x) const;
-    virtual wxCoord DeviceToLogicalY(wxCoord y) const;
-    virtual wxCoord DeviceToLogicalXRel(wxCoord x) const;
-    virtual wxCoord DeviceToLogicalYRel(wxCoord y) const;
-    virtual wxCoord LogicalToDeviceX(wxCoord x) const;
-    virtual wxCoord LogicalToDeviceY(wxCoord y) const;
-    virtual wxCoord LogicalToDeviceXRel(wxCoord x) const;
-    virtual wxCoord LogicalToDeviceYRel(wxCoord y) const;
+    wxCoord DeviceToLogicalX(wxCoord x) const
+    {
+        return DeviceToLogical(x, 0).x;
+    }
+
+    wxCoord DeviceToLogicalY(wxCoord y) const
+    {
+        return DeviceToLogical(0, y).y;
+    }
+
+    wxCoord DeviceToLogicalXRel(wxCoord x) const
+    {
+        return DeviceToLogicalRel(x, 0).x;
+    }
+
+    wxCoord DeviceToLogicalYRel(wxCoord y) const
+    {
+        return DeviceToLogicalRel(0, y).y;
+    }
+
+    wxCoord LogicalToDeviceX(wxCoord x) const
+    {
+        return LogicalToDevice(x, 0).x;
+    }
+
+    wxCoord LogicalToDeviceY(wxCoord y) const
+    {
+        return LogicalToDevice(0, y).y;
+    }
+
+    wxCoord LogicalToDeviceXRel(wxCoord x) const
+    {
+        return LogicalToDeviceRel(x, 0).x;
+    }
+
+    wxCoord LogicalToDeviceYRel(wxCoord y) const
+    {
+        return LogicalToDeviceRel(0, y).y;
+    }
 
     virtual void SetMapMode(wxMappingMode mode);
     virtual wxMappingMode GetMapMode() const { return m_mappingMode; }

--- a/include/wx/dfb/dc.h
+++ b/include/wx/dfb/dc.h
@@ -75,16 +75,6 @@ public:
     wxIDirectFBSurfacePtr GetDirectFBSurface() const { return m_surface; }
 
 protected:
-    // implementation
-    wxCoord XDEV2LOG(wxCoord x) const       { return DeviceToLogicalX(x); }
-    wxCoord XDEV2LOGREL(wxCoord x) const    { return DeviceToLogicalXRel(x); }
-    wxCoord YDEV2LOG(wxCoord y) const       { return DeviceToLogicalY(y); }
-    wxCoord YDEV2LOGREL(wxCoord y) const    { return DeviceToLogicalYRel(y); }
-    wxCoord XLOG2DEV(wxCoord x) const       { return LogicalToDeviceX(x); }
-    wxCoord XLOG2DEVREL(wxCoord x) const    { return LogicalToDeviceXRel(x); }
-    wxCoord YLOG2DEV(wxCoord y) const       { return LogicalToDeviceY(y); }
-    wxCoord YLOG2DEVREL(wxCoord y) const    { return LogicalToDeviceYRel(y); }
-
     // initializes the DC from a surface, must be called if default ctor
     // was used
     void DFBInit(const wxIDirectFBSurfacePtr& surface);

--- a/include/wx/gtk/print.h
+++ b/include/wx/gtk/print.h
@@ -309,8 +309,6 @@ private:
 
     GtkPrintContext        *m_gpc;
     int                     m_resolution;
-    double                  m_PS2DEV;
-    double                  m_DEV2PS;
 
     friend class wxGtkPrinterDCContextSaver;
 

--- a/include/wx/x11/dc.h
+++ b/include/wx/x11/dc.h
@@ -33,16 +33,6 @@ protected:
         wxCoord width, wxCoord height);
     virtual void DoGetSizeMM(int* width, int* height) const;
 
-    // implementation
-    wxCoord XDEV2LOG(wxCoord x) const       { return DeviceToLogicalX(x); }
-    wxCoord XDEV2LOGREL(wxCoord x) const    { return DeviceToLogicalXRel(x); }
-    wxCoord YDEV2LOG(wxCoord y) const       { return DeviceToLogicalY(y); }
-    wxCoord YDEV2LOGREL(wxCoord y) const    { return DeviceToLogicalYRel(y); }
-    wxCoord XLOG2DEV(wxCoord x) const       { return LogicalToDeviceX(x); }
-    wxCoord XLOG2DEVREL(wxCoord x) const    { return LogicalToDeviceXRel(x); }
-    wxCoord YLOG2DEV(wxCoord y) const       { return LogicalToDeviceY(y); }
-    wxCoord YLOG2DEVREL(wxCoord y) const    { return LogicalToDeviceYRel(y); }
-
 private:
     wxDECLARE_CLASS(wxX11DCImpl);
 };

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -302,8 +302,11 @@ public:
         Convert @e device X coordinate to logical coordinate, using the current
         mapping mode, user scale factor, device origin and axis orientation.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using DeviceToLogical() instead of this function in the new code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        DeviceToLogical() must be used instead in this case.
     */
     wxCoord DeviceToLogicalX(wxCoord x) const;
 
@@ -313,8 +316,12 @@ public:
         axis orientation. Use this for converting a horizontal distance like
         for example a width.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using DeviceToLogicalRel() instead of this function in the new
+        code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        DeviceToLogicalRel() must be used instead in this case.
     */
     wxCoord DeviceToLogicalXRel(wxCoord x) const;
 
@@ -322,8 +329,11 @@ public:
         Converts @e device Y coordinate to logical coordinate, using the current
         mapping mode, user scale factor, device origin and axis orientation.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using DeviceToLogical() instead of this function in the new code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        DeviceToLogical() must be used instead in this case.
     */
     wxCoord DeviceToLogicalY(wxCoord y) const;
 
@@ -333,8 +343,12 @@ public:
         axis orientation. Use this for converting a vertical distance like
         for example a height.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using DeviceToLogicalRel() instead of this function in the new
+        code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        DeviceToLogicalRel() must be used instead in this case.
     */
     wxCoord DeviceToLogicalYRel(wxCoord y) const;
 
@@ -342,8 +356,11 @@ public:
         Converts logical X coordinate to device coordinate, using the current
         mapping mode, user scale factor, device origin and axis orientation.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using LogicalToDevice() instead of this function in the new code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        LogicalToDevice() must be used instead in this case.
     */
     wxCoord LogicalToDeviceX(wxCoord x) const;
 
@@ -353,8 +370,12 @@ public:
         axis orientation. Use this for converting a horizontal distance like
         for example a width.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using LogicalToDeviceRel() instead of this function in the new
+        code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        LogicalToDeviceRel() must be used instead in this case.
     */
     wxCoord LogicalToDeviceXRel(wxCoord x) const;
 
@@ -362,8 +383,11 @@ public:
         Converts logical Y coordinate to device coordinate, using the current
         mapping mode, user scale factor, device origin and axis orientation.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using LogicalToDevice() instead of this function in the new code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        LogicalToDevice() must be used instead in this case.
     */
     wxCoord LogicalToDeviceY(wxCoord y) const;
 
@@ -373,8 +397,12 @@ public:
         axis orientation. Use this for converting a vertical distance like
         for example a height.
 
-        @note Affine transformation applied to the coordinate system
-        with SetTransformMatrix() is not taken into account.
+        Prefer using LogicalToDeviceRel() instead of this function in the new
+        code.
+
+        @note This function can't work correctly if the current transformation
+        matrix set with SetTransformMatrix() has a rotation component,
+        LogicalToDeviceRel() must be used instead in this case.
     */
     wxCoord LogicalToDeviceYRel(wxCoord y) const;
 

--- a/src/common/dcbase.cpp
+++ b/src/common/dcbase.cpp
@@ -432,64 +432,32 @@ void wxDCImpl::DoGetClippingBox(wxCoord *x, wxCoord *y,
 // coordinate conversions and transforms
 // ----------------------------------------------------------------------------
 
-wxCoord wxDCImpl::DeviceToLogicalX(wxCoord x) const
-{
-    return wxRound( (double)((x - m_deviceOriginX - m_deviceLocalOriginX) * m_signX) / m_scaleX ) + m_logicalOriginX ;
-}
-
-wxCoord wxDCImpl::DeviceToLogicalY(wxCoord y) const
-{
-    return wxRound( (double)((y - m_deviceOriginY - m_deviceLocalOriginY) * m_signY) / m_scaleY ) + m_logicalOriginY ;
-}
-
-wxCoord wxDCImpl::DeviceToLogicalXRel(wxCoord x) const
-{
-    return wxRound((double)(x) / m_scaleX);
-}
-
-wxCoord wxDCImpl::DeviceToLogicalYRel(wxCoord y) const
-{
-    return wxRound((double)(y) / m_scaleY);
-}
-
-wxCoord wxDCImpl::LogicalToDeviceX(wxCoord x) const
-{
-    return wxRound( (double)((x - m_logicalOriginX) * m_signX) * m_scaleX) + m_deviceOriginX + m_deviceLocalOriginX;
-}
-
-wxCoord wxDCImpl::LogicalToDeviceY(wxCoord y) const
-{
-    return wxRound( (double)((y - m_logicalOriginY) * m_signY) * m_scaleY) + m_deviceOriginY + m_deviceLocalOriginY;
-}
-
-wxCoord wxDCImpl::LogicalToDeviceXRel(wxCoord x) const
-{
-    return wxRound((double)(x) * m_scaleX);
-}
-
-wxCoord wxDCImpl::LogicalToDeviceYRel(wxCoord y) const
-{
-    return wxRound((double)(y) * m_scaleY);
-}
-
 wxPoint wxDCImpl::DeviceToLogical(wxCoord x, wxCoord y) const
 {
-    return wxPoint(DeviceToLogicalX(x), DeviceToLogicalY(y));
+    return wxRealPoint
+           (
+            ((x - m_deviceOriginX - m_deviceLocalOriginX) * m_signX) / m_scaleX + m_logicalOriginX,
+            ((y - m_deviceOriginY - m_deviceLocalOriginY) * m_signY) / m_scaleY + m_logicalOriginY
+           );
 }
 
 wxPoint wxDCImpl::LogicalToDevice(wxCoord x, wxCoord y) const
 {
-    return wxPoint(LogicalToDeviceX(x), LogicalToDeviceY(y));
+    return wxRealPoint
+           (
+            (x - m_logicalOriginX) * m_signX * m_scaleX + m_deviceOriginX + m_deviceLocalOriginX,
+            (y - m_logicalOriginY) * m_signY * m_scaleY + m_deviceOriginY + m_deviceLocalOriginY
+           );
 }
 
 wxSize wxDCImpl::DeviceToLogicalRel(int x, int y) const
 {
-    return wxSize(DeviceToLogicalXRel(x), DeviceToLogicalYRel(y));
+    return wxSize(wxRound(x / m_scaleX), wxRound(y / m_scaleY));
 }
 
 wxSize wxDCImpl::LogicalToDeviceRel(int x, int y) const
 {
-    return wxSize(LogicalToDeviceXRel(x), LogicalToDeviceYRel(y));
+    return wxSize(wxRound(x * m_scaleX), wxRound(y * m_scaleY));
 }
 
 void wxDCImpl::ComputeScaleAndOrigin()

--- a/src/dfb/dc.cpp
+++ b/src/dfb/dc.cpp
@@ -71,10 +71,10 @@ void wxDFBDCImpl::DoSetClippingRegion(wxCoord cx, wxCoord cy, wxCoord cw, wxCoor
     //     DirectFB will return an error if you try to set clipping rectangle
     //     that is partially outside of the surface.
     DFBRegion r;
-    r.x1 = wxMax(0, XLOG2DEV(cx));
-    r.y1 = wxMax(0, YLOG2DEV(cy));
-    r.x2 = wxMin(r.x1 + XLOG2DEVREL(cw), size.x) - 1;
-    r.y2 = wxMin(r.y1 + YLOG2DEVREL(ch), size.y) - 1;
+    r.x1 = wxMax(0, LogicalToDeviceX(cx));
+    r.y1 = wxMax(0, LogicalToDeviceY(cy));
+    r.x2 = wxMin(r.x1 + LogicalToDeviceXRel(cw), size.x) - 1;
+    r.y2 = wxMin(r.y1 + LogicalToDeviceYRel(ch), size.y) - 1;
 
     if ( !m_surface->SetClip(&r) )
         return;
@@ -93,10 +93,10 @@ void wxDFBDCImpl::DoSetDeviceClippingRegion(const wxRegion& region)
 
     // our parameter is in physical coordinates while DoSetClippingRegion()
     // takes logical ones
-    rect.x = XDEV2LOG(rect.x);
-    rect.y = YDEV2LOG(rect.y);
-    rect.width = XDEV2LOG(rect.width);
-    rect.height = YDEV2LOG(rect.height);
+    rect.x = DeviceToLogicalX(rect.x);
+    rect.y = DeviceToLogicalY(rect.y);
+    rect.width = DeviceToLogicalX(rect.width);
+    rect.height = DeviceToLogicalY(rect.height);
 
     DoSetClippingRegion(rect.x, rect.y, rect.width, rect.height);
 }
@@ -136,7 +136,7 @@ void wxDFBDCImpl::Clear()
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
     {
         wxSize size(GetSize());
-        CalcBoundingBox(XDEV2LOG(0), YDEV2LOG(0), XDEV2LOG(size.x), YDEV2LOG(size.y));
+        CalcBoundingBox(DeviceToLogicalX(0), DeviceToLogicalY(0), DeviceToLogicalX(size.x), DeviceToLogicalY(size.y));
     }
 }
 
@@ -178,10 +178,10 @@ void wxDFBDCImpl::DoDrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2)
     if ( m_pen.GetStyle() == wxPENSTYLE_TRANSPARENT )
         return;
 
-    wxCoord xx1 = XLOG2DEV(x1);
-    wxCoord yy1 = YLOG2DEV(y1);
-    wxCoord xx2 = XLOG2DEV(x2);
-    wxCoord yy2 = YLOG2DEV(y2);
+    wxCoord xx1 = LogicalToDeviceX(x1);
+    wxCoord yy1 = LogicalToDeviceY(y1);
+    wxCoord xx2 = LogicalToDeviceX(x2);
+    wxCoord yy2 = LogicalToDeviceY(y2);
 
     // FIXME: DrawLine() shouldn't draw the last pixel, but DFB's DrawLine()
     //        does draw it. We should undo any change to the last pixel by
@@ -254,10 +254,10 @@ void wxDFBDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord h
 {
     wxCHECK_RET( IsOk(), wxT("invalid dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
 
     if ( ww == 0 || hh == 0 ) return;
 
@@ -327,8 +327,8 @@ void wxDFBDCImpl::DoDrawText(const wxString& text, wxCoord x, wxCoord y)
 {
     wxCHECK_RET( IsOk(), wxT("invalid dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
 
     // update the bounding box
     wxCoord w, h;
@@ -343,7 +343,7 @@ void wxDFBDCImpl::DoDrawText(const wxString& text, wxCoord x, wxCoord y)
                      wxT("invalid background color") );
 
         SelectColour(m_textBackgroundColour);
-        m_surface->FillRectangle(xx, yy, XLOG2DEVREL(w), YLOG2DEVREL(h));
+        m_surface->FillRectangle(xx, yy, LogicalToDeviceXRel(w), LogicalToDeviceYRel(h));
     }
 
     // finally draw the text itself:
@@ -475,7 +475,7 @@ wxCoord wxDFBDCImpl::GetCharHeight() const
 
     int h = -1;
     GetCurrentFont()->GetHeight(&h);
-    return YDEV2LOGREL(h);
+    return DeviceToLogicalYRel(h);
 }
 
 wxCoord wxDFBDCImpl::GetCharWidth() const
@@ -487,7 +487,7 @@ wxCoord wxDFBDCImpl::GetCharWidth() const
     GetCurrentFont()->GetStringWidth("H", 1, &w);
     // VS: YDEV is correct, it should *not* be XDEV, because fonts are only
     //     scaled according to m_scaleY
-    return YDEV2LOGREL(w);
+    return DeviceToLogicalYRel(w);
 }
 
 void wxDFBDCImpl::DoGetTextExtent(const wxString& string, wxCoord *x, wxCoord *y,
@@ -513,14 +513,14 @@ void wxDFBDCImpl::DoGetTextExtent(const wxString& string, wxCoord *x, wxCoord *y
     {
         // VS: YDEV is correct, it should *not* be XDEV, because fonts are
         //     only scaled according to m_scaleY
-        xx = YDEV2LOGREL(rect.w);
-        yy = YDEV2LOGREL(rect.h);
+        xx = DeviceToLogicalYRel(rect.w);
+        yy = DeviceToLogicalYRel(rect.h);
 
         if ( descent )
         {
             int d;
             if ( f->GetDescender(&d) )
-                *descent = YDEV2LOGREL(-d);
+                *descent = DeviceToLogicalYRel(-d);
             else
                 *descent = 0;
         }
@@ -699,8 +699,8 @@ bool wxDFBDCImpl::DoBlitFromSurface(const wxIDirectFBSurfacePtr& src,
         CalcBoundingBox(wxPoint(dstx, dsty), wxSize(w, h));
 
     DFBRectangle srcRect = { srcx, srcy, w, h };
-    DFBRectangle dstRect = { XLOG2DEV(dstx), YLOG2DEV(dsty),
-                             XLOG2DEVREL(w), YLOG2DEVREL(h) };
+    DFBRectangle dstRect = { LogicalToDeviceX(dstx), LogicalToDeviceY(dsty),
+                             LogicalToDeviceXRel(w), LogicalToDeviceYRel(h) };
 
     wxIDirectFBSurfacePtr dst(m_surface);
 

--- a/src/gtk/dcclient.cpp
+++ b/src/gtk/dcclient.cpp
@@ -31,11 +31,6 @@
 // local defines
 //-----------------------------------------------------------------------------
 
-#define XLOG2DEV(x)    LogicalToDeviceX(x)
-#define XLOG2DEVREL(x) LogicalToDeviceXRel(x)
-#define YLOG2DEV(y)    LogicalToDeviceY(y)
-#define YLOG2DEVREL(y) LogicalToDeviceYRel(y)
-
 #define USE_PAINT_REGION 1
 
 //-----------------------------------------------------------------------------
@@ -525,7 +520,7 @@ void wxWindowDCImpl::DoDrawLine( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2 
     if ( m_pen.IsNonTransparent() )
     {
         if (m_gdkwindow)
-            gdk_draw_line( m_gdkwindow, m_penGC, XLOG2DEV(x1), YLOG2DEV(y1), XLOG2DEV(x2), YLOG2DEV(y2) );
+            gdk_draw_line( m_gdkwindow, m_penGC, LogicalToDeviceX(x1), LogicalToDeviceY(y1), LogicalToDeviceX(x2), LogicalToDeviceY(y2) );
 
         if ( AreAutomaticBoundingBoxUpdatesEnabled() )
             CalcBoundingBox(x1, y1, x2, y2);
@@ -541,12 +536,12 @@ void wxWindowDCImpl::DoCrossHair( wxCoord x, wxCoord y )
         int w = 0;
         int h = 0;
         GetOwner()->GetSize( &w, &h );
-        wxCoord xx = XLOG2DEV(x);
-        wxCoord yy = YLOG2DEV(y);
+        wxCoord xx = LogicalToDeviceX(x);
+        wxCoord yy = LogicalToDeviceY(y);
         if (m_gdkwindow)
         {
-            gdk_draw_line( m_gdkwindow, m_penGC, 0, yy, XLOG2DEVREL(w), yy );
-            gdk_draw_line( m_gdkwindow, m_penGC, xx, 0, xx, YLOG2DEVREL(h) );
+            gdk_draw_line( m_gdkwindow, m_penGC, 0, yy, LogicalToDeviceXRel(w), yy );
+            gdk_draw_line( m_gdkwindow, m_penGC, xx, 0, xx, LogicalToDeviceYRel(h) );
         }
     }
 }
@@ -596,12 +591,12 @@ void wxWindowDCImpl::DoDrawArc( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2,
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx1 = XLOG2DEV(x1);
-    wxCoord yy1 = YLOG2DEV(y1);
-    wxCoord xx2 = XLOG2DEV(x2);
-    wxCoord yy2 = YLOG2DEV(y2);
-    wxCoord xxc = XLOG2DEV(xc);
-    wxCoord yyc = YLOG2DEV(yc);
+    wxCoord xx1 = LogicalToDeviceX(x1);
+    wxCoord yy1 = LogicalToDeviceY(y1);
+    wxCoord xx2 = LogicalToDeviceX(x2);
+    wxCoord yy2 = LogicalToDeviceY(y2);
+    wxCoord xxc = LogicalToDeviceX(xc);
+    wxCoord yyc = LogicalToDeviceY(yc);
     double dx = xx1 - xxc;
     double dy = yy1 - yyc;
     double radius = sqrt((double)(dx*dx+dy*dy));
@@ -666,10 +661,10 @@ void wxWindowDCImpl::DoDrawEllipticArc( wxCoord x, wxCoord y, wxCoord width, wxC
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
 
     // CMB: handle -ve width and/or height
     if (ww < 0) { ww = -ww; xx = xx - ww; }
@@ -715,7 +710,7 @@ void wxWindowDCImpl::DoDrawPoint( wxCoord x, wxCoord y )
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
     if ( m_pen.IsNonTransparent() && m_gdkwindow )
-        gdk_draw_point( m_gdkwindow, m_penGC, XLOG2DEV(x), YLOG2DEV(y) );
+        gdk_draw_point( m_gdkwindow, m_penGC, LogicalToDeviceX(x), LogicalToDeviceY(y) );
 
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
         CalcBoundingBox (x, y);
@@ -732,7 +727,7 @@ void wxWindowDCImpl::DoDrawLines( int n, const wxPoint points[], wxCoord xoffset
 
     //Check, if scaling is necessary
     const bool doScale =
-        xoffset != 0 || yoffset != 0 || XLOG2DEV(10) != 10 || YLOG2DEV(10) != 10;
+        xoffset != 0 || yoffset != 0 || LogicalToDeviceX(10) != 10 || LogicalToDeviceY(10) != 10;
 
     // GdkPoint and wxPoint have the same memory layout, so we can cast one to the other
     const GdkPoint* gpts = reinterpret_cast<const GdkPoint*>(points);
@@ -748,8 +743,8 @@ void wxWindowDCImpl::DoDrawLines( int n, const wxPoint points[], wxCoord xoffset
     {
         if (doScale)
         {
-            gpts_alloc[i].x = XLOG2DEV(points[i].x + xoffset);
-            gpts_alloc[i].y = YLOG2DEV(points[i].y + yoffset);
+            gpts_alloc[i].x = LogicalToDeviceX(points[i].x + xoffset);
+            gpts_alloc[i].y = LogicalToDeviceY(points[i].y + yoffset);
         }
         if ( AreAutomaticBoundingBoxUpdatesEnabled() )
             CalcBoundingBox(points[i].x + xoffset, points[i].y + yoffset);
@@ -769,7 +764,7 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[],
 
     //Check, if scaling is necessary
     const bool doScale =
-        xoffset != 0 || yoffset != 0 || XLOG2DEV(10) != 10 || YLOG2DEV(10) != 10;
+        xoffset != 0 || yoffset != 0 || LogicalToDeviceX(10) != 10 || LogicalToDeviceY(10) != 10;
 
     // GdkPoint and wxPoint have the same memory layout, so we can cast one to the other
     const GdkPoint* gdkpoints = reinterpret_cast<const GdkPoint*>(points);
@@ -786,8 +781,8 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[],
     {
         if (doScale)
         {
-            gdkpoints_alloc[i].x = XLOG2DEV(points[i].x + xoffset);
-            gdkpoints_alloc[i].y = YLOG2DEV(points[i].y + yoffset);
+            gdkpoints_alloc[i].x = LogicalToDeviceX(points[i].x + xoffset);
+            gdkpoints_alloc[i].y = LogicalToDeviceY(points[i].y + yoffset);
         }
         if ( AreAutomaticBoundingBoxUpdatesEnabled() )
             CalcBoundingBox(points[i].x + xoffset, points[i].y + yoffset);
@@ -829,10 +824,10 @@ void wxWindowDCImpl::DoDrawRectangle( wxCoord x, wxCoord y, wxCoord width, wxCoo
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
 
     // CMB: draw nothing if transformed w or h is 0
     if (ww == 0 || hh == 0) return;
@@ -874,11 +869,11 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
     wxDouble maxR = std::min(width, height) / 2.0;
     if ( radius > maxR ) radius = maxR;
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
-    wxCoord rr = XLOG2DEVREL((wxCoord)radius);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
+    wxCoord rr = LogicalToDeviceXRel((wxCoord)radius);
 
     // CMB: handle -ve width and/or height
     if (ww < 0) { ww = -ww; xx = xx - ww; }
@@ -951,10 +946,10 @@ void wxWindowDCImpl::DoDrawEllipse( wxCoord x, wxCoord y, wxCoord width, wxCoord
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
 
     // CMB: handle -ve width and/or height
     if (ww < 0) { ww = -ww; xx = xx - ww; }
@@ -1598,8 +1593,8 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
         // X doesn't allow different width in x and y and so we take
         // the average
         double w = 0.5 +
-                   ( fabs((double) XLOG2DEVREL(width)) +
-                     fabs((double) YLOG2DEVREL(width)) ) / 2.0;
+                   ( fabs((double) LogicalToDeviceXRel(width)) +
+                     fabs((double) LogicalToDeviceYRel(width)) ) / 2.0;
         width = (int)w;
         if ( !width )
         {
@@ -1979,10 +1974,10 @@ void wxWindowDCImpl::DoSetClippingRegion( wxCoord x, wxCoord y, wxCoord width, w
     }
 
     wxRect rect;
-    rect.x = XLOG2DEV(x);
-    rect.y = YLOG2DEV(y);
-    rect.width = XLOG2DEVREL(width);
-    rect.height = YLOG2DEVREL(height);
+    rect.x = LogicalToDeviceX(x);
+    rect.y = LogicalToDeviceY(y);
+    rect.width = LogicalToDeviceXRel(width);
+    rect.height = LogicalToDeviceYRel(height);
 
     if (m_window && m_window->m_wxwindow &&
         (m_window->GetLayoutDirection() == wxLayout_RightToLeft))

--- a/src/gtk/print.cpp
+++ b/src/gtk/print.cpp
@@ -1164,23 +1164,10 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxGtkPrinterDCContextSaver);
 };
 
-#define wxCAIRO_SCALE 1
-
-#if wxCAIRO_SCALE
-
 #define XLOG2DEV(x)     LogicalToDeviceX(x)
 #define XLOG2DEVREL(x)  LogicalToDeviceXRel(x)
 #define YLOG2DEV(x)     LogicalToDeviceY(x)
 #define YLOG2DEVREL(x)  LogicalToDeviceYRel(x)
-
-#else
-
-#define XLOG2DEV(x)     ((double)(LogicalToDeviceX(x)) * m_DEV2PS)
-#define XLOG2DEVREL(x)  ((double)(LogicalToDeviceXRel(x)) * m_DEV2PS)
-#define YLOG2DEV(x)     ((double)(LogicalToDeviceY(x)) * m_DEV2PS)
-#define YLOG2DEVREL(x)  ((double)(LogicalToDeviceYRel(x)) * m_DEV2PS)
-
-#endif
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxGtkPrinterDCImpl, wxDCImpl);
 
@@ -1203,14 +1190,6 @@ wxGtkPrinterDCImpl::wxGtkPrinterDCImpl(wxPrinterDC *owner, const wxPrintData& da
     m_fontdesc = pango_font_description_from_string( "Sans 12" );
 
     m_cairo = gtk_print_context_get_cairo_context ( m_gpc );
-
-#if wxCAIRO_SCALE
-    m_PS2DEV = 1.0;
-    m_DEV2PS = 1.0;
-#else
-    m_PS2DEV = (double)m_resolution / 72.0;
-    m_DEV2PS = 72.0 / (double)m_resolution;
-#endif
 
     m_signX = 1;  // default x-axis left to right.
     m_signY = 1;  // default y-axis bottom up -> top down.
@@ -1306,7 +1285,7 @@ void wxGtkPrinterDCImpl::DoGradientFillConcentric(const wxRect& rect, const wxCo
 
     // Create a pattern with the gradient.
     cairo_pattern_t* gradient;
-    gradient = cairo_pattern_create_radial (XLOG2DEV(xC+xR), YLOG2DEV(yC+yR), 0, XLOG2DEV(xC+xR), YLOG2DEV(yC+yR), radius * m_DEV2PS );
+    gradient = cairo_pattern_create_radial (XLOG2DEV(xC+xR), YLOG2DEV(yC+yR), 0, XLOG2DEV(xC+xR), YLOG2DEV(yC+yR), radius );
     cairo_pattern_add_color_stop_rgba (gradient, 0.0, redIPS, greenIPS, blueIPS, alphaIPS);
     cairo_pattern_add_color_stop_rgba (gradient, 1.0, redDPS, greenDPS, blueDPS, alphaDPS);
 
@@ -1923,7 +1902,7 @@ void wxGtkPrinterDCImpl::SetPen( const wxPen& pen )
     else
         width = (double) m_pen.GetWidth() * m_scaleX;
 
-    cairo_set_line_width( m_cairo, width * m_DEV2PS );
+    cairo_set_line_width( m_cairo, width );
     static const double dotted[] = {2.0, 5.0};
     static const double short_dashed[] = {4.0, 4.0};
     static const double long_dashed[] = {4.0, 8.0};
@@ -2111,9 +2090,7 @@ void wxGtkPrinterDCImpl::StartPage()
     // is used in GTK+ itself and wouldn't work correctly if we applied these
     // transformations before it is called.
 
-#if wxCAIRO_SCALE
     cairo_scale( m_cairo, 72.0 / (double)m_resolution, 72.0 / (double)m_resolution );
-#endif
 }
 
 void wxGtkPrinterDCImpl::EndPage()
@@ -2128,7 +2105,7 @@ wxCoord wxGtkPrinterDCImpl::GetCharHeight() const
     int w,h;
     pango_layout_get_pixel_size( m_layout, &w, &h );
 
-    return wxRound( h * m_PS2DEV );
+    return h;
 }
 
 wxCoord wxGtkPrinterDCImpl::GetCharWidth() const
@@ -2138,7 +2115,7 @@ wxCoord wxGtkPrinterDCImpl::GetCharWidth() const
     int w,h;
     pango_layout_get_pixel_size( m_layout, &w, &h );
 
-    return wxRound( w * m_PS2DEV );
+    return w;
 }
 
 void wxGtkPrinterDCImpl::DoGetTextExtent(const wxString& string, wxCoord *width, wxCoord *height,

--- a/src/gtk/print.cpp
+++ b/src/gtk/print.cpp
@@ -1164,11 +1164,6 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxGtkPrinterDCContextSaver);
 };
 
-#define XLOG2DEV(x)     LogicalToDeviceX(x)
-#define XLOG2DEVREL(x)  LogicalToDeviceXRel(x)
-#define YLOG2DEV(x)     LogicalToDeviceY(x)
-#define YLOG2DEVREL(x)  LogicalToDeviceYRel(x)
-
 wxIMPLEMENT_ABSTRACT_CLASS(wxGtkPrinterDCImpl, wxDCImpl);
 
 wxGtkPrinterDCImpl::wxGtkPrinterDCImpl(wxPrinterDC *owner, const wxPrintData& data)
@@ -1285,13 +1280,13 @@ void wxGtkPrinterDCImpl::DoGradientFillConcentric(const wxRect& rect, const wxCo
 
     // Create a pattern with the gradient.
     cairo_pattern_t* gradient;
-    gradient = cairo_pattern_create_radial (XLOG2DEV(xC+xR), YLOG2DEV(yC+yR), 0, XLOG2DEV(xC+xR), YLOG2DEV(yC+yR), radius );
+    gradient = cairo_pattern_create_radial (LogicalToDeviceX(xC+xR), LogicalToDeviceY(yC+yR), 0, LogicalToDeviceX(xC+xR), LogicalToDeviceY(yC+yR), radius );
     cairo_pattern_add_color_stop_rgba (gradient, 0.0, redIPS, greenIPS, blueIPS, alphaIPS);
     cairo_pattern_add_color_stop_rgba (gradient, 1.0, redDPS, greenDPS, blueDPS, alphaDPS);
 
     // Fill the rectangle with this pattern.
     cairo_set_source(m_cairo, gradient);
-    cairo_rectangle (m_cairo, XLOG2DEV(xR), YLOG2DEV(yR), XLOG2DEVREL(w), YLOG2DEVREL(h) );
+    cairo_rectangle (m_cairo, LogicalToDeviceX(xR), LogicalToDeviceY(yR), LogicalToDeviceXRel(w), LogicalToDeviceYRel(h) );
     cairo_fill(m_cairo);
 
     cairo_pattern_destroy(gradient);
@@ -1327,7 +1322,7 @@ void wxGtkPrinterDCImpl::DoGradientFillLinear(const wxRect& rect, const wxColour
 
     // Create a pattern with the gradient.
     cairo_pattern_t* gradient;
-    gradient = cairo_pattern_create_linear (XLOG2DEV(x), YLOG2DEV(y), XLOG2DEV(x+w), YLOG2DEV(y));
+    gradient = cairo_pattern_create_linear (LogicalToDeviceX(x), LogicalToDeviceY(y), LogicalToDeviceX(x+w), LogicalToDeviceY(y));
 
     if (nDirection == wxWEST)
     {
@@ -1341,7 +1336,7 @@ void wxGtkPrinterDCImpl::DoGradientFillLinear(const wxRect& rect, const wxColour
 
     // Fill the rectangle with this pattern.
     cairo_set_source(m_cairo, gradient);
-    cairo_rectangle (m_cairo, XLOG2DEV(x), YLOG2DEV(y), XLOG2DEVREL(w), YLOG2DEVREL(h) );
+    cairo_rectangle (m_cairo, LogicalToDeviceX(x), LogicalToDeviceY(y), LogicalToDeviceXRel(w), LogicalToDeviceYRel(h) );
     cairo_fill(m_cairo);
 
     cairo_pattern_destroy(gradient);
@@ -1364,8 +1359,8 @@ void wxGtkPrinterDCImpl::DoDrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord 
         return;
 
     SetPen( m_pen );
-    cairo_move_to ( m_cairo, XLOG2DEV(x1), YLOG2DEV(y1) );
-    cairo_line_to ( m_cairo, XLOG2DEV(x2), YLOG2DEV(y2) );
+    cairo_move_to ( m_cairo, LogicalToDeviceX(x1), LogicalToDeviceY(y1) );
+    cairo_line_to ( m_cairo, LogicalToDeviceX(x2), LogicalToDeviceY(y2) );
     cairo_stroke ( m_cairo );
 
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
@@ -1379,10 +1374,10 @@ void wxGtkPrinterDCImpl::DoCrossHair(wxCoord x, wxCoord y)
 
     SetPen(m_pen);
 
-    cairo_move_to (m_cairo, XLOG2DEV(x), 0);
-    cairo_line_to (m_cairo, XLOG2DEV(x), YLOG2DEVREL(h));
-    cairo_move_to (m_cairo, 0, YLOG2DEV(y));
-    cairo_line_to (m_cairo, XLOG2DEVREL(w), YLOG2DEV(y));
+    cairo_move_to (m_cairo, LogicalToDeviceX(x), 0);
+    cairo_line_to (m_cairo, LogicalToDeviceX(x), LogicalToDeviceYRel(h));
+    cairo_move_to (m_cairo, 0, LogicalToDeviceY(y));
+    cairo_line_to (m_cairo, LogicalToDeviceXRel(w), LogicalToDeviceY(y));
 
     cairo_stroke (m_cairo);
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
@@ -1417,12 +1412,12 @@ void wxGtkPrinterDCImpl::DoDrawArc(wxCoord x1,wxCoord y1,wxCoord x2,wxCoord y2,w
     // while in the default coordinate system, with Y axis going down, Cairo
     // counts angles in the direction from positive X axis direction to
     // positive Y axis direction, i.e. clockwise.
-    cairo_arc_negative(m_cairo, XLOG2DEV(xc), YLOG2DEV(yc),
-                       XLOG2DEVREL(wxRound(radius)), alpha1, alpha2);
+    cairo_arc_negative(m_cairo, LogicalToDeviceX(xc), LogicalToDeviceY(yc),
+                       LogicalToDeviceXRel(wxRound(radius)), alpha1, alpha2);
 
     if ( m_brush.IsNonTransparent() )
     {
-        cairo_line_to(m_cairo, XLOG2DEV(xc), YLOG2DEV(yc));
+        cairo_line_to(m_cairo, LogicalToDeviceX(xc), LogicalToDeviceY(yc));
         cairo_close_path (m_cairo);
 
         SetBrush( m_brush );
@@ -1452,11 +1447,11 @@ void wxGtkPrinterDCImpl::DoDrawEllipticArc(wxCoord x,wxCoord y,wxCoord w,wxCoord
 
     cairo_new_path(m_cairo);
 
-    cairo_translate( m_cairo, XLOG2DEV((wxCoord) (x + w / 2.)), XLOG2DEV((wxCoord) (y + h / 2.)) );
-    double scale = (double)YLOG2DEVREL(h) / (double) XLOG2DEVREL(w);
+    cairo_translate( m_cairo, LogicalToDeviceX((wxCoord) (x + w / 2.)), LogicalToDeviceX((wxCoord) (y + h / 2.)) );
+    double scale = (double)LogicalToDeviceYRel(h) / (double) LogicalToDeviceXRel(w);
     cairo_scale( m_cairo, 1.0, scale );
 
-    cairo_arc_negative ( m_cairo, 0, 0, XLOG2DEVREL(w/2), -sa*DEG2RAD, -ea*DEG2RAD);
+    cairo_arc_negative ( m_cairo, 0, 0, LogicalToDeviceXRel(w/2), -sa*DEG2RAD, -ea*DEG2RAD);
 
     SetPen (m_pen);
     cairo_stroke_preserve( m_cairo );
@@ -1477,8 +1472,8 @@ void wxGtkPrinterDCImpl::DoDrawPoint(wxCoord x, wxCoord y)
 
     SetPen( m_pen );
 
-    cairo_move_to ( m_cairo, XLOG2DEV(x), YLOG2DEV(y) );
-    cairo_line_to ( m_cairo, XLOG2DEV(x), YLOG2DEV(y) );
+    cairo_move_to ( m_cairo, LogicalToDeviceX(x), LogicalToDeviceY(y) );
+    cairo_line_to ( m_cairo, LogicalToDeviceX(x), LogicalToDeviceY(y) );
     cairo_stroke ( m_cairo );
 
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
@@ -1502,10 +1497,10 @@ void wxGtkPrinterDCImpl::DoDrawLines(int n, const wxPoint points[], wxCoord xoff
             CalcBoundingBox( points[i].x+xoffset, points[i].y+yoffset);
     }
 
-    cairo_move_to ( m_cairo, XLOG2DEV(points[0].x+xoffset), YLOG2DEV(points[0].y+yoffset) );
+    cairo_move_to ( m_cairo, LogicalToDeviceX(points[0].x+xoffset), LogicalToDeviceY(points[0].y+yoffset) );
 
     for (i = 1; i < n; i++)
-        cairo_line_to ( m_cairo, XLOG2DEV(points[i].x+xoffset), YLOG2DEV(points[i].y+yoffset) );
+        cairo_line_to ( m_cairo, LogicalToDeviceX(points[i].x+xoffset), LogicalToDeviceY(points[i].y+yoffset) );
 
     cairo_stroke ( m_cairo);
 }
@@ -1526,13 +1521,13 @@ void wxGtkPrinterDCImpl::DoDrawPolygon(int n, const wxPoint points[],
     int x = points[0].x + xoffset;
     int y = points[0].y + yoffset;
     cairo_new_path(m_cairo);
-    cairo_move_to( m_cairo, XLOG2DEV(x), YLOG2DEV(y) );
+    cairo_move_to( m_cairo, LogicalToDeviceX(x), LogicalToDeviceY(y) );
     int i;
     for (i = 1; i < n; i++)
     {
         int xx = points[i].x + xoffset;
         int yy = points[i].y + yoffset;
-        cairo_line_to( m_cairo, XLOG2DEV(xx), YLOG2DEV(yy) );
+        cairo_line_to( m_cairo, LogicalToDeviceX(xx), LogicalToDeviceY(yy) );
     }
     cairo_close_path(m_cairo);
 
@@ -1569,7 +1564,7 @@ void wxGtkPrinterDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wx
     }
 
     cairo_new_path(m_cairo);
-    cairo_rectangle ( m_cairo, XLOG2DEV(x), YLOG2DEV(y), XLOG2DEVREL(width), YLOG2DEVREL(height));
+    cairo_rectangle ( m_cairo, LogicalToDeviceX(x), LogicalToDeviceY(y), LogicalToDeviceXRel(width), LogicalToDeviceYRel(height));
 
     SetBrush( m_brush );
     if ( m_pen.IsTransparent() )
@@ -1602,27 +1597,27 @@ void wxGtkPrinterDCImpl::DoDrawRoundedRectangle(wxCoord x, wxCoord y, wxCoord wi
     wxCoord rad = (wxCoord) radius;
 
     cairo_new_path(m_cairo);
-    cairo_move_to(m_cairo,XLOG2DEV(x + rad),YLOG2DEV(y));
+    cairo_move_to(m_cairo,LogicalToDeviceX(x + rad),LogicalToDeviceY(y));
     cairo_curve_to(m_cairo,
-                                XLOG2DEV(x + rad),YLOG2DEV(y),
-                                XLOG2DEV(x),YLOG2DEV(y),
-                                XLOG2DEV(x),YLOG2DEV(y + rad));
-    cairo_line_to(m_cairo,XLOG2DEV(x),YLOG2DEV(y + height - rad));
+                                LogicalToDeviceX(x + rad),LogicalToDeviceY(y),
+                                LogicalToDeviceX(x),LogicalToDeviceY(y),
+                                LogicalToDeviceX(x),LogicalToDeviceY(y + rad));
+    cairo_line_to(m_cairo,LogicalToDeviceX(x),LogicalToDeviceY(y + height - rad));
     cairo_curve_to(m_cairo,
-                                XLOG2DEV(x),YLOG2DEV(y + height - rad),
-                                XLOG2DEV(x),YLOG2DEV(y + height),
-                                XLOG2DEV(x + rad),YLOG2DEV(y + height));
-    cairo_line_to(m_cairo,XLOG2DEV(x + width - rad),YLOG2DEV(y + height));
+                                LogicalToDeviceX(x),LogicalToDeviceY(y + height - rad),
+                                LogicalToDeviceX(x),LogicalToDeviceY(y + height),
+                                LogicalToDeviceX(x + rad),LogicalToDeviceY(y + height));
+    cairo_line_to(m_cairo,LogicalToDeviceX(x + width - rad),LogicalToDeviceY(y + height));
     cairo_curve_to(m_cairo,
-                                XLOG2DEV(x + width - rad),YLOG2DEV(y + height),
-                                XLOG2DEV(x + width),YLOG2DEV(y + height),
-                                XLOG2DEV(x + width),YLOG2DEV(y + height - rad));
-    cairo_line_to(m_cairo,XLOG2DEV(x + width),YLOG2DEV(y + rad));
+                                LogicalToDeviceX(x + width - rad),LogicalToDeviceY(y + height),
+                                LogicalToDeviceX(x + width),LogicalToDeviceY(y + height),
+                                LogicalToDeviceX(x + width),LogicalToDeviceY(y + height - rad));
+    cairo_line_to(m_cairo,LogicalToDeviceX(x + width),LogicalToDeviceY(y + rad));
     cairo_curve_to(m_cairo,
-                                XLOG2DEV(x + width),YLOG2DEV(y + rad),
-                                XLOG2DEV(x + width),YLOG2DEV(y),
-                                XLOG2DEV(x + width - rad),YLOG2DEV(y));
-    cairo_line_to(m_cairo,XLOG2DEV(x + rad),YLOG2DEV(y));
+                                LogicalToDeviceX(x + width),LogicalToDeviceY(y + rad),
+                                LogicalToDeviceX(x + width),LogicalToDeviceY(y),
+                                LogicalToDeviceX(x + width - rad),LogicalToDeviceY(y));
+    cairo_line_to(m_cairo,LogicalToDeviceX(x + rad),LogicalToDeviceY(y));
     cairo_close_path(m_cairo);
 
     SetBrush(m_brush);
@@ -1650,9 +1645,9 @@ void wxGtkPrinterDCImpl::DoDrawEllipse(wxCoord x, wxCoord y, wxCoord width, wxCo
 
     cairo_new_path(m_cairo);
 
-    cairo_translate (m_cairo, XLOG2DEV((wxCoord) (x + width / 2.)), YLOG2DEV((wxCoord) (y + height / 2.)));
-    cairo_scale(m_cairo, 1, (double)YLOG2DEVREL(height)/(double)XLOG2DEVREL(width));
-    cairo_arc ( m_cairo, 0, 0, XLOG2DEVREL(width/2), 0, 2 * M_PI);
+    cairo_translate (m_cairo, LogicalToDeviceX((wxCoord) (x + width / 2.)), LogicalToDeviceY((wxCoord) (y + height / 2.)));
+    cairo_scale(m_cairo, 1, (double)LogicalToDeviceYRel(height)/(double)LogicalToDeviceXRel(width));
+    cairo_arc ( m_cairo, 0, 0, LogicalToDeviceXRel(width/2), 0, 2 * M_PI);
 
     SetBrush( m_brush );
     if ( m_pen.IsTransparent() )
@@ -1696,8 +1691,8 @@ void wxGtkPrinterDCImpl::DoDrawSpline(const wxPointList *points)
          (double)(y1 + d) / 2;
 
     cairo_new_path( m_cairo );
-    cairo_move_to( m_cairo, XLOG2DEV((wxCoord)x1), YLOG2DEV((wxCoord)y1) );
-    cairo_line_to( m_cairo, XLOG2DEV((wxCoord)x3), YLOG2DEV((wxCoord)y3) );
+    cairo_move_to( m_cairo, LogicalToDeviceX((wxCoord)x1), LogicalToDeviceY((wxCoord)y1) );
+    cairo_line_to( m_cairo, LogicalToDeviceX((wxCoord)x3), LogicalToDeviceY((wxCoord)y3) );
 
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
         CalcBoundingBox( (wxCoord)x1, (wxCoord)y1, (wxCoord)x3, (wxCoord)y3 );
@@ -1718,9 +1713,9 @@ void wxGtkPrinterDCImpl::DoDrawSpline(const wxPointList *points)
         y3 = (double)(y2 + d) / 2;
 
         cairo_curve_to(m_cairo,
-            XLOG2DEV((wxCoord)x1), YLOG2DEV((wxCoord)y1),
-            XLOG2DEV((wxCoord)x2), YLOG2DEV((wxCoord)y2),
-            XLOG2DEV((wxCoord)x3), YLOG2DEV((wxCoord)y3) );
+            LogicalToDeviceX((wxCoord)x1), LogicalToDeviceY((wxCoord)y1),
+            LogicalToDeviceX((wxCoord)x2), LogicalToDeviceY((wxCoord)y2),
+            LogicalToDeviceX((wxCoord)x3), LogicalToDeviceY((wxCoord)y3) );
 
         if ( AreAutomaticBoundingBoxUpdatesEnabled() )
             CalcBoundingBox( (wxCoord)x1, (wxCoord)y1, (wxCoord)x3, (wxCoord)y3 );
@@ -1728,7 +1723,7 @@ void wxGtkPrinterDCImpl::DoDrawSpline(const wxPointList *points)
         node = node->GetNext();
     }
 
-    cairo_line_to ( m_cairo, XLOG2DEV((wxCoord)c), YLOG2DEV((wxCoord)d) );
+    cairo_line_to ( m_cairo, LogicalToDeviceX((wxCoord)c), LogicalToDeviceY((wxCoord)d) );
 
     cairo_stroke( m_cairo );
 }
@@ -1768,8 +1763,8 @@ void wxGtkPrinterDCImpl::DoDrawBitmap( const wxBitmap& bitmap, wxCoord x, wxCoor
 {
     wxCHECK_RET( bitmap.IsOk(), wxT("Invalid bitmap in wxGtkPrinterDCImpl::DoDrawBitmap"));
 
-    x = wxCoord(XLOG2DEV(x));
-    y = wxCoord(YLOG2DEV(y));
+    x = wxCoord(LogicalToDeviceX(x));
+    y = wxCoord(LogicalToDeviceY(y));
     int bw = bitmap.GetWidth();
     int bh = bitmap.GetHeight();
 #ifndef __WXGTK3__
@@ -1784,8 +1779,8 @@ void wxGtkPrinterDCImpl::DoDrawBitmap( const wxBitmap& bitmap, wxCoord x, wxCoor
     cairo_translate(m_cairo, x, y);
 
     // Scale the image
-    wxDouble scaleX = (wxDouble) XLOG2DEVREL(bw) / (wxDouble) bw;
-    wxDouble scaleY = (wxDouble) YLOG2DEVREL(bh) / (wxDouble) bh;
+    wxDouble scaleX = (wxDouble) LogicalToDeviceXRel(bw) / (wxDouble) bw;
+    wxDouble scaleY = (wxDouble) LogicalToDeviceYRel(bh) / (wxDouble) bh;
     cairo_scale(m_cairo, scaleX, scaleY);
 
 #ifdef __WXGTK3__
@@ -1810,8 +1805,8 @@ void wxGtkPrinterDCImpl::DoDrawText(const wxString& text, wxCoord x, wxCoord y )
 
 void wxGtkPrinterDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y, double angle)
 {
-    double xx = XLOG2DEV(x);
-    double yy = YLOG2DEV(y);
+    double xx = LogicalToDeviceX(x);
+    double yy = LogicalToDeviceY(y);
 
     angle = -angle;
 
@@ -2059,7 +2054,7 @@ void wxGtkPrinterDCImpl::SetBackgroundMode(int mode)
 
 void wxGtkPrinterDCImpl::DoSetClippingRegion(wxCoord x, wxCoord y, wxCoord width, wxCoord height)
 {
-    cairo_rectangle ( m_cairo, XLOG2DEV(x), YLOG2DEV(y), XLOG2DEVREL(width), YLOG2DEVREL(height));
+    cairo_rectangle ( m_cairo, LogicalToDeviceX(x), LogicalToDeviceY(y), LogicalToDeviceXRel(width), LogicalToDeviceYRel(height));
     cairo_clip(m_cairo);
 
     wxDCImpl::DoSetClippingRegion(x, y, width, height);

--- a/src/x11/dcclient.cpp
+++ b/src/x11/dcclient.cpp
@@ -402,7 +402,7 @@ void wxWindowDCImpl::DoDrawLine( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2 
             DoDrawLines( 2, points, 0, 0 );
 
             // XDrawLine( (Display*) m_display, (Window) m_x11window,
-            //    (GC) m_penGC, XLOG2DEV(x1), YLOG2DEV(y1), XLOG2DEV(x2), YLOG2DEV(y2) );
+            //    (GC) m_penGC, LogicalToDeviceX(x1), LogicalToDeviceY(y1), LogicalToDeviceX(x2), LogicalToDeviceY(y2) );
         }
 
         if ( AreAutomaticBoundingBoxUpdatesEnabled() )
@@ -419,14 +419,14 @@ void wxWindowDCImpl::DoCrossHair( wxCoord x, wxCoord y )
         int w = 0;
         int h = 0;
         DoGetSize( &w, &h );
-        wxCoord xx = XLOG2DEV(x);
-        wxCoord yy = YLOG2DEV(y);
+        wxCoord xx = LogicalToDeviceX(x);
+        wxCoord yy = LogicalToDeviceY(y);
         if (m_x11window)
         {
             XDrawLine( (Display*) m_display, (Window) m_x11window,
-                (GC) m_penGC, 0, yy, XLOG2DEVREL(w), yy );
+                (GC) m_penGC, 0, yy, LogicalToDeviceXRel(w), yy );
             XDrawLine( (Display*) m_display, (Window) m_x11window,
-                (GC) m_penGC, xx, 0, xx, YLOG2DEVREL(h) );
+                (GC) m_penGC, xx, 0, xx, LogicalToDeviceYRel(h) );
         }
     }
 }
@@ -435,12 +435,12 @@ void wxWindowDCImpl::DoDrawArc( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2, 
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx1 = XLOG2DEV(x1);
-    wxCoord yy1 = YLOG2DEV(y1);
-    wxCoord xx2 = XLOG2DEV(x2);
-    wxCoord yy2 = YLOG2DEV(y2);
-    wxCoord xxc = XLOG2DEV(xc);
-    wxCoord yyc = YLOG2DEV(yc);
+    wxCoord xx1 = LogicalToDeviceX(x1);
+    wxCoord yy1 = LogicalToDeviceY(y1);
+    wxCoord xx2 = LogicalToDeviceX(x2);
+    wxCoord yy2 = LogicalToDeviceY(y2);
+    wxCoord xxc = LogicalToDeviceX(xc);
+    wxCoord yyc = LogicalToDeviceY(yc);
     double dx = xx1 - xxc;
     double dy = yy1 - yyc;
     double radius = sqrt((double)(dx*dx+dy*dy));
@@ -545,10 +545,10 @@ void wxWindowDCImpl::DoDrawEllipticArc( wxCoord x, wxCoord y, wxCoord width, wxC
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
 
     // CMB: handle -ve width and/or height
     if (ww < 0) { ww = -ww; xx = xx - ww; }
@@ -627,7 +627,7 @@ void wxWindowDCImpl::DoDrawPoint( wxCoord x, wxCoord y )
 
     if ((m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT) && m_x11window)
         XDrawPoint( (Display*) m_display, (Window) m_x11window,
-                (GC) m_penGC, XLOG2DEV(x), YLOG2DEV(y) );
+                (GC) m_penGC, LogicalToDeviceX(x), LogicalToDeviceY(y) );
 
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
         CalcBoundingBox (x, y);
@@ -643,8 +643,8 @@ void wxWindowDCImpl::DoDrawLines( int n, const wxPoint points[], wxCoord xoffset
     wxScopedArray<XPoint> xpoints(n);
     for (int i = 0; i < n; i++)
     {
-        xpoints[i].x = XLOG2DEV (points[i].x + xoffset);
-        xpoints[i].y = YLOG2DEV (points[i].y + yoffset);
+        xpoints[i].x = LogicalToDeviceX (points[i].x + xoffset);
+        xpoints[i].y = LogicalToDeviceY (points[i].y + yoffset);
 
         if ( AreAutomaticBoundingBoxUpdatesEnabled() )
             CalcBoundingBox( points[i].x + xoffset, points[i].y + yoffset );
@@ -664,8 +664,8 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[],
     int i;
     for (i = 0; i < n; i++)
     {
-        xpoints[i].x = XLOG2DEV (points[i].x + xoffset);
-        xpoints[i].y = YLOG2DEV (points[i].y + yoffset);
+        xpoints[i].x = LogicalToDeviceX (points[i].x + xoffset);
+        xpoints[i].y = LogicalToDeviceY (points[i].y + yoffset);
 
         if ( AreAutomaticBoundingBoxUpdatesEnabled() )
             CalcBoundingBox (points[i].x + xoffset, points[i].y + yoffset);
@@ -740,10 +740,10 @@ void wxWindowDCImpl::DoDrawRectangle( wxCoord x, wxCoord y, wxCoord width, wxCoo
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
 
     // CMB: draw nothing if transformed w or h is 0
     if (ww == 0 || hh == 0) return;
@@ -822,11 +822,11 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
 
     if (radius < 0.0) radius = - radius * ((width < height) ? width : height);
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
-    wxCoord rr = XLOG2DEVREL((wxCoord)radius);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
+    wxCoord rr = LogicalToDeviceXRel((wxCoord)radius);
 
     // CMB: handle -ve width and/or height
     if (ww < 0) { ww = -ww; xx = xx - ww; }
@@ -943,10 +943,10 @@ void wxWindowDCImpl::DoDrawEllipse( wxCoord x, wxCoord y, wxCoord width, wxCoord
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    wxCoord xx = XLOG2DEV(x);
-    wxCoord yy = YLOG2DEV(y);
-    wxCoord ww = m_signX * XLOG2DEVREL(width);
-    wxCoord hh = m_signY * YLOG2DEVREL(height);
+    wxCoord xx = LogicalToDeviceX(x);
+    wxCoord yy = LogicalToDeviceY(y);
+    wxCoord ww = m_signX * LogicalToDeviceXRel(width);
+    wxCoord hh = m_signY * LogicalToDeviceYRel(height);
 
     // CMB: handle -ve width and/or height
     if (ww < 0) { ww = -ww; xx = xx - ww; }
@@ -1033,8 +1033,8 @@ void wxWindowDCImpl::DoDrawBitmap( const wxBitmap &bitmap,
     bool is_mono = (bitmap.GetBitmap() != nullptr);
 
     /* scale/translate size and position */
-    int xx = XLOG2DEV(x);
-    int yy = YLOG2DEV(y);
+    int xx = LogicalToDeviceX(x);
+    int yy = LogicalToDeviceY(y);
 
     int w = bitmap.GetWidth();
     int h = bitmap.GetHeight();
@@ -1044,8 +1044,8 @@ void wxWindowDCImpl::DoDrawBitmap( const wxBitmap &bitmap,
 
     if (!m_x11window) return;
 
-    int ww = XLOG2DEVREL(w);
-    int hh = YLOG2DEVREL(h);
+    int ww = LogicalToDeviceXRel(w);
+    int hh = LogicalToDeviceYRel(h);
 
     /* compare to current clipping region */
     if (!m_currentClippingRegion.IsNull())
@@ -1152,8 +1152,8 @@ void wxWindowDCImpl::DoDrawBitmap( const wxBitmap &bitmap,
     bool is_mono = (bitmap.GetBitmap() != nullptr);
 
     // scale/translate size and position
-    int xx = XLOG2DEV(x);
-    int yy = YLOG2DEV(y);
+    int xx = LogicalToDeviceX(x);
+    int yy = LogicalToDeviceY(y);
 
     int w = bitmap.GetWidth();
     int h = bitmap.GetHeight();
@@ -1163,8 +1163,8 @@ void wxWindowDCImpl::DoDrawBitmap( const wxBitmap &bitmap,
 
     if (!m_x11window) return;
 
-    int ww = XLOG2DEVREL(w);
-    int hh = YLOG2DEVREL(h);
+    int ww = LogicalToDeviceXRel(w);
+    int hh = LogicalToDeviceYRel(h);
 
     // compare to current clipping region
     if (!m_currentClippingRegion.IsNull())
@@ -1381,11 +1381,11 @@ bool wxWindowDCImpl::DoBlit( wxCoord xdest, wxCoord ydest, wxCoord width, wxCoor
         CalcBoundingBox(wxPoint(xdest, ydest), wxSize(width, height));
 
     // scale/translate size and position
-    wxCoord xx = XLOG2DEV(xdest);
-    wxCoord yy = YLOG2DEV(ydest);
+    wxCoord xx = LogicalToDeviceX(xdest);
+    wxCoord yy = LogicalToDeviceY(ydest);
 
-    wxCoord ww = XLOG2DEVREL(width);
-    wxCoord hh = YLOG2DEVREL(height);
+    wxCoord ww = LogicalToDeviceXRel(width);
+    wxCoord hh = LogicalToDeviceYRel(height);
 
     // compare to current clipping region
     if (!m_currentClippingRegion.IsNull())
@@ -1407,8 +1407,8 @@ bool wxWindowDCImpl::DoBlit( wxCoord xdest, wxCoord ydest, wxCoord width, wxCoor
         wxCoord bm_width = selected.GetWidth();
         wxCoord bm_height = selected.GetHeight();
 
-        wxCoord bm_ww = XLOG2DEVREL( bm_width );
-        wxCoord bm_hh = YLOG2DEVREL( bm_height );
+        wxCoord bm_ww = LogicalToDeviceXRel( bm_width );
+        wxCoord bm_hh = LogicalToDeviceYRel( bm_height );
 
         // scale bitmap if required
         wxBitmap use_bitmap;
@@ -1573,8 +1573,8 @@ void wxWindowDCImpl::DoDrawText( const wxString &text, wxCoord x, wxCoord y )
 
     if (!m_x11window) return;
 
-    x = XLOG2DEV(x);
-    y = YLOG2DEV(y);
+    x = LogicalToDeviceX(x);
+    y = LogicalToDeviceY(y);
 
     PangoLayout *layout = pango_layout_new(m_context);
     pango_layout_set_font_description(layout, m_fontdesc);
@@ -1772,8 +1772,8 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
         // X doesn't allow different width in x and y and so we take
         // the average
         double w = 0.5 +
-                   ( fabs((double) XLOG2DEVREL(width)) +
-                     fabs((double) YLOG2DEVREL(width)) ) / 2.0;
+                   ( fabs((double) LogicalToDeviceXRel(width)) +
+                     fabs((double) LogicalToDeviceYRel(width)) ) / 2.0;
         width = (int)w;
     }
 
@@ -2135,10 +2135,10 @@ void wxWindowDCImpl::DoSetClippingRegion( wxCoord x, wxCoord y, wxCoord width, w
         height = 1;
 
     wxRect rect;
-    rect.x = XLOG2DEV(x);
-    rect.y = YLOG2DEV(y);
-    rect.width = XLOG2DEVREL(width);
-    rect.height = YLOG2DEVREL(height);
+    rect.x = LogicalToDeviceX(x);
+    rect.y = LogicalToDeviceY(y);
+    rect.width = LogicalToDeviceXRel(width);
+    rect.height = LogicalToDeviceYRel(height);
 
     if (!m_currentClippingRegion.IsEmpty())
         m_currentClippingRegion.Intersect( rect );

--- a/tests/graphics/coords.cpp
+++ b/tests/graphics/coords.cpp
@@ -400,22 +400,18 @@ static void TransformedWithMatrix(wxDC& dc)
         dc.SetTransformMatrix(m);
 
         // First convert from device to logical coordinates
-        // Results should be nagative because legacy functions
-        // don't take affine transformation into account.
         m.Invert();
         wxPoint2DDouble posLogRef = m.TransformPoint(wxPoint2DDouble(s_posDev));
         wxPoint posLog;
         posLog.x = dc.DeviceToLogicalX(s_posDev.x);
         posLog.y = dc.DeviceToLogicalY(s_posDev.y);
-        CHECK_FALSE(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
-        CHECK(posLog == s_posDev);
+        CHECK(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
 
         wxPoint2DDouble dimLogRef = m.TransformDistance(wxPoint2DDouble(s_dimDev.x, s_dimDev.y));
         wxSize dimLog;
         dimLog.x = dc.DeviceToLogicalXRel(s_dimDev.x);
         dimLog.y = dc.DeviceToLogicalYRel(s_dimDev.y);
-        CHECK_FALSE(dimLog == wxSize(wxRound(dimLogRef.m_x), wxRound(dimLogRef.m_y)));
-        CHECK(dimLog == s_dimDev);
+        CHECK(dimLog == wxSize(wxRound(dimLogRef.m_x), wxRound(dimLogRef.m_y)));
 
         // And next back from logical to device coordinates
         wxPoint posDev;
@@ -485,8 +481,6 @@ static void TransformedWithMatrixAndStd(wxDC& dc)
         dc.SetTransformMatrix(m);
 
         // First convert from device to logical coordinates
-        // Results should be nagative because legacy functions
-        // don't take affine transformation into account.
         wxAffineMatrix2D m1;
         m1.Translate(10 - (-15) * (0.5 * 4.0), 15 - (-20) * (1.5 * 2.0));
         m1.Scale(0.5 * 4.0, 1.5 * 2.0);
@@ -497,13 +491,13 @@ static void TransformedWithMatrixAndStd(wxDC& dc)
         wxPoint posLog;
         posLog.x = dc.DeviceToLogicalX(s_posDev.x);
         posLog.y = dc.DeviceToLogicalY(s_posDev.y);
-        CHECK_FALSE(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
+        CHECK(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
 
         wxPoint2DDouble dimLogRef = m1.TransformDistance(wxPoint2DDouble(s_dimDev.x, s_dimDev.y));
         wxSize dimLog;
         dimLog.x = dc.DeviceToLogicalXRel(s_dimDev.x);
         dimLog.y = dc.DeviceToLogicalYRel(s_dimDev.y);
-        CHECK_FALSE(dimLog == wxSize(wxRound(dimLogRef.m_x), wxRound(dimLogRef.m_y)));
+        CHECK(dimLog == wxSize(wxRound(dimLogRef.m_x), wxRound(dimLogRef.m_y)));
 
         // And next back from logical to device coordinates
         wxPoint posDev;
@@ -590,70 +584,26 @@ static void RotatedWithMatrix(wxDC& dc)
         m.Scale(2.0, 3.0);
         dc.SetTransformMatrix(m);
 
-        // First convert from device to logical coordinates
-        // Results should be nagative because legacy functions
-        // don't take affine transformation into account.
+        // First convert from device to logical coordinates.
+        //
+        // Note that we must use DeviceToLogical() and not individual
+        // DeviceToLogical{X,Y}() here because the latter can't take rotation
+        // into account and thus won't return correct results.
         m.Invert();
         wxPoint2DDouble posLogRef = m.TransformPoint(wxPoint2DDouble(s_posDev));
-        wxPoint posLog;
-        posLog.x = dc.DeviceToLogicalX(s_posDev.x);
-        posLog.y = dc.DeviceToLogicalY(s_posDev.y);
-        CHECK_FALSE(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
-        CHECK(posLog == s_posDev);
+        wxPoint posLog = dc.DeviceToLogical(s_posDev);
+        CHECK(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
 
         wxPoint2DDouble dimLogRef = m.TransformDistance(wxPoint2DDouble(s_dimDev.x, s_dimDev.y));
-        wxSize dimLog;
-        dimLog.x = dc.DeviceToLogicalXRel(s_dimDev.x);
-        dimLog.y = dc.DeviceToLogicalYRel(s_dimDev.y);
-        CHECK_FALSE(dimLog == wxSize(wxRound(dimLogRef.m_x), wxRound(dimLogRef.m_y)));
-        CHECK(dimLog == s_dimDev);
-
-        // And next back from logical to device coordinates
-        wxPoint posDev;
-        posDev.x = dc.LogicalToDeviceX(posLog.x);
-        posDev.y = dc.LogicalToDeviceY(posLog.y);
-        CHECK(posDev == s_posDev);
-
-        wxSize dimDev;
-        dimDev.x = dc.LogicalToDeviceXRel(dimLog.x);
-        dimDev.y = dc.LogicalToDeviceYRel(dimLog.y);
-        CHECK(dimDev == s_dimDev);
-    }
-#endif // wxUSE_DC_TRANSFORM_MATRIX
-}
-
-static void RotatedWithMatrixEx(wxDC& dc)
-{
-    // Apply matrix transformations with rotation component
-#if wxUSE_DC_TRANSFORM_MATRIX
-    if ( dc.CanUseTransformMatrix() )
-    {
-        wxAffineMatrix2D m = dc.GetTransformMatrix();
-        m.Rotate(6 * M_PI / 180.0);
-        m.Translate(10, 15);
-        m.Scale(2.0, 3.0);
-        dc.SetTransformMatrix(m);
-
-        // First convert from device to logical coordinates
-        m.Invert();
-        wxPoint2DDouble posLogRef = m.TransformPoint(wxPoint2DDouble(s_posDev));
-        wxPoint posLog;
-        posLog = dc.DeviceToLogical(s_posDev);
-        CHECK(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)) );
-
-        wxPoint2DDouble dimLogRef = m.TransformDistance(wxPoint2DDouble(s_dimDev.x, s_dimDev.y));
-        wxSize dimLog;
-        dimLog = dc.DeviceToLogicalRel(s_dimDev);
+        wxSize dimLog = dc.DeviceToLogicalRel(s_dimDev);
         CHECK(dimLog == wxSize(wxRound(dimLogRef.m_x), wxRound(dimLogRef.m_y)));
 
         // And next back from logical to device coordinates
-        wxPoint posDev;
-        posDev = dc.LogicalToDevice(posLog);
+        wxPoint posDev = dc.LogicalToDevice(posLog);
         CHECK(Approx(posDev.x).margin(1) == s_posDev.x);
         CHECK(Approx(posDev.y).margin(1) == s_posDev.y);
 
-        wxSize dimDev;
-        dimDev = dc.LogicalToDeviceRel(dimLog);
+        wxSize dimDev = dc.LogicalToDeviceRel(dimLog);
         CHECK(Approx(dimDev.x).margin(1) == s_dimDev.x);
         CHECK(Approx(dimDev.y).margin(1) == s_dimDev.y);
     }
@@ -769,12 +719,6 @@ TEST_CASE("CoordinatesTestCase::wxDC", "[coordinates][dc]")
         // Apply matrix transformations with rotation component
         RotatedWithMatrix(dc);
     }
-
-    SECTION("RotatedWithMatrixEx")
-    {
-        // Apply matrix transformations with rotation component
-        RotatedWithMatrixEx(dc);
-    }
 }
 
 #if wxUSE_GRAPHICS_CONTEXT
@@ -889,12 +833,6 @@ TEST_CASE("CoordinatesTestCase::wxGCDC", "[coordinates][dc][gcdc]")
     {
         // Apply matrix transformations with rotation component
         RotatedWithMatrix(dc);
-    }
-
-    SECTION("RotatedWithMatrixEx")
-    {
-        // Apply matrix transformations with rotation component
-        RotatedWithMatrixEx(dc);
     }
 }
 
@@ -1017,12 +955,6 @@ TEST_CASE("CoordinatesTestCase::wxGCDC(GDI+)", "[coordinates][dc][gcdc][gdiplus]
         // Apply matrix transformations with rotation component
         RotatedWithMatrix(dc);
     }
-
-    SECTION("RotatedWithMatrixEx")
-    {
-        // Apply matrix transformations with rotation component
-        RotatedWithMatrixEx(dc);
-    }
 }
 #endif // wxUSE_GRAPHICS_GDIPLUS
 
@@ -1143,12 +1075,6 @@ TEST_CASE("CoordinatesTestCase::wxGCDC(Direct2D)", "[coordinates][dc][gcdc][dire
     {
         // Apply matrix transformations with rotation component
         RotatedWithMatrix(dc);
-    }
-
-    SECTION("RotatedWithMatrixEx")
-    {
-        // Apply matrix transformations with rotation component
-        RotatedWithMatrixEx(dc);
     }
 }
 #endif // wxUSE_GRAPHICS_DIRECT2D
@@ -1275,12 +1201,6 @@ TEST_CASE("CoordinatesTestCase::wxGCDC(Cairo)", "[coordinates][dc][gcdc][cairo]"
     {
         // Apply matrix transformations with rotation component
         RotatedWithMatrix(dc);
-    }
-
-    SECTION("RotatedWithMatrixEx")
-    {
-        // Apply matrix transformations with rotation component
-        RotatedWithMatrixEx(dc);
     }
 }
 #endif // wxUSE_CAIRO

--- a/tests/graphics/coords.cpp
+++ b/tests/graphics/coords.cpp
@@ -463,6 +463,44 @@ static void TransformedWithMatrixEx(wxDC& dc)
 #endif // wxUSE_DC_TRANSFORM_MATRIX
 }
 
+static void
+ApplyWineWorkaround(wxPoint& posLog, const wxPoint2DDouble& posLogRef)
+{
+    if ( !wxIsRunningUnderWine() )
+        return;
+
+    static class WorkaroundWasUsed
+    {
+    public:
+        WorkaroundWasUsed() = default;
+
+        ~WorkaroundWasUsed()
+        {
+            if ( !m_wasUsed )
+                WARN("Wine workaround is not needed any longer");
+        }
+
+        void Apply(wxPoint& posLog, const wxPoint2DDouble& posLogRef)
+        {
+            // Current versions of Wine seem to have a bug and return a value
+            // which is one off from DPtoLP() used by wxDC::DeviceToLogical()
+            // and there doesn't seem to be anything we can do about it, so
+            // just tweak the result to pass this test.
+            if ( posLog.x == posLogRef.m_x + 1 )
+            {
+                posLog.x--;
+
+                m_wasUsed = true;
+            }
+        }
+
+    private:
+        bool m_wasUsed = false;
+    } s_workaroundWasUsed;
+
+    s_workaroundWasUsed.Apply(posLog, posLogRef);
+}
+
 static void TransformedWithMatrixAndStd(wxDC& dc)
 {
     // Apply combination of standard and matrix transformations
@@ -491,6 +529,8 @@ static void TransformedWithMatrixAndStd(wxDC& dc)
         wxPoint posLog;
         posLog.x = dc.DeviceToLogicalX(s_posDev.x);
         posLog.y = dc.DeviceToLogicalY(s_posDev.y);
+
+        ApplyWineWorkaround(posLog, posLogRef);
         CHECK(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
 
         wxPoint2DDouble dimLogRef = m1.TransformDistance(wxPoint2DDouble(s_dimDev.x, s_dimDev.y));
@@ -541,18 +581,7 @@ static void TransformedWithMatrixAndStdEx(wxDC& dc)
         wxPoint posLog;
         posLog = dc.DeviceToLogical(s_posDev);
 
-        if ( wxIsRunningUnderWine() )
-        {
-            // Current versions of Wine seem to have a bug and return a value
-            // which is one off from DPtoLP() used by wxDC::DeviceToLogical()
-            // and there doesn't seem to be anything we can do about it, so
-            // just tweak the result to pass this test.
-            if ( posLog.x == posLogRef.m_x + 1 )
-                posLog.x--;
-            else
-                WARN("Wine workaround might be not needed any longer");
-        }
-
+        ApplyWineWorkaround(posLog, posLogRef);
         CHECK(posLog == wxPoint(wxRound(posLogRef.m_x), wxRound(posLogRef.m_y)));
 
         wxPoint2DDouble dimLogRef = m1.TransformDistance(wxPoint2DDouble(s_dimDev.x, s_dimDev.y));


### PR DESCRIPTION
This wasn't the case before, resulting in confusing bugs such as #26266.

Also clean up the code by removing unnecessary macros/functions.