### PR TITLE
fix rowspan/colspan integer overflow in wxHtmlTableCell::AddCell

### DIFF
--- a/src/html/m_tables.cpp
+++ b/src/html/m_tables.cpp
@@ -330,6 +330,15 @@ void wxHtmlTableCell::AddCell(wxHtmlContainerCell *cell, const wxHtmlTag& tag)
         if (m_CellInfo[r][c].rowspan < 1)
             m_CellInfo[r][c].rowspan = 1;
 
+        // The values come straight from the markup and are used below as
+        // r + rowspan and c + colspan, which overflow for values near INT_MAX
+        // and so bypass the bounds growth, resulting in an out-of-bounds access
+        // in Layout(). Clamp them to the limits used by the HTML specification.
+        if (m_CellInfo[r][c].colspan > 1000)
+            m_CellInfo[r][c].colspan = 1000;
+        if (m_CellInfo[r][c].rowspan > 65534)
+            m_CellInfo[r][c].rowspan = 65534;
+
         if ((m_CellInfo[r][c].colspan > 1) || (m_CellInfo[r][c].rowspan > 1))
         {
             int i, j;


### PR DESCRIPTION
AddCell() reads COLSPAN and ROWSPAN from the markup into ints with no upper bound, then uses r + rowspan and c + colspan to grow the cell table and to index ypos[] in Layout(). A value near INT_MAX, e.g. <td rowspan="2147483647"> in the second row, overflows the addition so the `r + rowspan > m_NumRows` growth check is bypassed and Layout() writes past the end of ypos[]. Clamp colspan and rowspan to the limits from the HTML spec (1000 and 65534).