### PR TITLE
Avoid buffer read overflow in wxCharTypeBuffer ctor

### DIFF
--- a/include/wx/buffer.h
+++ b/include/wx/buffer.h
@@ -299,7 +299,13 @@ protected:
     {
         CharType *dst = (CharType*)malloc(sizeof(CharType) * (len + 1));
         if ( dst )
-            memcpy(dst, src, sizeof(CharType) * (len + 1));
+        {
+            memcpy(dst, src, sizeof(CharType) * len);
+
+            // Make sure the buffer is NUL-terminated, even if the source
+            // string isn't.
+            dst[len] = (CharType)0;
+        }
         return dst;
     }
 

--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -1233,6 +1233,9 @@ TEST_CASE("StringScopedBuffers", "[wxString]")
     wxCharBuffer buf5(5);
     buf5.extend(len);
     CHECK( buf5.data()[len] == '\0' );
+
+    const char buf8[8] = { };
+    CHECK( wxCharTypeBuffer<char>(buf8, sizeof(buf8)).length() == 8 );
 }
 
 TEST_CASE("StringSupplementaryUniChar", "[wxString]")


### PR DESCRIPTION
Don't assume that the data is always followed by NUL.

Closes #26527.