### PR TITLE
wxOSX perform cleanup when applicationWillTerminate: is called

### DIFF
--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -238,6 +238,17 @@ void wxBell()
 - (void)applicationWillTerminate:(NSNotification *)application {
     wxUnusedVar(application);
     wxTheApp->OSXOnWillTerminate();
+
+    // Cocoa will `exit(0)` soon after returning from
+    // `applicationWillTerminate:`, without another opportunity for cleanup, so
+    // do it here.
+
+    // Ignore the return code. It's probably better to let Cocoa do the rest of
+    // its cleanup like normal rather than calling `exit()` here, and the
+    // return code doesn't mean much, if anything, for macOS usually.
+    (void)wxTheApp->CallOnExit();
+
+    wxEntryCleanup();
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender


### PR DESCRIPTION
In the handling of `OSXOnWillTerminate()`, the TLW is `Close()`d, but not deleted (the pending cleanup never occurs), additionally, `OnExit()` is never called.

When clicking "Quit" from the Dock, Cocoa ends up in `-[NSApplication terminate:]`, which calls `exit(0)` more or less immediately after sending `applicationWillTerminate:`, and the documentation reads:
> Don’t bother to put final cleanup code in your app’s main() function—it will never be executed. If cleanup is necessary, perform that cleanup in the delegate’s [applicationWillTerminate:](doc://com.apple.documentation/documentation/appkit/nsapplicationdelegate/applicationwillterminate(_:)?language=occ) method.

So then, this PR changes wxOSX's `wxApp::OnEndSession()` to do cleanup similarly to the wxMSW port, making sure that `OnExit()` and all other cleanup is performed (part of that cleanup is deleting TLWs, so I've removed the `Close()`).