### PR TITLE
Fix positioning images in generic wx{List,Tree}Ctrl in high DPI

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -251,6 +251,9 @@ Changes in behaviour which may result in build errors
   configurations using EGL is not available any longer as exposing it doesn't
   make sense when wxGLCanvas may use either EGL or GLX.
 
+- wxWithImages::GetImageLogicalSize() overload taking the icon index didn't
+  make sense and was removed, please use the other overload instead if needed.
+
 
 3.3.3: (released 2026-??-??)
 ----------------------------

--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -623,7 +623,7 @@ public:
     void OnChildFocus(wxChildFocusEvent& event);
 
     void DrawImage( int index, wxDC *dc, int x, int y );
-    void GetImageSize( int index, int &width, int &height ) const;
+    void GetImageSize( int &width, int &height ) const;
 
     void SetImages( wxWithImages *images, const int which );
     void SetItemSpacing( int spacing, bool isSmall = false );

--- a/include/wx/withimages.h
+++ b/include/wx/withimages.h
@@ -183,32 +183,12 @@ public:
         return window->FromPhys(GetImageSize(window));
     }
 
-    // Return logical size of the image to use or (0, 0) if there are none.
-    wxSize GetImageLogicalSize(const wxWindow* window, int iconIndex) const
-    {
-        wxSize size;
-
-        if ( iconIndex != NO_IMAGE )
-        {
-            if ( !m_images.empty() )
-            {
-                size = m_images.at(iconIndex).GetPreferredLogicalSizeFor(window);
-            }
-            else if ( m_imageList )
-            {
-                size = m_imageList->GetBitmap(iconIndex).GetLogicalSize();
-            }
-        }
-
-        return size;
-    }
-
     // Overload provided to facilitate transition from the existing code using
     // wxImageList::GetSize() -- don't use it in the new code.
