### PR TITLE
Change wxSVGFileDC to create unique clip/gradient IDs across multiple outputs

### DIFF
--- a/include/wx/dcsvg.h
+++ b/include/wx/dcsvg.h
@@ -289,10 +289,10 @@ private:
 
     // Unique ID for every clipping graphics group: this is simply always
     // incremented in each SetClippingRegion() call.
-    size_t m_clipUniqueId;
+    static size_t m_clipUniqueId;
 
     // Unique ID for every gradient.
-    size_t m_gradientUniqueId;
+    static size_t m_gradientUniqueId;
 
     wxDECLARE_ABSTRACT_CLASS(wxSVGFileDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxSVGFileDCImpl);

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -519,6 +519,9 @@ bool wxSVGFileDC::Save()
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxSVGFileDCImpl, wxDCImpl);
 
+size_t wxSVGFileDCImpl::m_clipUniqueId = 0;
+size_t wxSVGFileDCImpl::m_gradientUniqueId = 0;
+
 wxSVGFileDCImpl::wxSVGFileDCImpl(wxSVGFileDC* owner, const wxString& filename,
                                  int width, int height, double dpi, const wxString& title)
     : wxDCImpl(owner)
@@ -537,10 +540,7 @@ void wxSVGFileDCImpl::Init(const wxString& filename, int width, int height,
     m_writeError = false;
     m_saved = false;
 
-    m_clipUniqueId = 0;
     m_clipNestingLevel = 0;
-
-    m_gradientUniqueId = 0;
 
     m_mm_to_pix_x = m_dpi / 25.4;
     m_mm_to_pix_y = m_dpi / 25.4;


### PR DESCRIPTION
Instead of resetting IDs to zero with every `wxSVGFileDC` construction, have it remember the IDs that were already used.

This is useful if you need to combine multiple output SVGs. In my situation, I am ouputting many SVGs from different graph renderings, extracting the body from them, and then combining them into a larger SVG report. (Perhaps this is a use case for others as well.) With the current behaviour, the IDs for my clip rects are not always unique, which then causes rendering failures.  This PR fixes this.