### PR TITLE
fix off-by-one buffer overflow in deepCopyHostent name copy

### DIFF
--- a/src/common/sckaddr.cpp
+++ b/src/common/sckaddr.cpp
@@ -131,7 +131,7 @@ hostent *deepCopyHostent(hostent *h,
 
     /* copy name */
     int len = strlen(h->h_name);
-    if (len > size)
+    if (len >= size)
     {
         *err = ENOMEM;
         return nullptr;


### PR DESCRIPTION
The name copy in deepCopyHostent() checks `len > size` but then writes buffer[len], so a hostname whose length equals the buffer size overflows it by one byte. deepCopyServent() just below already uses the correct `len >= size`.

ASan on a reduced reproducer of the name copy:

    heap-buffer-overflow WRITE of size 1
    0 bytes after 16-byte region ... in copy_name