### PR TITLE
Fix text rendering in RTL layout when using Direct2D backend

### DIFF
--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -4067,6 +4067,8 @@ private:
     bool m_isClipBoxValid;
     double m_clipX1, m_clipY1, m_clipX2, m_clipY2;
 
+    wxLayoutDirection m_layoutDir = wxLayout_Default;
+
 private:
     wxDECLARE_NO_COPY_CLASS(wxD2DContext);
 };
@@ -4125,6 +4127,9 @@ wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer,
     RECT r = wxGetWindowRect(hwnd);
     m_width = r.right - r.left;
     m_height = r.bottom - r.top;
+
+    m_layoutDir = window->GetLayoutDirection();
+
     Init();
 }
 
@@ -4154,6 +4159,8 @@ wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer,
     wxPoint org = dc.GetDeviceOrigin();
     m_inheritedTransform = D2D1::Matrix3x2F::Translation(org.x / sx, org.y / sy);
 
+    m_layoutDir = dc.GetLayoutDirection();
+
     Init();
 }
 
@@ -4170,6 +4177,10 @@ wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer, ID2D1Factory* direct2dF
     }
     m_width = r.right - r.left;
     m_height = r.bottom - r.top;
+
+    m_layoutDir = (::GetLayout(hdc) & LAYOUT_RTL) != 0
+                ? wxLayout_RightToLeft : wxLayout_LeftToRight;
+
     Init();
 }
 
@@ -4822,11 +4833,36 @@ void wxD2DContext::DoDrawText(const wxString& str, wxDouble x, wxDouble y)
 
     wxCOMPtr<IDWriteTextLayout> textLayout = fontData->CreateTextLayout(str);
 
+    wxGraphicsMatrix oldMatrix;
+
+    if ( m_layoutDir == wxLayout_RightToLeft )
+    {
+        wxDouble width;
+        GetTextExtent(str, &width, nullptr, nullptr, nullptr);
+
+        oldMatrix = GetTransform(); // save old matrix
+        wxGraphicsMatrix matrixRTL = CreateMatrix();
+        // Alternatively, we can translate to (x+width, y) and pass (0, 0) to
+        // GetRenderTarget()->DrawTextLayout() below.
+        matrixRTL.Translate(2*x+width, 0);
+        matrixRTL.Scale(-1, 1);
+        ConcatTransform(matrixRTL);
+
+        textLayout->SetReadingDirection(DWRITE_READING_DIRECTION_RIGHT_TO_LEFT);
+        textLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
+    }
+
     // Render the text
     GetRenderTarget()->DrawTextLayout(
         D2D1::Point2F(x, y),
         textLayout,
         fontData->GetBrushData().GetBrush());
+
+    if ( m_layoutDir == wxLayout_RightToLeft )
+    {
+        // Restore old matrix
+        SetTransform(oldMatrix);
+    }
 }
 
 bool wxD2DContext::EnsureInitialized()


### PR DESCRIPTION
**Before:**
<img width="786" height="700" alt="Direct2D_RTL_Bad" src="https://github.com/user-attachments/assets/75510669-2939-42cd-be0d-710dc3cbdb31" />

**After:**
<img width="786" height="704" alt="Direct2D_RTL_Ok" src="https://github.com/user-attachments/assets/ed6e9eeb-e420-4af0-8db3-cbb2f633535a" />


