### PR TITLE
fix off-by-one in hostent/servent pointer list terminator

### DIFF
--- a/src/common/sckaddr.cpp
+++ b/src/common/sckaddr.cpp
@@ -165,6 +165,7 @@ hostent *deepCopyHostent(hostent *h,
     char **h_addr_list = (char **)(buffer + pos);
     while(*(p++) != nullptr)
         pos += sizeof(char *);
+    pos += sizeof(char *); /* and one slot for the null terminator */
 
     /* copy addresses and fill new pointer list */
     for (p = h->h_addr_list, q = h_addr_list; *p != nullptr; p++, q++)
@@ -178,7 +179,7 @@ hostent *deepCopyHostent(hostent *h,
         *q = buffer + pos; /* set copied pointer to copied content */
         pos += len;
     }
-    *++q = nullptr; /* null terminate the pointer list */
+    *q = nullptr; /* null terminate the pointer list */
     h->h_addr_list = h_addr_list; /* copy pointer to pointers */
 
     /* ensure word alignment of pointers */
@@ -191,6 +192,7 @@ hostent *deepCopyHostent(hostent *h,
     char **h_aliases = (char **)(buffer + pos);
     while(*(p++) != nullptr)
         pos += sizeof(char *);
+    pos += sizeof(char *); /* and one slot for the null terminator */
 
     /* copy aliases and fill new pointer list */
     for (p = h->h_aliases, q = h_aliases; *p != nullptr; p++, q++)
@@ -206,7 +208,7 @@ hostent *deepCopyHostent(hostent *h,
         *q = buffer + pos; /* set copied pointer to copied content */
         pos += len + 1;
     }
-    *++q = nullptr; /* null terminate the pointer list */
+    *q = nullptr; /* null terminate the pointer list */
     h->h_aliases = h_aliases; /* copy pointer to pointers */
 
     return h;
@@ -310,6 +312,7 @@ servent *deepCopyServent(servent *s,
     char **s_aliases = (char **)(buffer + pos);
     while(*(p++) != nullptr)
         pos += sizeof(char *);
+    pos += sizeof(char *); /* and one slot for the null terminator */
 
     /* copy addresses and fill new pointer list */
     for (p = s->s_aliases, q = s_aliases; *p != nullptr; p++, q++){
@@ -323,7 +326,7 @@ servent *deepCopyServent(servent *s,
         *q = buffer + pos; /* set copied pointer to copied content */
         pos += len + 1;
     }
-    *++q = nullptr; /* null terminate the pointer list */
+    *q = nullptr; /* null terminate the pointer list */
     s->s_aliases = s_aliases; /* copy pointer to pointers */
     return s;
 }


### PR DESCRIPTION
The h_addr_list/h_aliases/s_aliases copy loops in deepCopyHostent()/deepCopyServent() reserve N pointer slots for N entries and then write the terminator with `*++q`, one slot too far, so the array isn't terminated right after the last entry and that slot holds copied address/alias bytes used as a pointer.

ASan on a reduced reproducer, after a consumer walks the returned list:

    AddressSanitizer: BUS, READ memory access in _platform_memmove
    x1 = 0x0200000a0100000a   (copied IPv4 bytes dereferenced as a pointer)

Reserve a slot for the terminator and write it with `*q`.