### PR TITLE
Add getters to wxSVGAttributes, add unit tests

### DIFF
--- a/build/cmake/tests/gui/CMakeLists.txt
+++ b/build/cmake/tests/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_GUI_SRC
     graphics/boundingbox.cpp
     graphics/clipper.cpp
     graphics/clippingbox.cpp
+    graphics/svgattributes.cpp
     graphics/coords.cpp
     graphics/graphbitmap.cpp
     graphics/graphmatrix.cpp

--- a/include/wx/dcsvg.h
+++ b/include/wx/dcsvg.h
@@ -53,8 +53,22 @@ public:
     wxSVGAttributes& Id(const wxString& id) { return Add(wxASCII_STR("id"), id); }
     wxSVGAttributes& Class(const wxString& classname) { return Add(wxASCII_STR("class"), classname); }
 
+    wxString GetRole() const { return GetAttribute(wxASCII_STR("role")); }
+    wxString GetAriaLabel() const { return GetAttribute(wxASCII_STR("aria-label")); }
+    wxString GetAriaLabelledBy() const { return GetAttribute(wxASCII_STR("aria-labelledby")); }
+    wxString GetAriaDescribedBy() const { return GetAttribute(wxASCII_STR("aria-describedby")); }
+    bool IsAriaHidden() const { return GetAttribute(wxASCII_STR("aria-hidden")) == wxASCII_STR("true"); }
+    wxString GetAriaDetails() const { return GetAttribute(wxASCII_STR("aria-details")); }
+    wxString GetAriaRoleDescription() const { return GetAttribute(wxASCII_STR("aria-roledescription")); }
+
+    wxString GetId() const { return GetAttribute(wxASCII_STR("id")); }
+    wxString GetClass() const { return GetAttribute(wxASCII_STR("class")); }
+
     // Add or update an attribute.
     wxSVGAttributes& Add(const wxString& name, const wxString& value);
+
+    // Get an attribute value, returns empty string if not found.
+    wxString GetAttribute(const wxString& name) const;
 
     // Returns the attributes as a string of name="value" pairs, each prefixed with a space.
     wxString GetAsString() const;

--- a/interface/wx/dcsvg.h
+++ b/interface/wx/dcsvg.h
@@ -72,10 +72,24 @@ public:
     wxSVGAttributes& Role(const wxString& role);
 
     /**
+        Returns the @c role attribute.
+
+        @since 3.3.3
+    */
+    wxString GetRole() const;
+
+    /**
         Sets the @c aria-label attribute: a short accessible name read
         aloud by screen readers. Use when no visible text label exists.
     */
     wxSVGAttributes& AriaLabel(const wxString& label);
+
+    /**
+        Returns the @c aria-label attribute.
+
+        @since 3.3.3
+    */
+    wxString GetAriaLabel() const;
 
     /**
         Sets the @c aria-labelledby attribute: instead of supplying a name
@@ -85,11 +99,25 @@ public:
     wxSVGAttributes& AriaLabelledBy(const wxString& id);
 
     /**
+        Returns the @c aria-labelledby attribute.
+
+        @since 3.3.3
+    */
+    wxString GetAriaLabelledBy() const;
+
+    /**
         Sets the @c aria-describedby attribute: points at the @c id of
         another element whose text content provides a longer description,
         announced after the accessible name.
     */
     wxSVGAttributes& AriaDescribedBy(const wxString& id);
+
+    /**
+        Returns the @c aria-describedby attribute.
+
+        @since 3.3.3
+    */
+    wxString GetAriaDescribedBy() const;
 
     /**
         Sets the @c aria-hidden attribute.
@@ -102,11 +130,25 @@ public:
     wxSVGAttributes& AriaHidden(bool hidden = true);
 
     /**
+        Returns @true if the @c aria-hidden attribute is set to @c "true".
+
+        @since 3.3.3
+    */
+    bool IsAriaHidden() const;
+
+    /**
         Sets the @c aria-details attribute: points at the @c id of another
         element containing extended information about this one
         (e.g., a data table describing a chart).
     */
     wxSVGAttributes& AriaDetails(const wxString& id);
