### PR TITLE
fix OOB write in wxVsnprintf and ConvertStringToBuf when size==0

### DIFF
--- a/src/common/wxcrt.cpp
+++ b/src/common/wxcrt.cpp
@@ -516,7 +516,7 @@ int ConvertStringToBuf(const wxString& s, char *out, size_t outsize)
     {
         memcpy(out, buf, len+1);
     }
-    else // not enough space
+    else if ( outsize > 0 ) // not enough space
     {
         memcpy(out, buf, outsize-1);
         out[outsize-1] = '\0';
@@ -535,7 +535,7 @@ int ConvertStringToBuf(const wxString& s, wchar_t *out, size_t outsize)
     {
         memcpy(out, buf, (len+1) * sizeof(wchar_t));
     }
-    else // not enough space
+    else if ( outsize > 0 ) // not enough space
     {
         memcpy(out, buf, (outsize-1) * sizeof(wchar_t));
         out[outsize-1] = 0;
@@ -605,7 +605,8 @@ int wxVsnprintf(char *str, size_t size, const wxString& format, va_list argptr)
 
     // VsnprintfTestCase reveals that glibc's implementation of vswprintf
     // doesn't nul terminate on truncation.
-    str[size - 1] = 0;
+    if ( size )
+        str[size - 1] = 0;
 
     return rv;
 }

--- a/src/common/wxprintf.cpp
+++ b/src/common/wxprintf.cpp
@@ -94,6 +94,12 @@ static int wxDoVsnprintf(CharType *buf, size_t lenMax,
     wprintf(L"Using wxCRT_VsnprintfW\n");
 #endif
 
+    // If the output buffer is of size 0 we can't write anything to it, not
+    // even the terminating NUL, so just bail out: continuing would underflow
+    // lenCur below and access buf[(size_t)-1], writing out of bounds.
+    if ( lenMax == 0 )
+        return -1;
+
     wxPrintfConvSpecParser<CharType> parser(format);
 
     wxPrintfArg argdata[wxMAX_SVNPRINTF_ARGUMENTS];

--- a/tests/strings/crt.cpp
+++ b/tests/strings/crt.cpp
@@ -278,3 +278,24 @@ TEST_CASE("CRT::Strtox", "[crt][strtod][strtol]")
 #endif
     }
 }
+
+TEST_CASE("CRT::SnprintfZeroSize", "[crt][snprintf]")
+{
+    // wxVsnprintf() used to unconditionally execute str[size - 1] = 0 on
+    // return; with size == 0 this wraps to str[SIZE_MAX] and corrupts memory
+    // (or crashes). The same off-by-one was present in the underlying
+    // ConvertStringToBuf() helper which performed memcpy of (outsize-1) bytes
+    // when outsize was 0. Check that both narrow and wide overloads of
+    // wxSnprintf() leave the supplied buffer untouched when size is 0.
+    char    bufa[8] = { 'a','b','c','d','e','f','g','h' };
+    wchar_t bufw[8] = { L'a',L'b',L'c',L'd',L'e',L'f',L'g',L'h' };
+
+    (void)wxSnprintf(bufa, 0, "test");
+    (void)wxSnprintf(bufw, 0, L"test");
+
+    for ( size_t i = 0; i < 8; i++ )
+    {
+        CHECK( bufa[i] == "abcdefgh"[i] );
+        CHECK( bufw[i] == L"abcdefgh"[i] );
+    }
+}

--- a/tests/strings/crt.cpp
+++ b/tests/strings/crt.cpp
@@ -295,6 +295,7 @@ TEST_CASE("CRT::SnprintfZeroSize", "[crt][snprintf]")
 
     for ( size_t i = 0; i < 8; i++ )
     {
+        INFO("i=" << i);
         CHECK( bufa[i] == "abcdefgh"[i] );
         CHECK( bufw[i] == L"abcdefgh"[i] );
     }


### PR DESCRIPTION
The trailing \`str[size - 1] = 0\` in the char-overload of wxVsnprintf()
in src/common/wxcrt.cpp:608 runs unconditionally, so calling
wxSnprintf(buf, 0, "...") writes to str[SIZE_MAX]. The same off-by-one
exists in both ConvertStringToBuf() helpers, whose else branch does
memcpy(out, buf, outsize-1) with outsize == 0. Guard each on a non-zero
size, matching what the wchar_t wxVsnprintf already does just below.