### PR TITLE
Improve speed of reading webp into memory

### DIFF
--- a/include/wx/stream.h
+++ b/include/wx/stream.h
@@ -134,6 +134,10 @@ public:
     // when EOF is reached or an error occurs
     wxInputStream& Read(wxOutputStream& streamOut);
 
+    // copy the entire contents of this stream into buffer, stopping only
+    // when EOF is reached or an error occurs
+    bool Read(std::vector<wxUint8>& buffer);
+
 
     // status functions
     // ----------------

--- a/interface/wx/stream.h
+++ b/interface/wx/stream.h
@@ -649,6 +649,17 @@ public:
     wxInputStream& Read(wxOutputStream& stream_out);
 
     /**
+        Read all data from the stream and stores it in the specified buffer.
+        Data is read until the end of the input stream, or until an error occurs.
+        The buffer will be resized to the number of bytes read.
+
+        @return Returns true if the entire stream is read.
+
+        @since 3.3.3
+    */
+    bool Read(std::vector<wxUint8>& buffer);
+
+    /**
         Reads exactly the specified number of bytes into the buffer.
 
         Returns @true only if the entire amount of data was read, otherwise

--- a/src/common/imagwebp.cpp
+++ b/src/common/imagwebp.cpp
@@ -34,8 +34,6 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxWEBPHandler, wxImageHandler);
 
 #if wxUSE_STREAMS
 
-#include "wx/mstream.h"
-
 #include <memory>
 #include <functional>
 
@@ -103,21 +101,20 @@ bool DecodeWebPDataIntoImage(wxImage* image, WebPData* webp_data, bool verbose)
     return true;
 }
 
-WebPDemuxerPtr CreateDemuxer(wxMemoryOutputStream& mos, bool verbose = false)
+WebPDemuxerPtr CreateDemuxer(wxInputStream& stream, std::vector<uint8_t>& buffer, bool verbose = false)
 {
-    wxStreamBuffer* mosb = mos.GetOutputStreamBuffer();
-    if (mosb == nullptr)
+    if (!stream.Read(buffer))
     {
         if (verbose)
         {
-            wxLogError(_("WebP: Allocating stream buffer failed."));
+            wxLogError(_("WebP: Error reading data."));
         }
         return nullptr;
     }
 
     WebPData webp_data{};
-    webp_data.bytes = reinterpret_cast<uint8_t*>(mosb->GetBufferStart());
-    webp_data.size = mosb->GetBufferSize();
+    webp_data.bytes = buffer.data();
+    webp_data.size = buffer.size();
 
     WebPDemuxerPtr demux(
         WebPDemux(&webp_data),
@@ -157,9 +154,8 @@ bool wxWEBPHandler::LoadFile(wxImage* image, wxInputStream& stream, bool verbose
         // be a sub-frame, smaller than the full image. Its size is known, but
         // the x_offset and y_offset can not be queried, so we can't
         // reconstruct the full-size image.
-        wxMemoryOutputStream mos;
-        stream.Read(mos);
-        WebPDemuxerPtr demux = CreateDemuxer(mos, verbose);
+        std::vector<uint8_t> buffer;
+        WebPDemuxerPtr demux = CreateDemuxer(stream, buffer, verbose);
         if (demux != nullptr)
         {
             WebPIterator iter;
@@ -191,21 +187,19 @@ bool wxWEBPHandler::LoadFile(wxImage* image, wxInputStream& stream, bool verbose
 
 bool wxWEBPHandler::LoadAnimation(std::vector<wxWebPAnimationFrame>& frames, wxInputStream& stream, bool verbose)
 {
-    wxMemoryOutputStream mos;
-    stream.Read(mos);
-    wxStreamBuffer* mosb = mos.GetOutputStreamBuffer();
-    if (mosb == nullptr)
+    std::vector<uint8_t> buffer;
+    if (!stream.Read(buffer))
     {
         if (verbose)
         {
-            wxLogError(_("WebP: Allocating stream buffer failed."));
+            wxLogError(_("WebP: Error reading data."));
         }
         return false;
     }
 
     WebPData webp_data{};
-    webp_data.bytes = reinterpret_cast<uint8_t*>(mosb->GetBufferStart());
-    webp_data.size = mosb->GetBufferSize();
+    webp_data.bytes = buffer.data();
+    webp_data.size = buffer.size();
 
     WebPAnimDecoderOptions dec_options;
     WebPAnimDecoderOptionsInit(&dec_options);
@@ -305,9 +299,8 @@ bool wxWEBPHandler::SaveFile(wxImage* image, wxOutputStream& stream, bool)
 int wxWEBPHandler::DoGetImageCount(wxInputStream& stream)
 {
     int frame_count = 0;
-    wxMemoryOutputStream mos;
-    stream.Read(mos);
-    WebPDemuxerPtr demux = CreateDemuxer(mos);
+    std::vector<uint8_t> buffer;
+    WebPDemuxerPtr demux = CreateDemuxer(stream, buffer);
     if (demux != nullptr)
     {
         frame_count = WebPDemuxGetI(demux.get(), WEBP_FF_FRAME_COUNT);

--- a/src/common/stream.cpp
+++ b/src/common/stream.cpp
@@ -915,6 +915,43 @@ wxInputStream& wxInputStream::Read(wxOutputStream& stream_out)
     return *this;
 }
 
+bool wxInputStream::Read(std::vector<wxUint8>& buffer)
+{
+    const size_t stream_size = IsOk() ? GetSize() : 0;
+    size_t lastcount = 0;
+
+    if ( stream_size > 0 )
+    {
+        buffer.resize(stream_size);
+        lastcount = Read(buffer.data(), stream_size).LastRead();
+
+        // Read one more byte to set EOF
+        wxUint8 temp;
+        Read(&temp, 1);
+    }
+    else if ( IsOk() )
+    {
+        const size_t read_size = BUF_TEMP_SIZE * 8;
+        for ( ;; )
+        {
+            if ( buffer.size() < (lastcount + read_size) )
+                buffer.resize(lastcount + read_size);
+
+            size_t bytes_read = Read(buffer.data() + lastcount, read_size).LastRead();
+            if ( !bytes_read )
+                break;
+
+            lastcount += bytes_read;
+        }
+    }
+
+    m_lastcount = lastcount;
+
+    buffer.resize(m_lastcount);
+
+    return Eof();
+}
+
 bool wxInputStream::ReadAll(void *buffer_, size_t size)
 {
     char* buffer = static_cast<char*>(buffer_);

--- a/src/common/stream.cpp
+++ b/src/common/stream.cpp
@@ -39,7 +39,7 @@
 // ----------------------------------------------------------------------------
 
 // the temporary buffer size used when copying from stream to stream
-#define BUF_TEMP_SIZE 4096
+#define BUF_TEMP_SIZE 65536
 
 // ============================================================================
 // implementation


### PR DESCRIPTION
Read the input stream directly into a buffer instead of using a `wxMemoryOutputStream`.

Increase default temporary buffer size of streams. Reading large files using a small buffer causes significant delays.

See #26457