### PR TITLE
Upgrade to Doxygen 1.15.0

### DIFF
--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Update Online Documentation
 
     steps:
@@ -31,8 +31,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install doxygen
+        env:
+          DOXYGEN_VERSION: '1.15.0'
         run: |
-          sudo apt-get -q -o=Dpkg::Use-Pty=0 -y install doxygen graphviz
+          wget --progress=dot:mega https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+          tar xzvf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+          cd doxygen-${DOXYGEN_VERSION}
+          sudo make install
+          cd ..
+          rm -rf doxygen-${DOXYGEN_VERSION}* # Clean up
+          sudo apt-get -q -o=Dpkg::Use-Pty=0 -y install graphviz
 
       - name: Customize for online docs
         working-directory: docs/doxygen

--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@
 /distrib/release
 
 # /docs/doxygen/
+/docs/doxygen/doxygen.log
 /docs/doxygen/out
 
 # /include/

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.8
+# Doxyfile 1.15.0
 
 #---------------------------------------------------------------------------
 # Project Options
@@ -9,8 +9,10 @@ PROJECT_NAME           = wxWidgets
 PROJECT_NUMBER         = 3.3.3
 PROJECT_BRIEF          =
 PROJECT_LOGO           = logo.png
+PROJECT_ICON           =
 OUTPUT_DIRECTORY       = out
 CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS_LEVEL   = 8
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES
@@ -24,8 +26,10 @@ STRIP_FROM_INC_PATH    = "$(WXWIDGETS)/include/" \
                          "$(WXWIDGETS)/interface/"
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = YES # Default: NO
+JAVADOC_BANNER         = NO
 QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 4
@@ -33,19 +37,27 @@ OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
 OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
 EXTENSION_MAPPING      =
 MARKDOWN_SUPPORT       = YES
+MARKDOWN_STRICT        = YES
+TOC_INCLUDE_HEADINGS   = 3
+MARKDOWN_ID_STYLE      = DOXYGEN
 AUTOLINK_SUPPORT       = YES
+AUTOLINK_IGNORE_WORDS  =
 BUILTIN_STL_SUPPORT    = NO
 CPP_CLI_SUPPORT        = NO
 SIP_SUPPORT            = NO
 IDL_PROPERTY_SUPPORT   = NO # Default: YES
 DISTRIBUTE_GROUP_DOC   = YES # Default: NO
+GROUP_NESTED_COMPOUNDS = NO
 SUBGROUPING            = YES
 INLINE_GROUPED_CLASSES = NO # TODO: Examine this setting.
 INLINE_SIMPLE_STRUCTS  = NO # TODO: Examine this setting.
 TYPEDEF_HIDES_STRUCT   = NO
 LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 1
+TIMESTAMP              = YES # Default: NO
 
 
 #---------------------------------------------------------------------------
@@ -244,25 +256,30 @@ ALIASES += buildwith{2}="<b>Build Note:</b> You may need to build the wxWidgets 
 
 EXTRACT_ALL            = YES # Default: NO
 EXTRACT_PRIVATE        = YES # Default: NO
+EXTRACT_PRIV_VIRTUAL   = NO
 EXTRACT_PACKAGE        = NO
 EXTRACT_STATIC         = YES # Default: NO
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = NO
 EXTRACT_ANON_NSPACES   = YES # TODO: Default: NO
+RESOLVE_UNNAMED_PARAMS = YES
 HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
+HIDE_UNDOC_NAMESPACES  = YES
 HIDE_FRIEND_COMPOUNDS  = NO
 HIDE_IN_BODY_DOCS      = NO
 INTERNAL_DOCS          = NO
 CASE_SENSE_NAMES       = NO # Default: YES
 HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
 SHOW_INCLUDE_FILES     = YES
 SHOW_GROUPED_MEMB_INC  = NO # TODO: YES
 FORCE_LOCAL_INCLUDES   = NO
 INLINE_INFO            = YES
 SORT_MEMBER_DOCS       = YES
 SORT_BRIEF_DOCS        = NO # Don't set to YES, it renders our named groups out of order.
-SORT_MEMBERS_CTORS_1ST = NO # Default: NO
+SORT_MEMBERS_CTORS_1ST = NO
 SORT_GROUP_NAMES       = YES # Default: NO
 SORT_BY_SCOPE_NAME     = NO
 STRICT_PROTO_MATCHING  = NO
@@ -279,6 +296,7 @@ SHOW_NAMESPACES        = NO # TODO: Default: YES
 FILE_VERSION_FILTER    =
 LAYOUT_FILE            = DoxygenLayout.xml
 CITE_BIB_FILES         =
+EXTERNAL_TOOL_PATH     =
 
 
 #---------------------------------------------------------------------------
@@ -289,8 +307,13 @@ QUIET                  = YES # Default: NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_NO_PARAMDOC       = YES # Default: NO
+WARN_IF_UNDOC_ENUM_VAL = NO
+WARN_LAYOUT_FILE       = YES
+WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
+WARN_LINE_FORMAT       = "at line $line of file $file"
 WARN_LOGFILE           = doxygen.log
 
 
@@ -309,6 +332,7 @@ INPUT                  = mainpages \
                          ../x11 \
                          ../../interface
 INPUT_ENCODING         = UTF-8
+INPUT_FILE_ENCODING    =
 FILE_PATTERNS          = *.h *.md
 RECURSIVE              = YES # Default: NO
 EXCLUDE                =
@@ -324,6 +348,8 @@ FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
 USE_MDFILE_AS_MAINPAGE =
+IMPLICIT_DIR_DOCS      = YES
+FORTRAN_COMMENT_AFTER  = 72
 
 
 #---------------------------------------------------------------------------
@@ -339,6 +365,10 @@ REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = NO # Default: YES
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
 
 
 #---------------------------------------------------------------------------
@@ -361,11 +391,15 @@ HTML_FOOTER            = custom_footer.html
 HTML_STYLESHEET        =
 HTML_EXTRA_STYLESHEET  = $(CUSTOM_THEME_CSS) extra_stylesheet.css
 HTML_EXTRA_FILES       = $(CUSTOM_THEME_JS1) $(CUSTOM_THEME_JS2) wxwidgets.js
+HTML_COLORSTYLE        = LIGHT # Required LIGHT for Doxygen Awesome
 HTML_COLORSTYLE_HUE    = 220 # Default: 220
 HTML_COLORSTYLE_SAT    = 255 # Default: 100
 HTML_COLORSTYLE_GAMMA  = 100 # Default: 80
-HTML_TIMESTAMP         = YES
+HTML_DYNAMIC_MENUS     = YES # TODO: Maybe NO
 HTML_DYNAMIC_SECTIONS  = YES # Default: NO
+HTML_CODE_FOLDING      = YES
+HTML_COPY_CLIPBOARD    = YES
+HTML_PROJECT_COOKIE    =
 HTML_INDEX_NUM_ENTRIES = 100
 
 
@@ -375,7 +409,8 @@ HTML_INDEX_NUM_ENTRIES = 100
 
 GENERATE_DOCSET        = $(GENERATE_DOCSET)
 DOCSET_FEEDNAME        = "wxWidgets 3.3"
-DOCSET_BUNDLE_ID       = org.wxwidgets.doxygen.wx31
+DOCSET_FEEDURL         =
+DOCSET_BUNDLE_ID       = org.wxwidgets.doxygen.wx33
 DOCSET_PUBLISHER_ID    = org.wxwidgets.doxygen
 DOCSET_PUBLISHER_NAME  = wxWidgets
 
@@ -391,7 +426,7 @@ GENERATE_CHI           = NO
 CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = NO
-TOC_INCLUDE_HEADINGS   = 3
+SITEMAP_URL            =
 
 
 #---------------------------------------------------------------------------
@@ -422,12 +457,18 @@ ECLIPSE_DOC_ID         = org.wxwidgets.doxygen
 
 DISABLE_INDEX          = NO
 GENERATE_TREEVIEW      = NO
+PAGE_OUTLINE_PANEL     = YES
+FULL_SIDEBAR           = NO # Required NO for Doxygen Awesome
 ENUM_VALUES_PER_LINE   = 1 # Default: 4
+SHOW_ENUM_VALUES       = NO
 TREEVIEW_WIDTH         = 250
 EXT_LINKS_IN_WINDOW    = YES # Default: NO
+OBFUSCATE_EMAILS       = YES
+HTML_FORMULA_FORMAT    = png
 FORMULA_FONTSIZE       = 10
-FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
 USE_MATHJAX            = NO
+MATHJAX_VERSION        = MathJax_2
 MATHJAX_FORMAT         = HTML-CSS
 MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
 MATHJAX_EXTENSIONS     =
@@ -449,18 +490,20 @@ GENERATE_LATEX         = $(GENERATE_LATEX)
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
 LATEX_HEADER           = latex_header.tex
 LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
 LATEX_EXTRA_FILES      =
 PDF_HYPERLINKS         = YES
 USE_PDFLATEX           = YES
 LATEX_BATCHMODE        = YES # Default: NO
 LATEX_HIDE_INDICES     = NO
-LATEX_SOURCE_CODE      = NO
 LATEX_BIB_STYLE        = plain
+LATEX_EMOJI_DIRECTORY  =
 
 
 #---------------------------------------------------------------------------
@@ -473,6 +516,7 @@ COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
 RTF_STYLESHEET_FILE    =
 RTF_EXTENSIONS_FILE    =
+RTF_EXTRA_FILES        =
 
 
 #---------------------------------------------------------------------------
@@ -493,6 +537,7 @@ MAN_LINKS              = NO
 GENERATE_XML           = $(GENERATE_XML)
 XML_OUTPUT             = xml
 XML_PROGRAMLISTING     = NO # Default: YES
+XML_NS_MEMB_FILE_SCOPE = NO
 
 
 #---------------------------------------------------------------------------
@@ -501,7 +546,6 @@ XML_PROGRAMLISTING     = NO # Default: YES
 
 GENERATE_DOCBOOK       = NO
 DOCBOOK_OUTPUT         = docbook
-DOCBOOK_PROGRAMLISTING = NO
 
 
 #---------------------------------------------------------------------------
@@ -509,6 +553,15 @@ DOCBOOK_PROGRAMLISTING = NO
 #---------------------------------------------------------------------------
 
 GENERATE_AUTOGEN_DEF   = NO
+
+
+#---------------------------------------------------------------------------
+# Sqlite3 Output Options
+#---------------------------------------------------------------------------
+
+GENERATE_SQLITE3       = NO
+SQLITE3_OUTPUT         = sqlite3
+SQLITE3_RECREATE_DB    = YES
 
 
 #---------------------------------------------------------------------------
@@ -552,19 +605,21 @@ EXTERNAL_PAGES         = YES
 # dot Tool Options
 #---------------------------------------------------------------------------
 
-CLASS_DIAGRAMS         = YES
-DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES # Default: NO
 DOT_NUM_THREADS        = 0
-DOT_FONTNAME           =
-DOT_FONTSIZE           = 10
+DOT_COMMON_ATTR        = "fontname=Helvetica,fontsize=10"
+DOT_EDGE_ATTR          = "labelfontname=Helvetica,labelfontsize=10"
+DOT_NODE_ATTR          = "shape=box,height=0.2,width=0.4"
 DOT_FONTPATH           =
 CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = NO # Default: YES
 GROUP_GRAPHS           = NO # Default: YES
 UML_LOOK               = NO
 UML_LIMIT_NUM_FIELDS   = 10
+UML_MAX_EDGE_LABELS    = 10
+DOT_UML_DETAILS        = NO
+DOT_WRAP_THRESHOLD     = 17
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = NO # Default: YES
 INCLUDED_BY_GRAPH      = NO # Default: YES
@@ -572,16 +627,21 @@ CALL_GRAPH             = NO
 CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = NO # TODO: Default: YES
 DIRECTORY_GRAPH        = NO # Default: YES
+DIR_GRAPH_MAX_DEPTH    = 1
 DOT_IMAGE_FORMAT       = $(DOT_IMAGE_FORMAT)
 INTERACTIVE_SVG        = NO
 DOT_PATH               =
 DOTFILE_DIRS           =
-MSCFILE_DIRS           =
+DIA_PATH               =
 DIAFILE_DIRS           =
 PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+PLANTUMLFILE_DIRS      =
 DOT_GRAPH_MAX_NODES    = 150 # Default 50, we currently have 108 for wxObject
 MAX_DOT_GRAPH_DEPTH    = 1000 # Default: 0
-DOT_TRANSPARENT        = yes
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
+MSCGEN_TOOL            =
+MSCFILE_DIRS           =

