### PR TITLE
CMake: Always install common headers

### DIFF
--- a/build/cmake/demos/CMakeLists.txt
+++ b/build/cmake/demos/CMakeLists.txt
@@ -36,6 +36,8 @@ wx_add_demo(forty
         about.htm
     LIBRARIES
         wxhtml wxxml
+    DEPENDS
+        wxUSE_HTML
     )
 
 wx_add_demo(fractal
@@ -62,6 +64,8 @@ wx_add_demo(poem
         wxpoem.txt wxpoem.dat wxpoem.idx
     LIBRARIES
         wxhtml
+    DEPENDS
+        wxUSE_HTML
     NAME
         wxpoem
     )

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -60,15 +60,18 @@ macro(wx_append_sources src_var source_base_name)
     endif()
     if(DEFINED ${source_base_name}_HDR)
         wx_add_headers(${src_var} ${${source_base_name}_HDR})
-
-        list(APPEND wxINSTALL_HEADERS ${${source_base_name}_HDR})
-        set(wxINSTALL_HEADERS ${wxINSTALL_HEADERS} PARENT_SCOPE)
+        wx_append_install_headers(${source_base_name}_HDR)
     endif()
 
     if(DEFINED ${source_base_name}_RSC)
-        list(APPEND wxINSTALL_HEADERS ${${source_base_name}_RSC})
-        set(wxINSTALL_HEADERS ${wxINSTALL_HEADERS} PARENT_SCOPE)
+        wx_append_install_headers(${source_base_name}_RSC)
     endif()
+endmacro()
+
+# Add headers from a variable to the list of headers to install
+macro(wx_append_install_headers header_base_name)
+    list(APPEND wxINSTALL_HEADERS ${${header_base_name}})
+    set(wxINSTALL_HEADERS ${wxINSTALL_HEADERS} PARENT_SCOPE)
 endmacro()
 
 # Add prefix to list of items

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -29,58 +29,34 @@ foreach(LIB IN LISTS LIBS_THIRDPARTY)
     include(${LIB}.cmake)
 endforeach()
 
-# add_opt_lib()
-# Add library which may have been disabled by wxUSE_...
-macro(add_opt_lib name)
-    set(add_lib ON)
-    foreach(var_name ${ARGN})
-        if(NOT ${var_name})
-            set(add_lib OFF)
-        endif()
-    endforeach()
-    if(add_lib)
-        list(APPEND LIBS ${name})
-    endif()
-endmacro()
-
 # Define base libraries
-set(LIBS base)
-
-# wxNet should be built if either wxUSE_SOCKETS or wxUSE_WEBREQUEST is on.
-if(wxUSE_SOCKETS OR wxUSE_WEBREQUEST)
-    set(wxUSE_NET ON)
-else()
-    set(wxUSE_NET OFF)
-endif()
-add_opt_lib(net wxUSE_NET)
+set(LIBS base net)
 
 # Define UI libraries
 if(wxUSE_GUI)
-    list(APPEND LIBS core adv)
-    foreach(lib
+    list(APPEND LIBS
+        core
+        adv
         aui
+        gl
         html
+        media
         propgrid
+        qa
         ribbon
         richtext
-        webview
         stc
+        webview
+        webview_chromium
         xrc
-        )
-        string(TOUPPER ${lib} _name_upper)
-        add_opt_lib(${lib} wxUSE_${_name_upper})
-    endforeach()
-    add_opt_lib(media wxUSE_MEDIACTRL)
-    add_opt_lib(gl wxUSE_OPENGL)
-    add_opt_lib(qa wxUSE_DEBUGREPORT)
-    add_opt_lib(webview_chromium wxUSE_WEBVIEW wxUSE_WEBVIEW_CHROMIUM)
+    )
 endif() # wxUSE_GUI
 
 # Include XML library last
 # In the monolithic build, where all target properties (include dirs) from different targets are concatenated,
 # wxml might include system expat, which might use Mono, which has it's own copy of png.
 # Thus to ensure wx's core library includes the right png class, core must be processed first before xml
-add_opt_lib(xml wxUSE_XML)
+list(APPEND LIBS xml)
 
 # Include cmake file for every library
 foreach(LIB ${LIBS})

--- a/build/cmake/lib/aui/CMakeLists.txt
+++ b/build/cmake/lib/aui/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_AUI)
+    wx_append_install_headers(AUI_CMN_HDR)
+    return()
+endif()
+
 wx_append_sources(AUI_FILES AUI_CMN)
 
 if(WXMSW)

