### PR TITLE
CMake: Fix libwebp build properties

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -274,7 +274,13 @@ function(wx_set_common_target_properties target_name)
     endif()
 
     if(wxUSE_THREADS)
-        target_link_libraries(${target_name} PRIVATE Threads::Threads)
+        set(LIB_VISIBILITY PRIVATE)
+        if (${target_name} MATCHES ".*webp.*" OR ${target_name} MATCHES "sharpyuv")
+            # libwebp libraries use the plain-signature of target_link_libraries
+            # this can't be mixed with the visibility keyword-signature
+            set(LIB_VISIBILITY)
+        endif()
+        target_link_libraries(${target_name} ${LIB_VISIBILITY} Threads::Threads)
     endif()
 
     wx_set_source_groups()
@@ -722,9 +728,31 @@ macro(wx_set_builtin_target_ouput_name target target_name)
     )
 endmacro()
 
-# Set common properties for a builtin third party library
-function(wx_set_builtin_target_properties target_name)
-    wx_set_builtin_target_ouput_name(${target_name} "${target_name}")
+# Add a third party builtin library
+function(wx_add_builtin_library target_name)
+    cmake_parse_arguments(BUILTIN "SKIP_INSTALL" "FOLDER" "" ${ARGN})
+
+    if(BUILTIN_UNPARSED_ARGUMENTS)
+        wx_list_add_prefix(src_list "${wxSOURCE_DIR}/" ${BUILTIN_UNPARSED_ARGUMENTS})
+
+        list(GET src_list 0 src_file)
+        if(NOT EXISTS "${src_file}")
+            message(FATAL_ERROR "${target_name} file does not exist: \"${src_file}\".\
+            Make sure you checkout the git submodules.")
+        endif()
+
+        add_library(${target_name} STATIC ${src_list})
+    endif()
+
+    if(${target_name} MATCHES "wx.*")
+        string(SUBSTRING ${target_name} 2 -1 name_short)
+        set(name_long ${target_name})
+    else()
+        set(name_short ${target_name})
+        set(name_long "wx${target_name}")
+    endif()
+
+    wx_set_builtin_target_ouput_name(${target_name} ${name_long})
 
     if(MSVC)
         # we're not interested in deprecation warnings about the use of
@@ -743,47 +771,32 @@ function(wx_set_builtin_target_properties target_name)
 
     target_include_directories(${target_name} BEFORE PRIVATE ${wxSETUP_HEADER_PATH})
 
-    set_target_properties(${target_name} PROPERTIES FOLDER "Third Party Libraries")
-
+    set_target_properties(${target_name} PROPERTIES
+        PROJECT_LABEL ${name_short}
+        PUBLIC_HEADER ""
+        FOLDER "Third Party Libraries${BUILTIN_FOLDER}"
+    )
     if(wxBUILD_SHARED OR wxBUILD_PIC)
         set_target_properties(${target_name} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     endif()
 
     wx_set_common_target_properties(${target_name} DEFAULT_WARNINGS)
-    if(NOT wxBUILD_SHARED)
-        wx_get_install_platform_dir(archive)
-        wx_install(TARGETS ${name} EXPORT wxWidgetsTargets ARCHIVE DESTINATION "${archive_dir}")
+
+    if(NOT BUILTIN_SKIP_INSTALL)
+        add_library(wx::${name_short} ALIAS ${target_name})
+        add_library(wxWidgets::${name_short} ALIAS ${target_name})
+        if(CREATE_WX_TARGET)
+            target_link_libraries(wxWidgets INTERFACE ${target_name})
+        endif()
+
+        list(APPEND wxLIB_BUILTIN_TARGETS ${target_name})
+        set(wxLIB_BUILTIN_TARGETS ${wxLIB_BUILTIN_TARGETS} PARENT_SCOPE)
+
+        if(NOT wxBUILD_SHARED)
+            wx_get_install_platform_dir(archive)
+            wx_install(TARGETS ${target_name} EXPORT wxWidgetsTargets ARCHIVE DESTINATION "${archive_dir}")
+        endif()
     endif()
-endfunction()
-
-# Add a third party builtin library
-function(wx_add_builtin_library name)
-    list(APPEND wxLIB_BUILTIN_TARGETS ${name})
-    set(wxLIB_BUILTIN_TARGETS ${wxLIB_BUILTIN_TARGETS} PARENT_SCOPE)
-
-    wx_list_add_prefix(src_list "${wxSOURCE_DIR}/" ${ARGN})
-
-    list(GET src_list 0 src_file)
-    if(NOT EXISTS "${src_file}")
-        message(FATAL_ERROR "${name} file does not exist: \"${src_file}\".\
-        Make sure you checkout the git submodules.")
-    endif()
-
-    if(${name} MATCHES "wx.*")
-        string(SUBSTRING ${name} 2 -1 name_short)
-    else()
-        set(name_short ${name})
-    endif()
-
-    add_library(${name} STATIC ${src_list})
-    add_library(wx::${name_short} ALIAS ${name})
-    add_library(wxWidgets::${name_short} ALIAS ${name})
-    if(CREATE_WX_TARGET)
-        target_link_libraries(wxWidgets INTERFACE ${name})
-    endif()
-
-    wx_set_builtin_target_properties(${name})
-    set_target_properties(${name} PROPERTIES PROJECT_LABEL ${name_short})
 endfunction()
 
 # List of third party libraries added via wx_add_thirdparty_library()

--- a/build/cmake/lib/webp.cmake
+++ b/build/cmake/lib/webp.cmake
@@ -61,23 +61,14 @@ if(wxUSE_LIBWEBP STREQUAL "builtin")
     mark_as_advanced(WEBP_UNICODE)
     mark_as_advanced(WEBP_USE_THREAD)
 
+    set(WebP_LIBRARIES webp webpdemux sharpyuv)
+
     get_property(webpTargets DIRECTORY "${WEBP_ROOT}" PROPERTY BUILDSYSTEM_TARGETS)
     foreach(target_name IN LISTS webpTargets)
-        wx_set_builtin_target_ouput_name(${target_name} "wx${target_name}")
-        set_target_properties(${target_name} PROPERTIES
-            FOLDER "Third Party Libraries/WebP"
-            PUBLIC_HEADER ""
-        )
+        set(builtin_props)
+        if (NOT ${target_name} IN_LIST WebP_LIBRARIES)
+            set(builtin_props SKIP_INSTALL)
+        endif()
+        wx_add_builtin_library(${target_name} ${builtin_props} FOLDER "/WebP")
     endforeach()
-
-    set(WebP_LIBRARIES webp webpdemux sharpyuv)
-    list(APPEND wxLIB_BUILTIN_TARGETS ${WebP_LIBRARIES})
-
-    if(NOT wxBUILD_SHARED)
-        wx_get_install_platform_dir(archive)
-        wx_install(TARGETS ${WebP_LIBRARIES}
-            EXPORT wxWidgetsTargets
-            ARCHIVE DESTINATION "${archive_dir}"
-        )
-    endif()
 endif()

--- a/build/cmake/wxWidgetsConfig.cmake.in
+++ b/build/cmake/wxWidgetsConfig.cmake.in
@@ -168,6 +168,8 @@ foreach(libname @wxLIB_TARGETS@)
         endif()
     endif()
 endforeach()
+
+# list all built-in libraries
 foreach(libname @wxLIB_BUILTIN_TARGETS@)
     if(TARGET wx::${libname})
         wx_map_release(${libname})


### PR DESCRIPTION
Allow to call `wx_add_builtin_library` for external targets. and use it for the libwebp targets.

See #26428