+
+    /**
+        Returns the @c aria-details attribute.
+
+        @since 3.3.3
+    */
+    wxString GetAriaDetails() const;
 
     /**
         Sets the @c aria-roledescription attribute: a human-readable,
@@ -116,11 +158,25 @@ public:
     wxSVGAttributes& AriaRoleDescription(const wxString& desc);
 
     /**
+        Returns the @c aria-roledescription attribute.
+
+        @since 3.3.3
+    */
+    wxString GetAriaRoleDescription() const;
+
+    /**
         Sets the @c id attribute, giving the element a unique identifier
         other attributes (such as @c aria-labelledby) or stylesheets can
         reference.
     */
     wxSVGAttributes& Id(const wxString& id);
+
+    /**
+        Returns the @c id attribute.
+
+        @since 3.3.3
+    */
+    wxString GetId() const;
 
     /**
         Sets the @c class attribute, used to associate the element with
@@ -129,12 +185,28 @@ public:
     wxSVGAttributes& Class(const wxString& classname);
 
     /**
+        Returns the @c class attribute.
+
+        @since 3.3.3
+    */
+    wxString GetClass() const;
+
+    /**
         Adds or updates an arbitrary attribute.
 
         If @a name is already set, its value is replaced; otherwise a new
         entry is appended.
     */
     wxSVGAttributes& Add(const wxString& name, const wxString& value);
+
+    /**
+        Returns the value of the attribute with the given @a name.
+
+        Returns an empty string if the attribute is not set.
+
+        @since 3.3.3
+    */
+    wxString GetAttribute(const wxString& name) const;
 
     /// Returns @true if no attributes have been set.
     bool IsEmpty() const;

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -554,6 +554,12 @@ wxSVGAttributes& wxSVGAttributes::Add(const wxString& name, const wxString& valu
     return *this;
 }
 