--- a/docs/doxygen/DoxygenLayout.xml
+++ b/docs/doxygen/DoxygenLayout.xml
@@ -3,7 +3,7 @@
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
-    <tab type="modules" visible="yes" title="Categories" intro=""/>
+    <tab type="topics" visible="yes" title="Categories" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>
       <tab type="namespacemembers" visible="yes" title="" intro=""/>

--- a/docs/doxygen/custom_header_simple.html
+++ b/docs/doxygen/custom_header_simple.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
-<!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+<!--BEGIN PROJECT_NAME--><title>$title | $projectname</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
 <link href="$relpath$tabs.css" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="$relpath$jquery.js"></script>

--- a/docs/doxygen/doxygen-awesome-css/README.md
+++ b/docs/doxygen/doxygen-awesome-css/README.md
@@ -1,4 +1,6 @@
 Files in this subdirectory were taken from the [Doxygen Awesome][1] CSS theme
 and are under MIT licence.
 
+Doxygen Awesome Version: 2.4.2
+
 [1]: https://github.com/jothepro/doxygen-awesome-css

--- a/docs/doxygen/doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js
+++ b/docs/doxygen/doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js
@@ -1,29 +1,10 @@
+// SPDX-License-Identifier: MIT
 /**
 
 Doxygen Awesome
 https://github.com/jothepro/doxygen-awesome-css
 
-MIT License
-
-Copyright (c) 2021 - 2022 jothepro
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright (c) 2021 - 2025 jothepro
 
 */
 

--- a/docs/doxygen/doxygen-awesome-css/doxygen-awesome-fragment-copy-button.js
+++ b/docs/doxygen/doxygen-awesome-css/doxygen-awesome-fragment-copy-button.js
@@ -1,29 +1,10 @@
+// SPDX-License-Identifier: MIT
 /**
 
 Doxygen Awesome
 https://github.com/jothepro/doxygen-awesome-css
 
-MIT License
-
-Copyright (c) 2022 jothepro
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright (c) 2022 - 2025 jothepro
 
 */
 
@@ -33,8 +14,8 @@ class DoxygenAwesomeFragmentCopyButton extends HTMLElement {
         this.onclick=this.copyContent
     }
     static title = "Copy to clipboard"
-    static copyIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>`
-    static successIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>`
+    static copyIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M23.04,10.322c0,-2.582 -2.096,-4.678 -4.678,-4.678l-6.918,-0c-2.582,-0 -4.678,2.096 -4.678,4.678c0,-0 0,8.04 0,8.04c0,2.582 2.096,4.678 4.678,4.678c0,-0 6.918,-0 6.918,-0c2.582,-0 4.678,-2.096 4.678,-4.678c0,-0 0,-8.04 0,-8.04Zm-2.438,-0l-0,8.04c-0,1.236 -1.004,2.24 -2.24,2.24l-6.918,-0c-1.236,-0 -2.239,-1.004 -2.239,-2.24l-0,-8.04c-0,-1.236 1.003,-2.24 2.239,-2.24c0,0 6.918,0 6.918,0c1.236,0 2.24,1.004 2.24,2.24Z"/><path d="M5.327,16.748c-0,0.358 -0.291,0.648 -0.649,0.648c0,0 0,0 0,0c-2.582,0 -4.678,-2.096 -4.678,-4.678c0,0 0,-8.04 0,-8.04c0,-2.582 2.096,-4.678 4.678,-4.678l6.918,0c2.168,0 3.994,1.478 4.523,3.481c0.038,0.149 0.005,0.306 -0.09,0.428c-0.094,0.121 -0.239,0.191 -0.392,0.191c-0.451,0.005 -1.057,0.005 -1.457,0.005c-0.238,0 -0.455,-0.14 -0.553,-0.357c-0.348,-0.773 -1.128,-1.31 -2.031,-1.31c-0,0 -6.918,0 -6.918,0c-1.236,0 -2.24,1.004 -2.24,2.24l0,8.04c0,1.236 1.004,2.24 2.24,2.24l0,-0c0.358,-0 0.649,0.29 0.649,0.648c-0,0.353 -0,0.789 -0,1.142Z" style="fill-opacity:0.6;"/></svg>`
+    static successIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M8.084,16.111c-0.09,0.09 -0.212,0.141 -0.34,0.141c-0.127,-0 -0.249,-0.051 -0.339,-0.141c-0.746,-0.746 -2.538,-2.538 -3.525,-3.525c-0.375,-0.375 -0.983,-0.375 -1.357,0c-0.178,0.178 -0.369,0.369 -0.547,0.547c-0.375,0.375 -0.375,0.982 -0,1.357c1.135,1.135 3.422,3.422 4.75,4.751c0.27,0.27 0.637,0.421 1.018,0.421c0.382,0 0.749,-0.151 1.019,-0.421c2.731,-2.732 10.166,-10.167 12.454,-12.455c0.375,-0.375 0.375,-0.982 -0,-1.357c-0.178,-0.178 -0.369,-0.369 -0.547,-0.547c-0.375,-0.375 -0.982,-0.375 -1.357,0c-2.273,2.273 -9.567,9.567 -11.229,11.229Z"/></svg>`
     static successDuration = 980
     static init() {
         $(function() {

--- a/docs/doxygen/doxygen-awesome-css/doxygen-awesome.css
+++ b/docs/doxygen/doxygen-awesome-css/doxygen-awesome.css
@@ -1,29 +1,10 @@
+/* SPDX-License-Identifier: MIT */
 /**
 
 Doxygen Awesome
 https://github.com/jothepro/doxygen-awesome-css
 
-MIT License
-
-Copyright (c) 2021 - 2022 jothepro
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright (c) 2021 - 2025 jothepro
 
 */
 
@@ -32,26 +13,30 @@ html {
     --primary-color: #1779c4;
     --primary-dark-color: #335c80;
     --primary-light-color: #70b1e9;
+    --on-primary-color: #ffffff;
+
+    --link-color: var(--primary-color);
 
     /* page base colors */
-    --page-background-color: white;
+    --page-background-color: #ffffff;
     --page-foreground-color: #2f4153;
-    --page-secondary-foreground-color: #637485;
+    --page-secondary-foreground-color: #6f7e8e;
 
     /* color for all separators on the website: hr, borders, ... */
     --separator-color: #dedede;
 
     /* border radius for all rounded components. Will affect many components, like dropdowns, memitems, codeblocks, ... */
-    --border-radius-large: 8px;
-    --border-radius-small: 4px;
-    --border-radius-medium: 6px;
+    --border-radius-large: 10px;
+    --border-radius-small: 5px;
+    --border-radius-medium: 8px;
 
-    /* default spacings. Most compontest reference these values for spacing, to provide uniform spacing on the page. */
+    /* default spacings. Most components reference these values for spacing, to provide uniform spacing on the page. */
     --spacing-small: 5px;
     --spacing-medium: 10px;
     --spacing-large: 16px;
+    --spacing-xlarge: 20px;
 
-    /* default box shadow used for raising an element above the normal content. Used in dropdowns, Searchresult, ... */
+    /* default box shadow used for raising an element above the normal content. Used in dropdowns, search result, ... */
     --box-shadow: 0 2px 8px 0 rgba(0,0,0,.075);
 
     --odd-color: rgba(0,0,0,.028);
@@ -66,30 +51,35 @@ html {
     /* font sizes */
     --page-font-size: 15.6px;
     --navigation-font-size: 14.4px;
+    --toc-font-size: 13.4px;
     --code-font-size: 14px; /* affects code, fragment */
     --title-font-size: 22px;
 
     /* content text properties. These only affect the page content, not the navigation or any other ui elements */
     --content-line-height: 27px;
     /* The content is centered and constraint in it's width. To make the content fill the whole page, set the variable to auto.*/
-    --content-maxwidth: 1000px;
+    --content-maxwidth: 1050px;
+    --table-line-height: 24px;
+    --toc-sticky-top: var(--spacing-medium);
+    --toc-width: 200px;
+    --toc-max-height: calc(100vh - 2 * var(--spacing-medium) - 85px);
 
     /* colors for various content boxes: @warning, @note, @deprecated @bug */
-    --warning-color: #f8d1cc;
-    --warning-color-dark: #b61825;
-    --warning-color-darker: #75070f;
-    --note-color: #faf3d8;
-    --note-color-dark: #f3a600;
-    --note-color-darker: #5f4204;
-    --todo-color: #e4f3ff;
-    --todo-color-dark: #1879C4;
-    --todo-color-darker: #274a5c;
+    --warning-color: #faf3d8;
+    --warning-color-dark: #f3a600;
+    --warning-color-darker: #5f4204;
+    --note-color: #e4f3ff;
+    --note-color-dark: #1879C4;
+    --note-color-darker: #274a5c;
+    --todo-color: #e4dafd;
+    --todo-color-dark: #5b2bdd;
+    --todo-color-darker: #2a0d72;
     --deprecated-color: #ecf0f3;
     --deprecated-color-dark: #5b6269;
     --deprecated-color-darker: #43454a;
-    --bug-color: #e4dafd;
-    --bug-color-dark: #5b2bdd;
-    --bug-color-darker: #2a0d72;
+    --bug-color: #f8d1cc;
+    --bug-color-dark: #b61825;
+    --bug-color-darker: #75070f;
     --invariant-color: #d8f1e3;
     --invariant-color-dark: #44b86f;
     --invariant-color-darker: #265532;
@@ -108,7 +98,7 @@ html {
      */
     --menu-display: block;
 
-    --menu-focus-foreground: var(--page-background-color);
+    --menu-focus-foreground: var(--on-primary-color);
     --menu-focus-background: var(--primary-color);
     --menu-selected-background: rgba(0,0,0,.05);
 
@@ -130,6 +120,8 @@ html {
     /* code block colors */
     --code-background: #f5f5f5;
     --code-foreground: var(--page-foreground-color);
+    --section-code-background: rgba(0, 0, 0, 0.06);
+    --section-code-border: rgba(0, 0, 0, 0.16);
 
     /* fragment colors */
     --fragment-background: #F8F9FA;
@@ -155,7 +147,7 @@ html {
     --toc-background: var(--side-nav-background);
     --toc-foreground: var(--side-nav-foreground);
 
-    /* height of an item in any tree / collapsable table */
+    /* height of an item in any tree / collapsible table */
     --tree-item-height: 30px;
 
     --memname-font-size: var(--code-font-size);
@@ -164,12 +156,15 @@ html {
     --webkit-scrollbar-size: 7px;
     --webkit-scrollbar-padding: 4px;
     --webkit-scrollbar-color: var(--separator-color);
+
+    --animation-duration: .12s
 }
 
 @media screen and (max-width: 767px) {
     html {
         --page-font-size: 16px;
         --navigation-font-size: 16px;
+        --toc-font-size: 15px;
         --code-font-size: 15px; /* affects code, fragment */
         --title-font-size: 22px;
     }
@@ -196,27 +191,29 @@ html {
         --side-nav-background: #252628;
 
         --code-background: #2a2c2f;
+        --section-code-background: rgba(255, 255, 255, 0.08);
+        --section-code-border: rgba(255, 255, 255, 0.18);
 
         --tablehead-background: #2a2c2f;
     
         --blockquote-background: #222325;
         --blockquote-foreground: #7e8c92;
 
-        --warning-color: #2e1917;
-        --warning-color-dark: #ad2617;
-        --warning-color-darker: #f5b1aa;
-        --note-color: #3b2e04;
-        --note-color-dark: #f1b602;
-        --note-color-darker: #ceb670;
-        --todo-color: #163750;
-        --todo-color-dark: #1982D2;
-        --todo-color-darker: #dcf0fa;
+        --warning-color: #3b2e04;
+        --warning-color-dark: #f1b602;
+        --warning-color-darker: #ceb670;
+        --note-color: #163750;
+        --note-color-dark: #1982D2;
+        --note-color-darker: #dcf0fa;
+        --todo-color: #2a2536;
+        --todo-color-dark: #7661b3;
+        --todo-color-darker: #ae9ed6;
         --deprecated-color: #2e323b;
         --deprecated-color-dark: #738396;
         --deprecated-color-darker: #abb0bd;
-        --bug-color: #2a2536;
-        --bug-color-dark: #7661b3;
-        --bug-color-darker: #ae9ed6;
+        --bug-color: #2e1917;
+        --bug-color-dark: #ad2617;
+        --bug-color-darker: #f5b1aa;
         --invariant-color: #303a35;
         --invariant-color-dark: #76ce96;
         --invariant-color-darker: #cceed5;
@@ -257,27 +254,29 @@ html.dark-mode {
     --side-nav-background: #252628;
 
     --code-background: #2a2c2f;
+    --section-code-background: rgba(255, 255, 255, 0.08);
+    --section-code-border: rgba(255, 255, 255, 0.18);
 
     --tablehead-background: #2a2c2f;
 
     --blockquote-background: #222325;
     --blockquote-foreground: #7e8c92;
 
-    --warning-color: #2e1917;
-    --warning-color-dark: #ad2617;
-    --warning-color-darker: #f5b1aa;
-    --note-color: #3b2e04;
-    --note-color-dark: #f1b602;
-    --note-color-darker: #ceb670;
-    --todo-color: #163750;
-    --todo-color-dark: #1982D2;
-    --todo-color-darker: #dcf0fa;
+    --warning-color: #3b2e04;
+    --warning-color-dark: #f1b602;
+    --warning-color-darker: #ceb670;
+    --note-color: #163750;
+    --note-color-dark: #1982D2;
+    --note-color-darker: #dcf0fa;
+    --todo-color: #2a2536;
+    --todo-color-dark: #7661b3;
+    --todo-color-darker: #ae9ed6;
     --deprecated-color: #2e323b;
     --deprecated-color-dark: #738396;
     --deprecated-color-darker: #abb0bd;
-    --bug-color: #2a2536;
-    --bug-color-dark: #7661b3;
-    --bug-color-darker: #ae9ed6;
+    --bug-color: #2e1917;
+    --bug-color-dark: #ad2617;
+    --bug-color-darker: #f5b1aa;
     --invariant-color: #303a35;
     --invariant-color-dark: #76ce96;
     --invariant-color-darker: #cceed5;
@@ -302,27 +301,41 @@ body {
     font-size: var(--page-font-size);
 }
 
-body, table, div, p, dl, #nav-tree .label, .title, .sm-dox a, .sm-dox a:hover, .sm-dox a:focus, #projectname, .SelectItem, #MSearchField, .navpath li.navelem a, .navpath li.navelem a:hover {
+body, table, div, p, dl, #nav-tree .label, #nav-tree a, .title,
+.sm-dox a, .sm-dox a:hover, .sm-dox a:focus, #projectname,
+.SelectItem, #MSearchField, .navpath li.navelem a,
+.navpath li.navelem a:hover, p.reference, p.definition, div.toc li, div.toc h3,
+#page-nav ul.page-outline li a {
     font-family: var(--font-family);
 }
 
 h1, h2, h3, h4, h5 {
-    margin-top: .9em;
+    margin-top: 1em;
     font-weight: 600;
     line-height: initial;
 }
 
-p, div, table, dl {
+p, div, table, dl, p.reference, p.definition {
     font-size: var(--page-font-size);
 }
 
+p.reference, p.definition {
+    color: var(--page-secondary-foreground-color);
+}
+
 a:link, a:visited, a:hover, a:focus, a:active {
-    color: var(--primary-color) !important;
+    color: var(--link-color) !important;
     font-weight: 500;
+    background: none;
+}
+
+a:hover {
+    text-decoration: underline;
 }
 
 a.anchor {
     scroll-margin-top: var(--spacing-large);
+    display: block;
 }
 
 /*
@@ -332,6 +345,8 @@ a.anchor {
 #top {
     background: var(--header-background);
     border-bottom: 1px solid var(--separator-color);
+    position: relative;
+    z-index: 99;
 }
 
 @media screen and (min-width: 768px) {
@@ -346,6 +361,7 @@ a.anchor {
 #main-nav {
     flex-grow: 5;
     padding: var(--spacing-small) var(--spacing-medium);
+    border-bottom: 0;
 }
 
 #titlearea {
@@ -400,6 +416,10 @@ a.anchor {
     margin-bottom: -1px;
 }
 
+.main-menu-btn-icon, .main-menu-btn-icon:before, .main-menu-btn-icon:after {
+    background: var(--page-secondary-foreground-color);
+}
+
 @media screen and (max-width: 767px) {
     .sm-dox a span.sub-arrow {
         background: var(--code-background);
@@ -421,19 +441,36 @@ a.anchor {
     }
 
     .sm-dox a span.sub-arrow {
-        border-color: var(--header-foreground) transparent transparent transparent;
+        top: 15px;
+        right: 10px;
+        box-sizing: content-box;
+        padding: 0;
+        margin: 0;
+        display: inline-block;
+        width: 5px;
+        height: 5px;
+        transform: rotate(45deg);
+        border-width: 0;
+        border-right: 2px solid var(--header-foreground);
+        border-bottom: 2px solid var(--header-foreground);
+        background: none;
     }
 
     .sm-dox a:hover span.sub-arrow {
-        border-color: var(--menu-focus-foreground) transparent transparent transparent;
+        border-color: var(--menu-focus-foreground);
+        background: none;
     }
 
     .sm-dox ul a span.sub-arrow {
-        border-color: transparent transparent transparent var(--page-foreground-color);
+        transform: rotate(-45deg);
+        border-width: 0;
+        border-right: 2px solid var(--header-foreground);
+        border-bottom: 2px solid var(--header-foreground);
     }
 
     .sm-dox ul a:hover span.sub-arrow {
-        border-color: transparent transparent transparent var(--menu-focus-foreground);
+        border-color: var(--menu-focus-foreground);
+        background: none;
     }
 }
 
@@ -460,7 +497,7 @@ a.anchor {
 
 .sm-dox ul a {
     color: var(--page-foreground-color) !important;
-    background: var(--page-background-color);
+    background: none;
     font-size: var(--navigation-font-size);
 }
 
@@ -532,16 +569,43 @@ a.anchor {
     box-shadow: none;
     display: block;
     margin-top: 0;
+    margin-right: 0;
 }
 
-.left #MSearchSelect {
+@media (min-width: 768px) {
+    .sm-dox li {
+        padding: 0;
+    }
+}
+
+/* until Doxygen 1.9.4 */
+.left img#MSearchSelect {
     left: 0;
     user-select: none;
     padding-left: 8px;
 }
 
+/* Doxygen 1.9.5 */
+.left span#MSearchSelect {
+    left: 0;
+    user-select: none;
+    margin-left: 8px;
+    padding: 0;
+}
+
 .left #MSearchSelect[src$=".png"] {
     padding-left: 0
+}
+
+/* Doxygen 1.14.0 */
+.search-icon::before {
+    background: none;
+    top: 5px;
+}
+
+.search-icon::after {
+    background: none;
+    top: 12px;
 }
 
 .SelectionMark {
@@ -656,6 +720,15 @@ html.dark-mode iframe#MSearchResults {
     filter: invert() hue-rotate(180deg);
 }
 
+#MSearchResults .SRPage {
+    background-color: transparent;
+}
+
+#MSearchResults .SRPage .SREntry {
+    font-size: 10pt;
+    padding: var(--spacing-small) var(--spacing-medium);
+}
+
 #MSearchSelectWindow {
     border: 1px solid var(--separator-color);
     border-radius: var(--border-radius-medium);
@@ -712,6 +785,7 @@ html.dark-mode iframe#MSearchResults {
         overflow: auto;
         transform: translate(0, 20px);
         animation: ease-out 280ms slideInSearchResultsMobile;
+        width: auto !important;
     }
 
     /*
@@ -737,8 +811,13 @@ html.dark-mode iframe#MSearchResults {
  */
 
 #side-nav {
-    padding: 0 !important;
-    background: var(--side-nav-background);
+    min-width: 8px;
+    max-width: 50vw;
+}
+
+
+#nav-tree, #top {
+    border-right: 1px solid var(--separator-color);
 }
 
 @media screen and (max-width: 767px) {
@@ -749,26 +828,86 @@ html.dark-mode iframe#MSearchResults {
     #doc-content {
         margin-left: 0 !important;
     }
+
+    #top {
+        border-right: none;
+    }
 }
 
 #nav-tree {
-    background: transparent;
+    background: var(--side-nav-background);
+    margin-right: -1px;
+    padding: 0;
 }
 
 #nav-tree .label {
     font-size: var(--navigation-font-size);
