### PR TITLE
Reject too-short ZIP64 extra field in wxZipEntry::LoadExtraInfo

### DIFF
--- a/src/common/zipstrm.cpp
+++ b/src/common/zipstrm.cpp
@@ -1026,7 +1026,28 @@ bool wxZipEntry::LoadExtraInfo(const char* extraData, wxUint16 extraLen, bool lo
             }
 
             // Data block for extra field with Header ID = 1 (ZIP64)
-            // can have length up to 28 bytes.
+            // can have length up to 28 bytes. A ZIP64 extra field is only
+            // required to contain a 64-bit value for each of the size,
+            // compressed size and offset fields whose 32-bit value in the
+            // surrounding header was set to the ZIP64 sentinel 0xffffffff.
+            // Reject the entry if fieldLen is too small to cover those
+            // values, otherwise wxZipHeader::Read64() would walk past the
+            // end of its initialised data and yield uninitialised bytes
+            // from the stack-allocated header buffer.
+            size_t z64Required = 0;
+            if ( m_Size == 0xffffffff )
+                z64Required += 8;
+            if ( m_CompressedSize == 0xffffffff )
+                z64Required += 8;
+            if ( !localInfo && m_Offset == 0xffffffff )
+                z64Required += 8;
+            if ( fieldLen < z64Required )
+            {
+                wxLogWarning(_("Ignoring malformed extra data record, "
+                               "ZIP file may be corrupted"));
+                return false;
+            }
+
             wxZipHeader ds(extraData+4, wxMin(fieldLen, 28));
             // A file may contain larger size, compressed size or offset
             // in a zip64 extra data block. Use the 64 bit values if available

--- a/tests/archive/ziptest.cpp
+++ b/tests/archive/ziptest.cpp
@@ -15,6 +15,7 @@
 #if wxUSE_STREAMS && wxUSE_ZIPSTREAM
 
 #include "archivetest.h"
+#include "wx/mstream.h"
 #include "wx/zipstrm.h"
 
 #include <memory>
@@ -249,5 +250,52 @@ CppUnit::Test *ziptest::makeTest(
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ziptest);
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(ziptest, "archive/zip");
+
+TEST_CASE("Zip::BadZip64ExtraField", "[zip][error]")
+{
+    // wxZipEntry::LoadExtraInfo() used to handle a ZIP64 extra field (Header
+    // ID = 1) that was too short to provide the 64-bit values the surrounding
+    // header had asked for by calling wxZipHeader::Read64() anyway. Read64()
+    // does not bounds-check against m_size, so it returned uninitialised
+    // bytes from the wxZipHeader stack object's 64-byte m_data array, which
+    // then ended up in m_Size, m_CompressedSize or m_Offset and was exposed
+    // to callers through GetSize() / GetCompressedSize() / GetOffset().
+    //
+    // The central directory entry below sets compressed size and uncompressed
+    // size to the ZIP64 sentinel 0xffffffff but pairs them with a zero-length
+    // ZIP64 extra field. After the fix the size fields are left at the
+    // sentinel value rather than overwritten with whatever Read64() happened
+    // to scrape off the stack.
+    static const unsigned char data[] = {
+        // Local file header for entry "a"
+        'P','K',0x03,0x04, 0x14,0x00, 0x00,0x00, 0x00,0x00,
+        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
+        0x01,0x00, 0x00,0x00, 'a',
+        // Central directory entry
+        'P','K',0x01,0x02, 0x14,0x00, 0x14,0x00, 0x00,0x00, 0x00,0x00,
+        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
+        0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
+        0x01,0x00, 0x04,0x00, 0x00,0x00, 0x00,0x00, 0x00,0x00,
+        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
+        'a',
+        // Extra field: ID=1 (ZIP64), fieldLen=0
+        0x01,0x00, 0x00,0x00,
+        // End of central directory record
+        'P','K',0x05,0x06, 0x00,0x00, 0x00,0x00, 0x01,0x00, 0x01,0x00,
+        0x33,0x00,0x00,0x00, 0x1f,0x00,0x00,0x00,
+        0x00,0x00,
+    };
+
+    wxMemoryInputStream mis(data, sizeof(data));
+    wxZipInputStream zip(mis);
+    std::unique_ptr<wxZipEntry> entry(zip.GetNextEntry());
+    REQUIRE( entry );
+    // Without the validation in LoadExtraInfo() the eight bytes returned by
+    // Read64() are uninitialised: assert the ZIP64 sentinel is left alone so
+    // that the malformed extra field cannot poison the entry's size fields.
+    CHECK( entry->GetSize() == wxFileOffset(0xffffffff) );
+    CHECK( entry->GetCompressedSize() == wxFileOffset(0xffffffff) );
+}
 
 #endif // wxUSE_STREAMS && wxUSE_ZIPSTREAM


### PR DESCRIPTION
Noticed wxZipEntry::LoadExtraInfo() calls wxZipHeader::Read64() up to three
times on a wxZipHeader of length min(fieldLen, 28). Read64() doesn't
bounds-check m_pos against m_size, so a short ZIP64 extra field returns
uninitialised bytes from the header's 64-byte stack-allocated m_data and
they end up in the entry's m_Size / m_CompressedSize / m_Offset. Reject the
entry when fieldLen is below the requested 64-bit total.