### PR TITLE
Don't show hidden TLWs in wxMSW when parent is restored

### DIFF
--- a/src/msw/nonownedwnd.cpp
+++ b/src/msw/nonownedwnd.cpp
@@ -255,6 +255,14 @@ WXLRESULT wxNonOwnedWindow::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPA
                                             wxRectFromRECT(*prcNewWindow));
             }
             break;
+
+        case WM_SHOWWINDOW:
+            // Default handling of this message in Windows restores the TLW
+            // even if it had been hidden before, and we don't want this to
+            // happen, so suppress the default behaviour and simply ignore it.
+            if ( lParam == SW_PARENTOPENING && !IsShown() )
+                processed = true;
+            break;
     }
 
     if (!processed)


### PR DESCRIPTION
The default Windows behaviour is to show the children of a hidden window when this window is restored from the taskbar, but we don't want this to happen as this is rather unexpected and, worse, breaks the relationship between the internal state of the window (m_isShown) and its actual visibility.

We could fix the latter problem by calling Show() explicitly ourselves, but it seems better to just not show the children.

Closes #23997.