### PR TITLE
Set wxSlider thumb size to match its initial size in wxMSW

### DIFF
--- a/src/msw/slider.cpp
+++ b/src/msw/slider.cpp
@@ -50,8 +50,10 @@ enum
 // the gaps between the slider and the labels, in pixels
 const int HGAP = 5;
 const int VGAP = 4;
-// this value is arbitrary:
-const int TICK = 8;
+// these values are arbitrary:
+const int THUMB = 20;
+const int THUMB_BORDER = 2;
+const int TICK = 4;
 
 } // anonymous namespace
 
@@ -175,13 +177,31 @@ bool wxSlider::Create(wxWindow *parent,
     SetValue(value);
     SetPageSize( wxMax(1, (maxValue - minValue)/10) );
 
-    // we need to position the labels correctly if we have them and if
-    // SetSize() hadn't been called before (when best size was determined by
-    // MSWCreateControl()) as in this case they haven't been put in place yet
-    if ( m_labels && size.x != wxDefaultCoord && size.y != wxDefaultCoord )
+    int len = 0;
+    if ( size.IsFullySpecified() )
     {
-        SetSize(size);
+        // we need to position the labels correctly if we have them and if
+        // SetSize() hadn't been called before (when best size was determined by
+        // MSWCreateControl()) as in this case they haven't been put in place yet
+        if ( m_labels )
+        {
+            SetSize(size);
+        }
+
+        // And use the thumb length appropriate for the initial size.
+        len = HasFlag(wxSL_VERTICAL) ? size.x : size.y;
+        if ( style & wxSL_TICKS )
+        {
+            len -= TICK;
+            if ( style & wxSL_BOTH )
+                len -= TICK;
+        }
+
+        len -= 2*THUMB_BORDER;
     }
+
+    // Use the length consistent with what our DoGetBestSize() does by default.
+    SetThumbLength(len > 0 ? len : FromDIP(THUMB));
 
     return true;
 }
@@ -406,7 +426,7 @@ void wxSlider::DoMoveWindow(int x, int y, int width, int height)
     }
 
     const int thumbSize = GetThumbLength();
-    const int tickSize = FromDIP(TICK);
+    const int tickSize = TICK;
 
     int minLabelWidth,
         maxLabelWidth;
@@ -556,11 +576,9 @@ wxSize wxSlider::DoGetBestSize() const
     // this value is arbitrary:
     const int length = FromDIP(100);
 
-    // We need 2 extra pixels (which are not scaled by the DPI by the native
+    // We need extra pixels (which are not scaled by the DPI by the native
     // control) on either side to account for the focus rectangle.
-    const int thumbSize = GetThumbLength() + 4;
-
-    const int tickSize = FromDIP(TICK);
+    const int thumbSize = FromDIP(THUMB) + 2*THUMB_BORDER;
 
     int *width;
     wxSize size;
@@ -609,10 +627,10 @@ wxSize wxSlider::DoGetBestSize() const
     // need extra space to show ticks
     if ( HasFlag(wxSL_TICKS) )
     {
-        *width += tickSize;
+        *width += TICK;
         // and maybe twice as much if we show them on both sides
         if ( HasFlag(wxSL_BOTH) )
-            *width += tickSize;
+            *width += TICK;
     }
     return size;
 }


### PR DESCRIPTION
The changes of 8f3b87dce7 (Fix wxSlider::SetThumbLength() on wxMSW, 2019-01-31) broke the behaviour of wxSlider controls created with a fixed height as their thumb didn't fit it any longer and left no space for ticks at all.

Work around this by setting the initial thumb size ourselves if a fixed control size is given. Also use the fixed default thumb size when calculating the best size as the value of GetThumbLength() could vary depending on how the control was created.

It might be better to revert the use of TBS_FIXEDLENGTH and just leave with the default thumb size in any DPI.

See #1208.

----

@MaartenBent I had to change this because existing code using fixed sizes for its controls got completely wrecked by this change. This is the minimal fix I can see for it, but as I mentioned above, I'm not sure why we can't leave the control manage its thumb size itself, it looks fine to me in 200% DPI (under Windows 10), do you remember by chance which problem did the original change fix? FWIW I don't think we care about `SetThumbLength()` one way or the other, nobody uses it anyhow.