### PR TITLE
fix width*chars_per_pixel overflow in wxXPMDecoder::ReadData

### DIFF
--- a/src/common/xpmdecod.cpp
+++ b/src/common/xpmdecod.cpp
@@ -787,7 +787,8 @@ wxImage wxXPMDecoder::ReadData(const char* const* xpm_data)
         for (i = 0; i < width; i++, img_data += 3)
         {
             const char *xpmImgLine = xpm_data[1 + colors_cnt + j];
-            if ( !xpmImgLine || strlen(xpmImgLine) < width*chars_per_pixel )
+            if ( !xpmImgLine ||
+                    strlen(xpmImgLine) < (unsigned long long)width*chars_per_pixel )
             {
                 wxLogError(_("XPM: truncated image data at line %d!"),
                            (int)(1 + colors_cnt + j));

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1542,6 +1542,26 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPMUnterminatedQuote",
     REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_XPM) );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPMWidthOverflow",
+                 "[image][xpm][error]")
+{
+    // width * chars_per_pixel was computed in 32-bit unsigned in
+    // wxXPMDecoder::ReadData() and used to check that each image line is long
+    // enough, but the per-pixel index uses size_t arithmetic. With width =
+    // 68174085 and chars_per_pixel = 63 the product is 4 294 967 355, which
+    // wraps to 59, so a one-pixel image line passes the length check and the
+    // key-reading loop then runs off the end of the buffer. Loading such a
+    // file must be rejected.
+    const std::string key(63, 'a');
+    const std::string xpm =
+        "\"68174085 1 1 63\"\n"
+        "\"" + key + " c #ffffff\"\n"
+        "\"" + key + "\"\n";
+    wxMemoryInputStream mis(xpm.data(), xpm.size());
+    wxImage img;
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_XPM) );
+}
+
 #endif // wxUSE_XPM
 
 #if wxUSE_IFF


### PR DESCRIPTION
Noticed wxXPMDecoder::ReadData() checks each image line with `strlen(xpmImgLine) < width*chars_per_pixel`, but the product is 32-bit unsigned while the per-pixel index uses size_t. A header like `68174085 1 1 63` wraps the product to 59, so a one-pixel line passes the check and the key-reading loop runs off the end of the buffer.

The added test feeds such an XPM and confirms it's now rejected; under ASAN it shows the over-read without the fix.