### PR TITLE
Update some color values for Windows dark mode

### DIFF
--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -62,8 +62,8 @@ enum wxSystemColour
     wxSYS_COLOUR_ACTIVEBORDER,        //!< Active window border colour.
     wxSYS_COLOUR_INACTIVEBORDER,      //!< Inactive window border colour.
     wxSYS_COLOUR_APPWORKSPACE,        //!< Background colour for MDI applications.
-    wxSYS_COLOUR_HIGHLIGHT,           //!< Colour of item(s) selected in a control.
-    wxSYS_COLOUR_HIGHLIGHTTEXT,       //!< Colour of the text of item(s) selected in a control.
+    wxSYS_COLOUR_HIGHLIGHT,           //!< Background colour of a selected item or selected text in a control.
+    wxSYS_COLOUR_HIGHLIGHTTEXT,       //!< Colour of selected text.
     wxSYS_COLOUR_BTNFACE,             //!< Face shading colour on push buttons.
     wxSYS_COLOUR_BTNSHADOW,           //!< Edge shading colour on push buttons.
     wxSYS_COLOUR_GRAYTEXT,            //!< Colour of greyed (disabled) text.

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -312,10 +312,13 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
 
         case wxSYS_COLOUR_ACTIVECAPTION:
         case wxSYS_COLOUR_APPWORKSPACE:
-        case wxSYS_COLOUR_INFOBK:
         case wxSYS_COLOUR_LISTBOX:
         case wxSYS_COLOUR_WINDOW:
             return wxColour(0x202020);
+
+        // Tooltip background of File Explorer toolbar button and file, averaged
+        case wxSYS_COLOUR_INFOBK:
+            return wxColour(0x2a2a2a);
 
         case wxSYS_COLOUR_BTNTEXT:
         case wxSYS_COLOUR_CAPTIONTEXT:
@@ -325,7 +328,7 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
         case wxSYS_COLOUR_LISTBOXTEXT:
         case wxSYS_COLOUR_MENUTEXT:
         case wxSYS_COLOUR_WINDOWTEXT:
-            return wxColour(0xe0e0e0);
+            return *wxWHITE;
 
         case wxSYS_COLOUR_HOTLIGHT:
             return wxColour(0xe48435);
@@ -346,8 +349,8 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
             return wxColour(0x626262);
 
         case wxSYS_COLOUR_HIGHLIGHT:
-        case wxSYS_COLOUR_MENUHILIGHT:
-            return wxColour(0x9e5315);
+            // Selected text background in File Open dialog
+            return wxColour(0xd47800);
 
         case wxSYS_COLOUR_BTNHIGHLIGHT:
             return wxColour(0x777777);

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -366,6 +366,7 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
         case wxSYS_COLOUR_GRADIENTINACTIVECAPTION:
         case wxSYS_COLOUR_GRAYTEXT:
         case wxSYS_COLOUR_INACTIVEBORDER:
+        case wxSYS_COLOUR_MENUHILIGHT:
         case wxSYS_COLOUR_WINDOWFRAME:
             return wxColour();
 

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -314,10 +314,11 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
         case wxSYS_COLOUR_APPWORKSPACE:
         case wxSYS_COLOUR_LISTBOX:
         case wxSYS_COLOUR_WINDOW:
-            return wxColour(0x202020);
+            // File Explorer background
+            return wxColour(0x191919);
 
-        // Tooltip background of File Explorer toolbar button and file, averaged
         case wxSYS_COLOUR_INFOBK:
+            // Tooltip background of File Explorer toolbar button and file, averaged
             return wxColour(0x2a2a2a);
 
         case wxSYS_COLOUR_BTNTEXT:


### PR DESCRIPTION
Update some color values in wxDarkModeSettings::GetColour() to better match the latest Windows version. See #26404 
