### PR TITLE
Validate IFF BMHD fields to prevent pixel-buffer overflow

### DIFF
--- a/src/common/imagiff.cpp
+++ b/src/common/imagiff.cpp
@@ -29,6 +29,7 @@
     #include "wx/palette.h"
 #endif // wxUSE_PALETTE
 
+#include <limits.h>     // for INT_MAX
 #include <stdlib.h>
 #include <string.h>
 
@@ -404,6 +405,23 @@ int wxIFFDecoder::ReadIFF()
         // bmhd_masking  = *(dataptr + 8 + 9); -- unused currently
         bmhd_compression = *(dataptr + 8 + 10);     // get compression
         bmhd_transcol    = iff_getword(dataptr + 8 + 12);
+
+        // Reject malformed BMHD chunks: zero width/height or bitplanes
+        // would later cause a divide-by-zero when computing the lineskip
+        // and row count for the BODY chunk; oversized dimensions would
+        // overflow the signed-int product used to size the pixel buffer
+        // (new byte[bmhd_width * bmhd_height * 3] below), leaving an
+        // undersized allocation behind for the BODY decode loop to
+        // overrun. Cap bmhd_width * bmhd_height so that the same product
+        // multiplied by 3 stays within INT_MAX.
+        if (bmhd_width <= 0 || bmhd_height <= 0
+                || bmhd_bitplanes <= 0 || bmhd_bitplanes > 32
+                || static_cast<wxUint64>(bmhd_width)
+                    * static_cast<wxUint64>(bmhd_height)
+                        > static_cast<wxUint64>(INT_MAX) / 3) {
+            break;
+        }
+
         BMHDok = true;                              // got BMHD
         dataptr += 8 + chunkLen;                    // to next chunk
     }

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1387,6 +1387,47 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadIFF", "[image][iff][error]")
     REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_IFF) );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadIFFBmhdOverflow",
+                 "[image][iff][error]")
+{
+    // BMHD width = 21849, height = 65535 gives bmhd_width * bmhd_height * 3
+    // = 4 295 622 645, which overflows the 32-bit signed int product used by
+    // wxIFFDecoder::ReadIFF() to size the pixel buffer and wraps down to
+    // 655 349. The subsequent BODY decode loop writes 3 * bmhd_width bytes
+    // per scanline, so a BODY chunk containing 10 lineskips' worth of zeros
+    // (lineskip = 2732 for this width, total 27320 bytes) is enough to
+    // overrun the undersized heap allocation. The fix rejects the file at
+    // BMHD validation time.
+    wxImage::AddHandler(new wxIFFHandler);
+
+    static const unsigned char header[] =
+    {
+        0x46,0x4f,0x52,0x4d,            // "FORM"
+        0x00,0x00,0x6a,0xe0,            // FORM length = 27360
+        0x49,0x4c,0x42,0x4d,            // "ILBM"
+        0x42,0x4d,0x48,0x44,            // "BMHD"
+        0x00,0x00,0x00,0x14,            // BMHD chunk length = 20
+        0x55,0x59,                      // width  = 21849
+        0xff,0xff,                      // height = 65535
+        0x00,0x00,0x00,0x00,            // x, y
+        0x01,                           // nPlanes
+        0x00,                           // masking
+        0x00,                           // compression (BI_RGB, uncompressed)
+        0x00,                           // pad
+        0x00,0x00,                      // transparentColor
+        0x00,0x00,                      // x/y aspect
+        0x00,0x00,0x00,0x00,            // page width / height
+        0x42,0x4f,0x44,0x59,            // "BODY"
+        0x00,0x00,0x6a,0xb8,            // BODY chunk length = 27320
+    };
+    std::vector<unsigned char> data(header, header + WXSIZEOF(header));
+    data.resize(data.size() + 27320, 0);
+
+    wxMemoryInputStream mis(data.data(), data.size());
+    wxImage img;
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_IFF) );
+}
+
 #endif // wxUSE_IFF
 
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::DibPadding", "[image]")


### PR DESCRIPTION
## Bug

`wxIFFDecoder::ReadIFF()` in `src/common/imagiff.cpp` parses the BMHD chunk and stores width/height/bitplanes without any bounds check, then allocates the pixel buffer with signed-int multiplication:

```cpp
m_image->p = new byte[bmhd_width * bmhd_height * 3];
```

With `bmhd_width = 21849` and `bmhd_height = 65535` (both legal 16-bit BMHD values), the product is `4,295,622,645`. The `int * int * int` expression overflows and wraps down to `655,349`, so only ~640 KiB is allocated. The BODY decode loop a little further down (`src/common/imagiff.cpp` around the `ILBM_NORMAL`/`ILBM_EHB` branch) then writes `3 * bmhd_width` bytes per scanline, so a BODY chunk containing 10 lineskips' worth of zeros (`lineskip = 2732` for this width, total 27,320 bytes) is enough to overrun the heap allocation.

Two further malformed-input cases land in the same place:

* `bmhd_width == 0` makes `lineskip = ((bmhd_width + 15) >> 4) << 1 == 0`, so the subsequent `chunkLen / (lineskip * bmhd_bitplanes)` divides by zero.
* `bmhd_bitplanes == 0` does the same, and additionally interacts badly with `1 << bmhd_bitplanes` later on; values above ~30 push that shift into undefined-behaviour territory.

## Reproducer

The new `wxImage::BadIFFBmhdOverflow` test case in `tests/image/image.cpp` constructs the malformed IFF in memory:

```
FORM 27360
  ILBM
  BMHD 20    width=21849 height=65535 nPlanes=1 compression=0
  BODY 27320 (zeros)
```

Without the fix, running the test under the address sanitiser reports a heap-buffer-overflow at the write loop in `wxIFFDecoder::ReadIFF()`; under a non-sanitised build `LoadFile()` returns `true` (silently scribbling over adjacent heap memory), so the `REQUIRE(!img.LoadFile(...))` assertion fails. With the fix the file is rejected at BMHD parse time and the test passes.

## Fix

Reject malformed BMHD chunks at parse time. The new check is local to the BMHD branch in `wxIFFDecoder::ReadIFF()` and bails via the same `break` the rest of the parser uses:

```cpp
if (bmhd_width <= 0 || bmhd_height <= 0
        || bmhd_bitplanes <= 0 || bmhd_bitplanes > 32
        || static_cast<wxUint64>(bmhd_width)
            * static_cast<wxUint64>(bmhd_height)
                > static_cast<wxUint64>(INT_MAX) / 3) {
    break;
}
```

The `INT_MAX / 3` cap makes the existing `new byte[bmhd_width * bmhd_height * 3]` allocation safe without having to widen any of the surrounding int arithmetic; the cap of 32 bitplanes is well above the largest format the decoder actually handles (24-bit ILBM). `INT_MAX` comes from `<limits.h>`, which the file did not already include, so the patch adds the include alongside the existing `<stdlib.h>` / `<string.h>`.

## Test evidence

```
$ cmake --build . --target test_gui
$ ./lib/test_gui.app/Contents/MacOS/test_gui "[iff]"
===============================================================================
All tests passed (2 assertions in 2 test cases)

$ ./lib/test_gui.app/Contents/MacOS/test_gui "[image]"
===============================================================================
All tests passed (13077 assertions in 37 test cases)
```

The full `[image]` suite (37 cases / 13,077 assertions) continues to pass, including the existing `wxImage::BadIFF`, `wxImage::PNM` and BMP malformed-image tests.