-    void GetImageLogicalSize(const wxWindow* window, int iconIndex,
+    void GetImageLogicalSize(const wxWindow* window,
                              int& width, int& height) const
     {
-        const wxSize size = GetImageLogicalSize(window, iconIndex);
+        const wxSize size = GetImageLogicalSize(window);
         width = size.x;
         height = size.y;
     }

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -460,7 +460,7 @@ void wxListLineData::CalculateSize( wxReadOnlyDC *dc, int spacing )
             if (item->HasImage())
             {
                 int w, h;
-                m_owner->GetImageSize( item->GetImage(), w, h );
+                m_owner->GetImageSize( w, h );
                 m_gi->m_rectIcon.width = w + 8;
                 m_gi->m_rectIcon.height = h + 8;
 
@@ -498,7 +498,7 @@ void wxListLineData::CalculateSize( wxReadOnlyDC *dc, int spacing )
             if (item->HasImage())
             {
                 int w, h;
-                m_owner->GetImageSize( item->GetImage(), w, h );
+                m_owner->GetImageSize( w, h );
                 m_gi->m_rectIcon.width = w;
                 m_gi->m_rectIcon.height = h;
 
@@ -784,7 +784,7 @@ void wxListLineData::DrawInReportMode( wxDC *dc,
         if ( item.HasImage() )
         {
             int ix, iy;
-            m_owner->GetImageSize( item.GetImage(), ix, iy );
+            m_owner->GetImageSize( ix, iy );
             m_owner->DrawImage( item.GetImage(), dc, xOld, yMid - iy/2 );
 
             ix += IMAGE_MARGIN_IN_REPORT_MODE;
@@ -1082,7 +1082,7 @@ void wxListHeaderWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
             smallImages = m_owner->GetSmallImages();
             if ( smallImages )
             {
-                smallImages->GetImageLogicalSize(this, image, ix, iy);
+                smallImages->GetImageLogicalSize(this, ix, iy);
                 wLabel += ix + HEADER_IMAGE_MARGIN_IN_REPORT_MODE;
             }
         }
@@ -1702,7 +1702,7 @@ wxCoord wxListMainWindow::GetLineHeight() const
         if ( m_small_images && m_small_images->GetImageCount() )
         {
             int iw = 0, ih = 0;
-            m_small_images->GetImageLogicalSize(this, 0, iw, ih);
+            m_small_images->GetImageLogicalSize(this, iw, ih);
             y = wxMax(y, ih);
         }
 
@@ -1747,7 +1747,7 @@ wxRect wxListMainWindow::GetLineLabelRect(size_t line) const
         if ( item->HasImage() )
         {
             int ix, iy;
-            GetImageSize( item->GetImage(), ix, iy );
+            GetImageSize( ix, iy );
             image_x = 3 + ix + IMAGE_MARGIN_IN_REPORT_MODE;
         }
     }
@@ -1766,8 +1766,7 @@ wxRect wxListMainWindow::GetLineIconRect(size_t line) const
     if ( !InReportView() )
         return GetLine(line)->m_gi->m_rectIcon;
 
-    wxListLineData *ld = GetLine(line);
-    wxASSERT_MSG( ld->HasImage(), wxT("should have an image") );
+    wxASSERT_MSG( GetLine(line)->HasImage(), wxT("should have an image") );
 
     wxRect rect = GetLineRect(line);
     rect.x += ICON_OFFSET_X;
@@ -1780,7 +1779,7 @@ wxRect wxListMainWindow::GetLineIconRect(size_t line) const
 
     // use full height of the line, same as win32 listctrl
     int ix, iy;
-    GetImageSize(ld->GetImage(), ix, iy);
+    GetImageSize(ix, iy);
     rect.width = ix;
 
     return rect;
@@ -3318,15 +3317,15 @@ void wxListMainWindow::DrawImage( int index, wxDC *dc, int x, int y )
     }
 }
 
-void wxListMainWindow::GetImageSize( int index, int &width, int &height ) const
+void wxListMainWindow::GetImageSize( int &width, int &height ) const
 {
     if ( HasFlag(wxLC_ICON) && m_normal_images )
     {
-        m_normal_images->GetImageLogicalSize(this, index, width, height);
+        m_normal_images->GetImageLogicalSize(this, width, height);
     }
     else if ( HasFlag(wxLC_SMALL_ICON | wxLC_LIST | wxLC_REPORT) && m_small_images )
     {
-        m_small_images->GetImageLogicalSize(this, index, width, height);
+        m_small_images->GetImageLogicalSize(this, width, height);
     }
     else
     {
@@ -3346,7 +3345,7 @@ void wxListMainWindow::SetImages( wxWithImages *images, const int which )
     if ((images) && (images->HasImages()) )
     {
         int height;
-        images->GetImageLogicalSize(this, 0, width, height);
+        images->GetImageLogicalSize(this, width, height);
     }
 
     if (which == wxIMAGE_LIST_NORMAL)
@@ -3397,7 +3396,7 @@ wxListMainWindow::ComputeMinHeaderWidth(const wxListHeaderData* column) const
         if ( m_small_images )
         {
             int ix = 0, iy = 0;
-            m_small_images->GetImageLogicalSize(this, image, ix, iy);
+            m_small_images->GetImageLogicalSize(this, ix, iy);
             width += ix + HEADER_IMAGE_MARGIN_IN_REPORT_MODE;
         }
     }
@@ -3905,7 +3904,7 @@ wxListMainWindow::GetSubItemRect(long item, long subItem, wxRect& rect,
                     if ( subItem == 0 && line->HasImage() )
                     {
                         int ix, iy;
-                        GetImageSize(line->GetImage(), ix, iy);
+                        GetImageSize(ix, iy);
 
                         if ( code == wxLIST_RECT_ICON )
                         {
@@ -4624,7 +4623,7 @@ void wxListMainWindow::InsertItem( wxListItem &item )
         if ( m_small_images && image != -1 && InReportView() )
         {
             int imageWidth, imageHeight;
-            m_small_images->GetImageLogicalSize(this, image, imageWidth, imageHeight);
+            m_small_images->GetImageLogicalSize(this, imageWidth, imageHeight);
 
             if ( imageHeight > m_lineHeight )
                 m_lineHeight = 0;
@@ -4700,7 +4699,7 @@ int wxListMainWindow::GetItemWidthWithImage(wxListItem * item)
     if (item->GetImage() != -1)
     {
         int ix, iy;
-        GetImageSize( item->GetImage(), ix, iy );
+        GetImageSize( ix, iy );
         width += ix + IMAGE_MARGIN_IN_REPORT_MODE;
     }
 

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -775,7 +775,7 @@ wxGenericTreeItem *wxGenericTreeItem::HitTest(const wxPoint& point,
                         theCtrl->m_imagesState.HasImages() )
                 {
                     int state_h;
-                    theCtrl->m_imagesState.GetImageLogicalSize(theCtrl, GetState(),
+                    theCtrl->m_imagesState.GetImageLogicalSize(theCtrl,
                                                        state_w, state_h);
                 }
 
@@ -899,7 +899,7 @@ wxGenericTreeItem::DoCalculateSize(wxGenericTreeCtrl* control,
     int state = GetState();
     if ( state != wxTREE_ITEMSTATE_NONE && control->m_imagesState.HasImages() )
     {
-        control->m_imagesState.GetImageLogicalSize(control, state, state_w, state_h);
+        control->m_imagesState.GetImageLogicalSize(control, state_w, state_h);
         if ( image_w != 0 )
             state_w += MARGIN_BETWEEN_STATE_AND_IMAGE;
         else
@@ -2400,14 +2400,9 @@ void wxGenericTreeCtrl::CalculateLineHeight()
         // Calculate a m_lineHeight value from the state Image sizes.
         // May be toggle off. Then wxGenericTreeCtrl will spread when
         // necessary (which might look ugly).
-        int n = m_imagesState.GetImageCount();
-        for (int i = 0; i < n ; i++)
-        {
-            int width = 0, height = 0;
-            m_imagesState.GetImageLogicalSize(this, i, width, height);
-            if (height > m_lineHeight)
-                m_lineHeight = height;
-        }
+        const int height = m_imagesState.GetImageLogicalSize(this).y;
+        if (height > m_lineHeight)
+            m_lineHeight = height;
     }
 
     if ( m_imagesButtons.HasImages() )
@@ -2415,14 +2410,9 @@ void wxGenericTreeCtrl::CalculateLineHeight()
         // Calculate a m_lineHeight value from the Button image sizes.
         // May be toggle off. Then wxGenericTreeCtrl will spread when
         // necessary (which might look ugly).
-        int n = m_imagesButtons.GetImageCount();
-        for (int i = 0; i < n ; i++)
-        {
-            int width = 0, height = 0;
-            m_imagesButtons.GetImageLogicalSize(this, i, width, height);
-            if (height > m_lineHeight)
-                m_lineHeight = height;
-        }
+        const int height = m_imagesButtons.GetImageLogicalSize(this).y;
+        if (height > m_lineHeight)
+            m_lineHeight = height;
     }
 
     m_lineHeight += FromDIP(2); // Add some extra interline space.
@@ -2548,7 +2538,7 @@ void wxGenericTreeCtrl::PaintItem(wxGenericTreeItem *item, wxDC& dc)
     {
         if ( m_imagesState.HasImages() )
         {
-            m_imagesState.GetImageLogicalSize(this, state, state_w, state_h);
+            m_imagesState.GetImageLogicalSize(this, state_w, state_h);
             if ( image_w != 0 )
                 state_w += MARGIN_BETWEEN_STATE_AND_IMAGE;
             else
@@ -2850,7 +2840,7 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
                     image += wxTreeItemIcon_Selected - wxTreeItemIcon_Normal;
 
                 int image_w, image_h;
-                m_imagesButtons.GetImageLogicalSize(this, image, image_w, image_h);
+                m_imagesButtons.GetImageLogicalSize(this, image_w, image_h);
                 int xx = x - image_w/2;
                 int yy = y_mid - image_h/2;
 
@@ -3467,7 +3457,7 @@ bool wxGenericTreeCtrl::GetBoundingRect(const wxTreeItemId& item,
         if ( state != wxTREE_ITEMSTATE_NONE && m_imagesState.HasImages() )
         {
             int state_h;
-            m_imagesState.GetImageLogicalSize( this, state, state_w, state_h );
+            m_imagesState.GetImageLogicalSize( this, state_w, state_h );
             if ( image_w != 0 )
                 state_w += MARGIN_BETWEEN_STATE_AND_IMAGE;
             else


### PR DESCRIPTION
The implementation of GetImageLogicalSize() overload taking the image index returned correct answer for this individual image, but was wrong when used in the control with multiple images with different logical sizes. This resulted in the actual bitmap being drawn, as returned by GetImageBitmapFor(), being of different size than the size returned by this function, as GetImageBitmapFor() uses the best ("consensus") size for all images, which is also returned by GetImageLogicalSize() overload not taking the image.

Solve this by simply getting rid of the overload taking the image and replacing all existing calls to it with the calls to the other overload. This is backwards-incompatible, but this function was only added in 3.3 and removing it is a lesser evil than either leaving a function which can only be misused, or keeping the unused image index parameter which would be confusing.

Closes #26391.