### PR TITLE
Honour `WX_APPNAME_DATA_DIR` environment variable in all ports

### DIFF
--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -279,7 +279,7 @@ public:
         - Windows: the directory where the executable file is located
         - Mac: @c appinfo.app/Contents/SharedSupport bundle subdirectory
 
-        Under Unix (only) it is possible to override the default value returned
+        Note that it is possible to override the default value returned
         from this function by setting the value of @c WX_APPNAME_DATA_DIR
         environment variable to the directory to use (where @c APPNAME is the
         upper-cased value of wxApp::GetAppName()). This is useful in order to

--- a/src/common/stdpbase.cpp
+++ b/src/common/stdpbase.cpp
@@ -26,6 +26,7 @@
 
 #include "wx/filename.h"
 #include "wx/stdpaths.h"
+#include "wx/utils.h"
 
 // ----------------------------------------------------------------------------
 // module globals
@@ -96,6 +97,18 @@ wxStandardPathsBase::wxStandardPathsBase()
 wxStandardPathsBase::~wxStandardPathsBase()
 {
     // nothing to do here
+}
+
+wxString wxStandardPathsBase::GetDataDir() const
+{
+    // allow to override the location of the data directory by setting
+    // WX_APPNAME_DATA_DIR environment variable: this is very useful in
+    // practice for running well-written (and so using wxStandardPaths to find
+    // their files) wx applications without installing them
+    wxString envOverride;
+    wxGetEnv("WX_" + wxTheApp->GetAppName().Upper() + "_DATA_DIR", &envOverride);
+
+    return envOverride;
 }
 
 wxString wxStandardPathsBase::GetLocalDataDir() const

--- a/src/msw/stdpaths.cpp
+++ b/src/msw/stdpaths.cpp
@@ -316,6 +316,10 @@ wxString wxStandardPaths::GetUserConfigDir() const
 
 wxString wxStandardPaths::GetDataDir() const
 {
+    const wxString& envOverride = wxStandardPathsBase::GetDataDir();
+    if ( !envOverride.empty() )
+        return envOverride;
+
     // under Windows each program is usually installed in its own directory and
     // so its datafiles are in the same directory as its main executable
     return GetAppDir();

--- a/src/unix/stdpaths.cpp
+++ b/src/unix/stdpaths.cpp
@@ -212,17 +212,7 @@ wxString wxStandardPaths::GetConfigDir() const
 
 wxString wxStandardPaths::GetDataDir() const
 {
-    // allow to override the location of the data directory by setting
-    // WX_APPNAME_DATA_DIR environment variable: this is very useful in
-    // practice for running well-written (and so using wxStandardPaths to find
-    // their files) wx applications without installing them
-    static const wxString
-      envOverride(
-        getenv(
-            ("WX_" + wxTheApp->GetAppName().Upper() + "_DATA_DIR").c_str()
-        )
-      );
-
+    const wxString& envOverride = wxStandardPathsBase::GetDataDir();
     if ( !envOverride.empty() )
         return envOverride;
 


### PR DESCRIPTION
Telling the program where to find its data/resource files can be useful under Windows too, so return the value of this variable if it is defined there too instead of always return the directory where the executable is located.