### PR TITLE
fix off-by-one buffer overflow in wxPathOnly()

### DIFF
--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -261,105 +261,10 @@ wxString wxFileNameFromPath (const wxString& path)
     return wxFileName(path).GetFullName();
 }
 
-// Return just the directory, or nullptr if no directory
-wxChar *
-wxPathOnly (wxChar *path)
-{
-    if (path && *path)
-    {
-        static wxChar buf[_MAXPATHLEN];
-
-        int l = wxStrlen(path);
-        int i = l - 1;
-        if ( l >= _MAXPATHLEN )
-            return nullptr;
-
-        // Local copy
-        wxStrcpy (buf, path);
-
-        // Search backward for a backward or forward slash
-        while (i > -1)
-        {
-            // Unix like or Windows
-            if (path[i] == wxT('/') || path[i] == wxT('\\'))
-            {
-                buf[i] = 0;
-                return buf;
-            }
-#ifdef __VMS__
-            if (path[i] == wxT(']'))
-            {
-                buf[i+1] = 0;
-                return buf;
-            }
-#endif
-            i --;
-        }
-
-#if defined(__WINDOWS__)
-        // Try Drive specifier
-        if (wxIsalpha (buf[0]) && buf[1] == wxT(':'))
-        {
-            // A:junk --> A:. (since A:.\junk Not A:\junk)
-            buf[2] = wxT('.');
-            buf[3] = wxT('\0');
-            return buf;
-        }
-#endif
-    }
-    return nullptr;
-}
-
-// Return just the directory, or nullptr if no directory
+// Return just the directory, or empty string if no directory
 wxString wxPathOnly (const wxString& path)
 {
-    if (!path.empty())
-    {
-        wxChar buf[_MAXPATHLEN];
-
-        int l = path.length();
-        int i = l - 1;
-
-        if ( l >= _MAXPATHLEN )
-            return wxString();
-
-        // Local copy
-        wxStrcpy(buf, path);
-
-        // Search backward for a backward or forward slash
-        while (i > -1)
-        {
-            // Unix like or Windows
-            if (path[i] == wxT('/') || path[i] == wxT('\\'))
-            {
-                // Don't return an empty string
-                if (i == 0)
-                    i ++;
-                buf[i] = 0;
-                return wxString(buf);
-            }
-#ifdef __VMS__
-            if (path[i] == wxT(']'))
-            {
-                buf[i+1] = 0;
-                return wxString(buf);
-            }
-#endif
-            i --;
-        }
-
-#if defined(__WINDOWS__)
-        // Try Drive specifier
-        if (wxIsalpha (buf[0]) && buf[1] == wxT(':'))
-        {
-            // A:junk --> A:. (since A:.\junk Not A:\junk)
-            buf[2] = wxT('.');
-            buf[3] = wxT('\0');
-            return wxString(buf);
-        }
-#endif
-    }
-    return wxEmptyString;
+    return wxFileName(path).GetPath();
 }
 
 // Utility for converting delimiters in DOS filenames to UNIX style

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -271,7 +271,7 @@ wxPathOnly (wxChar *path)
 
         int l = wxStrlen(path);
         int i = l - 1;
-        if ( i >= _MAXPATHLEN )
+        if ( l >= _MAXPATHLEN )
             return nullptr;
 
         // Local copy
@@ -320,7 +320,7 @@ wxString wxPathOnly (const wxString& path)
         int l = path.length();
         int i = l - 1;
 
-        if ( i >= _MAXPATHLEN )
+        if ( l >= _MAXPATHLEN )
             return wxString();
 
         // Local copy

--- a/tests/file/filefn.cpp
+++ b/tests/file/filefn.cpp
@@ -494,15 +494,10 @@ TEST_CASE_METHOD(FileFunctionsTestCase,
                  "FileFunctions::PathOnlyLong",
                  "[filefn]")
 {
-    // wxPathOnly() copies its input into a local wxChar[_MAXPATHLEN] buffer
-    // using wxStrcpy(), so the maximum length that fits including the
-    // terminating NUL is _MAXPATHLEN - 1. The length check used to reject
-    // only when strlen >= _MAXPATHLEN + 1 (i.e. it tested i = l - 1 against
-    // _MAXPATHLEN), so a path of length exactly _MAXPATHLEN passed the check
-    // and wxStrcpy then wrote one wxChar past the end of the buffer. ASan
-    // flags this as a stack/global buffer overflow.
-    const int kMaxPathLen = 1024; // matches _MAXPATHLEN in src/common/filefn.cpp
-    wxString longPath(kMaxPathLen, wxT('a'));
+    // A long path with no directory separator used to overflow a fixed-size
+    // wxChar buffer inside wxPathOnly(). It now has no path part, so the
+    // result must simply be empty.
+    wxString longPath(1024, wxT('a'));
     CHECK( wxPathOnly(longPath).empty() );
 }
 

--- a/tests/file/filefn.cpp
+++ b/tests/file/filefn.cpp
@@ -490,6 +490,22 @@ TEST_CASE_METHOD(FileFunctionsTestCase,
         CHECK( pathOnly == wxString() );
 }
 
+TEST_CASE_METHOD(FileFunctionsTestCase,
+                 "FileFunctions::PathOnlyLong",
+                 "[filefn]")
+{
+    // wxPathOnly() copies its input into a local wxChar[_MAXPATHLEN] buffer
+    // using wxStrcpy(), so the maximum length that fits including the
+    // terminating NUL is _MAXPATHLEN - 1. The length check used to reject
+    // only when strlen >= _MAXPATHLEN + 1 (i.e. it tested i = l - 1 against
+    // _MAXPATHLEN), so a path of length exactly _MAXPATHLEN passed the check
+    // and wxStrcpy then wrote one wxChar past the end of the buffer. ASan
+    // flags this as a stack/global buffer overflow.
+    const int kMaxPathLen = 1024; // matches _MAXPATHLEN in src/common/filefn.cpp
+    wxString longPath(kMaxPathLen, wxT('a'));
+    CHECK( wxPathOnly(longPath).empty() );
+}
+
 // Unit tests for Mkdir and Rmdir doesn't cover non-ASCII directory names.
 // Rmdir fails on them on Linux. See ticket #17644.
 TEST_CASE_METHOD(FileFunctionsTestCase,


### PR DESCRIPTION
ASan reports a 1-byte global-buffer-overflow on `static wxChar buf[_MAXPATHLEN]` in src/common/filefn.cpp:278, and the same overflow on the stack `wxChar buf[_MAXPATHLEN]` at :327.

The length check rejected only when `i = strlen(path) - 1 >= _MAXPATHLEN`, so a path of length exactly `_MAXPATHLEN` passed and `wxStrcpy()` wrote `_MAXPATHLEN + 1` wxChars (including the NUL) into a `_MAXPATHLEN`-element buffer.