+wxString wxSVGAttributes::GetAttribute(const wxString& name) const
+{
+    auto it = m_attributes.find(name);
+    return it != m_attributes.end() ? it->second : wxString();
+}
+
 wxString wxSVGAttributes::GetAsString() const
 {
     wxString s;

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -192,6 +192,7 @@ TEST_GUI_OBJECTS =  \
 	test_gui_boundingbox.o \
 	test_gui_clipper.o \
 	test_gui_clippingbox.o \
+	test_gui_svgattributes.o \
 	test_gui_coords.o \
 	test_gui_graphbitmap.o \
 	test_gui_graphmatrix.o \
@@ -997,6 +998,9 @@ test_gui_clipper.o: $(srcdir)/graphics/clipper.cpp $(TEST_GUI_ODEP)
 
 test_gui_clippingbox.o: $(srcdir)/graphics/clippingbox.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/graphics/clippingbox.cpp
+
+test_gui_svgattributes.o: $(srcdir)/graphics/svgattributes.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/graphics/svgattributes.cpp
 
 test_gui_coords.o: $(srcdir)/graphics/coords.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/graphics/coords.cpp

--- a/tests/graphics/svgattributes.cpp
+++ b/tests/graphics/svgattributes.cpp
@@ -1,0 +1,47 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/graphics/svgattributes.cpp
+// Purpose:     wxSVGAttributes unit tests
+// Author:      wxWidgets team
+// Created:     2026-05-19
+// Copyright:   (c) 2026 wxWidgets development team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#include "testprec.h"
+
+#if wxUSE_SVG
+
+#include "wx/dcsvg.h"
+
+TEST_CASE("wxSVGAttributes::Getters", "[svg][attributes]")
+{
+    wxSVGAttributes attr;
+    attr.Role("img")
+        .AriaLabel("label")
+        .AriaLabelledBy("id1")
+        .AriaDescribedBy("id2")
+        .AriaHidden(true)
+        .AriaDetails("id3")
+        .AriaRoleDescription("desc")
+        .Id("myid")
+        .Class("myclass");
+
+    CHECK( attr.GetRole() == "img" );
+    CHECK( attr.GetAriaLabel() == "label" );
+    CHECK( attr.GetAriaLabelledBy() == "id1" );
+    CHECK( attr.GetAriaDescribedBy() == "id2" );
+    CHECK( attr.IsAriaHidden() == true );
+    CHECK( attr.GetAriaDetails() == "id3" );
+    CHECK( attr.GetAriaRoleDescription() == "desc" );
+    CHECK( attr.GetId() == "myid" );
+    CHECK( attr.GetClass() == "myclass" );
+
+    attr.AriaHidden(false);
+    CHECK( attr.IsAriaHidden() == false );
+
+    attr.Add("custom", "value");
+    CHECK( attr.GetAttribute("custom") == "value" );
+    CHECK( attr.GetAttribute("nonexistent").empty() );
+}
+
+#endif // wxUSE_SVG

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -165,6 +165,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_boundingbox.o \
 	$(OBJS)\test_gui_clipper.o \
 	$(OBJS)\test_gui_clippingbox.o \
+	$(OBJS)\test_gui_svgattributes.o \
 	$(OBJS)\test_gui_coords.o \
 	$(OBJS)\test_gui_graphbitmap.o \
 	$(OBJS)\test_gui_graphmatrix.o \
@@ -943,6 +944,9 @@ $(OBJS)\test_gui_clipper.o: ./graphics/clipper.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_clippingbox.o: ./graphics/clippingbox.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_svgattributes.o: ./graphics/svgattributes.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_coords.o: ./graphics/coords.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -180,6 +180,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_boundingbox.obj \
 	$(OBJS)\test_gui_clipper.obj \
 	$(OBJS)\test_gui_clippingbox.obj \
+	$(OBJS)\test_gui_svgattributes.obj \
 	$(OBJS)\test_gui_coords.obj \
 	$(OBJS)\test_gui_graphbitmap.obj \
 	$(OBJS)\test_gui_graphmatrix.obj \
@@ -1251,6 +1252,9 @@ $(OBJS)\test_gui_clipper.obj: .\graphics\clipper.cpp
 
 $(OBJS)\test_gui_clippingbox.obj: .\graphics\clippingbox.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\graphics\clippingbox.cpp
+
+$(OBJS)\test_gui_svgattributes.obj: .\graphics\svgattributes.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\graphics\svgattributes.cpp
 
 $(OBJS)\test_gui_coords.obj: .\graphics\coords.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\graphics\coords.cpp

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -202,6 +202,7 @@
             graphics/boundingbox.cpp
             graphics/clipper.cpp
             graphics/clippingbox.cpp
+            graphics/svgattributes.cpp
             graphics/coords.cpp
             graphics/graphbitmap.cpp
             graphics/graphmatrix.cpp

--- a/tests/test_gui.vcxproj
+++ b/tests/test_gui.vcxproj
@@ -1001,6 +1001,7 @@
     <ClCompile Include="graphics\boundingbox.cpp" />
     <ClCompile Include="graphics\clipper.cpp" />
     <ClCompile Include="graphics\clippingbox.cpp" />
+    <ClCompile Include="graphics\svgattributes.cpp" />
     <ClCompile Include="graphics\coords.cpp" />
     <ClCompile Include="graphics\graphbitmap.cpp" />
     <ClCompile Include="graphics\graphmatrix.cpp" />

--- a/tests/test_gui.vcxproj.filters
+++ b/tests/test_gui.vcxproj.filters
@@ -311,6 +311,9 @@
     <ClCompile Include="graphics\clippingbox.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="graphics\svgattributes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="graphics\coords.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
I was wanting to mulipurpose `wxSVGAttributes` in another project and noticed that I forgot the getters, sorry. Adding these also allows for unit tests now.