### PR TITLE
Update non-client colors upon theme change

### DIFF
--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -20,8 +20,8 @@ namespace wxMSWDarkMode
 WXDLLIMPEXP_CORE
 bool IsActive();
 
-// Enable dark mode for the given TLW if appropriate.
-void EnableForTLW(HWND hwnd);
+// Enable or disable dark mode for the given TLW if appropriate.
+void ConfigureTLW(HWND hwnd);
 
 // Set dark theme for the given (child) window if appropriate.
 //

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -425,11 +425,7 @@ bool IsActive()
 
 void EnableForTLW(HWND hwnd)
 {
-    // Nothing to do, dark mode support not enabled or dark mode is not used.
-    if ( !wxMSWImpl::ShouldUseDarkMode() )
-        return;
-
-    BOOL useDarkMode = TRUE;
+    BOOL useDarkMode = wxMSWImpl::ShouldUseDarkMode();
 
     // DWMWA_USE_IMMERSIVE_DARK_MODE is 19 for v1809, but is 20 for later
     // versions, so to set title bar black for both v1809 and later versions,
@@ -455,7 +451,9 @@ void EnableForTLW(HWND hwnd)
     if ( FAILED(hr) )
         wxLogApiError("DwmSetWindowAttribute(USE_IMMERSIVE_DARK_MODE)", hr);
 
-    wxMSWImpl::AllowDarkModeForWindow(hwnd, true);
+    if ( wxMSWImpl::AllowDarkModeForWindow != nullptr ) {
+        wxMSWImpl::AllowDarkModeForWindow(hwnd, true);
+    }
 }
 
 void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -423,7 +423,7 @@ bool IsActive()
     return wxMSWImpl::ShouldUseDarkMode();
 }
 
-void EnableForTLW(HWND hwnd)
+void ConfigureTLW(HWND hwnd)
 {
     BOOL useDarkMode = wxMSWImpl::ShouldUseDarkMode();
 
@@ -451,9 +451,8 @@ void EnableForTLW(HWND hwnd)
     if ( FAILED(hr) )
         wxLogApiError("DwmSetWindowAttribute(USE_IMMERSIVE_DARK_MODE)", hr);
 
-    if ( wxMSWImpl::AllowDarkModeForWindow != nullptr ) {
+    if ( wxMSWImpl::AllowDarkModeForWindow != nullptr )
         wxMSWImpl::AllowDarkModeForWindow(hwnd, true);
-    }
 }
 
 void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
@@ -776,7 +775,7 @@ bool IsActive()
     return false;
 }
 
-void EnableForTLW(HWND WXUNUSED(hwnd))
+void ConfigureTLW(HWND WXUNUSED(hwnd))
 {
 }
 

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -589,7 +589,7 @@ wxTaskDialogCallback(HWND hwnd, UINT msg, WPARAM, LPARAM, LONG_PTR)
     switch ( msg )
     {
         case TDN_DIALOG_CONSTRUCTED:
-            wxMSWDarkMode::EnableForTLW(hwnd);
+            wxMSWDarkMode::ConfigureTLW(hwnd);
             break;
     }
 

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -510,7 +510,7 @@ bool wxTopLevelWindowMSW::Create(wxWindow *parent,
     // focus rectangles) work under Win2k+
     MSWUpdateUIState(UIS_INITIALIZE);
 
-    wxMSWDarkMode::EnableForTLW(GetHwnd());
+    wxMSWDarkMode::ConfigureTLW(GetHwnd());
 
     return true;
 }

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5202,6 +5202,9 @@ bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
     // Check for the special case of changing the system light/dark mode.
     if ( lParam && wxStrcmp((TCHAR*)lParam, wxT("ImmersiveColorSet")) == 0 )
     {
+        if (IsTopLevel()) {
+            wxMSWDarkMode::EnableForTLW(GetHwnd());
+        }
         // Forward to the existing function generating an event for this.
         HandleSysColorChange();
     }

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5202,7 +5202,7 @@ bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
     // Check for the special case of changing the system light/dark mode.
     if ( lParam && wxStrcmp((TCHAR*)lParam, wxT("ImmersiveColorSet")) == 0 )
     {
-        if (IsTopLevel())
+        if ( IsTopLevel() )
             wxMSWDarkMode::ConfigureTLW(GetHwnd());
 
         // Forward to the existing function generating an event for this.

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5202,9 +5202,9 @@ bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
     // Check for the special case of changing the system light/dark mode.
     if ( lParam && wxStrcmp((TCHAR*)lParam, wxT("ImmersiveColorSet")) == 0 )
     {
-        if (IsTopLevel()) {
-            wxMSWDarkMode::EnableForTLW(GetHwnd());
-        }
+        if (IsTopLevel())
+            wxMSWDarkMode::ConfigureTLW(GetHwnd());
+
         // Forward to the existing function generating an event for this.
         HandleSysColorChange();
     }


### PR DESCRIPTION
This change updates the colors in the top level window title bar, menu bar, etc, with dark/light theme change. Upon the "ImmersiveColorSet" setting change, call GetDwmSetWindowAttribute() with DWMWA_USE_IMMERSIVE_DARK_MODE to update the new dark/light mode.
