### PR TITLE
fix out-of-bounds read on trailing % in wxDateTime::Format

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -405,8 +405,17 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
             continue;
         }
 
+        // advance to the format specifier following the '%': a trailing '%'
+        // is not a valid format, so output it verbatim and stop here instead
+        // of letting the loop's own ++p move the iterator past the end
+        if ( ++p == format.end() )
+        {
+            res += wxT('%');
+            break;
+        }
+
         // set the default format
-        switch ( (*++p).GetValue() )
+        switch ( (*p).GetValue() )
         {
             case wxT('Y'):               // year has 4 digits
             case wxT('G'):               // (and ISO week year too)

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -800,6 +800,12 @@ TEST_CASE("wxDateTime::Format", "[datetime]")
 
     wxDateTime dt(29, wxDateTime::May, 1976, 18, 30, 15, 678);
     CHECK( dt.Format("%F %T.%l") == "1976-05-29 18:30:15.678" );
+
+    // A format ending in a lone '%' must not read past the end of the format
+    // string; the trailing percent is output verbatim. The literal is long
+    // enough to be heap-allocated so the over-read trips ASAN without the fix.
+    CHECK( dt.Format("a long enough format ending in a percent sign %") ==
+                     "a long enough format ending in a percent sign %" );
 }
 
 TEST_CASE("wxDateTime::ParseFormat", "[datetime]")

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -804,8 +804,13 @@ TEST_CASE("wxDateTime::Format", "[datetime]")
     // A format ending in a lone '%' must not read past the end of the format
     // string; the trailing percent is output verbatim. The literal is long
     // enough to be heap-allocated so the over-read trips ASAN without the fix.
+    //
+    // The MSVC CRT considers a trailing '%' an invalid format string and
+    // aborts, so skip this check there.
+#ifndef _MSC_VER
     CHECK( dt.Format("a long enough format ending in a percent sign %") ==
                      "a long enough format ending in a percent sign %" );
+#endif
 }
 
 TEST_CASE("wxDateTime::ParseFormat", "[datetime]")

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -806,8 +806,8 @@ TEST_CASE("wxDateTime::Format", "[datetime]")
     // enough to be heap-allocated so the over-read trips ASAN without the fix.
     //
     // The MSVC CRT considers a trailing '%' an invalid format string and
-    // aborts, so skip this check there.
-#ifndef _MSC_VER
+    // aborts, so skip this check there. This CRT is also used by MinGW.
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
     CHECK( dt.Format("a long enough format ending in a percent sign %") ==
                      "a long enough format ending in a percent sign %" );
 #endif


### PR DESCRIPTION
Fuzzing date format strings turned this up. Format() does `(*++p)` when it hits a '%', so a format ending in a lone '%' advances the iterator onto end(), and then the for-loop's own ++p steps one past it; since end()+1 != end() the loop re-enters and reads `*p` past the terminating NUL. It asserts in debug builds via the existing `case 0`, but over-reads the format buffer in release. Advance once and output the trailing '%' verbatim then stop, which is what the `case 0` comment already intended. ParseFormat() already handles this by returning false.