### PR TITLE
msw/listctrl: Fix more text overflow and column overflow issues

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1403,20 +1403,29 @@ bool wxListCtrl::GetSubItemRect(long item, long subItem, wxRect& rect, int code)
 
     wxCopyRECTToRect(rectWin, rect);
 
-    // We can't use wxGetListCtrlSubItemRect() for the 0th subitem as 0 means
-    // the entire row for this function, so we need to calculate it ourselves.
-    if ( subItem == 0 && code == wxLIST_RECT_BOUNDS )
+    // We can't trust the native LVM_GETSUBITEMRECT for LVIR_BOUNDS because:
+    //  - subitem 0 returns the entire row bounds, not just column 0
+    //  - when column 0 is narrower than the icon, the native control clamps
+    //    all subitems' left edge to at least the icon width, misaligning them
+    //
+    // So for all subitems we calculate x and width from GetColumnWidth() in
+    // visual (column order) order, which always reflects the real column sizes.
+    if ( subItem != wxLIST_GETSUBITEMRECT_WHOLEITEM && code == wxLIST_RECT_BOUNDS )
     {
-        // Because the columns can be reordered, we need to sum the widths of
-        // all preceding columns to get the correct x position.
+        // Start from the row's left edge (which accounts for scrolling).
+        RECT rowRect;
+        wxGetListCtrlItemRect(GetHwnd(), item, LVIR_BOUNDS, rowRect);
+        int x = rowRect.left;
+
         for ( auto col : GetColumnsOrder() )
         {
             if ( col == subItem )
                 break;
 
-            rect.x += GetColumnWidth(col);
+            x += GetColumnWidth(col);
         }
 
+        rect.x = x;
         rect.width = GetColumnWidth(subItem);
     }
 


### PR DESCRIPTION
In my previous PR (https://github.com/wxWidgets/wxWidgets/pull/25950), I tried to fix a few issues I was seeing from our usage of the wxListCtrl for our game list in Cemu. But I noticed a new regression after updating to wxWidgets 3.3.2.

It turns out that due to an unrelated change in https://github.com/wxWidgets/wxWidgets/pull/25962, an existing issue related to calculating the width of a row element was uncovered. This PR addresses the root cause of that uncovered bug, but also fixes another tell that was there to point towards this always having been an issue. But here were the symptoms.
- Columns being misaligned with their contents.
- Headers not being aligned with their content due to using an image.
- Probably other things that I hadn't noticed before, which caused different behavior between the two platforms.

### Screenshots

Here's the game list compiled with 3.3.2:
<img width="809" height="290" alt="image" src="https://github.com/user-attachments/assets/1670390e-7b69-47de-b10e-9875e592bc0e" />

You can see that text truncation is broken, and the headers and rows are not aligned correctly, which did work in the version compiled with my PR:

<img width="779" height="485" alt="image" src="https://github.com/user-attachments/assets/1dbde70d-aa5a-4227-a8ed-d0bf79533016" />

However, with the version of my previous PR, although it does not have the column misalignment regression that was added in 3.3.2, it still has the issue of the text being incorrectly truncated. I'm listing this not to point blame, but just to retrace my steps in the hopes of making this change more understandable and valid.

So, the fixed version has proper truncation and the row columns appear to correctly work too. I tested it with the white mode, and the ellipses amount changing also appears to be correct.

https://github.com/user-attachments/assets/6c4cfdf4-c8f9-4f4b-9f67-f709f2ab614c


Small disclaimer: I did work on this patch in March. As far as I'm aware however, the behavior is still there and I really do think that this is just correcting a wrong function signature causing havoc.