### PR TITLE
Slightly simplify and make more robust CMake version parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,18 +52,18 @@ set(wxOUTPUT_DIR ${wxBINARY_DIR}/lib)
 
 # parse the version number from wx/version.h and include in wxMAJOR_VERSION and wxMINOR_VERSION
 file(READ "${wxSOURCE_DIR}/include/wx/version.h" WX_VERSION_H_CONTENTS)
-string(REGEX MATCH "wxMAJOR_VERSION[ \t]+([0-9]+)"
-    wxMAJOR_VERSION ${WX_VERSION_H_CONTENTS})
-string (REGEX MATCH "([0-9]+)"
-    wxMAJOR_VERSION ${wxMAJOR_VERSION})
-string(REGEX MATCH "wxMINOR_VERSION[ \t]+([0-9]+)"
-    wxMINOR_VERSION ${WX_VERSION_H_CONTENTS})
-string (REGEX MATCH "([0-9]+)"
-    wxMINOR_VERSION ${wxMINOR_VERSION})
-string(REGEX MATCH "wxRELEASE_NUMBER[ \t]+([0-9]+)"
-    wxRELEASE_NUMBER ${WX_VERSION_H_CONTENTS})
-string (REGEX MATCH "([0-9]+)"
-    wxRELEASE_NUMBER ${wxRELEASE_NUMBER})
+
+function(wx_extract_version_component name)
+    string(REGEX MATCH "# *define +${name} +([0-9]+)" _dummy ${WX_VERSION_H_CONTENTS})
+    if("${CMAKE_MATCH_1}" STREQUAL "")
+        message(FATAL_ERROR "Failed to extract ${name} from wx/version.h")
+    endif()
+    set(${name} ${CMAKE_MATCH_1} PARENT_SCOPE)
+endfunction()
+
+wx_extract_version_component(wxMAJOR_VERSION)
+wx_extract_version_component(wxMINOR_VERSION)
+wx_extract_version_component(wxRELEASE_NUMBER)
 
 # Determine if current version is a "Development" release
 math(EXPR rel_dev "${wxMINOR_VERSION} % 2")


### PR DESCRIPTION
Check that we parsed all version components and avoid doing 2 regex matches for every component when we can just use CMAKE_MATCH_1 directly.

----

@MaartenBent This is very minor, but I was just implementing something similar in my own code and I was wondering why did wx do it in the more complicated way. I couldn't find any answer (`CMAKE_MATCH_1` seems to be available since always), so I've decided to change it and ask you if you see anything wrong with it, so that I could fix my own code if necessary. And if not, I think this is slightly better, isn't it?