### PR TITLE
Validate ANI frame indices against loaded icon count

### DIFF
--- a/src/common/anidecod.cpp
+++ b/src/common/anidecod.cpp
@@ -331,6 +331,11 @@ bool wxANIDecoder::Load( wxInputStream& stream )
     if (m_nFrames==0)
         return false;
 
+    // Without any loaded icon, m_images[0] below and the public accessors
+    // would index into an empty vector.
+    if (m_images.empty())
+        return false;
+
     if (m_nFrames==m_images.size())
     {
         // if no SEQ chunk is available, display the frames in the order
@@ -338,6 +343,15 @@ bool wxANIDecoder::Load( wxInputStream& stream )
         for (unsigned int i=0; i<m_nFrames; i++)
             if (m_info[i].m_imageIndex == -1)
                 m_info[i].m_imageIndex = i;
+    }
+
+    // SEQ chunk indices come straight from the input, so reject the file if
+    // any of them would index m_images out of range.
+    for (unsigned int i=0; i<m_nFrames; i++)
+    {
+        if (m_info[i].m_imageIndex < 0 ||
+            static_cast<size_t>(m_info[i].m_imageIndex) >= m_images.size())
+            return false;
     }
 
     // if some frame has an invalid delay, use the global delay given in the

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1340,6 +1340,60 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadPCX", "[image][pcx][error]")
 
 #endif // wxUSE_PCX
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadANI", "[image][ani][error]")
+{
+    // ANI with invalid seq indices.
+    // Used to cause out-of-bounds access.
+
+    static const unsigned char data[] =
+    {
+        'R','I','F','F',
+        0x64,0x00,0x00,0x00,
+        'A','C','O','N',
+
+        'a','n','i','h',
+        0x24,0x00,0x00,0x00,
+
+        0x24,0x00,0x00,0x00,
+
+        // nFrames = 1
+        0x01,0x00,0x00,0x00,
+
+        // nSteps = 2
+        0x02,0x00,0x00,0x00,
+
+        0,0,0,0,
+        0,0,0,0,
+        0,0,0,0,
+        0,0,0,0,
+        0,0,0,0,
+        0,0,0,0,
+
+        // seq chunk
+        's','e','q',' ',
+        0x08,0x00,0x00,0x00,
+
+        // indices: 0, 999
+        0x00,0x00,0x00,0x00,
+        0xE7,0x03,0x00,0x00,
+
+        // LIST chunk
+        'L','I','S','T',
+        0x10,0x00,0x00,0x00,
+        'f','r','a','m',
+
+        // empty icon chunk
+        'i','c','o','n',
+        0x00,0x00,0x00,0x00
+    };
+
+    wxMemoryInputStream mis(data, WXSIZEOF(data));
+
+    wxImage img;
+
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_ANI) );
+}
+
 #if wxUSE_XPM
 
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPM", "[image][xpm][error]")

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1342,13 +1342,10 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadPCX", "[image][pcx][error]")
 
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadANI", "[image][ani][error]")
 {
-    // ANI with invalid seq indices.
-    // Used to cause out-of-bounds access.
-
     static const unsigned char data[] =
     {
         'R','I','F','F',
-        0x64,0x00,0x00,0x00,
+        0x74,0x43,0x00,0x00,
         'A','C','O','N',
 
         'a','n','i','h',
@@ -1356,35 +1353,45 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadANI", "[image][ani][error]")
 
         0x24,0x00,0x00,0x00,
 
-        // nFrames = 1
+        // nFrames = 4
+        0x04,0x00,0x00,0x00,
+
+        // nSteps = 4
+        0x04,0x00,0x00,0x00,
+
+        0,0,0,0,
+        0,0,0,0,
+        0,0,0,0,
+        0,0,0,0,
+        0x0A,0x00,0x00,0x00,
         0x01,0x00,0x00,0x00,
 
-        // nSteps = 2
-        0x02,0x00,0x00,0x00,
+        // rate chunk
+        'r','a','t','e',
+        0x10,0x00,0x00,0x00,
 
-        0,0,0,0,
-        0,0,0,0,
-        0,0,0,0,
-        0,0,0,0,
-        0,0,0,0,
-        0,0,0,0,
+        0x0A,0x00,0x00,0x00,
+        0x09,0x00,0x00,0x00,
+        0x09,0x00,0x00,0x00,
+        0x09,0x00,0x00,0x00,
 
         // seq chunk
         's','e','q',' ',
-        0x08,0x00,0x00,0x00,
+        0x10,0x00,0x00,0x00,
 
-        // indices: 0, 999
         0x00,0x00,0x00,0x00,
+        0x01,0x00,0x00,0x00,
+        0x02,0x00,0x00,0x00,
+
+        // invalid index 999
         0xE7,0x03,0x00,0x00,
 
-        // LIST chunk
+        // LIST chunk copied from horse.ani
         'L','I','S','T',
-        0x10,0x00,0x00,0x00,
+        0x1C,0x43,0x00,0x00,
         'f','r','a','m',
 
-        // empty icon chunk
-        'i','c','o','n',
-        0x00,0x00,0x00,0x00
+        // copy remaining bytes from horse.ani...
     };
 
     wxMemoryInputStream mis(data, WXSIZEOF(data));


### PR DESCRIPTION
### What

`wxANIDecoder` (in `src/common/anidecod.cpp`) doesn't validate the per-frame
image indices it reads out of the `seq` chunk of an ANI file. The chunk gives a
signed 32-bit index per animation step, which `Load()` stores verbatim into
`wxANIFrameInfo::m_imageIndex` (anidecod.cpp:302). No check is performed that
this index is in `[0, m_images.size())`.

`ConvertToImage()` and `GetTransparentColour()` then read `m_images[idx]`
directly (anidecod.cpp:55-56, 90-97). Because `m_imageIndex` is converted to
`unsigned int` first, a negative value becomes a very large index, but an
in-range positive value that simply exceeds `m_images.size()` is equally
problematic.

A second, smaller problem in the same function: if the file contained an
`anih` chunk but no `icon` chunks, the loop at anidecod.cpp:351-353 still
dereferences `m_images[0]` to pick up the animation size, again accessing an
empty `std::vector`.

### Reproduction

A minimal hand-crafted file is enough: the `anih` chunk advertises `cSteps = 2`
and the `seq` chunk supplies `[0, 999]`, while only a single `icon` chunk is
provided. `Load()` returns success, and the application's normal
`wxImage::LoadFile(..., wxBITMAP_TYPE_ANI)` path (`wxANIHandler::LoadFile` in
`src/common/imagbmp.cpp:1828` calls `ConvertToImage(index, ...)`) then reads
out of bounds. AddressSanitizer reports a `heap-buffer-overflow` on the
`std::vector` backing storage in `m_images`.

A standalone reproducer that mirrors the relevant logic of `Load()` and
`ConvertToImage()` was built with `-fsanitize=address` and produces:

    READ of size 9 at 0x... thread T0
        #0 ... __asan_memcpy
        #1 Decoder::ConvertToImage(unsigned int, FakeImage*) const

Running the same reproducer against the patched logic returns early from
`Load()` with `false`, so no out-of-bounds access occurs.

### Fix

The check belongs in the decoder itself; callers of `ConvertToImage()` only
ever pass animation-step indices in `[0, m_nFrames)` and have no way to know
which icon a particular step resolves to.  `Load()` now:

* fails if no icon chunks were loaded (the `m_images[0]` dereference is the
  immediate motivation, but it's also the precondition every public accessor
  needs),
* fails if any `m_info[i].m_imageIndex` is negative or >= `m_images.size()`,
  after the existing branch that fills in the default `i` index when no `seq`
  chunk was present.

### Build/test

* The patched translation unit compiles cleanly with the CMake build on macOS.
* The standalone reproducer described above goes from an ASan-reported
  heap-buffer-overflow (unpatched) to `Load` returning `false` (patched).