### PR TITLE
Stop reading past wxCharBuffer end on unterminated XPM quote

### DIFF
--- a/src/common/xpmdecod.cpp
+++ b/src/common/xpmdecod.cpp
@@ -190,6 +190,12 @@ wxImage wxXPMDecoder::ReadFile(wxInputStream& stream)
         for (q = p + 1; *q != '\0'; q++)
             if (*q == '"')
                 break;
+
+        // unterminated quoted string: stop processing rather than reading
+        // past the end of the buffer when the outer loop next advances p.
+        if (*q == '\0')
+            break;
+
         strncpy(xpm_buffer + i, p + 1, q - p - 1);
         i += q - p - 1;
         xpm_buffer[i++] = '\n';

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1361,6 +1361,22 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPM", "[image][xpm][error]")
     REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_XPM) );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPMUnterminatedQuote",
+                 "[image][xpm][error]")
+{
+    // A payload whose final " is never closed: the quote-stripping loop in
+    // wxXPMDecoder::ReadFile() advanced p past the buffer terminator after
+    // strncpy() and then dereferenced one byte further on the next outer
+    // for-loop iteration, reading past the end of the wxCharBuffer.
+    static const unsigned char data[] =
+    {
+        0x22,0x61,0x62,0x63,
+    };
+    wxMemoryInputStream mis(data, WXSIZEOF(data));
+    wxImage img;
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_XPM) );
+}
+
 #endif // wxUSE_XPM
 
 #if wxUSE_IFF


### PR DESCRIPTION
The quote-stripping loop in `wxXPMDecoder::ReadFile()` sets `p = q + 1`
after the strncpy. If the closing `"` is missing, `q` stops at the
buffer terminator, so `p` ends up one past it and the next outer
for-loop iteration's `p++` then dereferences two bytes off the end of
the wxCharBuffer. Mirror the existing handling of an unterminated
`/*`-comment and break out of the loop when `*q == '\0'`.