### PR TITLE
validate data chunk header room in wxSound::LoadWAV

### DIFF
--- a/src/unix/sound.cpp
+++ b/src/unix/sound.cpp
@@ -672,6 +672,11 @@ bool wxSound::LoadWAV(const void* data_, size_t length, bool copyData)
         data_offset += (list_chunk_length + 8u);
     }
 
+    // After skipping any LIST chunk we must still have room for the
+    // 8-byte "data" chunk header that follows.
+    if (length - data_offset < 8u)
+        return false;
+
     if (memcmp(&data[data_offset], "data", 4) != 0)
         return false;
 


### PR DESCRIPTION
Noticed LoadWAV in src/unix/sound.cpp checks that the LIST chunk
length fits in the buffer but not that the 8-byte "data" chunk
header still has room afterwards. A 44-byte WAV with a LIST chunk
of length 0 lands data_offset at exactly length, and the next
memcmp(&data[data_offset], "data", 4) reads 4 bytes past the heap
buffer (also the memcpy of the data-chunk size four lines later).