### PR TITLE
Reject GIF files with LZW minimum code size > 11

### DIFF
--- a/src/common/gifdecod.cpp
+++ b/src/common/gifdecod.cpp
@@ -859,7 +859,11 @@ wxGIFErrorCode wxGIFDecoder::LoadGIF(wxInputStream& stream)
 
                 // get initial code size from first byte in raster data
                 bits = stream.GetC();
-                if (stream.Eof() || bits <= 0)
+                // dgif() sizes the LZW tables for codes up to 12 bits, so a
+                // minimum code size of 12 or more would start ab_free past the
+                // end of ab_prefix/ab_tail and corrupt the heap on the first
+                // alphabet update.
+                if (stream.Eof() || bits <= 0 || bits > 11)
                     return wxGIF_INVFORMAT;
 
                 // decode image

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1310,6 +1310,33 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadGIF", "[image][gif][error]")
     CHECK( image.GetSize() == wxSize(1200, 800) );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadGIFLZWMinCodeSize",
+                 "[image][gif][error]")
+{
+    // The LZW minimum code size byte that follows the local colour table is
+    // not validated. dgif() sizes ab_prefix/ab_tail for codes up to 12 bits
+    // (allocSize == 4096+1), so a code size of 12 makes ab_free start at 4098
+    // and the first alphabet update then writes one entry past the end of
+    // both arrays. The 2x1 image below is the minimum needed to exercise the
+    // second LZW iteration where the alphabet update happens.
+    static const unsigned char data[] =
+    {
+        0x47, 0x49, 0x46, 0x38, 0x39, 0x61,             // "GIF89a"
+        0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,       // LSDB: 2x1, no GCT
+        0x2c,                                            // image separator
+        0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00, // 2x1 frame at 0,0
+        0x80,                                            // LCT, depth=0 (2 col)
+        0x00, 0x00, 0x00, 0xff, 0xff, 0xff,             // LCT entries
+        0x0c,                                            // LZW min code size=12
+        0x04, 0x00, 0x20, 0x00, 0x00,                    // sub-block: codes 0,1
+        0x00,                                            // sub-block terminator
+        0x3b,                                            // trailer
+    };
+    wxMemoryInputStream mis(data, WXSIZEOF(data));
+    wxImage img;
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_GIF) );
+}
+
 #endif // wxUSE_GIF
 
 #if wxUSE_PCX


### PR DESCRIPTION
The minimum code size byte that follows the local colour table in
`wxGIFDecoder::LoadGIF()` is only checked for `<= 0`. `dgif()` sizes
`ab_prefix`/`ab_tail` with `allocSize = 4096 + 1`, so a value of 12
starts `ab_free` at 4098 and the first alphabet update at
`gifdecod.cpp:457` writes one entry past the end of both arrays. The
existing `wxASSERT(ab_free < allocSize)` already flagged this in debug
builds. The new `wxImage::BadGIFLZWMinCodeSize` test feeds a 37-byte
2x1 GIF with code size 12 to `LoadFile` and asserts it is rejected.