### PR TITLE
Fix non-resizable TLW size on GTK when client size is set to initial size

### DIFF
--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -1437,6 +1437,8 @@ void wxTopLevelWindowGTK::DoSetClientSize(int width, int height)
 
     if (m_wxwindow)
     {
+        DoGetClientSize(&width, &height);
+
         // If window is not resizable or not yet shown, set size request on
         // client widget, to make it more likely window will get correct size
         // even if our decorations size cache is incorrect (as it will be before
@@ -1444,11 +1446,11 @@ void wxTopLevelWindowGTK::DoSetClientSize(int width, int height)
         if (!gtk_window_get_resizable(GTK_WINDOW(m_widget)))
         {
             gtk_widget_set_size_request(m_widget, -1, -1);
-            gtk_widget_set_size_request(m_wxwindow, m_clientWidth, m_clientHeight);
+            gtk_widget_set_size_request(m_wxwindow, width, height);
         }
         else if (!IsShown())
         {
-            gtk_widget_set_size_request(m_wxwindow, m_clientWidth, m_clientHeight);
+            gtk_widget_set_size_request(m_wxwindow, width, height);
             // Cancel size request at next idle to allow resizing
             g_idle_add_full(G_PRIORITY_LOW - 1, reset_size_request, m_wxwindow, nullptr);
             g_object_ref(m_wxwindow);


### PR DESCRIPTION
There are a number of ways to fix this, hopefully this one is pretty safe.

See #26480