### PR TITLE
Fix out-of-bounds table read in wxMBConvUTF7::ToWChar

### DIFF
--- a/src/common/strconv.cpp
+++ b/src/common/strconv.cpp
@@ -702,7 +702,7 @@ size_t wxMBConvUTF7::ToWChar(wchar_t *dst, size_t dstLen,
                     len++;
                     src++;
                 }
-                else if ( utf7unb64[(unsigned)*src] == 0xff )
+                else if ( utf7unb64[(unsigned char)*src] == 0xff )
                 {
                     // empty encoded chunks are not allowed
                     if ( !len )

--- a/tests/mbconv/mbconvtest.cpp
+++ b/tests/mbconv/mbconvtest.cpp
@@ -1495,4 +1495,9 @@ TEST_CASE("wxMBConv::cMB2WC", "[mbconv][mb2wc]")
     CHECK( wxConvUTF7.cMB2WC("").length() == 0 );
     CHECK( wxConvUTF7.cMB2WC(wxCharBuffer()).length() == 0 );
     CHECK( wxConvUTF7.cMB2WC("+AKM-").length() == 1 );
+
+    // A non-ASCII byte right after the shift character used to be read past
+    // the end of the base-64 decoding table (signed char index), now it's
+    // just rejected as an invalid encoded chunk.
+    CHECK( wxConvUTF7.cMB2WC("+\xc3").length() == 0 );
 }


### PR DESCRIPTION
In wxMBConvUTF7::ToWChar the byte after '+' is looked up as utf7unb64[(unsigned)*src] at strconv.cpp:705, so with signed char a byte >= 0x80 sign-extends to a ~4 GiB index into the 256-entry table. Mask it with (unsigned char), like the cc lookup just above already does.