### PR TITLE
wxOSX: Don’t crash in wxNativeFontInfo::FromString()

### DIFF
--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -887,9 +887,10 @@ void wxNativeFontInfo::InitFromFontDescriptor(CTFontDescriptorRef desc)
 
     // determine approximate family
 
-    CTFontSymbolicTraits symbolicTraits;
+    CTFontSymbolicTraits symbolicTraits = 0;
     wxCFDictionaryRef traits((CFDictionaryRef)CTFontDescriptorCopyAttribute(desc, kCTFontTraitsAttribute));
-    traits.GetValue(kCTFontSymbolicTrait).GetValue((int32_t*)&symbolicTraits, 0);
+    if (traits)
+        traits.GetValue(kCTFontSymbolicTrait).GetValue((int32_t*)&symbolicTraits, 0);
 
     if (symbolicTraits & kCTFontMonoSpaceTrait)
         m_family = wxFONTFAMILY_TELETYPE;
@@ -1026,6 +1027,8 @@ CGFloat wxNativeFontInfo::GetCTWeight(CTFontDescriptorRef descr)
 {
     CGFloat weight;
     CFTypeRef fonttraitstype = CTFontDescriptorCopyAttribute(descr, kCTFontTraitsAttribute);
+    if (!fonttraitstype)
+        return CGFloat(0.0);
     wxCFDictionaryRef traits((CFDictionaryRef)fonttraitstype);
     traits.GetValue(kCTFontWeightTrait).GetValue(&weight, CGFloat(0.0));
     return weight;
@@ -1035,6 +1038,8 @@ CGFloat wxNativeFontInfo::GetCTwidth(CTFontDescriptorRef descr)
 {
     CGFloat weight;
     CFTypeRef fonttraitstype = CTFontDescriptorCopyAttribute(descr, kCTFontTraitsAttribute);
+    if (!fonttraitstype)
+        return CGFloat(0.0);
     wxCFDictionaryRef traits((CFDictionaryRef)fonttraitstype);
     traits.GetValue(kCTFontWidthTrait).GetValue(&weight, CGFloat(0.0));
     return weight;
@@ -1044,6 +1049,8 @@ CGFloat wxNativeFontInfo::GetCTSlant(CTFontDescriptorRef descr)
 {
     CGFloat slant;
     CFTypeRef fonttraitstype = CTFontDescriptorCopyAttribute(descr, kCTFontTraitsAttribute);
+    if (!fonttraitstype)
+        return CGFloat(0.0);
     wxCFDictionaryRef traits((CFDictionaryRef)fonttraitstype);
     traits.GetValue(kCTFontSlantTrait).GetValue(&slant, CGFloat(0.0));
     return slant;

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -1176,6 +1176,13 @@ bool wxNativeFontInfo::FromString(const wxString& s)
             descriptor = CTFontDescriptorCreateWithAttributes(attributes);
         if (descriptor != nullptr)
         {
+            wxCFDictionaryRef traits((CFDictionaryRef)CTFontDescriptorCopyAttribute(descriptor, kCTFontTraitsAttribute));
+            if (!traits)
+            {
+                CFRelease(descriptor);
+                return false;
+            }
+
             InitFromFontDescriptor(descriptor);
             CFRelease(descriptor);
             m_underlined = underlined;

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -383,6 +383,15 @@ TEST_CASE("wxFont::NativeFontInfo", "[font][fontinfo]")
     CHECK( !font.SetNativeFontInfo("bloordyblop") );
 #endif
 
+#ifdef __WXOSX__
+    CHECK( !font.SetNativeFontInfo(
+        "3;90;0;0;43;<plist version=\"1.0\"><dict>"
+        "<key>NSFontNameAttribute</key>"
+        "<string>DefinitelyNotARealWxFontTest-Regular</string>"
+        "<key>NSFontSizeAttribute</key><real>14</real>"
+        "</dict></plist>") );
+#endif
+
     // Pango font description doesn't have 'underlined' and 'strikethrough'
     // attributes, so wxNativeFontInfo implements these itself. Test if these
     // are properly preserved by wxNativeFontInfo or its string description.


### PR DESCRIPTION
This PR fixes crash when deserializing font info from string representation. This happens if the font face is missing on the current system; I don’t know if it can happen under other circumstances too.

Split into two commits:

1. 9c18a70ab7aee205a7b3b0fc0ae8a3ba6cf260c2 — this one is clear, no code should crash, period. This results in *some* font being created, bug degraded (no face, fallback traits).

2. 9ad3f86964da17313fdda99dde2cd4324d39367f — treats this failure as deserialization failure, so that the missing font is detectable, but I’m not sure if that’s the intention there. E.g. wxGTK seems to accept such fonts unless I’m mistaken...

Applies to 3.2 as-is.