### PR TITLE
Fix dangling pointer in propgrid

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5381,6 +5381,15 @@ wxStack<wxMSWImpl::PaintData> wxMSWImpl::paintStack;
 
 bool wxWindowMSW::HandlePaint()
 {
+    // Don't bother painting a window that is being destroyed -- its state
+    // may be partially torn down and event handlers may crash. Just validate
+    // the region so Windows stops sending WM_PAINT.
+    if ( IsBeingDeleted() )
+    {
+        ::ValidateRect(GetHwnd(), nullptr);
+        return true;
+    }
+
     HRGN hRegion = ::CreateRectRgn(0, 0, 0, 0); // Dummy call to get a handle
     if ( !hRegion )
     {

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1885,13 +1885,6 @@ wxPGProperty* wxPropertyGrid::DoGetItemAtY( int y ) const
 
 void wxPropertyGrid::OnPaint( wxPaintEvent& WXUNUSED(event) )
 {
-    // Don't paint after destruction has begun
-    if ( !HasInternalFlag(wxPG_FL_INITIALIZED) )
-    {
-        wxPaintDC dc(this);
-        return;
-    }
-
     wxDC* dcPtr = nullptr;
     if ( !HasExtraStyle(wxPG_EX_NATIVE_DOUBLE_BUFFERING) )
     {

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -518,6 +518,8 @@ void wxPropertyGrid::Init2()
 
 wxPropertyGrid::~wxPropertyGrid()
 {
+    SendDestroyEvent();   // Mark as being deleted before any teardown
+
 #if wxUSE_THREADS
     wxCriticalSectionLocker lock(wxPGGlobalVars->m_critSect);
 #endif

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -591,8 +591,7 @@ wxPropertyGrid::~wxPropertyGrid()
         DeletePendingObjects();
     }
 
-    if ( m_doubleBuffer )
-        delete m_doubleBuffer;
+    wxDELETE(m_doubleBuffer);
 
     if ( m_iFlags & wxPG_FL_CREATEDSTATE )
         delete m_pState;
@@ -1886,6 +1885,13 @@ wxPGProperty* wxPropertyGrid::DoGetItemAtY( int y ) const
 
 void wxPropertyGrid::OnPaint( wxPaintEvent& WXUNUSED(event) )
 {
+    // Don't paint after destruction has begun
+    if ( !HasInternalFlag(wxPG_FL_INITIALIZED) )
+    {
+        wxPaintDC dc(this);
+        return;
+    }
+
     wxDC* dcPtr = nullptr;
     if ( !HasExtraStyle(wxPG_EX_NATIVE_DOUBLE_BUFFERING) )
     {


### PR DESCRIPTION
On Windows 11, in wxUiEditor, its propgrid now generates an assert in src\common\dcbufcmn.cpp

```cpp
void wxBufferedDC::UnMask()
{
    wxCHECK_RET( m_dc, wxT("no underlying wxDC?") );
    wxASSERT_MSG( m_buffer && m_buffer->IsOk(), wxT("invalid backing store") );
```

`m_buffer` is invalid because it's been deleted.

The root cause of the bug is in propgrid.cpp at line 594:

```cpp
if ( m_doubleBuffer )
    delete m_doubleBuffer;
```

This deletes the buffer but does NOT null the pointer. During destruction, Windows sends a WM_PAINT message, which invokes OnPaint(). The code checks m_doubleBuffer != nullptr (it's still non-null — dangling pointer!), creates a wxBufferedPaintDC referencing the freed bitmap, and then the assert fires when UnMask() tries to check m_buffer->IsOk() on freed memory (m_refData = 0xFEEEFEEE).

The first fix is to use wxDELETE instead of delete, which deletes AND nullifies the pointer.

The second fix is in OnPaint() to check for destruction-in-progress before creating the wxBufferedPaintDC:

```cpp
    // Don't paint after destruction has begun
    if ( !HasInternalFlag(wxPG_FL_INITIALIZED) )
    {
        wxPaintDC dc(this);
        return;
    }
```

What Changed in wxWidgets:

In include/wx/dcbuffer.h, the macro wxALWAYS_NATIVE_DOUBLE_BUFFER changed:

| Version   | Value on Windows                           |
| --------- | ------------------------------------------ |
| Old       | 1 (unconditional for ALL platforms)        |
| New       | 0 (Windows-specific: #ifdef __WXMSW__ → 0) |

This single change has a cascading effect: it switches **wxAutoBufferedPaintDC** from **wxPaintDC** to **wxBufferedPaintDC** on Windows, and causes **wxPropertyGrid** to use its **m_doubleBuffer** bitmap for software double-buffering — a code path that was dead code on Windows in the old version.