+    line-height: var(--tree-item-height);
+}
+
+#nav-tree span.label a:hover {
+    background: none;
 }
 
 #nav-tree .item {
     height: var(--tree-item-height);
     line-height: var(--tree-item-height);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin: 0;
+    padding: 0;
+}
+
+#nav-tree-contents {
+    margin: 0;
+}
+
+#main-menu > li:last-child {
+    height: auto;
+}
+
+#nav-tree .item > a:focus {
+    outline: none;
 }
 
 #nav-sync {
-    bottom: 12px;
-    right: 12px;
+    bottom: var(--spacing-medium);
+    right: var(--spacing-medium) !important;
     top: auto !important;
     user-select: none;
+}
+
+div.nav-sync-icon {
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium);
+    background: var(--page-background-color);
+    width: 30px;
+    height: 20px;
+}
+
+div.nav-sync-icon:hover {
+    background: var(--page-background-color);
+}
+
+span.sync-icon-left, div.nav-sync-icon:hover span.sync-icon-left {
+    border-left: 2px solid var(--primary-color);
+    border-top: 2px solid var(--primary-color);
+    top: 5px;
+    left: 6px;
+}
+span.sync-icon-right, div.nav-sync-icon:hover span.sync-icon-right {
+    border-right: 2px solid var(--primary-color);
+    border-bottom: 2px solid var(--primary-color);
+    top: 5px;
+    left: initial;
+    right: 6px;
+}
+
+div.nav-sync-icon.active::after, div.nav-sync-icon.active:hover::after {
+    border-top: 2px solid var(--primary-color);
+    top: 9px;
+    left: 6px;
+    width: 19px;
 }
 
 #nav-tree .selected {
@@ -776,6 +915,8 @@ html.dark-mode iframe#MSearchResults {
     background-image: none;
     background-color: transparent;
     position: relative;
+    color: var(--primary-color) !important;
+    font-weight: 500;
 }
 
 #nav-tree .selected::after {
@@ -801,9 +942,27 @@ html.dark-mode iframe#MSearchResults {
 
 #nav-tree .arrow {
     opacity: var(--side-nav-arrow-opacity);
+    background: none;
 }
 
-.arrow {
+#nav-tree span.arrowhead {
+    margin: 0 0 1px 2px;
+}
+
+span.arrowhead {
+    border-color: var(--primary-light-color);
+}
+
+.selected span.arrowhead {
+    border-color: var(--primary-color);
+}
+
+#nav-tree-contents > ul > li:first-child > div > a {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.contents .arrow {
     color: inherit;
     cursor: pointer;
     font-size: 45%;
@@ -811,7 +970,7 @@ html.dark-mode iframe#MSearchResults {
     margin-right: 2px;
     font-family: serif;
     height: auto;
-    text-align: right;
+    padding-bottom: 4px;
 }
 
 #nav-tree div.item:hover .arrow, #nav-tree a:focus .arrow {
