### PR TITLE
Documentation - maximum one function is disconnected from an event handler

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -840,6 +840,9 @@ public:
 
         This overload takes the additional @a id parameter.
 
+        @remarks In case there are several functions in the event handler matching the
+                 specified parameters, only one of functions is disconnected.
+
         @beginWxPerlOnly
         Not supported by wxPerl.
         @endWxPerlOnly


### PR DESCRIPTION
Calling Disconnect(int id = wxID_ANY, wxEventType eventType = wxEVT_NULL, wxObjectEventFunction function = nullptr,
                                 wxObject* userData = nullptr, wxEvtHandler* eventSink = nullptr) will only disconnect one function from the event handler even if several functions match the specified parameters.
This behaviour is now documented.