### PR TITLE
Fix wxRendererXP::DrawItemText() text color for selected item when in dark mode

### DIFF
--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -956,7 +956,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
                                 int flags,
                                 wxEllipsizeMode ellipsizeMode)
 {
-    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW;LISTVIEW");
+    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW;LISTVIEW", L"DarkMode::LISTVIEW");
 
     const int itemState = GetListItemState(flags);
 
@@ -972,11 +972,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
         wxColour textColour = dc.GetTextForeground();
         if (flags & wxCONTROL_SELECTED)
         {
-            if (wxSystemSettings::GetAppearance().IsDark()) {
-                textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
-            } else {
-                textColour = hTheme.GetColour(LVP_LISTITEM, TMT_TEXTCOLOR, LISS_SELECTED);
-            }
+            textColour = hTheme.GetColour(LVP_LISTITEM, TMT_TEXTCOLOR, LISS_SELECTED);
         }
         else if (flags & wxCONTROL_DISABLED)
         {

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -972,7 +972,11 @@ void wxRendererXP::DrawItemText(wxWindow* win,
         wxColour textColour = dc.GetTextForeground();
         if (flags & wxCONTROL_SELECTED)
         {
-            textColour = hTheme.GetColour(LVP_LISTITEM, TMT_TEXTCOLOR, LISS_SELECTED);
+            if (wxSystemSettings::GetAppearance().IsDark()) {
+                textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
+            } else {
+                textColour = hTheme.GetColour(LVP_LISTITEM, TMT_TEXTCOLOR, LISS_SELECTED);
+            }
         }
         else if (flags & wxCONTROL_DISABLED)
         {


### PR DESCRIPTION
The fix for #26378 inadvertently broke dark mode. The proposed solution is to check for dark mode, and in that case, get the color wxSYS_COLOUR_HIGHLIGHTTEXT.