### PR TITLE
fix out-of-bounds read on trailing backslash in wxRegExImpl::Replace

### DIFF
--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -1158,6 +1158,13 @@ int wxRegExImpl::Replace(wxString *text,
                         index = (size_t)wxStrtoul(p, &end, 10);
                         p = end - 1; // -1 to compensate for p++ in the loop
                     }
+                    else if ( !*p )
+                    {
+                        // trailing backslash: keep it verbatim and stop here so
+                        // the loop's p++ doesn't read past the terminating NUL
+                        textNew += wxT('\\');
+                        break;
+                    }
                     //else: backslash used as escape character
                 }
                 else if ( *p == wxT('&') )

--- a/tests/regex/wxregextest.cpp
+++ b/tests/regex/wxregextest.cpp
@@ -161,6 +161,10 @@ TEST_CASE("wxRegEx::Replace", "[regex][replace]")
     CheckReplace(patn, "123foo456foo", "\\0\\0", "123foo456foo456foo", 1);
     CheckReplace(patn, "foo123foo123", "bar", "barbar", 2);
     CheckReplace(patn, "foo123_foo456_foo789", "bar", "bar_bar_bar", 3);
+
+    // A replacement string ending with a lone backslash used to read one byte
+    // past the end of the buffer; the backslash is now kept verbatim.
+    CheckReplace(patn, "foo123", "bar\\", "bar\\", 1);
 }
 
 TEST_CASE("wxRegEx::QuoteMeta", "[regex][meta]")


### PR DESCRIPTION
wxRegExImpl::Replace() scans replacement.c_str() and does `*++p` after a backslash. When the replacement ends in a lone backslash, that reads the terminating NUL, the else branch appends it, and the loop's `p++` then steps one byte past the NUL so the `*p` condition reads out of bounds (ASan: heap-buffer-overflow read, 1 byte past the buffer; if the byte is non-zero it keeps scanning and copies adjacent memory into the result). Reachable through the public Replace()/ReplaceAll(). Keep a trailing backslash verbatim and stop before the increment. Test added in tests/regex/wxregextest.cpp.