@@ -825,8 +984,11 @@ html.dark-mode iframe#MSearchResults {
 }
 
 .ui-resizable-e {
+    background: none;
+}
+
+.ui-resizable-e:hover {
     background: var(--separator-color);
-    width: 1px;
 }
 
 /*
@@ -835,8 +997,23 @@ html.dark-mode iframe#MSearchResults {
 
 div.header {
     border-bottom: 1px solid var(--separator-color);
-    background-color: var(--page-background-color);
+    background: none;
     background-image: none;
+}
+
+@media screen and (min-width: 1000px) {
+    #doc-content > div > div.contents,
+    .PageDoc > div.contents {
+        display: flex;
+        flex-direction: row-reverse;
+        flex-wrap: nowrap;
+        align-items: flex-start;
+    }
+    
+    div.contents .textblock {
+        min-width: 200px;
+        flex-grow: 1;
+    }
 }
 
 div.contents, div.header .title, div.header .summary {
@@ -858,8 +1035,8 @@ div.headertitle {
 
 div.header .title {
     font-weight: 600;
-    font-size: 210%;
-    padding: var(--spacing-medium) var(--spacing-large);
+    font-size: 225%;
+    padding: var(--spacing-medium) var(--spacing-xlarge);
     word-break: break-word;
 }
 
@@ -876,9 +1053,10 @@ td.memSeparator {
 
 span.mlabel {
     background: var(--primary-color);
+    color: var(--on-primary-color);
     border: none;
     padding: 4px 9px;
-    border-radius: 12px;
+    border-radius: var(--border-radius-large);
     margin-right: var(--spacing-medium);
 }
 
@@ -887,7 +1065,7 @@ span.mlabel:last-of-type {
 }
 
 div.contents {
-    padding: 0 var(--spacing-large);
+    padding: 0 var(--spacing-xlarge);
 }
 
 div.contents p, div.contents li {
@@ -898,27 +1076,40 @@ div.contents div.dyncontent {
     margin: var(--spacing-medium) 0;
 }
 
+@media screen and (max-width: 767px) {
+    div.contents {
+        padding: 0 var(--spacing-large);
+    }
+
+    div.header .title {
+        padding: var(--spacing-medium) var(--spacing-large);
+    }
+}
+
 @media (prefers-color-scheme: dark) {
     html:not(.light-mode) div.contents div.dyncontent img,
     html:not(.light-mode) div.contents center img,
-    html:not(.light-mode) div.contents table img,
+    html:not(.light-mode) div.contents > table img,
     html:not(.light-mode) div.contents div.dyncontent iframe,
     html:not(.light-mode) div.contents center iframe,
-    html:not(.light-mode) div.contents table iframe {
-        filter: hue-rotate(180deg) invert();
+    html:not(.light-mode) div.contents table iframe,
+    html:not(.light-mode) div.contents .dotgraph iframe {
+        filter: brightness(89%) hue-rotate(180deg) invert();
     }
 }
 
 html.dark-mode div.contents div.dyncontent img,
 html.dark-mode div.contents center img,
-html.dark-mode div.contents table img,
+html.dark-mode div.contents > table img,
 html.dark-mode div.contents div.dyncontent iframe,
 html.dark-mode div.contents center iframe,
-html.dark-mode div.contents table iframe {
-    filter: hue-rotate(180deg) invert();
+html.dark-mode div.contents table iframe,
+html.dark-mode div.contents .dotgraph iframe
+ {
+    filter: brightness(89%) hue-rotate(180deg) invert();
 }
 
-h2.groupheader {
+td h2.groupheader, h2.groupheader {
     border-bottom: 0px;
     color: var(--page-foreground-color);
     box-shadow: 
@@ -930,14 +1121,18 @@ h2.groupheader {
         -500px 0 var(--page-background-color),
         500px 0.75px var(--separator-color),
         -500px 0.75px var(--separator-color),
-        1500px 0 var(--page-background-color),
-        -1500px 0 var(--page-background-color), 
-        1500px 0.75px var(--separator-color),
-        -1500px 0.75px var(--separator-color),
-        2000px 0 var(--page-background-color),
-        -2000px 0 var(--page-background-color),
-        2000px 0.75px var(--separator-color),
-        -2000px 0.75px var(--separator-color);
+        900px 0 var(--page-background-color), 
+        -900px 0 var(--page-background-color),
+        900px 0.75px var(--separator-color),
+        -900px 0.75px var(--separator-color),
+        1400px 0 var(--page-background-color),
+        -1400px 0 var(--page-background-color), 
+        1400px 0.75px var(--separator-color),
+        -1400px 0.75px var(--separator-color),
+        1900px 0 var(--page-background-color),
+        -1900px 0 var(--page-background-color),
+        1900px 0.75px var(--separator-color),
+        -1900px 0.75px var(--separator-color);
 }
 
 blockquote {
@@ -975,7 +1170,7 @@ blockquote::after {
 blockquote p {
     margin: var(--spacing-small) 0 var(--spacing-medium) 0;
 }
-.paramname {
+.paramname, .paramname em {
     font-weight: 600;
     color: var(--primary-dark-color);
 }
@@ -989,66 +1184,237 @@ table.params .paramname {
     font-family: var(--font-family-monospace);
     font-size: var(--code-font-size);
     padding-right: var(--spacing-small);
+    line-height: var(--table-line-height);
 }
 
-.glow {
-    text-shadow: 0 0 15px var(--primary-light-color) !important;
+h1.glow, h2.glow, h3.glow, h4.glow, h5.glow, h6.glow {
+    text-shadow: 0 0 15px var(--primary-light-color);
 }
 
 .alphachar a {
     color: var(--page-foreground-color);
 }
 
+.dotgraph {
+    max-width: 100%;
+    overflow-x: scroll;
+}
+
+.dotgraph .caption {
+    position: sticky;
+    left: 0;
+}
+
+/* Wrap Graphviz graphs with the `interactive_dotgraph` class if `INTERACTIVE_SVG = YES` */
+.interactive_dotgraph .dotgraph iframe {
+    max-width: 100%;
+}
+
 /*
  Table of Contents
  */
 
-div.toc {
-    z-index: 10;
-    position: relative;
-    background-color: var(--toc-background);
-    border: 1px solid var(--separator-color);
-    border-radius: var(--border-radius-medium);
-    box-shadow: var(--box-shadow);
+div.contents .toc {
+    max-height: var(--toc-max-height);
+    min-width: var(--toc-width);
+    border: 0;
+    border-left: 1px solid var(--separator-color);
+    border-radius: 0;
+    background-color: var(--page-background-color);
+    box-shadow: none;
+    position: sticky;
+    top: var(--toc-sticky-top);
     padding: 0 var(--spacing-large);
-    margin: 0 0 var(--spacing-medium) var(--spacing-medium);
+    margin: var(--spacing-small) 0 var(--spacing-large) var(--spacing-large);
 }
 
 div.toc h3 {
     color: var(--toc-foreground);
     font-size: var(--navigation-font-size);
-    margin: var(--spacing-large) 0;
+    margin: var(--spacing-large) 0 var(--spacing-medium) 0;
 }
 
 div.toc li {
-    font-size: var(--navigation-font-size);
     padding: 0;
     background: none;
+    line-height: var(--toc-font-size);
+    margin: var(--toc-font-size) 0 0 0;
 }
 
-div.toc li:before {
-    content: '↓';
-    font-weight: 800;
-    font-family: var(--font-family);
-    margin-right: var(--spacing-small);
-    color: var(--toc-foreground);
-    opacity: .4;
+div.toc li::before {
+    display: none;
 }
 
-div.toc ul li.level1 {
-    margin: 0;
+div.toc ul {
+    margin-top: 0
 }
 
-div.toc ul li.level2, div.toc ul li.level3 {
-    margin-top: 0;
+div.toc li a {
+    font-size: var(--toc-font-size);
+    color: var(--page-foreground-color) !important;
+    text-decoration: none;
+}
+
+div.toc li a:hover, div.toc li a.active {
+    color: var(--primary-color) !important;
+}
+
+div.toc li a.aboveActive {
+    color: var(--page-secondary-foreground-color) !important;
 }
 
 
-@media screen and (max-width: 767px) {
-    div.toc {
+@media screen and (max-width: 999px) {
+    div.contents .toc {
+        max-height: 45vh;
         float: none;
         width: auto;
         margin: 0 0 var(--spacing-medium) 0;
+        position: relative;
+        top: 0;
+        position: relative;
+        border: 1px solid var(--separator-color);
+        border-radius: var(--border-radius-medium);
+        background-color: var(--toc-background);
+        box-shadow: var(--box-shadow);
+    }
+
+    div.contents .toc.interactive {
+        max-height: calc(var(--navigation-font-size) + 2 * var(--spacing-large));
+        overflow: hidden;
+    }
+
+    div.contents .toc > h3 {
+        -webkit-tap-highlight-color: transparent;
+        cursor: pointer;
+        position: sticky;
+        top: 0;
+        background-color: var(--toc-background);
+        margin: 0;
+        padding: var(--spacing-large) 0;
+        display: block;
+    }
+
+    div.contents .toc.interactive > h3::before {
+        content: "";
+        width: 0; 
+        height: 0; 
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-top: 5px solid var(--primary-color);
+        display: inline-block;
+        margin-right: var(--spacing-small);
+        margin-bottom: calc(var(--navigation-font-size) / 4);
+        transform: rotate(-90deg);
+        transition: transform var(--animation-duration) ease-out;
+    }
+
+    div.contents .toc.interactive.open > h3::before {
+        transform: rotate(0deg);
+    }
+
+    div.contents .toc.interactive.open {
+        max-height: 45vh;
+        overflow: auto;
+        transition: max-height 0.2s ease-in-out;
+    }
+
+    div.contents .toc a, div.contents .toc a.active {
+        color: var(--primary-color) !important;
+    }
+
+    div.contents .toc a:hover {
+        text-decoration: underline;
+    }
+}
+
+/*
+ Page Outline (Doxygen >= 1.14.0)
+*/
+
+#page-nav {
+    background: var(--page-background-color);
+    border-left: 1px solid var(--separator-color);
+}
+
+#page-nav #page-nav-resize-handle {
+    background: var(--separator-color);
+}
+
+#page-nav #page-nav-resize-handle::after {
+    border-left: 1px solid var(--primary-color);
+    border-right: 1px solid var(--primary-color);
+}
+
+#page-nav #page-nav-tree #page-nav-contents {
+    top: var(--spacing-large);
+}
+
+#page-nav ul.page-outline {
+    margin: 0 0 30px 0;
+    padding: 0;
+}
+
+#page-nav ul.page-outline li a {
+    font-size: var(--toc-font-size) !important;
+    color: var(--page-secondary-foreground-color) !important;
+    display: inline-block;
+    line-height: calc(2 * var(--toc-font-size));
+}
+
+#page-nav ul.page-outline li a a.anchorlink {
+    display: none;
+}
+
+#page-nav ul.page-outline li.vis ~ * a {
+    color: var(--page-foreground-color) !important;
+}
+
+#page-nav ul.page-outline li.vis:not(.vis ~ .vis) a, #page-nav ul.page-outline li a:hover {
+    color: var(--primary-color) !important;
+}
+
+#page-nav ul.page-outline .vis {
+    background: var(--page-background-color);
+    position: relative;
+}
+
+#page-nav ul.page-outline .vis::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    background: var(--page-secondary-foreground-color);
+}
+
+#page-nav ul.page-outline .vis:not(.vis ~ .vis)::after {
+    top: 1px;
+    border-top-right-radius: var(--border-radius-small);
+}
+
+#page-nav ul.page-outline .vis:not(:has(~ .vis))::after {
+    bottom: 1px;
+    border-bottom-right-radius: var(--border-radius-small);
+}
+
+
+#page-nav ul.page-outline .arrow {
+    display: inline-block;
+}
+
+#page-nav ul.page-outline .arrow span {
+    display: none;
+}
+
+@media screen and (max-width: 767px) {
+    #container {
+        grid-template-columns: initial !important;
+    }
+
+    #page-nav {
+        display: none;
     }
 }
 
