### PR TITLE
validate decoded pixel index against ncolours in wxGIFDecoder::ConvertToImage

### DIFF
--- a/src/common/gifdecod.cpp
+++ b/src/common/gifdecod.cpp
@@ -154,10 +154,13 @@ bool wxGIFDecoder::ConvertToImage(unsigned int frame, wxImage *image) const
     // Reject decoded pixels that reference palette entries past the
     // loaded portion of the per-frame palette buffer: GIF files where
     // the LZW minimum code size implies a larger alphabet than the
-    // declared colour table can emit literal codes >= ncolours, and
-    // pimg->pal is malloc'd at a fixed 768 bytes with only 3*ncolours
-    // of them populated from the file, so the pal[3*(*src) + ...] reads
-    // below would otherwise yield uninitialised heap bytes.
+    // declared colour table can emit literal codes >= ncolours. pimg->pal
+    // is a fixed 768 bytes but only 3*ncolours of them are populated from
+    // the file (the rest is left uninitialised), so the pal[3*(*src) + ...]
+    // reads below would otherwise pull uninitialised bytes into the image.
+    // The index stays within the 768-byte buffer (a pixel byte is at most
+    // 255), so this is an uninitialised read rather than an out-of-bounds
+    // one, but it still leaks junk into the decoded pixels.
     unsigned long npixel =
         static_cast<unsigned long>(sz.GetWidth()) * sz.GetHeight();
     const unsigned int ncolours = GetNcolours(frame);

--- a/src/common/gifdecod.cpp
+++ b/src/common/gifdecod.cpp
@@ -151,6 +151,22 @@ bool wxGIFDecoder::ConvertToImage(unsigned int frame, wxImage *image) const
     dst = image->GetData();
     transparent = GetTransparentColourIndex(frame);
 
+    // Reject decoded pixels that reference palette entries past the
+    // loaded portion of the per-frame palette buffer: GIF files where
+    // the LZW minimum code size implies a larger alphabet than the
+    // declared colour table can emit literal codes >= ncolours, and
+    // pimg->pal is malloc'd at a fixed 768 bytes with only 3*ncolours
+    // of them populated from the file, so the pal[3*(*src) + ...] reads
+    // below would otherwise yield uninitialised heap bytes.
+    unsigned long npixel =
+        static_cast<unsigned long>(sz.GetWidth()) * sz.GetHeight();
+    const unsigned int ncolours = GetNcolours(frame);
+    for (i = 0; i < npixel; i++)
+    {
+        if (src[i] >= ncolours)
+            return false;
+    }
+
     // set transparent colour mask
     if (transparent != -1)
     {
@@ -223,7 +239,6 @@ bool wxGIFDecoder::ConvertToImage(unsigned int frame, wxImage *image) const
 #endif // wxUSE_PALETTE
 
     // copy image data
-    unsigned long npixel = sz.GetWidth() * sz.GetHeight();
     for (i = 0; i < npixel; i++, src++)
     {
         *(dst++) = pal[3 * (*src) + 0];

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1422,9 +1422,10 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadGIFPaletteIndex",
     // LZW data emits CLEAR, literal 2, EOI -- pixel value 2 is a valid LZW
     // literal but past the end of the 2-entry palette, so the
     // pal[3*(*src) + ...] reads in wxGIFDecoder::ConvertToImage() previously
-    // returned uninitialised bytes from past the loaded portion of the
-    // 768-byte malloc'd pimg->pal buffer (ASAN with detect_uninits or msan
-    // would flag this as a use of uninitialised heap memory).
+    // pulled uninitialised bytes from the unpopulated tail of the 768-byte
+    // pimg->pal buffer into the decoded image. The index stays inside the
+    // buffer (a pixel byte is at most 255) so ASAN won't flag it, but it is
+    // an uninitialised read that MSAN catches and leaks junk into the pixels.
     static const unsigned char data[] =
     {
         0x47, 0x49, 0x46, 0x38, 0x39, 0x61,             // "GIF89a"

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1414,6 +1414,35 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadGIFLZWMinCodeSize",
     REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_GIF) );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadGIFPaletteIndex",
+                 "[image][gif][error]")
+{
+    // A 1x1 GIF whose LSDB declares a 2-entry global colour table but whose
+    // LZW minimum code size is 3, giving an 8-literal alphabet. The frame's
+    // LZW data emits CLEAR, literal 2, EOI -- pixel value 2 is a valid LZW
+    // literal but past the end of the 2-entry palette, so the
+    // pal[3*(*src) + ...] reads in wxGIFDecoder::ConvertToImage() previously
+    // returned uninitialised bytes from past the loaded portion of the
+    // 768-byte malloc'd pimg->pal buffer (ASAN with detect_uninits or msan
+    // would flag this as a use of uninitialised heap memory).
+    static const unsigned char data[] =
+    {
+        0x47, 0x49, 0x46, 0x38, 0x39, 0x61,             // "GIF89a"
+        0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00,       // LSDB: 1x1, GCT, 2col
+        0x00, 0x00, 0x00, 0xff, 0xff, 0xff,             // GCT entries
+        0x2c,                                           // image separator
+        0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, // 1x1 frame at 0,0
+        0x00,                                           // no LCT
+        0x03,                                           // LZW min code size=3
+        0x02, 0x28, 0x09,                               // sub-block: CLEAR,2,EOI
+        0x00,                                           // sub-block terminator
+        0x3b,                                           // trailer
+    };
+    wxMemoryInputStream mis(data, WXSIZEOF(data));
+    wxImage img;
+    REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_GIF) );
+}
+
 #endif // wxUSE_GIF
 
 #if wxUSE_PCX


### PR DESCRIPTION
wxGIFDecoder::ConvertToImage() in src/common/gifdecod.cpp reads pal[3*(*src) + ...] for each decoded pixel, but per-frame pal is malloc'd at a fixed 768 bytes and only 3*ncolours of them are populated from the file. A malformed GIF whose LZW minimum code size implies more literals than its declared colour table (e.g. min code size 3 with a 2-entry global colour table) can emit literal codes >= ncolours, and those reads then return uninitialised heap bytes into the wxImage RGB data. The patch validates each pixel against ncolours up front and rejects the frame, matching the pattern from #26511 and the recent imagiff fix.