### PR TITLE
wxURI::IsReference Update Description

### DIFF
--- a/interface/wx/uri.h
+++ b/interface/wx/uri.h
@@ -259,8 +259,8 @@ public:
     bool IsEmpty() const;
 
     /**
-        Returns @true if a valid [absolute] URI, otherwise this URI is a URI
-        reference and not a full URI, and this function returns @false.
+        Returns @false if a valid [absolute] URI, otherwise this URI is a URI
+        reference and not a full URI, and this function returns @true.
     */
     bool IsReference() const;
 


### PR DESCRIPTION
The documentation currently describes the inverse of the name of the function and what it actually does: `return !HasScheme() || !HasServer();`.

This PR flips `true` and `false` to make the documentation match the behavior.