### PR TITLE
wxMSW: Fix drawing vertical lines with pen width > 1 in RTL layout

### DIFF
--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -718,7 +718,18 @@ void wxMSWDCImpl::DoDrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2)
     }
     else
     {
-        wxDrawLine(GetHdc(), XLOG2DEV(x1), YLOG2DEV(y1), XLOG2DEV(x2), YLOG2DEV(y2));
+        int dx = 0;
+
+        // In RTL layout, we need this adjustment because vertical lines drawn
+        // with pen width > 1 are incorrectly shifted to the left by one pixel.
+        if ( x1 == x2 && y1 != y2 &&
+             m_pen.GetWidth() > 1 &&
+             GetLayoutDirection() == wxLayout_RightToLeft )
+        {
+            dx = -1;
+        }
+
+        wxDrawLine(GetHdc(), XLOG2DEV(x1) + dx, YLOG2DEV(y1), XLOG2DEV(x2) + dx, YLOG2DEV(y2));
     }
 
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )


### PR DESCRIPTION
In the following pictures, there are four (04) vertical lines (blue & red) in the middle drawn with pen width  == 1 and 2. Blue lines are drawn by calling `wxDrawLine()` function internally. Whereas red lines are drawn by  `wxDrawHVLine()` function.
I removed `m_pen.GetWidth() <= 1 ||` check from this line https://github.com/wxWidgets/wxWidgets/blob/4ed05f7b47d3bd3ac01c4b0d867bece20fe083ff/src/msw/dc.cpp#L710 to expose the bug only. The code I use to draw these line ():
```C++
    // Put this in MyCanvas::DrawDefault() in drawing sample
    for ( int i = 0; i < 2; i++ )
    {
        int dx = 400 + 3*(i);
        int pw = i+1; // pen width

        wxPen pen(*wxBLUE, pw);
        dc.SetPen(pen);

        dc.DrawLine(dx, 0, dx, 80); // calls wxDrawLine() internally

        pen = wxPen(*wxRED, pw);
        pen.SetCap(wxCAP_BUTT);
        dc.SetPen(pen);

        dc.DrawLine(dx, 80, dx, 160); // calls wxDrawHVLine() internally

        dc.SetPen(wxNullPen);
    }
```
### The results:

**In LTR layout:**

<img width="786" height="693" alt="drawline" src="https://github.com/user-attachments/assets/5017fa34-0fcd-4149-af1d-f6f3c49fb4fa" />


**In RTL layout (with this PR):**

<img width="786" height="693" alt="drawline_rtl_ok" src="https://github.com/user-attachments/assets/06724f15-784c-496c-8dc9-958846e5469f" />


**In RTL layout (before):**

<img width="786" height="693" alt="drawline_rtl_bad" src="https://github.com/user-attachments/assets/0270c618-9b1a-4865-b520-47e6e1fb0472" />


This PR also fixes a bug in `wxGrid` where the vertical frozen border was not drawn in RTL layout:

**Before:**

<img width="802" height="726" alt="grid_frozen_rtl_bad" src="https://github.com/user-attachments/assets/5241cbd3-297f-49c9-a6b7-de27d7dfebec" />

**After (I changed the grid lines colour to grey):**

<img width="802" height="726" alt="grid_frozen_rtl_ok" src="https://github.com/user-attachments/assets/2daac0bc-039c-46ba-b39f-e809f2eff566" />
