### PR TITLE
Fix gcc 16 warnings

### DIFF
--- a/src/generic/msgdlgg.cpp
+++ b/src/generic/msgdlgg.cpp
@@ -75,6 +75,14 @@ wxEND_EVENT_TABLE()
 
 wxIMPLEMENT_CLASS(wxGenericMessageDialog, wxDialog);
 
+// gcc 16.0 gives a bogus warning about "'<unknown>' may be used uninitialized"
+// (sic) for GetParentForModalDialog() call below, this is almost certainly a
+// compiler bug, so disable it for this version only for now.
+#if wxCHECK_GCC_VERSION(16, 0) && !wxCHECK_GCC_VERSION(16, 1)
+#define wxGCC_WARNING_SUPPRESS_MAYBE_UNINITIALIZED
+wxGCC_WARNING_SUPPRESS(maybe-uninitialized)
+#endif
+
 wxGenericMessageDialog::wxGenericMessageDialog( wxWindow *parent,
                                                 const wxString& message,
                                                 const wxString& caption,
@@ -88,6 +96,10 @@ wxGenericMessageDialog::wxGenericMessageDialog( wxWindow *parent,
 {
     m_created = false;
 }
+
+#ifdef wxGCC_WARNING_SUPPRESS_MAYBE_UNINITIALIZED
+wxGCC_WARNING_RESTORE(maybe-uninitialized)
+#endif
 
 wxSizer *wxGenericMessageDialog::CreateMsgDlgButtonSizer()
 {

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -430,9 +430,8 @@ void wxHtmlWinParser::AddPreBlock(const wxString& text)
 
         const wxString::const_iterator end = text.end();
         wxString::const_iterator copyFrom = text.begin();
-        size_t pos = 0;
         int posColumn = m_posColumn;
-        for ( wxString::const_iterator i = copyFrom; i != end; ++i, ++pos )
+        for ( wxString::const_iterator i = copyFrom; i != end; ++i )
         {
             if ( *i == '\t' )
             {

--- a/tests/misc/guifuncs.cpp
+++ b/tests/misc/guifuncs.cpp
@@ -31,6 +31,13 @@
 
 #include <memory>
 
+// gcc 16.0 gives many bogus warnings about array subscripts being out of
+// bounds in basic_string.h, so disable them for this particular version as it
+// looks like a compiler bug.
+#if wxCHECK_GCC_VERSION(16, 0) && !wxCHECK_GCC_VERSION(16, 1)
+wxGCC_WARNING_SUPPRESS(array-bounds)
+#endif
+
 // ----------------------------------------------------------------------------
 // the tests
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This should fix Circle CI job which has started using the (prerelease version of) this compiler.