### PR TITLE
Add annotations to WinMain() to avoid MSVC analyzer warnings

### DIFF
--- a/include/wx/msw/init.h
+++ b/include/wx/msw/init.h
@@ -46,11 +46,22 @@ extern WXDLLIMPEXP_CORE int
             wxCmdLineArgType pCmdLine = nullptr,
             int nCmdShow = SW_SHOWNORMAL);
 
+#ifdef _In_
+    #define wxIN _In_
+#else
+    #define wxIN
+#endif
+#ifdef _In_opt_
+    #define wxIN_OPT _In_opt_
+#else
+    #define wxIN_OPT
+#endif
+
 #define wxIMPLEMENT_WXWIN_MAIN                                              \
-    extern "C" int WINAPI WinMain(HINSTANCE hInstance,                      \
-                                  HINSTANCE hPrevInstance,                  \
-                                  wxCmdLineArgType lpCmdLine,               \
-                                  int nCmdShow)                             \
+    extern "C" int WINAPI WinMain(wxIN HINSTANCE hInstance,                 \
+                                  wxIN_OPT HINSTANCE hPrevInstance,         \
+                                  wxIN wxCmdLineArgType lpCmdLine,          \
+                                  wxIN int nCmdShow)                        \
     {                                                                       \
         wxDISABLE_DEBUG_SUPPORT();                                          \
                                                                             \


### PR DESCRIPTION
Avoid MSVC code analysis warning

C28251: Inconsistent annotation for 'WinMain': this instance has no annotations.

by providing the same annotations as in the SDK header.

Closes #18529.

Closes #26322.