### PR TITLE
validate 4-bit BMP palette index in LoadBMPData

### DIFF
--- a/src/common/imagbmp.cpp
+++ b/src/common/imagbmp.cpp
@@ -783,6 +783,8 @@ bool LoadBMPData(wxImage * image, const BMPDesc& desc,
                                         nibble[0] = (wxUint8)( (aByte & 0xF0) >> 4 ) ;
                                         nibble[1] = (wxUint8)( aByte & 0x0F ) ;
                                     }
+                                    if ( nibble[k%2] >= ncolors )
+                                        return false;
                                     ptr[poffset    ] = cmap[nibble[k%2]].r;
                                     ptr[poffset + 1] = cmap[nibble[k%2]].g;
                                     ptr[poffset + 2] = cmap[nibble[k%2]].b;
@@ -804,6 +806,8 @@ bool LoadBMPData(wxImage * image, const BMPDesc& desc,
 
                             for ( int l = 0; l < first && column < width; l++ )
                             {
+                                if ( nibble[l%2] >= ncolors )
+                                    return false;
                                 ptr[poffset    ] = cmap[nibble[l%2]].r;
                                 ptr[poffset + 1] = cmap[nibble[l%2]].g;
                                 ptr[poffset + 2] = cmap[nibble[l%2]].b;
@@ -816,8 +820,8 @@ bool LoadBMPData(wxImage * image, const BMPDesc& desc,
                         for (int nibble = 0; nibble < 2 && column < width; nibble++)
                         {
                             int index = ((aByte & (0xF0 >> (nibble * 4))) >> (!nibble * 4));
-                            if ( index >= 16 )
-                                index = 15;
+                            if ( index >= ncolors )
+                                return false;
                             ptr[poffset] = cmap[index].r;
                             ptr[poffset + 1] = cmap[index].g;
                             ptr[poffset + 2] = cmap[index].b;

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1231,6 +1231,41 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::ReadCorruptedTGA", "[image]")
     );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadBMPPaletteIndex", "[image][bmp][error]")
+{
+    // A 4-bit BMP that declares only a single palette entry (biClrUsed = 1)
+    // but uses a higher nibble value as the pixel index. The 8-bit decode
+    // path rejects indices >= ncolors, but the 4-bit path used to read
+    // cmap[index] for any 0..15 nibble, running past the palette array.
+    static const unsigned char data[] =
+    {
+        'B','M',
+        0x3e,0,0,0,         // file size = 62
+        0,0,0,0,            // reserved
+        0x3a,0,0,0,         // pixel data offset = 58
+
+        0x28,0,0,0,         // DIB header size = 40
+        1,0,0,0,            // width = 1
+        1,0,0,0,            // height = 1
+        1,0,                // planes
+        4,0,                // bpp = 4
+        0,0,0,0,            // compression = BI_RGB
+        0,0,0,0,            // image size
+        0,0,0,0,            // x ppm
+        0,0,0,0,            // y ppm
+        1,0,0,0,            // biClrUsed = 1
+        0,0,0,0,            // biClrImportant
+
+        0,0,0,0,            // single palette entry (BGRA)
+
+        0xf0,0,0,0          // one scanline, high nibble = 15
+    };
+
+    wxMemoryInputStream mis(data, WXSIZEOF(data));
+    wxImage img;
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_BMP) );
+}
+
 #if wxUSE_GIF
 
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::SaveAnimatedGIF", "[image]")


### PR DESCRIPTION
The 8-bit decode path in LoadBMPData already rejects a pixel value that isn't below ncolors before indexing cmap, but the three 4-bit branches index cmap with the raw nibble (0 to 15) and never compare it against the palette size. A BMP that sets biClrUsed below 16 yet stores higher nibble values then reads past the cmap array; with biClrUsed = 1 the index can reach 15 against a one-entry palette. Apply the same ncolors check the 8-bit path uses.