### PR TITLE
Fix crash when using EGL-based `wxGLCanvas` in a `wxNotebook`

### DIFF
--- a/include/wx/gtk/glcanvas.h
+++ b/include/wx/gtk/glcanvas.h
@@ -68,6 +68,7 @@ public:
 
     // implementation from now on
     virtual void GTKHandleRealized() override;
+    virtual void GTKHandleUnrealized() override;
 
 #ifdef __WXGTK3__
     wxSize m_size;

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -203,10 +203,11 @@ public:
     void GTKHandleFocusOutNoDeferring();
     void GTKHandleDeferredFocusOut();
 
-    // Called when m_widget becomes realized. Derived classes must call the
-    // base class method if they override it.
+    // Called when m_widget becomes realized or unrealized (may be called
+    // multiple times). Derived classes must call the base class version if
+    // they override these functions.
     virtual void GTKHandleRealized();
-    void GTKHandleUnrealize();
+    virtual void GTKHandleUnrealize();
 
     // Apply the widget style to the given window. Should normally only be
     // called from the overridden DoApplyWidgetStyle() implementation in

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -207,7 +207,7 @@ public:
     // multiple times). Derived classes must call the base class version if
     // they override these functions.
     virtual void GTKHandleRealized();
-    virtual void GTKHandleUnrealize();
+    virtual void GTKHandleUnrealized();
 
     // Apply the widget style to the given window. Should normally only be
     // called from the overridden DoApplyWidgetStyle() implementation in

--- a/include/wx/unix/glcanvas.h
+++ b/include/wx/unix/glcanvas.h
@@ -92,8 +92,9 @@ protected:
 
     bool InitVisual(const wxGLAttributes& dispAttrs);
 
-    // This is only called by wxGTK but defined in any case.
+    // These functions are currently only called by wxGTK but always defined.
     void CallOnRealized();
+    void CallOnUnrealized();
 
 private:
     std::unique_ptr<wxGLCanvasUnixImpl> m_impl;

--- a/include/wx/unix/private/glcanvas.h
+++ b/include/wx/unix/private/glcanvas.h
@@ -75,6 +75,8 @@ public:
 
     virtual void OnRealized() = 0;
 
+    virtual void OnUnrealized() = 0;
+
     virtual bool HasWindow() const = 0;
 
     virtual void* GetXVisualInfo() const = 0;

--- a/include/wx/unix/private/glegl.h
+++ b/include/wx/unix/private/glegl.h
@@ -63,6 +63,7 @@ public:
     virtual int GetSwapInterval() const override;
 
     virtual void OnRealized() override;
+    virtual void OnUnrealized() override;
 
     virtual bool HasWindow() const override;
 

--- a/include/wx/unix/private/glx11.h
+++ b/include/wx/unix/private/glx11.h
@@ -51,6 +51,7 @@ public:
     virtual int GetSwapInterval() const override;
 
     virtual void OnRealized() override { /* nothing to do here for GLX */ }
+    virtual void OnUnrealized() override { /* nothing to do here for GLX */ }
 
     virtual bool HasWindow() const override;
 

--- a/src/gtk/glcanvas.cpp
+++ b/src/gtk/glcanvas.cpp
@@ -227,4 +227,11 @@ void wxGLCanvas::GTKHandleRealized()
     SendSizeEvent();
 }
 
+void wxGLCanvas::GTKHandleUnrealized()
+{
+    CallOnUnrealized();
+
+    wxGLCanvasUnix::GTKHandleUnrealized();
+}
+
 #endif // wxUSE_GLCANVAS

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2650,7 +2650,7 @@ gtk_window_grab_broken( GtkWidget*,
 // "unrealize"
 //-----------------------------------------------------------------------------
 
-static void unrealize(GtkWidget*, wxWindow* win)
+static void gtk_window_unrealized_callback(GtkWidget*, wxWindow* win)
 {
     win->GTKHandleUnrealize();
 }
@@ -3259,7 +3259,8 @@ void wxWindowGTK::PostCreation()
     // must be notified when the widget is re-realized again.
     g_signal_connect (connect_widget, "realize",
                       G_CALLBACK (gtk_window_realized_callback), this);
-    g_signal_connect(connect_widget, "unrealize", G_CALLBACK(unrealize), this);
+    g_signal_connect(connect_widget, "unrealize",
+                      G_CALLBACK(gtk_window_unrealized_callback), this);
 
     if (!IsTopLevel())
     {

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -3253,11 +3253,12 @@ void wxWindowGTK::PostCreation()
     {
         GTKHandleRealized();
     }
-    else
-    {
-        g_signal_connect (connect_widget, "realize",
-                          G_CALLBACK (gtk_window_realized_callback), this);
-    }
+
+    // Note that we connect to "realize" even if the widget is already realized
+    // because we might be unrealized later and then realized again, and we
+    // must be notified when the widget is re-realized again.
+    g_signal_connect (connect_widget, "realize",
+                      G_CALLBACK (gtk_window_realized_callback), this);
     g_signal_connect(connect_widget, "unrealize", G_CALLBACK(unrealize), this);
 
     if (!IsTopLevel())

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2652,7 +2652,7 @@ gtk_window_grab_broken( GtkWidget*,
 
 static void gtk_window_unrealized_callback(GtkWidget*, wxWindow* win)
 {
-    win->GTKHandleUnrealize();
+    win->GTKHandleUnrealized();
 }
 
 #if GTK_CHECK_VERSION(3,8,0)
@@ -2758,7 +2758,7 @@ void wxWindowGTK::GTKHandleRealized()
     WXUpdateCursor();
 }
 
-void wxWindowGTK::GTKHandleUnrealize()
+void wxWindowGTK::GTKHandleUnrealized()
 {
     m_isGtkPositionValid = false;
 

--- a/src/unix/glcanvas.cpp
+++ b/src/unix/glcanvas.cpp
@@ -318,6 +318,11 @@ void wxGLCanvasUnix::CallOnRealized()
     m_impl->OnRealized();
 }
 
+void wxGLCanvasUnix::CallOnUnrealized()
+{
+    m_impl->OnUnrealized();
+}
+
 /* static */
 void wxGLCanvasUnix::PreferGLX()
 {

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -683,6 +683,25 @@ void wxGLCanvasEGL::OnRealized()
     }
 }
 
+void wxGLCanvasEGL::OnUnrealized()
+{
+    // We would destroy the surface anyhow either in OnRealized() or in the
+    // dtor, but do it here as well just to free it sooner, in case the window
+    // remains unrealized for some time.
+    //
+    // Do it only for X11 as we don't recreate the surface under Wayland.
+#ifdef GDK_WINDOWING_X11
+    if ( m_canvas && wxGTKImpl::IsX11(m_canvas->GTKGetDrawingWindow()) )
+    {
+        if ( m_surface != EGL_NO_SURFACE )
+        {
+            eglDestroySurface(m_display, m_surface);
+            m_surface = EGL_NO_SURFACE;
+        }
+    }
+#endif // GDK_WINDOWING_X11
+}
+
 wxGLCanvasEGL::~wxGLCanvasEGL()
 {
 #ifdef GDK_WINDOWING_WAYLAND


### PR DESCRIPTION
And some more tidying up.