--- a/build/cmake/lib/gl/CMakeLists.txt
+++ b/build/cmake/lib/gl/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_OPENGL)
+    wx_append_install_headers(OPENGL_CMN_HDR)
+    return()
+endif()
+
 wx_append_sources(GL_FILES OPENGL_CMN)
 
 if(WXMSW)

--- a/build/cmake/lib/html/CMakeLists.txt
+++ b/build/cmake/lib/html/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_HTML)
+    wx_append_install_headers(HTML_CMN_HDR)
+    return()
+endif()
+
 wx_append_sources(HTML_FILES HTML_CMN)
 
 if(WXMSW)

--- a/build/cmake/lib/media/CMakeLists.txt
+++ b/build/cmake/lib/media/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_MEDIACTRL)
+    wx_append_install_headers(MEDIA_CMN_HDR)
+    return()
+endif()
+
 wx_append_sources(MEDIA_FILES MEDIA_CMN)
 
 if(WXMSW)

--- a/build/cmake/lib/net/CMakeLists.txt
+++ b/build/cmake/lib/net/CMakeLists.txt
@@ -7,6 +7,12 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+# wxNet should be built if either wxUSE_SOCKETS or wxUSE_WEBREQUEST is on.
+if(NOT wxUSE_SOCKETS AND NOT wxUSE_WEBREQUEST)
+    wx_append_install_headers(NET_CMN_HDR)
+    return()
+endif()
+
 wx_append_sources(NET_FILES NET_CMN)
 
 if(WIN32)

--- a/build/cmake/lib/propgrid/CMakeLists.txt
+++ b/build/cmake/lib/propgrid/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_PROPGRID)
+    wx_append_install_headers(PROPGRID_HDR)
+    return()
+endif()
+
 wx_append_sources(PROPGRID_FILES PROPGRID)
 
 wx_add_library(wxpropgrid ${PROPGRID_FILES})

--- a/build/cmake/lib/qa/CMakeLists.txt
+++ b/build/cmake/lib/qa/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_DEBUGREPORT)
+    wx_append_install_headers(QA_HDR)
+    return()
+endif()
+
 wx_append_sources(QA_FILES QA)
 
 wx_add_library(wxqa ${QA_FILES})

--- a/build/cmake/lib/ribbon/CMakeLists.txt
+++ b/build/cmake/lib/ribbon/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_RIBBON)
+    wx_append_install_headers(RIBBON_HDR)
+    return()
+endif()
+
 wx_append_sources(RIBBON_FILES RIBBON)
 
 wx_add_library(wxribbon ${RIBBON_FILES})

--- a/build/cmake/lib/richtext/CMakeLists.txt
+++ b/build/cmake/lib/richtext/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_RICHTEXT)
+    wx_append_install_headers(RICHTEXT_HDR)
+    return()
+endif()
+
 wx_append_sources(RICHTEXT_FILES RICHTEXT)
 
 wx_add_library(wxrichtext ${RICHTEXT_FILES})

--- a/build/cmake/lib/stc/CMakeLists.txt
+++ b/build/cmake/lib/stc/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_STC)
+    wx_append_install_headers(STC_CMN_HDR)
+    return()
+endif()
+
 include(scintilla.cmake)
 include(lexilla.cmake)
 

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_WEBVIEW)
+    wx_append_install_headers(WEBVIEW_CMN_HDR)
+    return()
+endif()
+
 macro(wx_set_webview2_arch)
     if(wxPLATFORM_ARCH)
         set(WEBVIEW2_ARCH ${wxPLATFORM_ARCH})

--- a/build/cmake/lib/webview_chromium/CMakeLists.txt
+++ b/build/cmake/lib/webview_chromium/CMakeLists.txt
@@ -7,6 +7,10 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_WEBVIEW OR NOT wxUSE_WEBVIEW_CHROMIUM)
+    return()
+endif()
+
 include(../../source_groups.cmake)
 
 set(KNOWN_CONFIGS "Debug;Release;RelWithDebInfo;MinSizeRel")

--- a/build/cmake/lib/xml/CMakeLists.txt
+++ b/build/cmake/lib/xml/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_XML)
+    wx_append_install_headers(XML_HDR)
+    return()
+endif()
+
 wx_append_sources(XML_FILES XML)
 wx_add_library(wxxml IS_BASE ${XML_FILES})
 wx_lib_link_libraries(wxxml PRIVATE ${EXPAT_LIBRARIES})

