### PR TITLE
Reject TGA files with non-zero colour map origin

### DIFF
--- a/src/common/imagtga.cpp
+++ b/src/common/imagtga.cpp
@@ -294,6 +294,18 @@ int ReadTGA(wxImage* image, wxInputStream& stream)
     // Load a palette if we have one.
     if (colorType == wxTGA_MAPPED)
     {
+        // The palette buffer below is sized for paletteLength entries
+        // indexed 0..paletteLength-1, and the wxPalette built from it
+        // later (see SetPalette() below) is constructed starting at
+        // index 0 as well. The loop writes entries at indices
+        // [paletteStart, paletteStart+paletteLength), so any non-zero
+        // paletteStart would cause Palette_SetRGB()/Palette_SetRGBA()
+        // to write past the end of the buffer.
+        if (paletteStart != 0)
+        {
+            return wxTGA_INVFORMAT;
+        }
+
         {
             int palEntrySize = (palettebpp == 15 || palettebpp == 24) ? 3 : 4;
             wxScopedArray<unsigned char> paletteTmp(paletteLength*palEntrySize);

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1187,6 +1187,48 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::ReadCorruptedTGA", "[image]")
     */
     corruptTGA[18] = 0x7f;
     REQUIRE( !tgaImage.LoadFile(memIn) );
+
+    /*
+    A colour-mapped TGA with a non-zero colour-map origin.
+    Older code allocated the palette using paletteLength only, but
+    indexed it using paletteStart + i, leading to OOB writes.
+    */
+    static const unsigned char badPaletteTGA[] =
+    {
+        0,          // ID length
+        1,          // Color map type
+        1,          // Image type = color mapped
+
+        1, 0,       // Color map origin (paletteStart = 1)
+        1, 0,       // Color map length = 1 entry
+        24,         // Color map entry size
+
+        0, 0,       // X-origin
+        0, 0,       // Y-origin
+
+        1, 0,       // Width = 1
+        1, 0,       // Height = 1
+
+        8,          // Bits per pixel
+        0,          // Image descriptor
+
+        // One palette entry (BGR)
+        0xff, 0x00, 0x00,
+
+        // One pixel index
+        0x00
+    };
+
+    wxMemoryInputStream badPaletteStream(
+        badPaletteTGA,
+        WXSIZEOF(badPaletteTGA)
+    );
+
+    REQUIRE( badPaletteStream.IsOk() );
+
+    REQUIRE(
+        !tgaImage.LoadFile(badPaletteStream, wxBITMAP_TYPE_TGA)
+    );
 }
 
 #if wxUSE_GIF


### PR DESCRIPTION
## Summary

`ReadTGA()` in `src/common/imagtga.cpp` allocates the palette buffer
based on `paletteLength`, but writes entries at `paletteStart + i`.
Both values are read directly from the TGA colour map specification
field of the file header and are not bounded against each other.

For any file with `paletteStart > 0`, the palette write loop overflows
the heap buffer. Example: `paletteStart = 100`, `paletteLength = 10`,
`palettebpp = 24` allocates 30 bytes (`paletteLength * palEntrySize`),
then `Palette_SetRGB()` writes the red component at index 100, the
green at 110, and the blue at 120 — all out of bounds.

## Where the bug lives

`src/common/imagtga.cpp`, in `ReadTGA()` around line 295:

```cpp
if (colorType == wxTGA_MAPPED)
{
    {
        int palEntrySize = (palettebpp == 15 || palettebpp == 24) ? 3 : 4;
        wxScopedArray<unsigned char> paletteTmp(paletteLength*palEntrySize);
        palette.swap(paletteTmp);
    }

    for (unsigned int i = 0; i < paletteLength; i++)
    {
        ...
        Palette_SetRGB(palette.get(), paletteLength, paletteStart+i, r, g, b);
        ...
    }

#if wxUSE_PALETTE
    image->SetPalette(wxPalette((int) paletteLength, &palette[0],
        &palette[paletteLength * 1], &palette[paletteLength * 2]));
#endif
}
```

`Palette_SetRGB(palette, paletteCount, index, ...)` writes to
`palette[index]`, `palette[paletteCount + index]`, and
`palette[paletteCount*2 + index]`. With `paletteCount = paletteLength`
and `index = paletteStart + i`, the highest byte offset touched is
`paletteLength*3 + paletteStart - 1` for 24-bit palettes (and one
stride higher for 32-bit), which exceeds the
`paletteLength * palEntrySize`-byte buffer by `paletteStart` bytes.

Note also that the `wxPalette` built immediately after this loop reads
the entries starting at `&palette[0]`, so the rest of the loader was
already implicitly assuming `paletteStart == 0`.

## How to reproduce

A minimal TGA header is sufficient. Any file with `colorType == 1`
(`wxTGA_MAPPED`), a valid `palettebpp` (15/16/24/32), a non-zero
colour-map origin (bytes 3-4 of the header), and a non-zero colour-map
length (bytes 5-6) will trigger the OOB write in
`Palette_SetRGB()`/`Palette_SetRGBA()` when the file is passed to
`wxImage::LoadFile()` with the TGA handler installed.

The arithmetic is independent of platform — a 30-byte buffer plus
writes at indices 100, 110, 120 is unambiguous OOB. ASan reports it as
`heap-buffer-overflow WRITE of size 1` on the first
`palette[paletteStart+i] = red;` store.

## What the fix does

Reject the file with `wxTGA_INVFORMAT` when `paletteStart != 0`. The
check is local to the callee (`ReadTGA()`) and matches the assumption
already made by the rest of the function (the subsequent
`SetPalette()` call also indexes the palette starting at zero), so no
caller behaviour changes.

## Build evidence

`wxcore` (which contains `imagtga.cpp`) builds cleanly with the patch
on macOS using the CMake build:

```
[ 60%] Building CXX object libs/core/CMakeFiles/wxcore.dir/.../src/common/imagtga.cpp.o
[100%] Linking CXX static library ../../lib/libwx_osx_cocoau_core-3.3.a
[100%] Built target wxcore
```

## Test plan

- [ ] Existing `wxImage::ReadCorruptedTGA` test still passes (the
      handcrafted bytes there have `paletteStart == 0`, so the new
      check doesn't fire).
- [ ] Loading a TGA crafted with `paletteStart != 0` returns
      `wxTGA_INVFORMAT` instead of corrupting the heap.
- [ ] Loading regular (non-colour-mapped) TGAs is unchanged.