### PR TITLE
wxGTK: Fix wxTextCtrl crash with GSpell attached

### DIFF
--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -654,7 +654,7 @@ extern "C" {
 static void mark_set(GtkTextBuffer*, GtkTextIter*, GtkTextMark* mark, GSList** markList)
 {
     if (gtk_text_mark_get_name(mark) == nullptr)
-        *markList = g_slist_prepend(*markList, mark);
+        *markList = g_slist_prepend(*markList, g_object_ref(mark));
 }
 }
 
@@ -730,7 +730,7 @@ wxTextCtrl::~wxTextCtrl()
         Thaw();
 
     if (m_anonymousMarkList)
-        g_slist_free(m_anonymousMarkList);
+        g_slist_free_full(m_anonymousMarkList, g_object_unref);
     if (m_afterLayoutId)
         g_source_remove(m_afterLayoutId);
 }
@@ -2339,7 +2339,7 @@ void wxTextCtrl::DoFreeze()
                 if (GTK_IS_TEXT_MARK(mark) && !gtk_text_mark_get_deleted(mark))
                     gtk_text_buffer_delete_mark(m_buffer, mark);
             }
-            g_slist_free(m_anonymousMarkList);
+            g_slist_free_full(m_anonymousMarkList, g_object_unref);
             m_anonymousMarkList = nullptr;
         }
     }


### PR DESCRIPTION
The logic in `wxTextCtrl::DoFreeze()` for deleting leaked anonymous marks when detaching the buffer kept raw pointers to `GtkTextMark` objects without managing their reference count.

This worked for the specific internal mark targeted by this code, but broke with other marks that may have become invalid in the meantime. Specifically, GSpell uses such marks internally too, causing a use-after-free crash.

Fixed by ref-counting the objects kept in `m_anonymousMarkList`.

An alternative approach would be to to amend `mark_set` with a corresponding `mark_deleted`, but this fix is both simpler and feels more obviously correct: if wxGTK is keeping pointers to GObjects, it should as a general rule refcount them and not store raw pointers. In other words, this should be done *even if it didn’t crash with GSpell*.

The crash is hard to work around from user code (you’d have to override `DoFreeze`/`DoThaw` and ensure the spellchecker is not present when `m_anonymousMarkList` is being captured), i.e. the fix should be backported to 3.2.