### PR TITLE
MSW: Repaint all windows upon setting change

### DIFF
--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -362,8 +362,6 @@ public:     // utility functions not part of the API
 
     virtual void OnInternalIdle() override;
 
-    void OnSysColourChanged(wxSysColourChangedEvent& event);
-
 #if wxUSE_ACCESSIBILITY
     virtual wxAccessible* CreateAccessible() override;
 #endif // wxUSE_ACCESSIBILITY

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5683,8 +5683,6 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
 
     EnableSystemThemeByDefault();
 
-    Bind(wxEVT_SYS_COLOUR_CHANGED, &wxDataViewCtrl::OnSysColourChanged, this);
-
 #if wxUSE_ACCESSIBILITY
     wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_CREATE, this, wxOBJID_CLIENT, wxACC_SELF);
 #endif // wxUSE_ACCESSIBILITY
@@ -6266,12 +6264,6 @@ void wxDataViewCtrl::OnInternalIdle()
 
     if ( m_colsDirty )
         UpdateColWidths();
-}
-
-void wxDataViewCtrl::OnSysColourChanged(wxSysColourChangedEvent& event)
-{
-    Refresh();
-    event.Skip();
 }
 
 int wxDataViewCtrl::GetColumnPosition( const wxDataViewColumn *column ) const

--- a/src/msw/mdi.cpp
+++ b/src/msw/mdi.cpp
@@ -522,10 +522,7 @@ void wxMDIParentFrame::OnIconized(wxIconizeEvent& event)
 void wxMDIParentFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
     if ( m_clientWindow )
-    {
         m_clientWindow->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
-        m_clientWindow->Refresh();
-    }
 
     event.Skip();
 }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -2074,8 +2074,6 @@ void wxToolBar::OnSysColourChanged(wxSysColourChangedEvent& event)
     int nrows = m_maxRows;
     m_maxRows = 0;      // otherwise SetRows() wouldn't do anything
     SetRows(nrows);
-
-    Refresh();
 }
 
 void wxToolBar::OnMouseEvent(wxMouseEvent& event)

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5236,7 +5236,8 @@ bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
         node = node->GetNext();
     }
 
-    Refresh();
+    if (IsTopLevel())
+        Refresh();
 
     // let the system handle it
     return false;
@@ -5300,7 +5301,6 @@ void wxWindowMSW::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
 
         node = node->GetNext();
     }
-    Refresh();
 }
 
 extern wxCOLORMAP *wxGetStdColourMap()

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5236,7 +5236,7 @@ bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
         node = node->GetNext();
     }
 
-    if (IsTopLevel())
+    if ( IsTopLevel() )
         Refresh();
 
     // let the system handle it

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5298,6 +5298,7 @@ void wxWindowMSW::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
 
         node = node->GetNext();
     }
+    Refresh();
 }
 
 extern wxCOLORMAP *wxGetStdColourMap()

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5236,6 +5236,8 @@ bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
         node = node->GetNext();
     }
 
+    Refresh();
+
     // let the system handle it
     return false;
 }


### PR DESCRIPTION
Per feedback in #26420, this change adds a Refresh() into wxWindowMSW::OnSysColourChanged() so that all Windows are repainted upon theme change.

This change supersedes #26420. Those changes are no longer needed.

