### PR TITLE
MSW: Eliminate redundant system color change events

### DIFF
--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -482,15 +482,6 @@ void wxFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
         Refresh();
     }
 
-#if wxUSE_STATUSBAR
-    if ( m_frameStatusBar )
-    {
-        wxSysColourChangedEvent event2;
-        event2.SetEventObject( m_frameStatusBar );
-        m_frameStatusBar->HandleWindowEvent(event2);
-    }
-#endif // wxUSE_STATUSBAR
-
 #if wxUSE_MENUS && wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__)
     if ( wxMenuBar* const menuBar = GetMenuBar() )
     {

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3563,7 +3563,14 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             break;
 
         case WM_SETTINGCHANGE:
-            processed = HandleSettingChange(wParam, lParam);
+            // Check for the special case of changing the system light/dark or high contrast mode.
+            // When changing high contrast mode, an additional WM_SETTINGCHANGE occurs with "WindowsThemeElement"
+            // There is no need to check for "WindowsThemeElement" since "ImmersiveColorSet" always occurs.
+            if ( lParam && wxStrcmp((TCHAR*)lParam, wxT("ImmersiveColorSet")) == 0 )
+                // This is a theme/color change only
+                processed = HandleSysColorChange();
+            else
+                processed = HandleSettingChange(wParam, lParam);
             break;
 
         case WM_QUERYNEWPALETTE:
@@ -5199,13 +5206,6 @@ bool wxWindowMSW::HandleCaptureChanged(WXHWND hWndGainedCapture)
 
 bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
 {
-    // Check for the special case of changing the system light/dark mode.
-    if ( lParam && wxStrcmp((TCHAR*)lParam, wxT("ImmersiveColorSet")) == 0 )
-    {
-        // Forward to the existing function generating an event for this.
-        HandleSysColorChange();
-    }
-
     // Another special case: even with this wParam value is sent when the user
     // changes the mouse pointer size in the Control Panel.
     if ( wParam == 0x2029 )


### PR DESCRIPTION
The handling for WM_SETTINGCHANGE is modified to eliminate redundant wxSysColourChangedEvent events. Prior to this change, the handling for WM_SETTINGCHANGE with the "ImmersiveColorSet" argument introduced an additional system color change event in addition to handling the message normally. This doubled the number of events per window. Since WM_SETTINGCHANGE is applied recursively to child windows, this resulted in an exponential increase in the number of events generated, doubling with each level of child windows. The solution is to handle WM_SETTINGCHANGE with "ImmersiveColorSet" as a system color change only - as if it were WM_SYSCOLORCHANGE.

Also, the wxFrame::OnSysColourChanged() is fixed so that it does explicitly send a wxSysColourChangedEvent to the status bar. The status bar is assumed to be a descendant of the frame and so already gets the event. Now the status bar is handled the same as the toolbar.
