### PR TITLE
Add Save function to wxSVGFileDC

### DIFF
--- a/include/wx/dcsvg.h
+++ b/include/wx/dcsvg.h
@@ -146,6 +146,8 @@ public:
 
     wxString GetSVGDocument() const;
 
+    bool Save();
+
 private:
     virtual bool DoGetPixel(wxCoord WXUNUSED(x), wxCoord WXUNUSED(y),
                             wxColour* WXUNUSED(col)) const override
@@ -273,6 +275,7 @@ private:
 
     wxString            m_filename;
     bool                m_writeError;
+    bool                m_saved;
     bool                m_graphics_changed;  // set by Set{Brush,Pen}()
     int                 m_width, m_height;
     double              m_dpi;
@@ -325,6 +328,8 @@ public:
 
     // Return the SVG document as a string.
     wxString GetSVGDocument() const;
+
+    bool Save();
 
 private:
     wxDECLARE_ABSTRACT_CLASS(wxSVGFileDC);

--- a/interface/wx/dcsvg.h
+++ b/interface/wx/dcsvg.h
@@ -137,6 +137,20 @@ public:
     wxString GetSVGDocument() const;
 
     /**
+        Saves the SVG document to the file specified in the constructor.
+
+        This is called automatically by the destructor if a filename was
+        provided, but calling it explicitly allows checking for errors.
+        Does nothing if no filename was provided or if the file has already
+        been saved.
+
+        @return @true if the file was written successfully, @false otherwise.
+
+        @since 3.3.3
+    */
+    bool Save();
+
+    /**
         Destroys the current clipping region so that none of the DC is clipped.
         Since intersections arising from sequential calls to SetClippingRegion are represented
         with nested SVG group elements (\<g\>), all such groups are closed when

--- a/interface/wx/dcsvg.h
+++ b/interface/wx/dcsvg.h
@@ -35,9 +35,9 @@ constexpr double wxSVG_DEFAULT_DPI = 72.0;
     A wxSVGFileDC is a device context onto which graphics and text can be
     drawn, and the output produced as a vector file, in SVG format.
 
-    This format can be read by a range of programs, including a Netscape plugin
-    (Adobe) and the open source Inkscape program (http://inkscape.org/).  Full
-    details are given in the W3C SVG recommendation (http://www.w3.org/TR/SVG/).
+    This format can be read by a range of programs, including most web
+    browsers and the open source Inkscape program (http://inkscape.org/).
+    Full details are given in the W3C SVG recommendation (http://www.w3.org/TR/SVG/).
 
     The intention behind wxSVGFileDC is that it can be used to produce a file
     corresponding to the screen display context, wxSVGFileDC, by passing the

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -602,7 +602,7 @@ bool wxSVGFileDCImpl::Save()
 
     wxFile file(m_filename, wxFile::write);
     if ( file.IsOpened() )
-        m_saved = file.Write(GetSVGDocument(), wxConvUTF8);
+        m_saved = file.Write(GetSVGDocument(), wxConvUTF8) && file.Close();
 
     if ( !m_saved )
         m_writeError = true;

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -137,9 +137,6 @@ wxString GetBrushFill(const wxColour& c, int style = wxBRUSHSTYLE_SOLID)
 
 wxString GetPenPattern(const wxPen& pen)
 {
-    if ( !pen.IsOk() )
-        return wxString();
-
     wxString s;
 
     // The length of the dashes and gaps have a constant factor.
@@ -242,9 +239,6 @@ wxString GetPenStyle(const wxPen& pen)
 
 wxString GetBrushStyleName(const wxBrush& brush)
 {
-    if ( !brush.IsOk() )
-        return wxString();
-
     wxString brushStyle;
 
     switch (brush.GetStyle())
@@ -287,9 +281,6 @@ wxString GetBrushStyleName(const wxBrush& brush)
 
 wxString GetBrushPattern(const wxBrush& brush)
 {
-    if ( !brush.IsOk() )
-        return wxString();
-
     wxString s;
     wxString brushStyle = GetBrushStyleName(brush);
 
@@ -1410,13 +1401,10 @@ void wxSVGFileDCImpl::DoStartNewGraphics()
 {
     wxString s;
 
-    const wxPen& pen = m_pen.IsOk() ? m_pen : *wxTRANSPARENT_PEN;
-    const wxBrush& brush = m_brush.IsOk() ? m_brush : *wxTRANSPARENT_BRUSH;
-
     s = wxString::Format(wxS("<g %s %s %s transform=\"translate(%d %d) scale(%s %s)\">\n"),
-        GetPenStyle(pen),
-        GetBrushFill(brush.GetColour(), brush.GetStyle()),
-        GetPenStroke(pen.GetColour(), pen.GetStyle()),
+        GetPenStyle(m_pen),
+        GetBrushFill(m_brush.GetColour(), m_brush.GetStyle()),
+        GetPenStroke(m_pen.GetColour(), m_pen.GetStyle()),
         (m_deviceOriginX - m_logicalOriginX) * m_signX,
         (m_deviceOriginY - m_logicalOriginY) * m_signY,
         NumStr(m_scaleX * m_signX),

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -516,6 +516,11 @@ wxString wxSVGFileDC::GetSVGDocument() const
     return ((wxSVGFileDCImpl*)GetImpl())->GetSVGDocument();
 }
 
+bool wxSVGFileDC::Save()
+{
+    return ((wxSVGFileDCImpl*)GetImpl())->Save();
+}
+
 // ----------------------------------------------------------
 // wxSVGFileDCImpl
 // ----------------------------------------------------------
@@ -538,6 +543,7 @@ void wxSVGFileDCImpl::Init(const wxString& filename, int width, int height,
     m_dpi = dpi;
 
     m_writeError = false;
+    m_saved = false;
 
     m_clipUniqueId = 0;
     m_clipNestingLevel = 0;
@@ -589,14 +595,24 @@ wxString wxSVGFileDCImpl::GetSVGDocument() const
     return doc;
 }
 
+bool wxSVGFileDCImpl::Save()
+{
+    if ( m_saved || m_filename.empty() )
+        return m_saved;
+
+    wxFile file(m_filename, wxFile::write);
+    if ( file.IsOpened() )
+        m_saved = file.Write(GetSVGDocument(), wxConvUTF8);
+
+    if ( !m_saved )
+        m_writeError = true;
+
+    return m_saved;
+}
+
 wxSVGFileDCImpl::~wxSVGFileDCImpl()
 {
-    if ( !m_filename.empty() )
-    {
-        wxFile file(m_filename, wxFile::write);
-        if ( file.IsOpened() )
-            file.Write(GetSVGDocument(), wxConvUTF8);
-    }
+    Save();
 }
 
 void wxSVGFileDCImpl::DoGetSizeMM(int* width, int* height) const

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -137,6 +137,9 @@ wxString GetBrushFill(const wxColour& c, int style = wxBRUSHSTYLE_SOLID)
 
 wxString GetPenPattern(const wxPen& pen)
 {
+    if ( !pen.IsOk() )
+        return wxString();
+
     wxString s;
 
     // The length of the dashes and gaps have a constant factor.
@@ -239,6 +242,9 @@ wxString GetPenStyle(const wxPen& pen)
 
 wxString GetBrushStyleName(const wxBrush& brush)
 {
+    if ( !brush.IsOk() )
+        return wxString();
+
     wxString brushStyle;
 
     switch (brush.GetStyle())
@@ -281,6 +287,9 @@ wxString GetBrushStyleName(const wxBrush& brush)
 
 wxString GetBrushPattern(const wxBrush& brush)
 {
+    if ( !brush.IsOk() )
+        return wxString();
+
     wxString s;
     wxString brushStyle = GetBrushStyleName(brush);
 
@@ -1385,10 +1394,13 @@ void wxSVGFileDCImpl::DoStartNewGraphics()
 {
     wxString s;
 
+    const wxPen& pen = m_pen.IsOk() ? m_pen : *wxTRANSPARENT_PEN;
+    const wxBrush& brush = m_brush.IsOk() ? m_brush : *wxTRANSPARENT_BRUSH;
+
     s = wxString::Format(wxS("<g %s %s %s transform=\"translate(%d %d) scale(%s %s)\">\n"),
-        GetPenStyle(m_pen),
-        GetBrushFill(m_brush.GetColour(), m_brush.GetStyle()),
-        GetPenStroke(m_pen.GetColour(), m_pen.GetStyle()),
+        GetPenStyle(pen),
+        GetBrushFill(brush.GetColour(), brush.GetStyle()),
+        GetPenStroke(pen.GetColour(), pen.GetStyle()),
         (m_deviceOriginX - m_logicalOriginX) * m_signX,
         (m_deviceOriginY - m_logicalOriginY) * m_signY,
         NumStr(m_scaleX * m_signX),


### PR DESCRIPTION
Also, add validity checks for pens and brushes, update docs.

I have it so that once you call `Save`, the DTOR will skip calling it. I'm torn on that design choice, so let me know if you disagree.