### PR TITLE
Fix setting wxListCtrl column widths from wxEVT_SIZE in wxMSW

### DIFF
--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -469,6 +469,12 @@ private:
     // Object using for header custom drawing if necessary, may be null.
     wxMSWHeaderCtrlCustomDraw* m_headerCustomDraw;
 
+    // Non-zero while we're handling WM_SIZE. This is a counter and not a bool
+    // to account for the possibility of nested WM_SIZE messages, as it looks
+    // like it might happen if a wxEVT_SIZE handler does something that causes
+    // another WM_SIZE to be generated.
+    int m_inResize = 0;
+
 
     wxDECLARE_DYNAMIC_CLASS(wxListCtrl);
     wxDECLARE_EVENT_TABLE();

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1104,6 +1104,12 @@ public:
 
         In small or normal icon view, @a col must be -1, and the column width is set
         for all columns.
+
+        @note In wxMSW, the width of the column may not change immediately when
+            calling this function from wxEVT_SIZE handler due to the native
+            control limitations and calling GetColumnWidth() immediately after
+            SetColumnWidth() may still return the old width. The width is
+            still guaranteed to be updated after the event handler returns.
     */
     bool SetColumnWidth(int col, int width);
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -845,6 +845,24 @@ bool wxListCtrl::SetColumnWidth(int col, int width)
     else if ( width == wxLIST_AUTOSIZE_USEHEADER)
         width = LVSCW_AUTOSIZE_USEHEADER;
 
+    if ( m_inResize )
+    {
+        // Changing column width while handling WM_SIZE seems to be break
+        // something inside the native control, resulting in it not redrawing
+        // at all any longer in some circumstances, see #26394, so defer the
+        // call until resizing is done.
+        CallAfter([this, col, width]()
+        {
+            // This is a recursive call but it shouldn't recurse for ever (or,
+            // normally, more than once) as m_inResize should be reset "soon".
+            SetColumnWidth(col, width);
+        });
+
+        // Optimistically assume setting the column width later will succeed:
+        // better this than returning a bogus failure.
+        return true;
+    }
+
     if ( !ListView_SetColumnWidth(GetHwnd(), col, width) )
         return false;
 
@@ -3782,7 +3800,13 @@ wxListCtrl::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
             // so just ignore them
             if ( (HWND)wParam == ListView_GetHeader(GetHwnd()) )
                 return 0;
-            //else: break
+            break;
+
+        case WM_SIZE:
+            m_inResize++;
+            auto const rc = wxListCtrlBase::MSWWindowProc(nMsg, wParam, lParam);
+            m_inResize--;
+            return rc;
     }
 
     return wxListCtrlBase::MSWWindowProc(nMsg, wParam, lParam);


### PR DESCRIPTION
Calling SetColumnWidth() from wxEVT_SIZE handler could break the native control refresh logic and result in it not being refreshed at all any more.

Work around this by delaying actually setting the column width until the resizing is done.

Closes #26394.