### PR TITLE
Use proxy credentials preemptively too in `wxWebRequestCURL`

### DIFF
--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -493,6 +493,10 @@ public:
         Execute(): this will use the provided credentials for the initial
         request.
 
+        Note that when using a proxy with credentials information, proxy
+        credentials will be also included in the initial request if this
+        function is called when using libcurl backend.
+
         @since 3.3.2
      */
     void UseBasicAuth(const wxWebCredentials& cred);
@@ -1000,6 +1004,10 @@ public:
         can avoid this extra request by calling this function before calling
         Execute(): this will use the provided credentials for the initial
         request.
+
+        Note that when using a proxy with credentials information, proxy
+        credentials will be also included in the initial request if this
+        function is called when using libcurl backend.
 
         @since 3.3.2
      */

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -548,6 +548,23 @@ wxWebRequest::Result wxWebRequestCURL::DoFinishPrepare()
                      basicAuthCred.GetUser());
         wxCURLSetOpt(m_handle, CURLOPT_PASSWORD,
                      basicAuthCred.GetPassword().GetAsString());
+
+        const wxWebProxy& proxy = GetSessionImpl().GetProxy();
+        if ( proxy.GetType() == wxWebProxy::Type::URL )
+        {
+            // If we're using proxy, we should set credentials for it too,
+            // otherwise we'd still use more than one request.
+            const wxURI proxyURL(proxy.GetURL());
+            if ( proxyURL.HasUserInfo() )
+            {
+                wxCURLSetOpt(m_handle, CURLOPT_PROXYAUTH, CURLAUTH_BASIC);
+
+                wxCURLSetOpt(m_handle, CURLOPT_PROXYUSERNAME,
+                             proxyURL.GetUser());
+                wxCURLSetOpt(m_handle, CURLOPT_PROXYPASSWORD,
+                             proxyURL.GetPassword());
+            }
+        }
     }
 
     wxCURLSetOpt(m_handle, CURLOPT_HTTPAUTH, httpAuthMethod);


### PR DESCRIPTION
Extend the changes of 2be7895e8a (Add support for preemptively using "Basic" HTTP authentication, 2025-12-22) to proxy credentials as well.

Currently this is only implemented for libcurl backend.