### PR TITLE
MSW: Repaint all windows upon system color change

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5110,6 +5110,9 @@ bool wxWindowMSW::HandleSysColorChange()
 
     (void)HandleWindowEvent(event);
 
+    if ( IsTopLevel() )
+        Refresh();
+
     // always let the system carry on the default processing to allow the
     // native controls to react to the colours update
     return false;


### PR DESCRIPTION
Adding back some code that got dropped in the consolidation of #26424 into #26503.

The problem is when the system switches between dark and light mode, Refresh() is never called. More specifically, when WM_SETTINGCHANGE occurs with "ImmersiveColorSet", HandleSettingChange() is not called. But that is where the only Refresh() call is.

Top level windows should get Refresh() upon WM_SYSCOLORCHANGE as well as WM_SETTINGCHANGE. Adding another Refresh() call into HandleSysColorChange() solves the problem.
