### PR TITLE
MSW: Dark mode theme for wxDataViewCtrl item buttons

### DIFF
--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -670,7 +670,7 @@ wxRendererXP::DrawTreeItemButton(wxWindow *win,
                                  const wxRect& rect,
                                  int flags)
 {
-    wxUxThemeHandle hTheme(win, L"TREEVIEW");
+    wxUxThemeHandle hTheme(win, L"TREEVIEW", L"DarkMode_Explorer::TreeView");
     if ( !hTheme )
     {
         m_rendererNative.DrawTreeItemButton(win, dc, rect, flags);
@@ -851,7 +851,7 @@ wxSize wxRendererXP::GetExpanderSize(wxWindow* win)
 {
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 
-    wxUxThemeHandle hTheme(win, L"TREEVIEW");
+    wxUxThemeHandle hTheme(win, L"TREEVIEW", L"DarkMode_Explorer::TreeView");
     if ( hTheme )
     {
         if ( ::IsThemePartDefined(hTheme, TVP_GLYPH, 0) )


### PR DESCRIPTION
Add dark mode theme class for collapse/expand tree item buttons. This fix is for the wxDataViewCtrl when switching between dark and light themes. The problem solved is that the button colors fail to update and so they disappear.