### PR TITLE
fix out-of-bounds read on trailing % in ExpandCommand

### DIFF
--- a/src/common/mimecmn.cpp
+++ b/src/common/mimecmn.cpp
@@ -139,6 +139,15 @@ wxString wxFileType::ExpandCommand(const wxString& command,
     wxString str;
     for ( const wxChar *pc = command.c_str(); *pc != wxT('\0'); pc++ ) {
         if ( *pc == wxT('%') ) {
+            // A trailing '%' must be handled here: otherwise the increment in
+            // the switch below would step onto the terminating NUL and the
+            // loop increment would then move pc one byte past the end of the
+            // string, reading out of bounds on the next condition check.
+            if ( pc[1] == wxT('\0') ) {
+                str << wxT('%');
+                break;
+            }
+
             switch ( *++pc ) {
                 case wxT('s'):
                     // don't quote the file name if it's already quoted: notice

--- a/tests/misc/misctests.cpp
+++ b/tests/misc/misctests.cpp
@@ -262,6 +262,17 @@ TEST_CASE("wxFileTypeInfo", "[mime]")
         CHECK( fti.GetExtensions()[1] == "jpeg" );
     }
 }
+
+TEST_CASE("wxFileType::ExpandCommand", "[mime]")
+{
+    const wxFileType::MessageParameters params("file.txt", "text/plain");
+
+    CHECK( wxFileType::ExpandCommand("view %s", params) == "view file.txt" );
+
+    // A command ending with a bare '%' used to read past the end of the
+    // string; check that the trailing '%' is just copied verbatim instead.
+    CHECK( wxFileType::ExpandCommand("show %s %", params) == "show file.txt %" );
+}
 #endif // wxUSE_MIMETYPE
 
 TEST_CASE("wxVersionInfo", "[version]")


### PR DESCRIPTION
Found this fuzzing wxFileType::ExpandCommand with mailcap-style strings. A command ending in a bare '%' makes the loop advance pc onto the terminating NUL inside the switch, then the for-loop increment steps one byte past the end of the c_str() buffer and the next condition check reads it (ASAN reports a heap-buffer-overflow read). If that byte is non-zero the loop keeps going and appends adjacent memory into the expanded command. Handle the trailing '%' before the increment so it is just copied verbatim.