### PR TITLE
wxOSX Cache Alignment Rect Insets

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -268,6 +268,11 @@ protected:
     // events, don't resend them
     bool m_hasEditor;
 
+    mutable int m_insetLeft;
+    mutable int m_insetRight;
+    mutable int m_insetTop;
+    mutable int m_insetBottom;
+
     friend class wxWidgetCocoaNativeKeyDownSuspender;
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxWidgetCocoaImpl);

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -113,7 +113,10 @@ public :
     virtual void        GetPosition( int &x, int &y ) const override;
     virtual void        GetSize( int &width, int &height ) const override;
     virtual void        SetControlSize( wxWindowVariant variant ) override;
+
     virtual void        GetLayoutInset(int &left , int &top , int &right, int &bottom) const override;
+    virtual void        InvalidateLayoutInset() const override;
+
     virtual void        SetNeedsDisplay( const wxRect* where = nullptr ) override;
     virtual bool        GetNeedsDisplay() const override;
 

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -312,6 +312,8 @@ public :
         left = top = right = bottom = 0;
     }
 
+    virtual void        InvalidateLayoutInset() const {}
+
     // native view coordinates are topleft to bottom right (flipped regarding CoreGraphics origin)
     virtual bool        IsFlipped() const { return true; }
 

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -23,6 +23,13 @@ class WXDLLIMPEXP_FWD_CORE wxNonOwnedWindow;
     typedef wxWidgetImpl wxOSXWidgetImpl;
 #endif
 
+struct wxMacBorderSize
+{
+    long left;
+    long top;
+    long right;
+    long bottom;
+};
 
 class WXDLLIMPEXP_CORE wxWindowMac: public wxWindowBase
 {
@@ -189,10 +196,13 @@ public:
     wxNonOwnedWindow*   MacGetTopLevelWindow() const ;
 
     virtual long        MacGetWXBorderSize() const;
-    virtual long        MacGetLeftBorderSize() const ;
-    virtual long        MacGetRightBorderSize() const ;
-    virtual long        MacGetTopBorderSize() const ;
-    virtual long        MacGetBottomBorderSize() const ;
+
+    // Border adjusted for inset/"aura", if any.
+    virtual wxMacBorderSize MacGetBorderSize() const;
+    virtual long            MacGetLeftBorderSize() const;
+    virtual long            MacGetRightBorderSize() const;
+    virtual long            MacGetTopBorderSize() const;
+    virtual long            MacGetBottomBorderSize() const;
 
     virtual void        MacSuperChangedPosition() ;
 
@@ -329,9 +339,6 @@ protected:
     mutable wxRegion    m_cachedClippedRegion ;
     mutable wxRegion    m_cachedClippedClientRegion ;
 
-    // insets of the mac control from the wx top left corner
-    wxPoint             m_macTopLeftInset ;
-    wxPoint             m_macBottomRightInset ;
     wxByte              m_macAlpha ;
 
     wxScrollBar*        m_hScrollBar ;

--- a/src/osx/carbon/dcclient.cpp
+++ b/src/osx/carbon/dcclient.cpp
@@ -54,12 +54,14 @@ wxWindowDCImpl::wxWindowDCImpl( wxDC *owner, wxWindow *window )
 
     CGContextRef cg = (CGContextRef) window->MacGetCGContextRef();
 
+    auto macBorder{window->MacGetBorderSize()};
+
     m_release = false;
     if ( cg == nullptr )
     {
         SetGraphicsContext( wxGraphicsContext::Create( window ) ) ;
         m_contentScaleFactor = window->GetContentScaleFactor();
-        SetDeviceOrigin(-window->MacGetLeftBorderSize() , -window->MacGetTopBorderSize());
+        SetDeviceOrigin(-macBorder.left, -macBorder.top);
     }
     else
     {
@@ -71,10 +73,12 @@ wxWindowDCImpl::wxWindowDCImpl( wxDC *owner, wxWindow *window )
 
         CGContextSaveGState( cg );
         m_release = true ;
-        // make sure the context is having its origin at the wx-window coordinates of the
-        // view (read at the top of window.cpp about the differences)
-        if ( window->MacGetLeftBorderSize() != 0 || window->MacGetTopBorderSize() != 0 )
-            CGContextTranslateCTM( cg , -window->MacGetLeftBorderSize() , -window->MacGetTopBorderSize() );
+
+        // make sure the context is having its origin at the wx-window
+        // coordinates of the view (read at the top of window.cpp about the
+        // differences)
+        if ( macBorder.left != 0 || macBorder.top != 0 )
+            CGContextTranslateCTM( cg, -macBorder.left, -macBorder.top );
 
         wxWidgetImpl *impl = (wxWidgetImpl *) window->GetPeer();
         wxPoint origin( impl->GetDeviceLocalOrigin() );

--- a/src/osx/cocoa/anybutton.mm
+++ b/src/osx/cocoa/anybutton.mm
@@ -28,11 +28,11 @@ wxSize wxAnyButton::DoGetBestSize() const
     wxRect r ;
     GetPeer()->GetBestRect(&r);
 
+    auto macBorder{MacGetBorderSize()};
+
     wxSize sz = r.GetSize();
-    sz.x  = sz.x  + MacGetLeftBorderSize() +
-    MacGetRightBorderSize();
-    sz.y = sz.y + MacGetTopBorderSize() +
-    MacGetBottomBorderSize();
+    sz.x  = sz.x + macBorder.left + macBorder.right;
+    sz.y = sz.y + macBorder.top + macBorder.bottom;
 
     const int wBtnStd = GetDefaultSize().x;
 

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3878,6 +3878,9 @@ void wxWidgetCocoaImpl::SetControlSize( wxWindowVariant variant )
                 [cell setControlSize:size];
         }
     }
