### PR TITLE
Fix wxPreferencesEditor only showing once on GTK

### DIFF
--- a/src/generic/preferencesg.cpp
+++ b/src/generic/preferencesg.cpp
@@ -172,6 +172,7 @@ public:
             // probably not worth the hassle. We know the old parent is still
             // valid, because otherwise Dismiss() would have been called and
             // m_win cleared.
+            m_win->Show();
             m_win->Raise();
         }
     }


### PR DESCRIPTION
Explicit Show() is required before Raise() since
3c93711f4b (Don't show the window if it is currently hidden in Raise(), 2026-02-28) See #26467