--- a/build/cmake/lib/xrc/CMakeLists.txt
+++ b/build/cmake/lib/xrc/CMakeLists.txt
@@ -7,7 +7,17 @@
 # Licence:     wxWindows licence
 #############################################################################
 
+if(NOT wxUSE_XRC)
+    wx_append_install_headers(XRC_HDR)
+    return()
+endif()
+
 wx_append_sources(XRC_FILES XRC)
 
 wx_add_library(wxxrc ${XRC_FILES})
-wx_lib_link_libraries(wxxrc PRIVATE wxhtml wxxml)
+if(wxUSE_XML)
+    wx_lib_link_libraries(wxxrc PRIVATE wxxml)
+endif()
+if(wxUSE_HTML)
+    wx_lib_link_libraries(wxxrc PRIVATE wxhtml)
+endif()

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -11,7 +11,7 @@ wx_add_sample(access accesstest.cpp DEPENDS wxUSE_ACCESSIBILITY)
 wx_add_sample(animate anitest.cpp anitest.h DATA throbber.gif throbber_2x.gif hourglass.ani DEPENDS wxUSE_ANIMATIONCTRL)
 wx_add_sample(archive CONSOLE)
 wx_add_sample(artprov arttest.cpp artbrows.cpp artbrows.h)
-wx_add_sample(aui auidemo.cpp LIBRARIES wxaui wxhtml wxxml NAME auidemo DEPENDS wxUSE_AUI)
+wx_add_sample(aui auidemo.cpp LIBRARIES wxaui wxhtml wxxml NAME auidemo DEPENDS wxUSE_AUI wxUSE_XML wxUSE_HTML)
 wx_add_sample(calendar DEPENDS wxUSE_CALENDARCTRL)
 wx_add_sample(caret DEPENDS wxUSE_CARET)
 wx_add_sample(collpane DEPENDS wxUSE_COLLPANE)
@@ -33,11 +33,11 @@ if(WXGTK2)
     wx_list_add_prefix(SAMPLE_DIALOGS_SRC ../../src/generic/ filedlgg.cpp)
 endif()
 wx_add_sample(dialogs ${SAMPLE_DIALOGS_SRC} DATA tips.txt)
-wx_add_sample(dialup nettest.cpp LIBRARIES wxnet DEPENDS wxUSE_DIALUP_MANAGER)
+wx_add_sample(dialup nettest.cpp LIBRARIES wxnet DEPENDS wxUSE_DIALUP_MANAGER wxUSE_SOCKETS)
 wx_add_sample(display)
 wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP)
 wx_add_sample(docview docview.cpp doc.cpp view.cpp docview.h doc.h view.h
-    RES docview.rc PLIST Info.plist.in LIBRARIES wxaui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE)
+    RES docview.rc PLIST Info.plist.in LIBRARIES wxaui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE wxUSE_AUI)
 wx_add_sample(dragimag dragimag.cpp dragimag.h RES dragimag.rc
     DATA backgrnd.png shape01.png shape02.png shape03.png
     DEPENDS wxUSE_DRAGIMAGE)
@@ -60,7 +60,7 @@ wx_add_sample(help demo.cpp LIBRARIES wxhtml
     doc.hhk doc.hhp doc.hlp doc.hpj doc.zip forward.gif up.gif
     ${HELP_DOC_FILES}
     NAME helpdemo
-    DEPENDS wxUSE_HELP
+    DEPENDS wxUSE_HELP wxUSE_HTML
     )
 wx_add_sample(htlbox LIBRARIES wxhtml DEPENDS wxUSE_HTML)
 if(wxUSE_HTML)
@@ -77,10 +77,10 @@ endforeach()
 wx_add_sample(internat DATA ${INTERNAT_DATA_FILES} PLIST Info.plist.in DEPENDS wxUSE_INTL)
 # IPC samples
 set(wxSAMPLE_FOLDER ipc)
