### PR TITLE
Fix MSW dark mode selection in list controls

### DIFF
--- a/include/wx/msw/listbox.h
+++ b/include/wx/msw/listbox.h
@@ -134,6 +134,7 @@ public:
     // Windows callbacks
     bool MSWCommand(WXUINT param, WXWORD id) override;
     WXDWORD MSWGetStyle(long style, WXDWORD *exstyle) const override;
+    bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
 
     // under XP when using "transition effect for menus and tooltips" if we
     // return true for WM_PRINTCLIENT here then it causes noticeable slowdown

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -223,7 +223,7 @@ bool wxChoice::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
     WinStruct<COMBOBOXINFO> info;
     if ( ::GetComboBoxInfo(GetHwnd(), &info) && info.hwndList )
     {
-        wxMSWDarkMode::AllowForWindow(info.hwndList);
+        wxMSWDarkMode::AllowForWindow(info.hwndList, L"Explorer", L"ScrollBar");
     }
 
     return true;

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -173,6 +173,14 @@ WXDWORD wxListBox::MSWGetStyle(long style, WXDWORD *exstyle) const
     return msStyle;
 }
 
+bool wxListBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    support.themeName = L"Explorer";
+    support.themeId = L"ScrollBar";
+
+    return true;
+}
+
 void wxListBox::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
 {
     wxListBoxBase::MSWUpdateFontOnDPIChange(newDPI);


### PR DESCRIPTION
Fixes #26535.

## Summary

This limits the dark-mode theme applied to native list HWNDs to the `ScrollBar` class instead of applying a full list/control theme.

The main combobox control still keeps the existing `CFD` theme, preserving the dark drop button/trigger. The popup list HWND for `wxChoice`/`wxComboBox`, and standalone `wxListBox`, now use `Explorer` with the `ScrollBar` sub-id so scrollbars remain dark without applying the list item theme that makes selected rows unreadable.

## Root cause

On Windows 11 Insider 26300.8553, applying a full explicit theme such as `CFD`, `Explorer`, `DarkMode_CFD`, `DarkMode_Explorer`, `ItemsView`, or `DarkMode_ItemsView` to the popup/list HWND draws the selected row with a white background while keeping white text. Removing the explicit theme fixes selection but leaves scrollbars unthemed. Applying only `Explorer`/`ScrollBar` preserves dark scrollbars and keeps item selection readable.

## Validation

Tested locally on Windows 11 Insider 26300.8553 with:

```powershell
cmake --build C:\wxWidgets-master\build-master --config Release --target widgets
$env:wx_msw_dark_mode = "2"
.\widgets.exe
```

Verified in the `widgets` sample with `wxChoice`, `wxComboBox`, and a `wxListBox` containing enough items to show scrollbars.