### PR TITLE
Fix Retina display issues with ribbon

### DIFF
--- a/src/ribbon/art_aui.cpp
+++ b/src/ribbon/art_aui.cpp
@@ -1110,6 +1110,7 @@ void wxRibbonAUIArtProvider::DrawButtonBarButton(
                 }
                 break;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
+            case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 {
                     int iArrowWidth = 9;
                     if(state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED)
@@ -1128,8 +1129,6 @@ void wxRibbonAUIArtProvider::DrawButtonBarButton(
                             bg_rect.x - 1, rect.y + rect.height);
                     }
                 }
-                break;
-            case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 break;
             }
         }

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -2544,6 +2544,7 @@ void wxRibbonMSWArtProvider::DrawButtonBarButton(
                 }
                 break;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
+            case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 {
                     int iArrowWidth = 9;
                     if(state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED)
@@ -2565,8 +2566,6 @@ void wxRibbonMSWArtProvider::DrawButtonBarButton(
                             bg_rect_top.x - 1, rect.y + rect.height);
                     }
                 }
-                break;
-            case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 break;
             }
         }
@@ -2700,8 +2699,20 @@ void wxRibbonMSWArtProvider::DrawButtonBarButtonForeground(
             }
             break;
         }
+    case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
+        {
+            int avail_width = rect.width;
+            if(kind != wxRIBBON_BUTTON_NORMAL)
+            {
+                avail_width -= 8;
+                DrawDropdownArrow(dc, rect.x + avail_width + 4, rect.y + rect.height / 2, arrowColour);
+            }
+            int x_cursor = rect.x + (avail_width - bitmap_small.GetLogicalWidth()) / 2;
+            dc.DrawBitmap(bitmap_small, x_cursor,
+                    rect.y + (rect.height - bitmap_small.GetLogicalHeight()) / 2, true);
+            break;
+        }
     default:
-        // TODO
         break;
     }
 }

--- a/src/ribbon/art_msw_flat.cpp
+++ b/src/ribbon/art_msw_flat.cpp
@@ -723,6 +723,7 @@ void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
                 }
                 break;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
+            case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 {
                     int iArrowWidth = 9;
                     if ( state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED )
@@ -741,8 +742,6 @@ void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
                             bg_rect.x - 1, rect.y + rect.height);
                     }
                 }
-                break;
-            case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 break;
             }
         }

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -519,18 +519,12 @@ void wxRibbonButtonBar::FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,
         wxRibbonButtonBarButtonState size, wxReadOnlyDC& dc)
 {
     wxRibbonButtonBarButtonSizeInfo& info = button->sizes[size];
+    const double scale = GetDPIScaleFactor() / GetContentScaleFactor();
+    const wxSize bmpSizeLarge = m_bitmap_size_large * scale;
+    const wxSize bmpSizeSmall = m_bitmap_size_small * scale;
+
     if(m_art)
     {
-#ifdef __WXOSX__
-        // macOS DC is in logical units (points); use base sizes directly
-        const wxSize& bmpSizeLarge = m_bitmap_size_large;
-        const wxSize& bmpSizeSmall = m_bitmap_size_small;
-#else
-        // Windows DC is in physical pixels; scale bitmap sizes to match
-        const double scale = GetDPIScaleFactor();
-        const wxSize bmpSizeLarge = m_bitmap_size_large * scale;
-        const wxSize bmpSizeSmall = m_bitmap_size_small * scale;
-#endif
         info.is_supported = m_art->GetButtonBarButtonSize(dc, this,
             button->kind, size, button->label, button->text_min_width[size],
             bmpSizeLarge, bmpSizeSmall, &info.size,
@@ -950,11 +944,8 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
     wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
 
     // Calculate DPI-scaled bitmap sizes (must match layout calculation)
-#ifdef __WXOSX__
-    const double scale = GetContentScaleFactor();
-#else
     const double scale = GetDPIScaleFactor();
-#endif
+    const double contentScale = GetContentScaleFactor();
     const wxSize scaledLarge = m_bitmap_size_large * scale;
     const wxSize scaledSmall = m_bitmap_size_small * scale;
 
@@ -978,10 +969,8 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesLargeDisabled[idx] : m_bundlesLarge[idx];
                 bitmap = bundle.GetBitmap(scaledLarge);
-#ifdef __WXOSX__
                 if ( bitmap.IsOk() )
-                    bitmap.SetScaleFactor(scale);
-#endif
+                    bitmap.SetScaleFactor(contentScale);
             }
         }
 
@@ -993,10 +982,8 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesSmallDisabled[idx] : m_bundlesSmall[idx];
                 bitmap_small = bundle.GetBitmap(scaledSmall);
-#ifdef __WXOSX__
                 if ( bitmap_small.IsOk() )
-                    bitmap_small.SetScaleFactor(scale);
-#endif
+                    bitmap_small.SetScaleFactor(contentScale);
             }
         }
 

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -1184,14 +1184,12 @@ void wxRibbonButtonBar::MakeLayouts()
                               wxRIBBON_BUTTONBAR_BUTTON_MEDIUM);
         }
 