-wx_add_sample(ipc client.cpp client.h connection.h ipcsetup.h NAME ipcclient LIBRARIES wxnet DEPENDS wxUSE_IPC)
-wx_add_sample(ipc server.cpp server.h connection.h ipcsetup.h NAME ipcserver LIBRARIES wxnet DEPENDS wxUSE_IPC)
-wx_add_sample(ipc CONSOLE baseclient.cpp connection.h ipcsetup.h NAME baseipcclient LIBRARIES wxnet DEPENDS wxUSE_IPC)
-wx_add_sample(ipc CONSOLE baseserver.cpp connection.h ipcsetup.h NAME baseipcserver LIBRARIES wxnet DEPENDS wxUSE_IPC)
+wx_add_sample(ipc client.cpp client.h connection.h ipcsetup.h NAME ipcclient LIBRARIES wxnet DEPENDS wxUSE_IPC wxUSE_SOCKETS)
+wx_add_sample(ipc server.cpp server.h connection.h ipcsetup.h NAME ipcserver LIBRARIES wxnet DEPENDS wxUSE_IPC wxUSE_SOCKETS)
+wx_add_sample(ipc CONSOLE baseclient.cpp connection.h ipcsetup.h NAME baseipcclient LIBRARIES wxnet DEPENDS wxUSE_IPC wxUSE_SOCKETS)
+wx_add_sample(ipc CONSOLE baseserver.cpp connection.h ipcsetup.h NAME baseipcserver LIBRARIES wxnet DEPENDS wxUSE_IPC wxUSE_SOCKETS)
 set(wxSAMPLE_FOLDER)
 wx_add_sample(joytest joytest.cpp joytest.h DATA buttonpress.wav DEPENDS wxUSE_JOYSTICK)
 wx_add_sample(keyboard)
@@ -90,7 +90,7 @@ wx_add_sample(mdi mdi.cpp mdi.h RES mdi.rc DEPENDS wxUSE_MDI wxUSE_DOC_VIEW_ARCH
 wx_add_sample(mediaplayer LIBRARIES wxmedia DEPENDS wxUSE_MEDIACTRL)
 wx_add_sample(menu DEPENDS wxUSE_MENUS wxUSE_MENUBAR)
 wx_add_sample(minimal IMPORTANT)
-wx_add_sample(notebook notebook.cpp notebook.h LIBRARIES wxaui DEPENDS wxUSE_NOTEBOOK)
+wx_add_sample(notebook notebook.cpp notebook.h LIBRARIES wxaui DEPENDS wxUSE_NOTEBOOK wxUSE_AUI)
 if(wxUSE_OPENGL)
     set(wxSAMPLE_SUBDIR opengl/)
     set(wxSAMPLE_FOLDER OpenGL)
@@ -250,7 +250,7 @@ wx_add_sample(xrc
     DATA ${XRC_RC_FILES}
     LIBRARIES wxaui wxribbon wxxrc wxhtml
     NAME xrcdemo
-    DEPENDS wxUSE_XML wxUSE_XRC
+    DEPENDS wxUSE_XML wxUSE_XRC wxUSE_AUI
     )
 wx_add_sample(xti xti.cpp classlist.cpp codereadercallback.cpp
     classlist.h codereadercallback.h LIBRARIES wxxml

--- a/build/cmake/samples/html.cmake
+++ b/build/cmake/samples/html.cmake
@@ -32,7 +32,7 @@ wx_add_sample(test
         imagemap.png pic.png pic2.bmp i18n.gif
         imagemap.htm tables.htm test.htm id.html listtest.htm 8859_2.htm cp1250.htm
         regres.htm foo.png subsup.html
-    LIBRARIES wxnet wxhtml NAME htmltest)
+    LIBRARIES wxnet wxhtml NAME htmltest DEPENDS wxUSE_SOCKETS)
 wx_add_sample(virtual DATA start.htm LIBRARIES wxhtml)
 wx_add_sample(widget DATA start.htm LIBRARIES wxhtml)
 wx_add_sample(zip DATA pages.zip start.htm LIBRARIES wxhtml DEPENDS wxUSE_FS_ZIP)

--- a/include/wx/chkconf.h
+++ b/include/wx/chkconf.h
@@ -1337,6 +1337,15 @@
 #            define wxUSE_PROTOCOL 1
 #        endif
 #   endif
+
+#   if !wxUSE_SOCKETS
+#       ifdef wxABORT_ON_CONFIG_ERROR
+#           error "wxUSE_URL requires wxUSE_SOCKETS"
+#        else
+#           undef wxUSE_SOCKETS
+#           define wxUSE_SOCKETS 1
+#       endif
+#   endif
 #endif /* wxUSE_URL */
 
 #if wxUSE_PROTOCOL

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -135,6 +135,8 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::LoadFromFile", "[image]")
     CHECK(img.LoadFile("image/bitfields.bmp", wxBITMAP_TYPE_BMP));
 }
 
