### PR TITLE
MSW: Fix wxFrame system color change

### DIFF
--- a/include/wx/msw/frame.h
+++ b/include/wx/msw/frame.h
@@ -150,6 +150,8 @@ protected:
 
     virtual bool IsMDIChild() const { return false; }
 
+    virtual wxVisualAttributes GetDefaultAttributes() const override;
+
     // get default (wxWidgets) icon for the frame
     virtual WXHICON GetDefaultIcon() const;
 

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -123,8 +123,6 @@ bool wxFrame::Create(wxWindow *parent,
     if ( !wxTopLevelWindow::Create(parent, id, title, pos, size, style, name) )
         return false;
 
-    SetOwnBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
-
 #if wxUSE_TASKBARBUTTON
     static bool s_taskbarButtonCreatedMsgRegistered = false;
     if ( !s_taskbarButtonCreatedMsgRegistered )
@@ -475,13 +473,6 @@ wxTaskBarButton* wxFrame::MSWGetTaskBarButton()
 // Responds to colour changes, and passes event on to children.
 void wxFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
-    // Don't override the colour explicitly set by the user, if any.
-    if ( !UseBgCol() )
-    {
-        SetOwnBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
-        Refresh();
-    }
-
 #if wxUSE_STATUSBAR
     if ( m_frameStatusBar )
     {
@@ -727,6 +718,13 @@ void wxFrame::IconizeChildFrames(bool bIconize)
                 frame->Iconize(bIconize);
         }
     }
+}
+
+wxVisualAttributes wxFrame::GetDefaultAttributes() const
+{
+    wxVisualAttributes attrs = GetClassDefaultAttributes(GetWindowVariant());
+    attrs.colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
+    return attrs;
 }
 
 WXHICON wxFrame::GetDefaultIcon() const

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5604,16 +5604,8 @@ wxWindowMSW::MSWGetBgBrushForChild(WXHDC hDC, wxWindowMSW *child)
         return hbrush;
     }
 
-    // Otherwise see if we have a custom background colour.
-    if ( m_hasBgCol )
-    {
-        wxBrush *
-            brush = wxTheBrushList->FindOrCreateBrush(GetBackgroundColour());
-
-        return (WXHBRUSH)GetHbrushOf(*brush);
-    }
-
-    return 0;
+    wxBrush *brush = wxTheBrushList->FindOrCreateBrush(GetBackgroundColour());
+    return (WXHBRUSH)GetHbrushOf(*brush);
 }
 
 WXHBRUSH wxWindowMSW::MSWGetBgBrush(WXHDC hDC)


### PR DESCRIPTION
I accidentally closed #26421, this continues that work.

These changes fix the wxFrame system color change by setting colors in an overridden GetDefaultAttributes() rather than by the Create() calling SetOwnBackgroundColour().

This required deleting a check on m_hasBgCol that was preventing erasure of the background using our default color.
