### PR TITLE
wxOSX: Add wxDF_UNICODETEXT flag for text sample

### DIFF
--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -190,7 +190,7 @@ public:
     {
         wxClipboardLocker lockClip;
 
-        event.Enable( wxTheClipboard->IsSupported(wxDF_TEXT) );
+        event.Enable( wxTheClipboard->IsSupported(wxDF_TEXT) || wxTheClipboard->IsSupported(wxDF_UNICODETEXT) );
     }
 
     void OnUpdateCopyToClipboard(wxUpdateUIEvent& event)


### PR DESCRIPTION
Based on my testing, when copying text from Terminal and TextEdit, the logic here triggers the `wxDF_TEXT` condition. My OS is Sonoma 14.8.7.