### PR TITLE
Fix implementation of `wxCondition::WaitTimeout()` for dates after 2038

### DIFF
--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -498,13 +498,10 @@ wxCondError wxConditionInternal::Wait()
 
 wxCondError wxConditionInternal::WaitTimeout(unsigned long milliseconds)
 {
-    wxLongLong curtime = wxGetUTCTimeMillis();
+    wxLongLong_t curtime = wxGetUTCTimeMillis().GetValue();
     curtime += milliseconds;
-    wxLongLong temp = curtime / 1000;
-    int sec = temp.GetLo();
-    temp *= 1000;
-    temp = curtime - temp;
-    int millis = temp.GetLo();
+    const wxLongLong_t sec = curtime / 1000;
+    const int millis = curtime - sec * 1000;
 
     timespec tspec;
 

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -498,10 +498,9 @@ wxCondError wxConditionInternal::Wait()
 
 wxCondError wxConditionInternal::WaitTimeout(unsigned long milliseconds)
 {
-    wxLongLong_t curtime = wxGetUTCTimeMillis().GetValue();
-    curtime += milliseconds;
-    const wxLongLong_t sec = curtime / 1000;
-    const int millis = curtime - sec * 1000;
+    const wxLongLong_t endtime = wxGetUTCTimeMillis().GetValue() + milliseconds;
+    const wxLongLong_t sec = endtime / 1000;
+    const int millis = endtime - sec * 1000;
 
     timespec tspec;
 

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -80,6 +80,7 @@
 #endif
 
 #include <atomic>
+#include <cstdlib>
 #include <exception>
 
 #define THR_ID_CAST(id)  (reinterpret_cast<void*>(id))
@@ -499,13 +500,12 @@ wxCondError wxConditionInternal::Wait()
 wxCondError wxConditionInternal::WaitTimeout(unsigned long milliseconds)
 {
     const wxLongLong_t endtime = wxGetUTCTimeMillis().GetValue() + milliseconds;
-    const wxLongLong_t sec = endtime / 1000;
-    const int millis = endtime - sec * 1000;
+    const auto div = std::div(endtime, 1000LL);
 
     timespec tspec;
 
-    tspec.tv_sec = sec;
-    tspec.tv_nsec = millis * 1000L * 1000L;
+    tspec.tv_sec = div.quot;
+    tspec.tv_nsec = div.rem * 1000L * 1000L;
 
     int err = pthread_cond_timedwait( &m_cond, GetPMutex(), &tspec );
     switch ( err )


### PR DESCRIPTION
Only the first commit here is significant (and will be backported to 3.2).