### PR TITLE
Don't use /MP option when not using MSVS CMake generator

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -107,7 +107,7 @@ if(MSVC)
     wx_string_append(CMAKE_EXE_LINKER_FLAGS_RELEASE "${MSVC_PDB_FLAG}")
     wx_string_append(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${MSVC_PDB_FLAG}")
 
-    if(wxBUILD_MSVC_MULTIPROC)
+    if(wxBUILD_MSVC_MULTIPROC AND ${CMAKE_GENERATOR} MATCHES "Visual Studio")
         wx_string_append(CMAKE_C_FLAGS " /MP")
         wx_string_append(CMAKE_CXX_FLAGS " /MP")
     endif()


### PR DESCRIPTION
It is useless in this case as make/Ninja generators only compile a single file at once anyhow and can also be harmful when using clang-cl compiler which gives warnings about unsupported option.

---

@MaartenBent Please let me know if you have any objections or see a better way to do this, but I need some way to fix it to avoid getting warnings about unrecognized option for every source file when using clang-cl.