### PR TITLE
Avoid out-of-bounds palette write in wxIFFDecoder::ConvertToImage

### DIFF
--- a/src/common/imagiff.cpp
+++ b/src/common/imagiff.cpp
@@ -146,7 +146,7 @@ bool wxIFFDecoder::ConvertToImage(wxImage *image) const
     long i;
 
     // set transparent colour mask
-    if (transparent != -1)
+    if (transparent >= 0 && transparent < colors)
     {
         for (i = 0; i < colors; i++)
         {

--- a/src/common/imagiff.cpp
+++ b/src/common/imagiff.cpp
@@ -146,8 +146,11 @@ bool wxIFFDecoder::ConvertToImage(wxImage *image) const
     long i;
 
     // set transparent colour mask
-    if (transparent >= 0 && transparent < colors)
+    if (transparent != -1)
     {
+        if (transparent < 0 || transparent >= colors)
+            return false;
+
         for (i = 0; i < colors; i++)
         {
             if ((pal[3 * i + 0] == 255) &&

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1363,6 +1363,31 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPM", "[image][xpm][error]")
 
 #endif // wxUSE_XPM
 
+#if wxUSE_IFF
+
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadIFF", "[image][iff][error]")
+{
+    // A FORM/ILBM file whose BMHD transparent-colour field is 0x4000 while
+    // no CMAP chunk is present, so the palette colour count stays at 0. The
+    // transparent index used to be applied to the palette without a bounds
+    // check, writing past the end of the palette buffer.
+    static const unsigned char data[] =
+    {
+        0x46,0x4f,0x52,0x4d,0x00,0x00,0x00,0x2e,
+        0x49,0x4c,0x42,0x4d,0x42,0x4d,0x48,0x44,
+        0x00,0x00,0x00,0x14,0x00,0x01,0x00,0x01,
+        0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,
+        0x40,0x00,0x00,0x00,0x00,0x01,0x00,0x01,
+        0x42,0x4f,0x44,0x59,0x00,0x00,0x00,0x02,
+        0x00,0x00,
+    };
+    wxMemoryInputStream mis(data, WXSIZEOF(data));
+    wxImage img;
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_IFF) );
+}
+
+#endif // wxUSE_IFF
+
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::DibPadding", "[image]")
 {
     /*

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1368,9 +1368,10 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPM", "[image][xpm][error]")
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadIFF", "[image][iff][error]")
 {
     // A FORM/ILBM file whose BMHD transparent-colour field is 0x4000 while
-    // no CMAP chunk is present, so the palette colour count stays at 0. The
+    // the palette only has 2 entries (1 bitplane and no CMAP chunk). The
     // transparent index used to be applied to the palette without a bounds
-    // check, writing past the end of the palette buffer.
+    // check, writing past the end of the palette buffer; loading such a file
+    // must now be rejected.
     static const unsigned char data[] =
     {
         0x46,0x4f,0x52,0x4d,0x00,0x00,0x00,0x2e,


### PR DESCRIPTION
Fix https://github.com/wxWidgets/wxWidgets/issues/26437:
The transparent colour index from the IFF BMHD chunk is a 16-bit value stored unclamped in m_image->transparent. Using it as a palette index without checking it against the CMAP-derived colour count writes 3 bytes at an attacker-controlled offset past the palette buffer.

Validate the index against the actual palette size before applying the magenta mask.