### PR TITLE
Update GitHub Actions to be Node v24 compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,13 +222,13 @@ jobs:
 
       - name: Checkout
         if: matrix.container != 'ubuntu:18.04'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
       - name: Install CCache
         if: matrix.container != 'ubuntu:18.04'
-        uses: hendrikmuhs/ccache-action@v1.2.12
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ matrix.name }}
 
@@ -371,7 +371,7 @@ jobs:
 
       - name: Setup Go
         if: matrix.container != 'ubuntu:18.04'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1'
           cache: false

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -218,7 +218,7 @@ jobs:
       # MSYS2, or we'd end up using MSVC clang instead of its own.
       - name: Setup MSVC Environment
         if: ${{ runner.os == 'Windows' && matrix.cmake_generator != 'MinGW Makefiles' }}
-        uses: wxWidgets/gha-setup-vsdevenv@wx
+        uses: step-security/gha-setup-vsdevenv@v6
 
       - name: Configuring
         run: |
@@ -243,7 +243,7 @@ jobs:
 
       - name: Setup Go
         if: matrix.cmake_tests != 'OFF'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1'
           cache: false

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -120,7 +120,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -159,7 +159,7 @@ jobs:
         echo "PATH=/opt/homebrew/bin:/opt/homebrew/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
 
     - name: Install CCache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ matrix.name }}
 
@@ -219,9 +219,9 @@ jobs:
 
     - name: Setup Go
       if: matrix.skip_testing != true
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: '>=1.21.0'
+        go-version: '>=1.25.0'
         cache: false
 
     - name: Testing

--- a/.github/workflows/ci_mac_gtk.yml
+++ b/.github/workflows/ci_mac_gtk.yml
@@ -35,7 +35,7 @@ jobs:
         
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -81,7 +81,7 @@ jobs:
           echo "PATH=/opt/homebrew/bin:/opt/homebrew/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
   
       - name: Install CCache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ matrix.name }}
   
@@ -141,7 +141,7 @@ jobs:
   
       - name: Setup Go
         if: matrix.skip_testing != true
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '>=1.21.0'
           cache: false

--- a/.github/workflows/ci_mac_xcode.yml
+++ b/.github/workflows/ci_mac_xcode.yml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 

--- a/.github/workflows/ci_msw.yml
+++ b/.github/workflows/ci_msw.yml
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -130,7 +130,7 @@ jobs:
             }
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
             vs-prerelease: true
 

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -129,12 +129,12 @@ jobs:
           echo "wxTEST_RUNNER=wine" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
       - name: Install CCache
-        uses: hendrikmuhs/ccache-action@v1.2.12
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ matrix.name }}
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install codespell
         run: |
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for trailing whitespace and TABs
         run: |
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dos2unix
         run: |
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for obsolete macros use
         run: |
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check that all headers are listed in tests/allheaders.h
         run: |

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install doxygen
         env:

--- a/.github/workflows/genlangdb.yml
+++ b/.github/workflows/genlangdb.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Enable MSVC command line
       uses: ilammy/msvc-dev-cmd@v1.13.0

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Release Archive
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Node v20 has gone EOL and will be removed from GitHub Actions soon. This migrates all the GitHub Actions to use versions that are Node 24 compatible.

The only change of real substance is moving to the step-security fork of gha-setup-vsdevenv which seems probably better than wx maintaining its own fork.