### PR TITLE
fix out-of-bounds read on truncated UTF-8 in wxUString::assignFromUTF8

### DIFF
--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -78,6 +78,13 @@ wxUString &wxUString::assignFromUTF8( const char *str )
         size_type len = tableUtf8Lengths[c];
         if (!len)
            return assign( wxUString() );  // don't try to convert invalid UTF-8
+        // a multibyte sequence truncated by the terminating NUL must not make
+        // us skip past the end of the string
+        for ( size_type i = 1; i < len; i++ )
+        {
+            if ( !p[i] )
+                return assign( wxUString() );
+        }
         ucs4_len++;
         p += len;
     }


### PR DESCRIPTION
The length-counting pass in the NUL-terminated assignFromUTF8 advances p by the lead byte's UTF-8 sequence length without checking those bytes are really there. A string ending in a truncated multibyte sequence (e.g. a lone 0xC3 before the NUL) skips p past the terminating NUL, so the while(*p) test then reads past the end of the buffer. The assignFromUTF8(str, n) overload below already guards this via utf8_pos + len > n; this just adds the equivalent check for the terminated form. Reachable through wxUString::FromUTF8(const char*).