### PR TITLE
Don't impose arbitrary maximum length on picker controls text

### DIFF
--- a/src/common/filepickercmn.cpp
+++ b/src/common/filepickercmn.cpp
@@ -86,10 +86,6 @@ bool wxFileDirPickerCtrlBase::CreateBase(wxWindow *parent,
 
     DoConnect( m_picker, this );
 
-    // default's wxPickerBase textctrl limit is too small for this control:
-    // make it bigger
-    if (m_text) m_text->SetMaxLength(512);
-
     return true;
 }
 

--- a/src/common/pickerbase.cpp
+++ b/src/common/pickerbase.cpp
@@ -77,13 +77,6 @@ bool wxPickerBase::CreateBase(wxWindow *parent,
             return false;
         }
 
-        // set the maximum length allowed for this textctrl.
-        // This is very important since any change to it will trigger an update in
-        // the m_picker; for very long strings, this real-time synchronization could
-        // become a CPU-blocker and thus should be avoided.
-        // 32 characters will be more than enough for all common uses.
-        m_text->SetMaxLength(32);
-
         // set the initial contents of the textctrl
         m_text->SetValue(text);
 


### PR DESCRIPTION
This code was there ever since ec376c8fd9 (added
wx{Colour|File|Dir|Font}PickerCtrl (patch 1472329 by Francesco), 2006-05-31), but didn't make any sense because it should be possible to enter arbitrarily long strings in these controls.

Additionally, the maximum length was increased for wxFilePickerCtrl after creation which meant that that its initial contents was not shown in it, but the same string could be shown later, which was even more confusing.

Just stop imposing any length constraints.

See #7863.

Closes #26314.