### PR TITLE
Add system color change event handler to dataview control

### DIFF
--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -362,6 +362,8 @@ public:     // utility functions not part of the API
 
     virtual void OnInternalIdle() override;
 
+    void OnSysColourChanged(wxSysColourChangedEvent& event);
+
 #if wxUSE_ACCESSIBILITY
     virtual wxAccessible* CreateAccessible() override;
 #endif // wxUSE_ACCESSIBILITY

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5683,6 +5683,8 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
 
     EnableSystemThemeByDefault();
 
+    Bind(wxEVT_SYS_COLOUR_CHANGED, &wxDataViewCtrl::OnSysColourChanged, this);
+
 #if wxUSE_ACCESSIBILITY
     wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_CREATE, this, wxOBJID_CLIENT, wxACC_SELF);
 #endif // wxUSE_ACCESSIBILITY
@@ -6264,6 +6266,12 @@ void wxDataViewCtrl::OnInternalIdle()
 
     if ( m_colsDirty )
         UpdateColWidths();
+}
+
+void wxDataViewCtrl::OnSysColourChanged(wxSysColourChangedEvent& event)
+{
+    Refresh();
+    event.Skip();
 }
 
 int wxDataViewCtrl::GetColumnPosition( const wxDataViewColumn *column ) const


### PR DESCRIPTION
Add wxDataViewCtrl::OnSysColourChanged() so that wxDataViewCtrl redraws properly after system colors change on Windows. This works when changing high contrast themes and dark mode themes.