### PR TITLE
fix palette buffer overflow in wxGIFHandler_GetPalette

### DIFF
--- a/src/common/imaggif.cpp
+++ b/src/common/imaggif.cpp
@@ -554,7 +554,7 @@ bool wxGIFHandler_GetPalette(const wxImage& image,
     }
 
     const wxPalette& palette = image.GetPalette();
-    const int palCount = palette.GetColoursCount();
+    int palCount = palette.GetColoursCount();
 
     // The caller's pal[] buffer only has room for the 256 entries a GIF can
     // hold. A wxImage palette may be larger, e.g. when the image was loaded

--- a/src/common/imaggif.cpp
+++ b/src/common/imaggif.cpp
@@ -554,7 +554,17 @@ bool wxGIFHandler_GetPalette(const wxImage& image,
     }
 
     const wxPalette& palette = image.GetPalette();
-    int palCount = palette.GetColoursCount();
+    const int palCount = palette.GetColoursCount();
+
+    // The caller's pal[] buffer only has room for the 256 entries a GIF can
+    // hold. A wxImage palette may be larger, e.g. when the image was loaded
+    // from an XPM declaring more than 256 colours, and such an image can't be
+    // represented as a GIF, so fail the save here rather than overflow pal[].
+    if (palCount > 256)
+    {
+        wxLogError(_("Image palette has too many colours to save as GIF."));
+        return false;
+    }
 
     for (int i = 0; i < palCount; ++i)
     {

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1304,6 +1304,30 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::SaveAnimatedGIF", "[image]")
 #endif // #if wxUSE_PALETTE
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::SaveGIFBigPalette", "[image][gif][error]")
+{
+#if wxUSE_PALETTE
+    // An image palette can have more than the 256 entries a GIF supports, for
+    // instance when the image was loaded from an XPM declaring a larger colour
+    // count. Saving such an image as GIF must not overflow the fixed 256-entry
+    // palette buffer used by the encoder; instead the save should fail cleanly.
+    const int numColours = 300;
+    unsigned char r[numColours], g[numColours], b[numColours];
+    for (int i = 0; i < numColours; ++i)
+    {
+        r[i] = g[i] = b[i] = static_cast<unsigned char>(i);
+    }
+
+    wxImage image(1, 1);
+    image.SetRGB(0, 0, 0, 0, 0);
+    image.SetPalette(wxPalette(numColours, r, g, b));
+
+    wxMemoryOutputStream memOut;
+    wxLogNull noLog;
+    CHECK( !image.SaveFile(memOut, wxBITMAP_TYPE_GIF) );
+#endif // wxUSE_PALETTE
+}
+
 static void TestGIFComment(const wxString& comment)
 {
     wxImage image("horse.gif");


### PR DESCRIPTION
Found by round-tripping XPM files through GIF save: an XPM can declare more than 256 colours (xpmdecod.cpp), so the wxImage palette can exceed the fixed 256-entry wxRGB pal[] buffer that wxGIFHandler_GetPalette() fills, overflowing the stack. The over-large count is also returned and reused by WritePalette() later, reading past the same buffer. Cap palCount at 256, which is all a GIF can hold.