-        // TODO: small buttons are not implemented yet in
-        //       art_msw.cpp:2581 and will be invisible
-        /*iLast = btn_count;
+        iLast = btn_count;
         while(iLast-- > 0)
         {
             TryCollapseLayout(m_layouts.Last(), iLast, &iLast,
                               wxRIBBON_BUTTONBAR_BUTTON_SMALL);
-        }*/
+        }
     }
 }
 

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -521,14 +521,19 @@ void wxRibbonButtonBar::FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,
     wxRibbonButtonBarButtonSizeInfo& info = button->sizes[size];
     if(m_art)
     {
-        // Scale base bitmap sizes by current DPI for layout calculation
+#ifdef __WXOSX__
+        // macOS DC is in logical units (points); use base sizes directly
+        const wxSize& bmpSizeLarge = m_bitmap_size_large;
+        const wxSize& bmpSizeSmall = m_bitmap_size_small;
+#else
+        // Windows DC is in physical pixels; scale bitmap sizes to match
         const double scale = GetDPIScaleFactor();
-        wxSize scaledLarge = m_bitmap_size_large * scale;
-        wxSize scaledSmall = m_bitmap_size_small * scale;
-
+        const wxSize bmpSizeLarge = m_bitmap_size_large * scale;
+        const wxSize bmpSizeSmall = m_bitmap_size_small * scale;
+#endif
         info.is_supported = m_art->GetButtonBarButtonSize(dc, this,
             button->kind, size, button->label, button->text_min_width[size],
-            scaledLarge, scaledSmall, &info.size,
+            bmpSizeLarge, bmpSizeSmall, &info.size,
             &info.normal_region, &info.dropdown_region);
     }
     else
@@ -945,7 +950,11 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
     wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
 
     // Calculate DPI-scaled bitmap sizes (must match layout calculation)
+#ifdef __WXOSX__
+    const double scale = GetContentScaleFactor();
+#else
     const double scale = GetDPIScaleFactor();
+#endif
     const wxSize scaledLarge = m_bitmap_size_large * scale;
     const wxSize scaledSmall = m_bitmap_size_small * scale;
 
@@ -969,6 +978,10 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesLargeDisabled[idx] : m_bundlesLarge[idx];
                 bitmap = bundle.GetBitmap(scaledLarge);
+#ifdef __WXOSX__
+                if ( bitmap.IsOk() )
+                    bitmap.SetScaleFactor(scale);
+#endif
             }
         }
 
@@ -980,6 +993,10 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesSmallDisabled[idx] : m_bundlesSmall[idx];
                 bitmap_small = bundle.GetBitmap(scaledSmall);