+
+    // In case changing the size also affects the insets.
+    InvalidateLayoutInset();
 }
 
 NSView* wxWidgetCocoaImpl::GetViewWithText() const

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3312,6 +3312,11 @@ void wxWidgetCocoaImpl::GetLayoutInset(int &left , int &top , int &right, int &b
     bottom = m_insetBottom;
 }
 
+void wxWidgetCocoaImpl::InvalidateLayoutInset() const {
+    // GetLayoutInset() above only checks `m_insetLeft` for caching.
+    m_insetLeft = -1;
+}
+
 namespace
 {
 

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2726,6 +2726,11 @@ wxWidgetImpl( peer, flags )
     m_osxView = w;
     m_osxClipView = nil;
 
+    m_insetLeft     = -1;
+    m_insetRight    = -1;
+    m_insetTop      = -1;
+    m_insetBottom   = -1;
+
     // check if the user wants to create the control initially hidden
     if ( !peer->IsShown() )
         SetVisibility(false);
@@ -3288,11 +3293,21 @@ void wxWidgetCocoaImpl::GetContentArea( int&left, int &top, int &width, int &hei
 
 void wxWidgetCocoaImpl::GetLayoutInset(int &left , int &top , int &right, int &bottom) const
 {
-    NSEdgeInsets insets = [m_osxView alignmentRectInsets];
-    left = insets.left;
-    top = insets.top;
-    right = insets.right;
-    bottom = insets.bottom;
+    if (m_insetLeft == -1)
+    {
+        // It's not entirely clear if/when this needs to be invalidated.
+        // For most (all?) normal controls/views, this is effectively static.
+        NSEdgeInsets insets = [m_osxView alignmentRectInsets];
+        m_insetLeft     = insets.left;
+        m_insetRight    = insets.right;
+        m_insetTop      = insets.top;
+        m_insetBottom   = insets.bottom;
+    }
+
+    left = m_insetLeft;
+    top = m_insetTop;
+    right = m_insetRight;
+    bottom = m_insetBottom;
 }
 
 namespace

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2457,10 +2457,12 @@ void wxWidgetCocoaImpl::drawRect(void* rect, WXWidget slf, void *WXUNUSED(_cmd))
 
     wxWindow* wxpeer = GetWXPeer();
 
-    if ( wxpeer->MacGetLeftBorderSize() != 0 || wxpeer->MacGetTopBorderSize() != 0 )
+    auto macBorder{wxpeer->MacGetBorderSize()};
+    if ( macBorder.left != 0 || macBorder.top != 0 )
     {
-        // as this update region is in native window locals we must adapt it to wx window local
-        updateRgn.Offset( wxpeer->MacGetLeftBorderSize() , wxpeer->MacGetTopBorderSize() );
+        // as this update region is in native window locals we must adapt it
+        // to wx window local
+        updateRgn.Offset( macBorder.left , macBorder.top );
     }
 
     // Restrict the update region to the shape of the window, if any, and also

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2271,65 +2271,46 @@ long wxWindowMac::MacGetWXBorderSize() const
     return border ;
 }
 
-long wxWindowMac::MacGetLeftBorderSize() const
+wxMacBorderSize wxWindowMac::MacGetBorderSize() const
 {
     // the wx borders are all symmetric in mac themes
-    long border = MacGetWXBorderSize() ;
+    long borderWX = MacGetWXBorderSize();
+
+    wxMacBorderSize border{
+        .left   = borderWX,
+        .top    = borderWX,
+        .right  = borderWX,
+        .bottom = borderWX,
+    };
 
     if ( GetPeer() )
     {
         int left, top, right, bottom;
         GetPeer()->GetLayoutInset( left, top, right, bottom );
-        border -= left;
+
+        border.left     -= left;
+        border.top      -= top;
+        border.right    -= right;
+        border.bottom   -= bottom;
     }
 
     return border;
 }
 
-
-long wxWindowMac::MacGetRightBorderSize() const
-{
-    // the wx borders are all symmetric in mac themes
-    long border = MacGetWXBorderSize() ;
-
-    if ( GetPeer() )
-    {
-        int left, top, right, bottom;
-        GetPeer()->GetLayoutInset( left, top, right, bottom );
-        border -= right;
-    }
-
-    return border;
+long wxWindowMac::MacGetLeftBorderSize() const {
+    return MacGetBorderSize().left;
 }
 
-long wxWindowMac::MacGetTopBorderSize() const
-{
-    // the wx borders are all symmetric in mac themes
-    long border = MacGetWXBorderSize() ;
-
-    if ( GetPeer() )
-    {
-        int left, top, right, bottom;
-        GetPeer()->GetLayoutInset( left, top, right, bottom );
-        border -= top;
-    }
-
-    return border;
+long wxWindowMac::MacGetRightBorderSize() const {
+    return MacGetBorderSize().right;
 }
 
-long wxWindowMac::MacGetBottomBorderSize() const
-{
-    // the wx borders are all symmetric in mac themes
-    long border = MacGetWXBorderSize() ;
+long wxWindowMac::MacGetTopBorderSize() const {
+    return MacGetBorderSize().top;
+}
 
-    if ( GetPeer() )
-    {
-        int left, top, right, bottom;
-        GetPeer()->GetLayoutInset( left, top, right, bottom );
-        border -= bottom;
-    }
-
-    return border;
+long wxWindowMac::MacGetBottomBorderSize() const {
+    return MacGetBorderSize().bottom;
 }
 
 long wxWindowMac::MacRemoveBordersFromStyle( long style )

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -639,10 +639,11 @@ bool wxWindowMac::MacGetBoundsForControl(
     w = WidthDefault( size.x );
     h = HeightDefault( size.y );
 
-    x += MacGetLeftBorderSize() ;
-    y += MacGetTopBorderSize() ;
-    w -= MacGetLeftBorderSize() + MacGetRightBorderSize() ;
-    h -= MacGetTopBorderSize() + MacGetBottomBorderSize() ;
+    auto macBorder{MacGetBorderSize()};
+    x += macBorder.left;
+    y += macBorder.top;
+    w -= macBorder.left + macBorder.right;
+    h -= macBorder.top + macBorder.bottom;
 
     if ( adjustOrigin )
         AdjustForParentClientOrigin( x , y ) ;
@@ -650,8 +651,9 @@ bool wxWindowMac::MacGetBoundsForControl(
     // this is in window relative coordinate, as this parent may have a border, its physical position is offset by this border
     if ( GetParent() && !GetParent()->IsTopLevel() )
     {
-        x -= GetParent()->MacGetLeftBorderSize() ;
-        y -= GetParent()->MacGetTopBorderSize() ;
+        auto parentMacBorder{GetParent()->MacGetBorderSize()};
+        x -= parentMacBorder.left;
+        y -= parentMacBorder.top;
     }
 
     return true ;
@@ -663,10 +665,12 @@ void wxWindowMac::DoGetSize(int *x, int *y) const
     int width, height;
     GetPeer()->GetSize( width, height );
 
+    auto macBorder{MacGetBorderSize()};
+
     if (x)
-       *x = width + MacGetLeftBorderSize() + MacGetRightBorderSize() ;
+       *x = width + macBorder.left + macBorder.right;
     if (y)
-       *y = height + MacGetTopBorderSize() + MacGetBottomBorderSize() ;
+       *y = height + macBorder.top + macBorder.bottom;
 }
 
 // get the position of the bounds of this window in client coordinates of its parent
@@ -677,8 +681,9 @@ void wxWindowMac::DoGetPosition(int *x, int *y) const
     GetPeer()->GetPosition( x1, y1 ) ;
 
     // get the wx window position from the native one
-    x1 -= MacGetLeftBorderSize() ;
-    y1 -= MacGetTopBorderSize() ;
+    auto macBorder{MacGetBorderSize()};
+    x1 -= macBorder.left;
+    y1 -= macBorder.top;
 
     if ( !IsTopLevel() )
     {
@@ -687,8 +692,9 @@ void wxWindowMac::DoGetPosition(int *x, int *y) const
         {
             // we must first adjust it to be in window coordinates of the parent,
             // as otherwise it gets lost by the ClientAreaOrigin fix
-            x1 += parent->MacGetLeftBorderSize() ;
-            y1 += parent->MacGetTopBorderSize() ;
+            auto parentMacBorder{parent->MacGetBorderSize()};
+            x1 += parentMacBorder.left;
+            y1 += parentMacBorder.top;
 
             // and now to client coordinates
             wxPoint pt(parent->GetClientAreaOrigin());
@@ -757,8 +763,9 @@ void wxWindowMac::MacWindowToRootWindow( int *x , int *y ) const
         wxNonOwnedWindow* top = MacGetTopLevelWindow();
         if (top)
         {
-            pt.x -= MacGetLeftBorderSize() ;
-            pt.y -= MacGetTopBorderSize() ;
+            auto macBorder{MacGetBorderSize()};
+            pt.x -= macBorder.left;
+            pt.y -= macBorder.top;
             wxWidgetImpl::Convert( &pt , GetPeer() , top->GetPeer() ) ;
         }
     }
@@ -784,8 +791,10 @@ void wxWindowMac::MacRootWindowToWindow( int *x , int *y ) const
         if (top)
         {
             wxWidgetImpl::Convert( &pt , top->GetPeer() , GetPeer() ) ;
-            pt.x += MacGetLeftBorderSize() ;
-            pt.y += MacGetTopBorderSize() ;
+
+            auto macBorder{MacGetBorderSize()};
+            pt.x += macBorder.left;
+            pt.y += macBorder.top;
         }
     }
 
@@ -809,8 +818,9 @@ wxSize wxWindowMac::DoGetSizeFromClientSize( const wxSize & size )  const
     sizeTotal.x += outerwidth-innerwidth;
     sizeTotal.y += outerheight-innerheight;
 
-    sizeTotal.x += MacGetLeftBorderSize() + MacGetRightBorderSize() ;
-    sizeTotal.y += MacGetTopBorderSize() + MacGetBottomBorderSize() ;
+    auto macBorder{MacGetBorderSize()};
+    sizeTotal.x += macBorder.left + macBorder.right;
+    sizeTotal.y += macBorder.top + macBorder.bottom;
 
     return sizeTotal;
 }
@@ -991,13 +1001,23 @@ void wxWindowMac::DoMoveWindow(int x, int y, int width, int height)
     {
         // as the borders are drawn outside the native control, we adjust now
 
-        wxRect bounds( wxPoint( actualX + MacGetLeftBorderSize() ,actualY + MacGetTopBorderSize() ),
-            wxSize( actualWidth - (MacGetLeftBorderSize() + MacGetRightBorderSize()) ,
-                actualHeight - (MacGetTopBorderSize() + MacGetBottomBorderSize()) ) ) ;
+        auto macBorder{MacGetBorderSize()};
+
+        wxRect bounds(
+            wxPoint(
+                actualX + macBorder.left,
+                actualY + macBorder.top
+            ),
+            wxSize(
+                actualWidth - (macBorder.left + macBorder.right),
+                actualHeight - (macBorder.top + macBorder.bottom)
+            )
+        );
 
         if ( parent && !parent->IsTopLevel() )
         {
-            bounds.Offset( -parent->MacGetLeftBorderSize(), -parent->MacGetTopBorderSize() );
+            auto parentMacBorder{parent->MacGetBorderSize()};
+            bounds.Offset( -parentMacBorder.left, -parentMacBorder.top );
         }
 
         MacInvalidateBorders() ;
@@ -1058,10 +1078,11 @@ wxSize wxWindowMac::DoGetBestSize() const
             }
         }
 
-        int bestWidth = r.width + MacGetLeftBorderSize() +
-                    MacGetRightBorderSize();
-        int bestHeight = r.height + MacGetTopBorderSize() +
-                     MacGetBottomBorderSize();
+        auto macBorder{MacGetBorderSize()};
+
+        int bestWidth = r.width + macBorder.left + macBorder.right;
+        int bestHeight = r.height + macBorder.top + macBorder.bottom;
+
         if ( bestHeight < 10 )
             bestHeight = 13 ;
 
@@ -1156,7 +1177,10 @@ wxPoint wxWindowMac::GetClientAreaOrigin() const
 {
     int left,top,width,height;
     GetPeer()->GetContentArea( left , top , width , height);
-    return wxPoint( left + MacGetLeftBorderSize() , top + MacGetTopBorderSize() );
+
+    auto macBorder{MacGetBorderSize()};
+
+    return wxPoint( left + macBorder.left , top + macBorder.top );
 }
 
 void wxWindowMac::DoSetClientSize(int clientwidth, int clientheight)
@@ -1706,11 +1730,18 @@ void wxWindowMac::ScrollWindow(int dx, int dy, const wxRect *rect)
     GetClientSize( &width , &height ) ;
 
     {
-        wxRect scrollrect( MacGetLeftBorderSize() , MacGetTopBorderSize() , width , height ) ;
+        auto macBorder{MacGetBorderSize()};
+
+        wxRect scrollrect(
+            macBorder.left, macBorder.top, width, height
+        );
+
         if ( rect )
-            scrollrect.Intersect( *rect ) ;
-        // as the native control might be not a 0/0 wx window coordinates, we have to offset
-        scrollrect.Offset( -MacGetLeftBorderSize() , -MacGetTopBorderSize() ) ;
+            scrollrect.Intersect( *rect );
+
+        // as the native control might be not a 0/0 wx window coordinates, we
+        // have to offset
+        scrollrect.Offset( -macBorder.left , -macBorder.top );
 
         GetPeer()->ScrollRect( &scrollrect, dx, dy );
     }
@@ -2159,8 +2190,9 @@ void wxWindowMac::MacRepositionScrollBars()
         int width, height ;
         GetSize( &width , &height );
 
-        width -= MacGetLeftBorderSize() + MacGetRightBorderSize();
-        height -= MacGetTopBorderSize() + MacGetBottomBorderSize();
+        auto macBorder{MacGetBorderSize()};
+        width -= macBorder.left + macBorder.right;
+        height -= macBorder.top + macBorder.bottom;
 
         wxPoint vPoint( width - scrlsize, 0 ) ;
         wxSize vSize( scrlsize, height - adjust ) ;


### PR DESCRIPTION
Partially addresses #26318

The first commit da08c5761342 is the interesting one. As noted, it's unclear if there's ever a time where the insets would be invalidated and would need to be refetched, but the Apple documentation is sparse on how the usual Auto Layout system would query it. It doesn't seem like something that would ever change, but worth noting.

The second and third commits are related, but I guess it depends on opinions if they should be included or not.

The second commit 25e46b903075 adds `MacGetBorderSize()` following the logic that the `MacGet*Border...` functions are almost never called on their own, and in fact `GetLayoutInset()` always returns all the values, so it's (superficially... it ultimately doesn't matter much for performance and is moreso semantic I guess) "wasteful" in the current setup w/o a way to grab all of the values, as would be more natural given the underlying API.

The third commit 7b2307e2c521 uses the new function where appropriate in wxCocoa code and, IMO, cleans things up a bit.

I've added `wxMacBorderSize` as it doesn't seem like there's an already-existing suitable structure, and 25e46b903075 also removed `m_macTopLeftInset` and `m_macBottomRightInset` from `wxWindowMac` as those are never used, and seem like they were intended to be used to store these inset values. But such storage makes more sense in the Impl class.