### PR TITLE
wxMSW: Add runtime checks for Windows 8+ Pointer API functions

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -6412,19 +6412,17 @@ bool wxWindowMSW::HandlePointer(WXUINT message, WXWPARAM wParam, WXLPARAM lParam
     typedef BOOL (WINAPI *GetPointerPenInfo_t)(UINT32 pointerId, POINTER_PEN_INFO *penInfo);
     static GetPointerType_t s_pfnGetPointerType = nullptr;
     static GetPointerPenInfo_t s_pfnGetPointerPenInfo = nullptr;
-    static bool s_initDone = false;
 
-    if ( !s_initDone )
+    if ( !s_pfnGetPointerType )
     {
         wxLoadedDLL dllUser32("user32.dll");
         wxDL_INIT_FUNC(s_pfn, GetPointerType, dllUser32);
         wxDL_INIT_FUNC(s_pfn, GetPointerPenInfo, dllUser32);
-        s_initDone = true;
     }
 
     const UINT32 pointerId = GET_POINTERID_WPARAM(wParam);
     POINTER_INPUT_TYPE pType = 0;
-    if ( s_pfnGetPointerType && s_pfnGetPointerType(pointerId, &pType) )
+    if ( s_pfnGetPointerType(pointerId, &pType) )
     {
         if (pType != PT_PEN)
         {
@@ -6438,7 +6436,7 @@ bool wxWindowMSW::HandlePointer(WXUINT message, WXWPARAM wParam, WXLPARAM lParam
 
     // here we already know we have a pen generated event
     POINTER_PEN_INFO penInfo;
-    if ( s_pfnGetPointerPenInfo && s_pfnGetPointerPenInfo(pointerId, &penInfo) )
+    if ( s_pfnGetPointerPenInfo(pointerId, &penInfo) )
     {
         if (penInfo.penMask & PEN_MASK_PRESSURE)
         {

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -6405,9 +6405,26 @@ bool wxWindowMSW::HandlePointer(WXUINT message, WXWPARAM wParam, WXLPARAM lParam
             return false;
     }
 
+    // GetPointerType() and GetPointerPenInfo() are only available on Windows 8+.
+    // To maintain backward compatibility with legacy Windows versions, a runtime
+    // availability check must be performed for these API functions.
+    typedef BOOL (WINAPI *GetPointerType_t)(UINT32 pointerId, POINTER_INPUT_TYPE *pointerType);
+    typedef BOOL (WINAPI *GetPointerPenInfo_t)(UINT32 pointerId, POINTER_PEN_INFO *penInfo);
+    static GetPointerType_t s_pfnGetPointerType = nullptr;
+    static GetPointerPenInfo_t s_pfnGetPointerPenInfo = nullptr;
+    static bool s_initDone = false;
+
+    if ( !s_initDone )
+    {
+        wxLoadedDLL dllUser32("user32.dll");
+        wxDL_INIT_FUNC(s_pfn, GetPointerType, dllUser32);
+        wxDL_INIT_FUNC(s_pfn, GetPointerPenInfo, dllUser32);
+        s_initDone = true;
+    }
+
     const UINT32 pointerId = GET_POINTERID_WPARAM(wParam);
     POINTER_INPUT_TYPE pType = 0;
-    if ( ::GetPointerType(pointerId, &pType) )
+    if ( s_pfnGetPointerType && s_pfnGetPointerType(pointerId, &pType) )
     {
         if (pType != PT_PEN)
         {
@@ -6421,7 +6438,7 @@ bool wxWindowMSW::HandlePointer(WXUINT message, WXWPARAM wParam, WXLPARAM lParam
 
     // here we already know we have a pen generated event
     POINTER_PEN_INFO penInfo;
-    if ( ::GetPointerPenInfo(pointerId, &penInfo) )
+    if ( s_pfnGetPointerPenInfo && s_pfnGetPointerPenInfo(pointerId, &penInfo) )
     {
         if (penInfo.penMask & PEN_MASK_PRESSURE)
         {


### PR DESCRIPTION
To support legacy Windows versions, this commit ensures that `GetPointerType()` and `GetPointerPenInfo()` are only invoked if available at runtime. This prevents "Procedure entry point not found" errors on Windows 7.

This adds the missing runtime checks to fix the compatibility issue introduced in 3732496 (Add support for generating wxStylusEvent for graphical tablets, 2026-02-02).