+#ifdef __WXOSX__
+                if ( bitmap_small.IsOk() )
+                    bitmap_small.SetScaleFactor(scale);
+#endif
             }
         }
 

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -328,8 +328,6 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
 {
     wxASSERT(bitmap.IsOk() || bitmap_small.IsOk());
 
-    // Determine base bitmap sizes on first button (at 100% scale)
-    // These are scaled by DPI when used for layout and drawing
     if(m_buttons.IsEmpty())
     {
         if(bitmap.IsOk())
@@ -395,20 +393,25 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
     }
     else if(bitmap.IsOk())
     {
-        // Use large bitmap scaled down for small
+        // No dedicated small bitmap was provided, so derive one from the large
+        // bundle. The derived bitmap must have the small default size; otherwise
+        // wxBitmapBundle::GetBitmap() would keep returning bitmaps whose logical
+        // size is the large default size and the "small" buttons would be drawn
+        // too big.
+        const wxSize sizeSmallPhys = ToPhys(FromDIP(m_bitmap_size_small));
+        wxBitmap smallBmp = bitmap.GetBitmap(sizeSmallPhys);
+        // Tag the derived bitmap with the small logical size (its scale factor
+        // is simply physical/logical) so that the resulting bundle's default
+        // size is correct and small buttons are not drawn at the large size.
+        smallBmp.SetScaleFactor(static_cast<double>(sizeSmallPhys.y) /
+                                m_bitmap_size_small.y);
+
         idxSmall = m_bundlesSmall.size();
-        m_bundlesSmall.push_back(bitmap);
+        m_bundlesSmall.push_back(wxBitmapBundle::FromBitmap(smallBmp));
 
         idxSmallDisabled = m_bundlesSmallDisabled.size();
-        if(bitmap_disabled.IsOk())
-        {
-            m_bundlesSmallDisabled.push_back(bitmap_disabled);
-        }
-        else
-        {
-            wxBitmap bmp = bitmap.GetBitmap(m_bitmap_size_small);
-            m_bundlesSmallDisabled.push_back(wxBitmapBundle::FromBitmap(MakeDisabledBitmap(bmp)));
-        }
+        m_bundlesSmallDisabled.push_back(
+            wxBitmapBundle::FromBitmap(MakeDisabledBitmap(smallBmp)));
     }
 
     wxRibbonButtonBarButtonBase* base = new wxRibbonButtonBarButtonBase;
@@ -519,9 +522,8 @@ void wxRibbonButtonBar::FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,
         wxRibbonButtonBarButtonState size, wxReadOnlyDC& dc)
 {
     wxRibbonButtonBarButtonSizeInfo& info = button->sizes[size];
-    const double scale = GetDPIScaleFactor() / GetContentScaleFactor();
-    const wxSize bmpSizeLarge = m_bitmap_size_large * scale;
-    const wxSize bmpSizeSmall = m_bitmap_size_small * scale;
+    const wxSize bmpSizeLarge = FromDIP(m_bitmap_size_large);
+    const wxSize bmpSizeSmall = FromDIP(m_bitmap_size_small);
 
     if(m_art)
     {
@@ -943,20 +945,18 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
     wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
 
-    // Calculate DPI-scaled bitmap sizes (must match layout calculation)
-    const double scale = GetDPIScaleFactor();
-    const double contentScale = GetContentScaleFactor();
-    const wxSize scaledLarge = m_bitmap_size_large * scale;
-    const wxSize scaledSmall = m_bitmap_size_small * scale;
+    // wxBitmapBundle::GetBitmap() expects a size in physical pixels, so convert
+    // the stored DIP sizes all the way to physical pixels (ToPhys() is a no-op
+    // under MSW, while FromDIP() is a no-op under the ports using DPI-independent
+    // pixels, so this gives the right result everywhere).
+    const wxSize scaledLarge = ToPhys(FromDIP(m_bitmap_size_large));
+    const wxSize scaledSmall = ToPhys(FromDIP(m_bitmap_size_small));
 
     for ( auto& button : layout->buttons )
     {
         wxRibbonButtonBarButtonBase* base = button.base;
         wxRect rect(button.position + m_layout_offset, base->sizes[button.size].size);
 
-        // Get bitmaps at the DPI-scaled sizes used for layout
-        // Using explicit sizes ensures bundles are scaled correctly even if
-        // the small bundle contains a large source image
         wxBitmap bitmap, bitmap_small;
 
         bool disabled = (base->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) != 0;
@@ -969,8 +969,6 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesLargeDisabled[idx] : m_bundlesLarge[idx];
                 bitmap = bundle.GetBitmap(scaledLarge);
-                if ( bitmap.IsOk() )
-                    bitmap.SetScaleFactor(contentScale);
             }
         }
 
@@ -982,8 +980,6 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesSmallDisabled[idx] : m_bundlesSmall[idx];
                 bitmap_small = bundle.GetBitmap(scaledSmall);
-                if ( bitmap_small.IsOk() )
-                    bitmap_small.SetScaleFactor(contentScale);
             }
         }
 


### PR DESCRIPTION
In macOS, there were two issues:

- The area drawn around regular-sized buttons was twice the size it should be.
<img width="529" height="147" alt="Screenshot 2026-04-25 at 12 52 33 PM" src="https://github.com/user-attachments/assets/bd8d5af0-9418-44b9-b542-011549a3509c" />
- Smaller sized buttons would display the icon at the wrong (too large) size.
<img width="260" height="131" alt="Screenshot 2026-04-25 at 12 53 28 PM" src="https://github.com/user-attachments/assets/9e95f95b-e909-49e0-af32-f461a5833b02" />

This PR fixes the size calculation of the button area, bitmap scaling, and implements some dead code with small button sizing.