+#if wxUSE_URL
+
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::LoadFromSocketStream", "[image]")
 {
     // This test doesn't work any more even using the IP address below as the
@@ -160,6 +162,8 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::LoadFromSocketStream", "[image]")
     //       requires a seekable stream!
     CHECK( img.LoadFile(*in_stream, wxBITMAP_TYPE_PNG) );
 }
+
+#endif // wxUSE_URL
 
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::LoadFromZipStream", "[image]")
 {

--- a/tests/interactive/input.cpp
+++ b/tests/interactive/input.cpp
@@ -26,7 +26,9 @@
 // ----------------------------------------------------------------------------
 
 #define TEST_SNGLINST
-#define TEST_FTP
+#if wxUSE_PROTOCOL_FTP
+    #define TEST_FTP
+#endif
 #define TEST_INFO_FUNCTIONS
 #if wxUSE_REGEX
     #define TEST_REGEX

--- a/tests/net/socket.cpp
+++ b/tests/net/socket.cpp
@@ -288,6 +288,7 @@ void SocketTestCase::ReadAnotherThread()
 
 void SocketTestCase::UrlTest()
 {
+#if wxUSE_URL
     if ( gs_serverHost.empty() )
         return;
 
@@ -300,6 +301,7 @@ void SocketTestCase::UrlTest()
 
     wxStringOutputStream out;
     CPPUNIT_ASSERT_EQUAL( wxSTREAM_EOF, in->Read(out).GetLastError() );
+#endif
 }
 
 TEST_CASE("wxDatagramSocket::ShortRead", "[socket][dgram]")

--- a/tests/streams/socketstream.cpp
+++ b/tests/streams/socketstream.cpp
@@ -11,6 +11,8 @@
 #include "testprec.h"
 
 
+#if wxUSE_SOCKETS
+
 // for all others, include the necessary headers
 #ifndef WX_PRECOMP
     #include "wx/log.h"
@@ -243,3 +245,5 @@ void socketStream::DoCheckInputStream(wxSocketInputStream& stream_in)
 
 // Register the stream sub suite, by using some stream helper macro.
 STREAM_TEST_SUBSUITE_NAMED_REGISTRATION(socketStream)
+
+#endif // wxUSE_SOCKETS

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -448,6 +448,7 @@ extern void SetProcessEventFunc(ProcessEventFunc func)
 
 static bool DoCheckConnection()
 {
+#if wxUSE_SOCKETS
     // NOTE: we could use wxDialUpManager here if it was in wxNet; since it's in
     //       wxCore we use a simple rough test:
 
@@ -466,6 +467,9 @@ static bool DoCheckConnection()
                     (sock.Write(HTTP_GET, strlen(HTTP_GET)), sock.WaitForRead(1));
 
     return online;
+#else
+    return false;
+#endif
 }
 
 extern bool IsNetworkAvailable()

--- a/tests/uris/ftp.cpp
+++ b/tests/uris/ftp.cpp
@@ -13,6 +13,8 @@
 #include "testprec.h"
 
 
+#if wxUSE_PROTOCOL_FTP
+
 #ifndef WX_PRECOMP
     #include "wx/wx.h"
 #endif // WX_PRECOMP
@@ -134,3 +136,5 @@ TEST_CASE("FTP", "[net][.]")
         CHECK( ftp.GetLastResult() == "11" );
     }
 }
+
+#endif // wxUSE_PROTOCOL_FTP

--- a/tests/uris/url.cpp
+++ b/tests/uris/url.cpp
@@ -13,6 +13,8 @@
 #include "testprec.h"
 
 
+#if wxUSE_URL
+
 #ifndef WX_PRECOMP
     #include "wx/wx.h"
 #endif // WX_PRECOMP
@@ -108,3 +110,5 @@ TEST_CASE("wxURL::CopyAndAssignment", "[url]")
     puri = new wxURL();
     delete puri;
 }
+
+#endif // wxUSE_URL

--- a/tests/xml/xmltest.cpp
+++ b/tests/xml/xmltest.cpp
@@ -13,6 +13,8 @@
 #include "testprec.h"
 
 
+#if wxUSE_XML
+
 #ifndef WX_PRECOMP
     #include "wx/wx.h"
 #endif // WX_PRECOMP
@@ -626,3 +628,5 @@ TEST_CASE("XML::Load", "[xml][.]")
 
     WARN("Dump of " << file << ":\n" << sos.GetString());
 }
+
+#endif // wxUSE_XML


### PR DESCRIPTION
See #26515

And fix building when some options are disabled.