### PR TITLE
fix stack buffer overflow in TGA DecodeRLE for oversized bpp

### DIFF
--- a/src/common/imagtga.cpp
+++ b/src/common/imagtga.cpp
@@ -106,6 +106,12 @@ int DecodeRLE(unsigned char* imageData, unsigned long imageSize,
     unsigned int length;
     unsigned char buf[4];
 
+    // A pixel is at most 4 bytes (32 bpp); a larger pixelSize comes from a
+    // corrupt bpp field in the header and would overflow buf when reading an
+    // RLE run below.
+    if ( pixelSize > (short)sizeof(buf) )
+        return wxTGA_INVFORMAT;
+
     while (outputLength < imageSize)
     {
         int ch = stream.GetC();

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1229,6 +1229,39 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::ReadCorruptedTGA", "[image]")
     REQUIRE(
         !tgaImage.LoadFile(badPaletteStream, wxBITMAP_TYPE_TGA)
     );
+
+    /*
+    An RLE TGA whose bpp field gives a pixel size larger than 4 bytes.
+    DecodeRLE() reads one run's pixel into a 4-byte buffer, so this would
+    overflow it on the stream read before the bpp is otherwise rejected.
+    */
+    static const unsigned char bigBppTGA[] =
+    {
+        0,          // ID length
+        0,          // Color map type (none)
+        10,         // Image type = RLE RGB
+
+        0, 0,       // Color map origin
+        0, 0,       // Color map length
+        0,          // Color map entry size
+
+        0, 0,       // X-origin
+        0, 0,       // Y-origin
+
+        1, 0,       // Width = 1
+        1, 0,       // Height = 1
+
+        64,         // Bits per pixel (pixel size = 8 bytes)
+        0,          // Image descriptor
+
+        0x80,       // RLE packet, run length 1
+        1, 2, 3, 4, 5, 6, 7, 8 // 8 bytes of pixel data
+    };
+
+    wxMemoryInputStream bigBppStream(bigBppTGA, WXSIZEOF(bigBppTGA));
+    REQUIRE( bigBppStream.IsOk() );
+
+    REQUIRE( !tgaImage.LoadFile(bigBppStream, wxBITMAP_TYPE_TGA) );
 }
 
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadBMPPaletteIndex", "[image][bmp][error]")


### PR DESCRIPTION
DecodeRLE() reads each RLE run's pixel into a 4-byte stack buffer with stream.Read(buf, pixelSize), but pixelSize is bpp/8 from an unchecked header byte. An RLE TGA (image type 9/10/11) declaring bpp >= 40 makes pixelSize 5..31 and overruns buf; ReadTGA() only rejects unsupported depths in the switch that runs after decoding, so the read happens first. A 1x1 RLE-RGB file with bpp=64 smashes the stack. Reject pixelSize larger than buf at the top of DecodeRLE, which is also where the unsupported depth would be rejected anyway.