### PR TITLE
Ensure child is visually disabled on creation if appropriate (MSW and OSX)

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1497,7 +1497,10 @@ WXDWORD wxWindowMSW::MSWGetStyle(long flags, WXDWORD *exstyle) const
     // wxTopLevelWindow) should remove WS_CHILD in their MSWGetStyle()
     WXDWORD style = WS_CHILD;
 
-    if ( !IsThisEnabled() )
+    // For creation, check not only the enable state of this window, but also
+    // its parent hierarchy when setting this style, as any disabled parent
+    // logically disables this window.
+    if ( !IsEnabled() )
         style |= WS_DISABLED;
 
     // using this flag results in very significant reduction in flicker,

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2737,6 +2737,12 @@ wxWidgetImpl( peer, flags )
     if ( !peer->IsShown() )
         SetVisibility(false);
 
+    // If the widget is created with a disabled parent, the widget will be
+    // logically disabled as well. Make sure its appearance is made consistent
+    // if this is the case.
+    if ( !peer->IsEnabled() )
+        Enable(false);
+
     if ( IsUserPane() )
         ClipsToBounds(true);
 }


### PR DESCRIPTION
Addresses #26408 for macOS.

I've not yet looked to see if it's a problem on MSW, the other platform which doesn't have `wxHAS_NATIVE_ENABLED_MANAGEMENT`, but it's separate anyways.

Afaics, especially in light of the check for IsShown() immediately above, this would be the proper place to put this. It seems to make things work correctly for me.