@@ -1056,21 +1422,21 @@ div.toc ul li.level2, div.toc ul li.level3 {
  Code & Fragments
  */
 
-code, div.fragment, pre.fragment {
-    border-radius: var(--border-radius-small);
+code, div.fragment, pre.fragment, span.tt {
     border: 1px solid var(--separator-color);
     overflow: hidden;
 }
 
-code {
+code, span.tt {
     display: inline;
     background: var(--code-background);
     color: var(--code-foreground);
     padding: 2px 6px;
-    word-break: break-word;
+    border-radius: var(--border-radius-small);
 }
 
 div.fragment, pre.fragment {
+    border-radius: var(--border-radius-medium);
     margin: var(--spacing-medium) 0;
     padding: calc(var(--spacing-large) - (var(--spacing-large) / 6)) var(--spacing-large);
     background: var(--fragment-background);
@@ -1088,9 +1454,13 @@ div.fragment, pre.fragment {
     .contents > div.fragment,
     .textblock > div.fragment,
     .textblock > pre.fragment,
+    .textblock > .tabbed > ul > li > div.fragment,
+    .textblock > .tabbed > ul > li > pre.fragment,
     .contents > .doxygen-awesome-fragment-wrapper > div.fragment,
     .textblock > .doxygen-awesome-fragment-wrapper > div.fragment,
-    .textblock > .doxygen-awesome-fragment-wrapper > pre.fragment {
+    .textblock > .doxygen-awesome-fragment-wrapper > pre.fragment,
+    .textblock > .tabbed > ul > li > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .textblock > .tabbed > ul > li > .doxygen-awesome-fragment-wrapper > pre.fragment {
         margin: var(--spacing-medium) calc(0px - var(--spacing-large));
         border-radius: 0;
         border-left: 0;
@@ -1124,7 +1494,7 @@ div.fragment, pre.fragment {
     }
 }
 
-code, code a, pre.fragment, div.fragment, div.fragment .line, div.fragment span, div.fragment .line a, div.fragment .line span {
+code, code a, pre.fragment, div.fragment, div.fragment .line, div.fragment span, div.fragment .line a, div.fragment .line span, span.tt {
     font-family: var(--font-family-monospace);
     font-size: var(--code-font-size) !important;
 }
@@ -1180,19 +1550,33 @@ div.fragment span.lineno a {
     color: var(--fragment-link) !important;
 }
 
-div.fragment .line:first-child .lineno {
+div.fragment > .line:first-child .lineno {
     box-shadow: -999999px 0px 0 999999px var(--fragment-linenumber-background), -999998px 0px 0 999999px var(--fragment-linenumber-border);
+    background-color: var(--fragment-linenumber-background) !important;
+}
+
+div.line {
+    border-radius: var(--border-radius-small);
+}
+
+div.line.glow {
+    background-color: var(--primary-light-color);
+    box-shadow: none;
 }
 
 /*
  dl warning, attention, note, deprecated, bug, ...
  */
 
+dl {
+    line-height: calc(1.65 * var(--page-font-size));
+}
+
 dl.bug dt a, dl.deprecated dt a, dl.todo dt a {
     font-weight: bold !important;
 }
 
-dl.warning, dl.attention, dl.note, dl.deprecated, dl.bug, dl.invariant, dl.pre, dl.todo, dl.remark {
+dl.warning, dl.attention, dl.note, dl.deprecated, dl.bug, dl.invariant, dl.pre, dl.post, dl.todo, dl.remark {
     padding: var(--spacing-medium);
     margin: var(--spacing-medium) 0;
     color: var(--page-background-color);
@@ -1231,8 +1615,8 @@ dl.todo {
     color: var(--todo-color-darker);
 }
 
-dl.todo dt {
-    color: var(--todo-color-dark);
+dl.todo dt a {
+    color: var(--todo-color-dark) !important;
 }
 
 dl.bug dt a {
@@ -1263,14 +1647,42 @@ dl.section dd, dl.bug dd, dl.deprecated dd, dl.todo dd {
     margin-inline-start: 0px;
 }
 
-dl.invariant, dl.pre {
+dl.invariant, dl.pre, dl.post {
     background: var(--invariant-color);
     border-left: 8px solid var(--invariant-color-dark);
     color: var(--invariant-color-darker);
 }
 
-dl.invariant dt, dl.pre dt {
+dl.invariant dt, dl.pre dt, dl.post dt {
     color: var(--invariant-color-dark);
+}
+
+dl.warning code, dl.warning span.tt,
+dl.attention code, dl.attention span.tt,
+dl.note code, dl.note span.tt,
+dl.remark code, dl.remark span.tt,
+dl.todo code, dl.todo span.tt,
+dl.bug code, dl.bug span.tt,
+dl.deprecated code, dl.deprecated span.tt,
+dl.invariant code, dl.invariant span.tt,
+dl.pre code, dl.pre span.tt,
+dl.post code, dl.post span.tt {
+    background: var(--section-code-background);
+    border: 1px solid var(--section-code-border);
+}
+
+dl.warning div.fragment, dl.warning pre.fragment,
+dl.attention div.fragment, dl.attention pre.fragment,
+dl.note div.fragment, dl.note pre.fragment,
+dl.remark div.fragment, dl.remark pre.fragment,
+dl.todo div.fragment, dl.todo pre.fragment,
+dl.bug div.fragment, dl.bug pre.fragment,
+dl.deprecated div.fragment, dl.deprecated pre.fragment,
+dl.invariant div.fragment, dl.invariant pre.fragment,
+dl.pre div.fragment, dl.pre pre.fragment,
+dl.post div.fragment, dl.post pre.fragment {
+    background: var(--section-code-background);
+    border: 1px solid var(--section-code-border);
 }
 
 /*
@@ -1303,7 +1715,6 @@ div.memitem {
 
 div.memproto, h2.memtitle {
     background: var(--fragment-background);
-    text-shadow: none;
 }
 
 h2.memtitle {
@@ -1354,6 +1765,7 @@ div.memitem {
     border-top-right-radius: var(--border-radius-medium);
     border-bottom-right-radius: var(--border-radius-medium);
     border-bottom-left-radius: var(--border-radius-medium);
+    border-top-left-radius: 0;
     overflow: hidden;
     display: block !important;
 }
@@ -1379,6 +1791,7 @@ div.memproto table.memname {
     font-family: var(--font-family-monospace);
     color: var(--page-foreground-color);
     font-size: var(--memname-font-size);
+    text-shadow: none;
 }
 
 div.memproto div.memtemplate {
@@ -1386,6 +1799,7 @@ div.memproto div.memtemplate {
     color: var(--primary-dark-color);
     font-size: var(--memname-font-size);
     margin-left: 2px;
+    text-shadow: none;
 }
 
 table.mlabels, table.mlabels > tbody {
@@ -1451,10 +1865,11 @@ dl.reflist dd {
  Table
  */
 
-.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) {
-     display: inline-block;
-     max-width: 100%;
- }
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname),
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody {
+    display: inline-block;
+    max-width: 100%;
+}
 
 .contents > table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname):not(.classindex) {
     margin-left: calc(0px - var(--spacing-large));
@@ -1462,48 +1877,116 @@ dl.reflist dd {
     max-width: calc(100% + 2 * var(--spacing-large));
 }
 
-table.markdownTable, table.fieldtable {
+table.fieldtable,
+table.markdownTable tbody,
+table.doxtable tbody {
     border: none;
     margin: var(--spacing-medium) 0;
     box-shadow: 0 0 0 1px var(--separator-color);
     border-radius: var(--border-radius-small);
 }
 
+table.markdownTable, table.doxtable, table.fieldtable {
+    padding: 1px;
+}
+
+table.doxtable caption {
+    display: block;
+}
+
 table.fieldtable {
+    border-collapse: collapse;
     width: 100%;
 }
 
-th.markdownTableHeadLeft, th.markdownTableHeadRight, th.markdownTableHeadCenter, th.markdownTableHeadNone {
+th.markdownTableHeadLeft,
+th.markdownTableHeadRight,
+th.markdownTableHeadCenter,
+th.markdownTableHeadNone,
+table.doxtable th {
     background: var(--tablehead-background);
     color: var(--tablehead-foreground);
     font-weight: 600;
     font-size: var(--page-font-size);
 }
 
-th.markdownTableHeadLeft:first-child, th.markdownTableHeadRight:first-child, th.markdownTableHeadCenter:first-child, th.markdownTableHeadNone:first-child {
+th.markdownTableHeadLeft:first-child,
+th.markdownTableHeadRight:first-child,
+th.markdownTableHeadCenter:first-child,
+th.markdownTableHeadNone:first-child,
+table.doxtable tr th:first-child {
     border-top-left-radius: var(--border-radius-small);
 }
 
-th.markdownTableHeadLeft:last-child, th.markdownTableHeadRight:last-child, th.markdownTableHeadCenter:last-child, th.markdownTableHeadNone:last-child {
+th.markdownTableHeadLeft:last-child,
+th.markdownTableHeadRight:last-child,
+th.markdownTableHeadCenter:last-child,
+th.markdownTableHeadNone:last-child,
+table.doxtable tr th:last-child {
     border-top-right-radius: var(--border-radius-small);
 }
 
-table.markdownTable td, table.markdownTable th, table.fieldtable dt {
-    border: none;
-    border-right: 1px solid var(--separator-color);
+table.markdownTable td,
+table.markdownTable th,
+table.fieldtable td,
+table.fieldtable th,
+table.doxtable td,
+table.doxtable th {
+    border: 1px solid var(--separator-color);
     padding: var(--spacing-small) var(--spacing-medium);
 }
 
-table.markdownTable td:last-child, table.markdownTable th:last-child, table.fieldtable dt:last-child {
-    border: none;
+table.markdownTable td:last-child,
+table.markdownTable th:last-child,
+table.fieldtable td:last-child,
+table.fieldtable th:last-child,
+table.doxtable td:last-child,
+table.doxtable th:last-child {
+    border-right: none;
 }
 
-table.markdownTable tr, table.markdownTable tr {
+table.markdownTable td:first-child,
+table.markdownTable th:first-child,
+table.fieldtable td:first-child,
+table.fieldtable th:first-child,
+table.doxtable td:first-child,
+table.doxtable th:first-child {
+    border-left: none;
+}
+
+table.markdownTable tr:first-child td,
+table.markdownTable tr:first-child th,
+table.fieldtable tr:first-child td,
+table.fieldtable tr:first-child th,
+table.doxtable tr:first-child td,
+table.doxtable tr:first-child th {
+    border-top: none;
+}
+
+table.markdownTable tr:last-child td,
+table.markdownTable tr:last-child th,
+table.fieldtable tr:last-child td,
+table.fieldtable tr:last-child th,
+table.doxtable tr:last-child td,
+table.doxtable tr:last-child th {
+    border-bottom: none;
+}
+
+table.markdownTable tr, table.doxtable tr {
     border-bottom: 1px solid var(--separator-color);
 }
 
-table.markdownTable tr:last-child, table.markdownTable tr:last-child {
+table.markdownTable tr:last-child, table.doxtable tr:last-child {
     border-bottom: none;
+}
+
+.full_width_table table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) {
+    display: block;
+}
+
+.full_width_table table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody {
+    display: table;
+    width: 100%;
 }
 
 table.fieldtable th {
@@ -1512,25 +1995,29 @@ table.fieldtable th {
     background-image: none;
     background-color: var(--tablehead-background);
     color: var(--tablehead-foreground);
-    border-bottom: 1px solid var(--separator-color);
 }
 
-.fieldtable td.fieldtype, .fieldtable td.fieldname {
+table.fieldtable td.fieldtype, .fieldtable td.fieldname, .fieldtable td.fieldinit, .fieldtable td.fielddoc, .fieldtable th {
     border-bottom: 1px solid var(--separator-color);
     border-right: 1px solid var(--separator-color);
 }
 
-.fieldtable td.fielddoc {
-    border-bottom: 1px solid var(--separator-color);
+table.fieldtable tr:last-child td:first-child {
+    border-bottom-left-radius: var(--border-radius-small);
+}
+
+table.fieldtable tr:last-child td:last-child {
+    border-bottom-right-radius: var(--border-radius-small);
 }
 
 .memberdecls td.glow, .fieldtable tr.glow {
     background-color: var(--primary-light-color);
-    box-shadow: 0 0 15px var(--primary-light-color);
+    box-shadow: none;
 }
 
 table.memberdecls {
     display: block;
+    -webkit-tap-highlight-color: transparent;
 }
 
 table.memberdecls tr[class^='memitem'] {
@@ -1542,10 +2029,13 @@ table.memberdecls tr[class^='memitem'] .memTemplParams {
     font-family: var(--font-family-monospace);
     font-size: var(--code-font-size);
     color: var(--primary-dark-color);
+    white-space: normal;
 }
 
-table.memberdecls .memItemLeft,
-table.memberdecls .memItemRight,
+table.memberdecls tr.heading + tr[class^='memitem'] td.memItemLeft,
+table.memberdecls tr.heading + tr[class^='memitem'] td.memItemRight,
+table.memberdecls td.memItemLeft,
+table.memberdecls td.memItemRight,
 table.memberdecls .memTemplItemLeft,
 table.memberdecls .memTemplItemRight,
 table.memberdecls .memTemplParams {
@@ -1557,8 +2047,34 @@ table.memberdecls .memTemplParams {
     background-color: var(--fragment-background);
 }
 
+@media screen and (min-width: 768px) {
+
+    tr.heading + tr[class^='memitem'] td.memItemRight, tr.groupHeader + tr[class^='memitem'] td.memItemRight, tr.inherit_header + tr[class^='memitem'] td.memItemRight {
+        border-top-right-radius: var(--border-radius-small);
+    }
+
+    table.memberdecls tr:last-child td.memItemRight, table.memberdecls tr:last-child td.mdescRight, table.memberdecls tr[class^='memitem']:has(+ tr.groupHeader) td.memItemRight, table.memberdecls tr[class^='memitem']:has(+ tr.inherit_header) td.memItemRight, table.memberdecls tr[class^='memdesc']:has(+ tr.groupHeader) td.mdescRight, table.memberdecls tr[class^='memdesc']:has(+ tr.inherit_header) td.mdescRight {
+        border-bottom-right-radius: var(--border-radius-small);
+    }
+
+    table.memberdecls tr:last-child td.memItemLeft, table.memberdecls tr:last-child td.mdescLeft, table.memberdecls tr[class^='memitem']:has(+ tr.groupHeader) td.memItemLeft, table.memberdecls tr[class^='memitem']:has(+ tr.inherit_header) td.memItemLeft, table.memberdecls tr[class^='memdesc']:has(+ tr.groupHeader) td.mdescLeft, table.memberdecls tr[class^='memdesc']:has(+ tr.inherit_header) td.mdescLeft {
+        border-bottom-left-radius: var(--border-radius-small);
+    }
+
+    tr.heading + tr[class^='memitem'] td.memItemLeft, tr.groupHeader + tr[class^='memitem'] td.memItemLeft, tr.inherit_header + tr[class^='memitem'] td.memItemLeft {
+        border-top-left-radius: var(--border-radius-small);
+    }
+
+}
+
+table.memname td.memname {
+    font-size: var(--memname-font-size);
+}
+
 table.memberdecls .memTemplItemLeft,
-table.memberdecls .memTemplItemRight {
+table.memberdecls .template .memItemLeft,
+table.memberdecls .memTemplItemRight,
+table.memberdecls .template .memItemRight {
     padding-top: 2px;
 }
 
@@ -1567,18 +2083,19 @@ table.memberdecls .memTemplParams {
     border-left: 1px solid var(--separator-color);
     border-right: 1px solid var(--separator-color);
     border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
-    padding-bottom: 0;
+    padding-bottom: var(--spacing-small);
 }
 
-table.memberdecls .memTemplItemLeft {
+table.memberdecls .memTemplItemLeft, table.memberdecls .template .memItemLeft {
     border-radius: 0 0 0 var(--border-radius-small);
     border-left: 1px solid var(--separator-color);
     border-top: 0;
 }
 
-table.memberdecls .memTemplItemRight {
+table.memberdecls .memTemplItemRight, table.memberdecls .template .memItemRight {
     border-radius: 0 0 var(--border-radius-small) 0;
     border-right: 1px solid var(--separator-color);
+    padding-left: 0;
     border-top: 0;
 }
 
@@ -1601,6 +2118,17 @@ table.memberdecls .mdescLeft, table.memberdecls .mdescRight {
     background: none;
     color: var(--page-foreground-color);
     padding: var(--spacing-small) 0;
+    border: 0;
+}
+
+table.memberdecls [class^="memdesc"] {
+    box-shadow: none;
+}
+
+
+table.memberdecls .memItemLeft,
+table.memberdecls .memTemplItemLeft {
+    padding-right: var(--spacing-medium);
 }
 
 table.memberdecls .memSeparator {
@@ -1617,8 +2145,47 @@ table.memberdecls .groupheader {
 table.memberdecls .inherit_header td {
     padding: 0 0 var(--spacing-medium) 0;
     text-indent: -12px;
-    line-height: 1.5em;
     color: var(--page-secondary-foreground-color);
+}
+
+table.memberdecls span.dynarrow {
+    left: 10px;
+}
+
+table.memberdecls img[src="closed.png"],
+table.memberdecls img[src="open.png"],
+div.dynheader img[src="open.png"],
+div.dynheader img[src="closed.png"] {
+    width: 0; 
+    height: 0; 
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid var(--primary-color);
+    margin-top: 8px;
+    display: block;
+    float: left;
+    margin-left: -10px;
+    transition: transform var(--animation-duration) ease-out;
+}
+
+tr.heading + tr[class^='memitem'] td.memItemLeft, tr.groupHeader + tr[class^='memitem'] td.memItemLeft, tr.inherit_header + tr[class^='memitem'] td.memItemLeft, tr.heading + tr[class^='memitem'] td.memItemRight, tr.groupHeader + tr[class^='memitem'] td.memItemRight, tr.inherit_header + tr[class^='memitem'] td.memItemRight {
+    border-top: 1px solid var(--separator-color);
+}
+
+table.memberdecls img {
+    margin-right: 10px;
+}
+
+table.memberdecls img[src="closed.png"],
+div.dynheader img[src="closed.png"] {
+    transform: rotate(-90deg);
+    
+}
+
+.compoundTemplParams {
+    font-family: var(--font-family-monospace);
+    color: var(--primary-dark-color);
+    font-size: var(--code-font-size);
 }
 
 @media screen and (max-width: 767px) {
@@ -1629,7 +2196,10 @@ table.memberdecls .inherit_header td {
     table.memberdecls .mdescRight,
     table.memberdecls .memTemplItemLeft,
     table.memberdecls .memTemplItemRight,
-    table.memberdecls .memTemplParams {
+    table.memberdecls .memTemplParams,
+    table.memberdecls .template .memItemLeft,
+    table.memberdecls .template .memItemRight,
+    table.memberdecls .template .memParams {
         display: block;
         text-align: left;
         padding-left: var(--spacing-large);
@@ -1637,29 +2207,34 @@ table.memberdecls .inherit_header td {
         border-right: none;
         border-left: none;
         border-radius: 0;
+        white-space: normal;
     }
 
     table.memberdecls .memItemLeft,
     table.memberdecls .mdescLeft,
-    table.memberdecls .memTemplItemLeft {
-        border-bottom: 0;
-        padding-bottom: 0;
+    table.memberdecls .memTemplItemLeft,
+    table.memberdecls .template .memItemLeft {
+        border-bottom: 0 !important;
+        padding-bottom: 0 !important;
     }
 
-    table.memberdecls .memTemplItemLeft {
+    table.memberdecls .memTemplItemLeft,
+    table.memberdecls .template .memItemLeft {
         padding-top: 0;
     }
 
     table.memberdecls .mdescLeft {
-        margin-top: calc(0px - var(--page-font-size));
+        margin-bottom: calc(0px - var(--page-font-size));
     }
 
     table.memberdecls .memItemRight, 
     table.memberdecls .mdescRight,
-    table.memberdecls .memTemplItemRight {
-        border-top: 0;
-        padding-top: 0;
+    table.memberdecls .memTemplItemRight,
+    table.memberdecls .template .memItemRight {
+        border-top: 0 !important;
+        padding-top: 0 !important;
         padding-right: var(--spacing-large);
+        padding-bottom: var(--spacing-medium);
         overflow-x: auto;
     }
 
@@ -1694,6 +2269,22 @@ table.memberdecls .inherit_header td {
             max-height: 200px;
         }
     }
+
+    tr.heading + tr[class^='memitem'] td.memItemRight, tr.groupHeader + tr[class^='memitem'] td.memItemRight, tr.inherit_header + tr[class^='memitem'] td.memItemRight {
+        border-top-right-radius: 0;
+    }
+
+    table.memberdecls tr:last-child td.memItemRight, table.memberdecls tr:last-child td.mdescRight, table.memberdecls tr[class^='memitem']:has(+ tr.groupHeader) td.memItemRight, table.memberdecls tr[class^='memitem']:has(+ tr.inherit_header) td.memItemRight, table.memberdecls tr[class^='memdesc']:has(+ tr.groupHeader) td.mdescRight, table.memberdecls tr[class^='memdesc']:has(+ tr.inherit_header) td.mdescRight {
+        border-bottom-right-radius: 0;
+    }
+
+    table.memberdecls tr:last-child td.memItemLeft, table.memberdecls tr:last-child td.mdescLeft, table.memberdecls tr[class^='memitem']:has(+ tr.groupHeader) td.memItemLeft, table.memberdecls tr[class^='memitem']:has(+ tr.inherit_header) td.memItemLeft, table.memberdecls tr[class^='memdesc']:has(+ tr.groupHeader) td.mdescLeft, table.memberdecls tr[class^='memdesc']:has(+ tr.inherit_header) td.mdescLeft {
+        border-bottom-left-radius: 0;
+    }
+
+    tr.heading + tr[class^='memitem'] td.memItemLeft, tr.groupHeader + tr[class^='memitem'] td.memItemLeft, tr.inherit_header + tr[class^='memitem'] td.memItemLeft {
+        border-top-left-radius: 0;
+    }
 }
 
 
@@ -1710,14 +2301,16 @@ hr {
 }
 
 .contents hr {
-    box-shadow: 100px 0 0 var(--separator-color),
-                -100px 0 0 var(--separator-color),
-                500px 0 0 var(--separator-color),
-                -500px 0 0 var(--separator-color),
-                1500px 0 0 var(--separator-color),
-                -1500px 0 0 var(--separator-color),
-                2000px 0 0 var(--separator-color),
-                -2000px 0 0 var(--separator-color);
+    box-shadow: 100px 0 var(--separator-color),
+                -100px 0 var(--separator-color),
+                500px 0 var(--separator-color),
+                -500px 0 var(--separator-color),
+                900px 0 var(--separator-color),
+                -900px 0 var(--separator-color),
+                1400px 0 var(--separator-color),
+                -1400px 0 var(--separator-color),
+                1900px 0 var(--separator-color),
+                -1900px 0 var(--separator-color);       
 }
 
 .contents img, .contents .center, .contents center, .contents div.image object {
@@ -1749,8 +2342,25 @@ table.directory {
     width: 100%;
 }
 
-table.directory td.entry {
-    padding: var(--spacing-small);
+table.directory td.entry, table.directory td.desc {
+    padding: calc(var(--spacing-small) / 2) var(--spacing-small);
+    line-height: var(--table-line-height);
+}
+
+table.directory tr.even td:last-child {
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
+}
+
+table.directory tr.even td:first-child {
+    border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+}
+
+table.directory tr.even:last-child td:last-child {
+    border-radius: 0 var(--border-radius-small) 0 0;
+}
+
+table.directory tr.even:last-child td:first-child {
+    border-radius: var(--border-radius-small) 0 0 0;
 }
 
 table.directory td.desc {
@@ -1761,6 +2371,10 @@ table.directory tr.even {
     background-color: var(--odd-color);
 }
 
+table.directory tr.odd {
+    background-color: transparent;
+}
+
 .icona {
     width: auto;
     height: auto;
@@ -1769,14 +2383,20 @@ table.directory tr.even {
 
 .icon {
     background: var(--primary-color);
-    width: 18px;
-    height: 18px;
-    line-height: 18px;
+    border-radius: var(--border-radius-small);
+    font-size: var(--page-font-size);
+    padding: calc(var(--page-font-size) / 5);
+    line-height: var(--page-font-size);
+    transform: scale(0.8);
+    height: auto;
+    width: var(--page-font-size);
+    user-select: none;
 }
 
 .iconfopen, .icondoc, .iconfclosed {
     background-position: center;
     margin-bottom: 0;
+    height: var(--table-line-height);
 }
 
 .icondoc {
@@ -1807,6 +2427,10 @@ html.dark-mode .iconfopen, html.dark-mode .iconfclosed {
 .classindex dl.odd {
     background: var(--odd-color);
     border-radius: var(--border-radius-small);
+}
+
+.classindex dl.even {
+    background-color: transparent;
 }
 
 /* 
@@ -1849,9 +2473,7 @@ div.qindex {
     background: var(--page-background-color);
     border: none;
     border-top: 1px solid var(--separator-color);
-    border-bottom: 1px solid var(--separator-color);
     border-bottom: 0;
-    box-shadow: 0 0.75px 0 var(--separator-color);
     font-size: var(--navigation-font-size);
 }
 
@@ -1880,6 +2502,10 @@ address.footer {
     color: var(--primary-color) !important;
 }
 
+.navpath li.navelem a:hover {
+    text-shadow: none;
+}
+
 .navpath li.navelem b {
     color: var(--primary-dark-color);
     font-weight: 500;
@@ -1898,7 +2524,11 @@ li.navelem:first-child:before {
     display: none;
 }
 
-#nav-path li.navelem:after {
+#nav-path ul {
+    padding-left: 0;
+}
+
+#nav-path li.navelem:has(.el):after {
     content: '';
     border: 5px solid var(--page-background-color);
     border-bottom-color: transparent;
@@ -1909,7 +2539,21 @@ li.navelem:first-child:before {
     margin-left: 6px;
 }
 
-#nav-path li.navelem:before {
+#nav-path li.navelem:not(:has(.el)):after {
+    background: var(--page-background-color);
+    box-shadow: 1px -1px 0 1px var(--separator-color);
+    border-radius: 0 var(--border-radius-medium) 0 50px;
+}
+
+#nav-path li.navelem:not(:has(.el)) {
+    margin-left: 0;
+}
+
+#nav-path li.navelem:not(:has(.el)):hover, #nav-path li.navelem:not(:has(.el)):hover:after {
+    background-color: var(--separator-color);
+}
+
+#nav-path li.navelem:has(.el):before {
     content: '';
     border: 5px solid var(--separator-color);
     border-bottom-color: transparent;
@@ -1933,7 +2577,11 @@ pre.fragment::-webkit-scrollbar,
 div.memproto::-webkit-scrollbar,
 .contents center::-webkit-scrollbar,
 .contents .center::-webkit-scrollbar,
-.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname)::-webkit-scrollbar {
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar,
+div.contents .toc::-webkit-scrollbar,
+.contents .dotgraph::-webkit-scrollbar,
+.contents .tabs-overview-container::-webkit-scrollbar {
+    background: transparent;
     width: calc(var(--webkit-scrollbar-size) + var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
     height: calc(var(--webkit-scrollbar-size) + var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
 }
@@ -1944,7 +2592,10 @@ pre.fragment::-webkit-scrollbar-thumb,
 div.memproto::-webkit-scrollbar-thumb,
 .contents center::-webkit-scrollbar-thumb,
 .contents .center::-webkit-scrollbar-thumb,
-.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname)::-webkit-scrollbar-thumb {
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar-thumb,
+div.contents .toc::-webkit-scrollbar-thumb,
+.contents .dotgraph::-webkit-scrollbar-thumb,
+.contents .tabs-overview-container::-webkit-scrollbar-thumb {
     background-color: transparent;
     border: var(--webkit-scrollbar-padding) solid transparent;
     border-radius: calc(var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
@@ -1957,7 +2608,10 @@ pre.fragment:hover::-webkit-scrollbar-thumb,
 div.memproto:hover::-webkit-scrollbar-thumb,
 .contents center:hover::-webkit-scrollbar-thumb,
 .contents .center:hover::-webkit-scrollbar-thumb,
-.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname):hover::-webkit-scrollbar-thumb {
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody:hover::-webkit-scrollbar-thumb,
+div.contents .toc:hover::-webkit-scrollbar-thumb,
+.contents .dotgraph:hover::-webkit-scrollbar-thumb,
+.contents .tabs-overview-container:hover::-webkit-scrollbar-thumb {
     background-color: var(--webkit-scrollbar-color);
 }
 
@@ -1967,7 +2621,10 @@ pre.fragment::-webkit-scrollbar-track,
 div.memproto::-webkit-scrollbar-track,
 .contents center::-webkit-scrollbar-track,
 .contents .center::-webkit-scrollbar-track,
-.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname)::-webkit-scrollbar-track {
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar-track,
+div.contents .toc::-webkit-scrollbar-track,
+.contents .dotgraph::-webkit-scrollbar-track,
+.contents .tabs-overview-container::-webkit-scrollbar-track {
     background: transparent;
 }
 
@@ -1981,7 +2638,8 @@ pre.fragment,
 div.memproto,
 .contents center,
 .contents .center,
-.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) {
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody,
+div.contents .toc {
     overflow-x: auto;
     overflow-x: overlay;
 }
@@ -2002,7 +2660,10 @@ pre.fragment,
 div.memproto,
 .contents center,
 .contents .center,
-.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) {
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody,
+div.contents .toc,
+.contents .dotgraph,
+.contents .tabs-overview-container {
     scrollbar-width: thin;
 }
 
@@ -2018,7 +2679,7 @@ doxygen-awesome-dark-mode-toggle {
     height: var(--searchbar-height);
     background: none;
     border: none;
-    border-radius: var(--searchbar-height);
+    border-radius: var(--searchbar-border-radius);
     vertical-align: middle;
     text-align: center;
     line-height: var(--searchbar-height);
@@ -2031,7 +2692,7 @@ doxygen-awesome-dark-mode-toggle {
 }
 
 doxygen-awesome-dark-mode-toggle > svg {
-    transition: transform .1s ease-in-out;
+    transition: transform var(--animation-duration) ease-in-out;
 }
 
 doxygen-awesome-dark-mode-toggle:active > svg {
@@ -2116,7 +2777,7 @@ a.anchorlink {
     text-decoration: none;
     opacity: .15;
     display: none;
-    transition: opacity .1s ease-in-out, color .1s ease-in-out;
+    transition: opacity var(--animation-duration) ease-in-out, color var(--animation-duration) ease-in-out;
 }
 
 a.anchorlink svg {
@@ -2134,4 +2795,260 @@ a.anchorlink:hover {
 
 h2:hover a.anchorlink, h1:hover a.anchorlink, h3:hover a.anchorlink, h4:hover a.anchorlink  {
     display: inline-block;
+}
+
+/*
+ Optional tab feature
+*/
+
+.tabbed > ul {
+    padding-inline-start: 0px;
+    margin: 0;
+    padding: var(--spacing-small) 0;
+}
+
+.tabbed > ul > li {
+    display: none;
+}
+
+.tabbed > ul > li.selected {
+    display: block;
+}
+
+.tabs-overview-container {
+    overflow-x: auto;
+    display: block;
+    overflow-y: visible;
+}
+
+.tabs-overview {
+    border-bottom: 1px solid var(--separator-color);
+    display: flex;
+    flex-direction: row;
+}
+
+@media screen and (max-width: 767px) {
+    .tabs-overview-container {
+        margin: 0 calc(0px - var(--spacing-large));
+    }
+    .tabs-overview {
+        padding: 0 var(--spacing-large)
+    }
+}
+
+.tabs-overview button.tab-button {
+    color: var(--page-foreground-color);
+    margin: 0;
+    border: none;
+    background: transparent;
+    padding: calc(var(--spacing-large) / 2) 0;
+    display: inline-block;
+    font-size: var(--page-font-size);
+    cursor: pointer;
+    box-shadow: 0 1px 0 0 var(--separator-color);
+    position: relative;
+    
+    -webkit-tap-highlight-color: transparent;
+}
+
+.tabs-overview button.tab-button .tab-title::before {
+    display: block;
+    content: attr(title);
+    font-weight: 600;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+}
+
+.tabs-overview button.tab-button .tab-title {
+    float: left;
+    white-space: nowrap;
+    font-weight: normal;
+    font-family: var(--font-family);
+    padding: calc(var(--spacing-large) / 2) var(--spacing-large);
+    border-radius: var(--border-radius-medium);
+    transition: background-color var(--animation-duration) ease-in-out, font-weight var(--animation-duration) ease-in-out;
+}
+
+.tabs-overview button.tab-button:not(:last-child) .tab-title {
+    box-shadow: 8px 0 0 -7px var(--separator-color);
+}
+
+.tabs-overview button.tab-button:hover .tab-title {
+    background: var(--separator-color);
+    box-shadow: none;
+}
+
+.tabs-overview button.tab-button.active .tab-title {
+    font-weight: 600;
+}
+
+.tabs-overview button.tab-button::after {
+    content: '';
+    display: block;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    height: 0;
+    width: 0%;
+    margin: 0 auto;
+    border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
+    background-color: var(--primary-color);
+    transition: width var(--animation-duration) ease-in-out, height var(--animation-duration) ease-in-out;
+}
+
+.tabs-overview button.tab-button.active::after {
+    width: 100%;
+    box-sizing: border-box;
+    height: 3px;
+}
+
+
+/*
+ Navigation Buttons
+*/
+
+.section_buttons:not(:empty) {
+    margin-top: calc(var(--spacing-large) * 3);
+}
+
+.section_buttons table.markdownTable {
+    display: block;
+    width: 100%;
+}
+
+.section_buttons table.markdownTable tbody {
+    display: table !important;
+    width: 100%;
+    box-shadow: none;
+    border-spacing: 10px;
+}
+
+.section_buttons table.markdownTable td {
+    padding: 0;
+}
+
+.section_buttons table.markdownTable th {
+    display: none;
+}
+
+.section_buttons table.markdownTable tr.markdownTableHead {
+    border: none;
+}
+
+.section_buttons tr th, .section_buttons tr td {
+    background: none;
+    border: none;
+    padding: var(--spacing-large) 0 var(--spacing-small);
+}
+
+.section_buttons a {
+    display: inline-block;
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium);
+    color: var(--page-secondary-foreground-color) !important;
+    text-decoration: none;
+    transition: color var(--animation-duration) ease-in-out, background-color var(--animation-duration) ease-in-out;
+}
+
+.section_buttons a:hover {
+    color: var(--page-foreground-color) !important;
+    background-color: var(--odd-color);
+}
+
+.section_buttons tr td.markdownTableBodyLeft a {
+    padding: var(--spacing-medium) var(--spacing-large) var(--spacing-medium) calc(var(--spacing-large) / 2);
+}
+
+.section_buttons tr td.markdownTableBodyRight a {
+    padding: var(--spacing-medium) calc(var(--spacing-large) / 2) var(--spacing-medium) var(--spacing-large);
+}
+
+.section_buttons tr td.markdownTableBodyLeft a::before,
+.section_buttons tr td.markdownTableBodyRight a::after {
+    color: var(--page-secondary-foreground-color) !important;
+    display: inline-block;
+    transition: color .08s ease-in-out, transform .09s ease-in-out;
+}
+
+.section_buttons tr td.markdownTableBodyLeft a::before {
+    content: '〈';
+    padding-right: var(--spacing-large);
+}
+
+
+.section_buttons tr td.markdownTableBodyRight a::after {
+    content: '〉';
+    padding-left: var(--spacing-large);
+}
+
+
+.section_buttons tr td.markdownTableBodyLeft a:hover::before {
+    color: var(--page-foreground-color) !important;
+    transform: translateX(-3px);
+}
+
+.section_buttons tr td.markdownTableBodyRight a:hover::after {
+    color: var(--page-foreground-color) !important;
+    transform: translateX(3px);
+}
+
+@media screen and (max-width: 450px) {
+    .section_buttons a {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .section_buttons tr td:nth-of-type(1).markdownTableBodyLeft a {
+        border-radius: var(--border-radius-medium) 0 0 var(--border-radius-medium);
+        border-right: none;
+    }
+
+    .section_buttons tr td:nth-of-type(2).markdownTableBodyRight a {
+        border-radius: 0 var(--border-radius-medium) var(--border-radius-medium) 0;
+    }
+}
+
+/* 
+ Bordered image
+*/
+
+html.dark-mode .darkmode_inverted_image img, /* < doxygen 1.9.3 */
+html.dark-mode .darkmode_inverted_image object[type="image/svg+xml"] /* doxygen 1.9.3 */ {
+    filter: brightness(89%) hue-rotate(180deg) invert();
+}
+
+.bordered_image {
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--separator-color);
+    display: inline-block;
+    overflow: hidden;
+}
+
+.bordered_image:empty {
+    border: none;
+}
+
+html.dark-mode .bordered_image img, /* < doxygen 1.9.3 */
+html.dark-mode .bordered_image object[type="image/svg+xml"] /* doxygen 1.9.3 */ {
+    border-radius: var(--border-radius-small);
+}
+
+/*
+ Button
+*/
+
+.primary-button {
+    display: inline-block;
+    cursor: pointer;
+    background: var(--primary-color);
+    color: var(--page-background-color) !important;
+    border-radius: var(--border-radius-medium);
+    padding: var(--spacing-small) var(--spacing-medium);
+    text-decoration: none;
+}
+
+.primary-button:hover {
+    background: var(--primary-dark-color);
 }

--- a/docs/doxygen/extra_stylesheet.css
+++ b/docs/doxygen/extra_stylesheet.css
@@ -1,5 +1,30 @@
 /* wxWidgets Custom Styles */
 
+/* Give top navigation buttons more breathing room, matching older style */
+.sm-dox li {
+    margin: 0 0.2em;
+    padding: 0 0.2em;
+}
+
+/* Hopefully temporary tweaks to get a better looking search icon until eventual fixes in Doxygen Awesome */
+.search-icon:before {
+    width: 10px;
+    height: 10px;
+}
+.search-icon:after {
+    width: 2px;
+    height: 5px;
+    top: 16px;
+    left: 11px;
+    background-color: #707070;
+}
+#MSearchSelectExt.search-icon {
+    width: 20px;
+    height: 1.4em;
+    top: 3px;
+    margin-left: 6px;
+}
+
 div.appearance {
     margin: 1em 0em;
 }
@@ -43,6 +68,24 @@ div.appearance_brief table td {
 td.green { color: green; }
 td.orange { color: #ff8000; }
 td.red { color: red; }
+
+/* Fix up class member groups - Doxygen Awesome doesn't fix these up yet */
+.memberdecls tr.groupHeader td {
+    padding-top: 1em;
+}
+.memberdecls div.groupHeader {
+    box-shadow: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    color: inherit;
+}
+.memberdecls td.ititle {
+    border: none !important;
+    color: inherit;
+}
+.memberdecls div.groupText {
+    font-style: inherit;
+}
 
 span.literal {
     text-decoration: none;

--- a/docs/doxygen/mainpages/cat_classes.h
+++ b/docs/doxygen/mainpages/cat_classes.h
@@ -136,7 +136,7 @@ Controls that are not static can have wxValidator associated with them.
 @li wxStaticBox: A static, or group box for visually grouping related controls
 @li wxScrollBar: Scrollbar control
 @li wxSearchCtrl: A text input control used to initiate a search
-@li wxSpinButton: A spin or `up-down' control
+@li wxSpinButton: A spin or 'up-down' control
 @li wxSpinCtrl: A spin control - i.e. spin button and text control displaying
     an integer
 @li wxSpinCtrlDouble: A spin control - i.e. spin button and text control displaying
@@ -830,4 +830,3 @@ Related overview: @ref overview_ipc
 @li wxSingleInstanceChecker: Check that only single program instance is running
 
 */
-

--- a/docs/doxygen/mainpages/copyright.h
+++ b/docs/doxygen/mainpages/copyright.h
@@ -141,7 +141,7 @@ longer:
 
 @li Julian Smart
 @li Robert Roebling
-@li Wlodzimierz `ABX' Skiba
+@li Wlodzimierz 'ABX' Skiba
 @li Chris Elliott
 @li David Elliott
 @li Kevin Hock
@@ -173,7 +173,7 @@ David Webster, Otto Wyss, Xiaokun Zhu, Edward Zimmermann.
 Many thanks also to AIAI for being willing to release the original version of
 wxWidgets into the public domain, and to our patient partners.
 
-`Graphplace', the basis for the wxGraphLayout library, is copyright Dr. Jos
+'Graphplace', the basis for the wxGraphLayout library, is copyright Dr. Jos
 T.J. van Eijndhoven of Eindhoven University of Technology. The code has
 been used in wxGraphLayout (not in wxWidgets anymore) with his permission.
 
@@ -190,7 +190,7 @@ copyright notice and this permission notice appear in supporting
 documentation, and that the name of M.I.T. not be used in advertising or
 publicity pertaining to distribution of the software without specific,
 written prior permission.  M.I.T. makes no representations about the
-suitability of this software for any purpose.  It is provided ``as is''
+suitability of this software for any purpose.  It is provided 'as is'
 without express or implied warranty.
 </em>
 

--- a/docs/doxygen/mainpages/devtips.h
+++ b/docs/doxygen/mainpages/devtips.h
@@ -321,7 +321,7 @@ conditions that should or should not hold, and print out appropriate error
 messages.
 
 These can be compiled out of a non-debugging version of wxWidgets and your
-application. Using ASSERT is an example of `defensive programming': it can
+application. Using ASSERT is an example of 'defensive programming': it can
 alert you to problems later on.
 
 See wxASSERT() for more info.
@@ -410,4 +410,3 @@ of time in the long run.
 See the @ref overview_debugging for further information.
 
 */
-

--- a/docs/doxygen/mainpages/samples.h
+++ b/docs/doxygen/mainpages/samples.h
@@ -216,7 +216,7 @@ startup, before the main window is shown.
 This sample shows the wxDialUpManager
 class. In the status bar, it displays the information gathered through its
 interface: in particular, the current connection status (online or offline) and
-whether the connection is permanent (in which case a string `LAN' appears in
+whether the connection is permanent (in which case a string 'LAN' appears in
 the third status bar field - but note that you may be on a LAN not
 connected to the Internet, in which case you will not see this) or not.
 

--- a/docs/doxygen/overviews/envvars.h
+++ b/docs/doxygen/overviews/envvars.h
@@ -58,6 +58,8 @@ wxWidgets programs.
          href="https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html">LANGUAGE</a>
          variable: a colon-separated list of language tags (which are, in their
          simplest form, just the language names).}
+@endDefList
+
 */
 
 @see wxSystemOptions

--- a/docs/doxygen/regen.sh
+++ b/docs/doxygen/regen.sh
@@ -40,8 +40,8 @@ fi
 #
 # Still allow using incompatible version if explicitly requested.
 if [[ -z $WX_SKIP_DOXYGEN_VERSION_CHECK ]]; then
-    doxygen_version=`$DOXYGEN --version`
-    doxygen_version_required=1.9.1
+    doxygen_version=`$DOXYGEN --version | cut -d ' ' -f 1`
+    doxygen_version_required=1.15.0
     if [[ $doxygen_version != $doxygen_version_required ]]; then
         echo "Doxygen version $doxygen_version is not officially supported."
         echo "Please use Doxygen $doxygen_version_required or export WX_SKIP_DOXYGEN_VERSION_CHECK."
@@ -243,11 +243,7 @@ if [[ -s doxygen.log ]]; then
     topsrcdir=`cd ../.. && pwd`
     sed -i'' -e "s|$topsrcdir/||g" doxygen.log
 
-    # Filter out warnings from interface/wx/stc/stc.h for now, there are tons
-    # of them and it's not clear what to do about them, see #25603
-    if grep -q -v "interface/wx/stc/stc.h" doxygen.log; then
-        echo '*** There were warnings during docs generation ***'
-    fi
+    echo '*** There were warnings during docs generation ***'
 else
     # Don't leave empty file lying around.
     rm doxygen.log

--- a/interface/wx/config.h
+++ b/interface/wx/config.h
@@ -36,7 +36,7 @@ enum
         configuration file location to `~/.config/appname.conf`.
 
         In combination with wxCONFIG_USE_SUBDIR, this flag changes the default
-        configuration file location to ~/.config/appname/appname.conf`.
+        configuration file location to `~/.config/appname/appname.conf`.
 
         If neither this flag nor wxCONFIG_USE_HOME is specified, XDG-compliant
         configuration file path will be used by default, but if there is an
@@ -1071,4 +1071,3 @@ public:
     */
     void UpdateIfDeleted();
 };
-

--- a/interface/wx/mimetype.h
+++ b/interface/wx/mimetype.h
@@ -89,7 +89,7 @@ public:
     /**
         This function returns @true if either the given @a mimeType is exactly
         the same as @a wildcard or if it has the same category and the subtype of
-        @a wildcard is '*'. Note that the '*' wildcard is not allowed in
+        @a wildcard is "*". Note that the "*" wildcard is not allowed in
         @a mimeType itself.
 
         The comparison done by this function is case insensitive so it is not

--- a/interface/wx/propgrid/advprops.h
+++ b/interface/wx/propgrid/advprops.h
@@ -63,7 +63,7 @@ public:
 
 
 /** @class wxFontProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Property representing wxFont.
 
     <b>Supported special attributes:</b>
@@ -90,7 +90,7 @@ protected:
 
 
 /** @class wxSystemColourProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Has dropdown list of wxWidgets system colours. Value used is
     of wxColourPropertyValue type.
 
@@ -169,7 +169,7 @@ protected:
 
 
 /** @class wxColourProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Allows to select a colour from the list or with colour dialog. Value used
     is of wxColourPropertyValue type.
 
@@ -195,7 +195,7 @@ protected:
 
 
 /** @class wxCursorProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Property representing wxCursor.
 */
 class wxCursorProperty : public wxEnumProperty
@@ -217,7 +217,7 @@ public:
 const wxString& wxPGGetDefaultImageWildcard();
 
 /** @class wxImageFileProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Property representing image file(name).
 
     <b>Supported special attributes:</b>
@@ -250,7 +250,7 @@ public:
 
 
 /** @class wxMultiChoiceProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Property that manages a value resulting from wxMultiChoiceDialog. Value is
     array of strings. You can get value as array of choice values/indices by
     calling wxMultiChoiceProperty::GetValueAsArrayInt().
@@ -306,7 +306,7 @@ protected:
 
 
 /** @class wxDateProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Property representing wxDateTime.
 
     <b>Supported special attributes:</b>

--- a/interface/wx/propgrid/props.h
+++ b/interface/wx/propgrid/props.h
@@ -8,7 +8,7 @@
 
 
 /** @class wxPGInDialogValidator
-    @ingroup classes
+    @ingroup group_class_propgrid
     Creates and manages a temporary wxTextCtrl for validation purposes.
     Uses wxPropertyGrid's current editor, if available.
 */
@@ -29,7 +29,7 @@ public:
 // -----------------------------------------------------------------------
 
 /** @class wxStringProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Basic property with string value.
 
     <b>Supported special attributes:</b>
@@ -99,7 +99,7 @@ public:
 };
 
 /** @class wxNumericProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
 
     This is an abstract class which serves as a base class for numeric properties,
     like wxIntProperty, wxUIntProperty, wxFloatProperty.
@@ -162,7 +162,7 @@ protected:
 
 
 /** @class wxIntProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Basic property with integer value.
 
     Seamlessly supports 64-bit integer (wxLongLong) on overflow.
@@ -230,7 +230,7 @@ public:
 
 
 /** @class wxUIntProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Basic property with unsigned integer value.
     Seamlessly supports 64-bit integer (wxULongLong) on overflow.
 
@@ -279,7 +279,7 @@ protected:
 
 
 /** @class wxFloatProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Basic property with double-precision floating point value.
 
     <b>Supported special attributes:</b>
@@ -316,7 +316,7 @@ protected:
 
 
 /** @class wxBoolProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Basic property with boolean value.
 
     <b>Supported special attributes:</b>
@@ -344,7 +344,7 @@ public:
 
 
 /** @class wxEnumProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     You can derive custom properties with choices from this class. See
     wxBaseEnumProperty for remarks.
 
@@ -425,7 +425,7 @@ protected:
 
 
 /** @class wxEditEnumProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     wxEnumProperty with wxString value and writable combo box editor.
 
     @remarks
@@ -473,7 +473,7 @@ public:
 
 
 /** @class wxFlagsProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Represents a bit set that fits in a long integer. wxBoolProperty
     sub-properties are created for editing individual bits. Textctrl is created
     to manually edit the flags as a text; a continuous sequence of spaces,
@@ -528,7 +528,7 @@ protected:
 
 
 /** @class wxEditorDialogProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
 
     This is an abstract class which serves as a base class for the properties
     having a button triggering an editor dialog, like e.g. wxLongStringProperty,
@@ -577,7 +577,7 @@ protected:
 
 
 /** @class wxFileProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Like wxLongStringProperty, but the button triggers file selector instead.
 
     <b>Supported special attributes:</b>
@@ -627,7 +627,7 @@ protected:
 
 
 /** @class wxLongStringProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Like wxStringProperty, but has a button that triggers a small text
     editor dialog.
 
@@ -654,7 +654,7 @@ protected:
 
 
 /** @class wxDirProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Like wxLongStringProperty, but the button triggers directory selector
     instead.
 
@@ -681,7 +681,7 @@ protected:
 
 
 /** @class wxArrayStringProperty
-    @ingroup classes
+    @ingroup group_class_propgrid
     Property that manages a list of strings.
 
     <b>Supported special attributes:</b>
@@ -857,4 +857,3 @@ protected:
     virtual void ArrayRemoveAt( int index );
     virtual void ArraySwap( size_t first, size_t second );
 };
-

--- a/interface/wx/stc/stc.h
+++ b/interface/wx/stc/stc.h
@@ -5293,7 +5293,7 @@ public:
     void SetMarginCount(int margins);
 
     /**
-        How many margins are there?.
+        Returns the count of margins.
 
         @since 3.1.1
     */

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -530,7 +530,7 @@ public:
     /**
         Assignment from UTF-8 string.
 
-        Calling `s.AssignFromUTF8(utf8, len) is equivalent to doing
+        Calling `s.AssignFromUTF8(utf8, len)` is equivalent to doing
         `s = wxString::FromUTF8(utf8, len)` but may be more efficient as it can
         reuse the existing string buffer instead of always having to allocate a
         new one.


### PR DESCRIPTION
While Doxygen 1.17.0 is the latest release, I've chosen to use 1.15.0 here for similar reasons we've stuck with older releases before. Doxygen 1.15.0 is the version bundled with Ubuntu 26.04 LTS, and also the current version slated for Debian Forky (maybe that changes before release though?). It is also the latest version of Doxygen that I have any kind of confirmation that Doxygen Awesome CSS is updated to be compatible with (changes in newer Doxygen may break DA styles in DA's latest release used here).

The GitHub docs update workflow manually installs Doxygen 1.15.0 from it's binary release hosted on GitHub, but only because there isn't a `ubuntu-26.04` GitHub Actions image yet. Once that's out, we can switch back to using the official distro package again. I still haven't tested the workflow changes, not sure how to do that without merging, but will followup with fixes if necessary.

Since we're using Doxygen Awesome, even though Doxygen has wildly changed the default style of docs in 1.14.0 (though I still don't really like their new style, DA is still a big improvement), our docs still look nearly identical with this update.

Other changes as detailed in commit:
- Upgrade Doxyfile configuration for 1.15.0
- Upgrade Doxygen Awesome to v2.4.2 (compatible up to Doxygen 1.15.0)
- Upgrade GitHub workflow Doxygen version to 1.15.0
- Tweak main navigation button spacing to match previous style
- Fix search box icon styles
- Fix class member definition group styles (missed by DA)
- Replace backticks used as apostrophe/quote in docs
- Fix remaining Doxygen warnings when processed with 1.15.0
- Bump required Doxygen version to 1.15.0

Closes: #25603