### PR TITLE
Fix artifacting issue with Edge WebView

### DIFF
--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -130,6 +130,8 @@ private:
 
     void OnTopLevelParentIconized(wxIconizeEvent& event);
 
+    void OnParentShow(wxShowEvent& event);
+
     wxDECLARE_DYNAMIC_CLASS(wxWebViewEdge);
 
     friend class wxWebViewEdgeImpl;

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -130,7 +130,7 @@ private:
 
     void OnTopLevelParentIconized(wxIconizeEvent& event);
 
-    void OnParentShow(wxShowEvent& event);
+    void OnShow(wxShowEvent& event);
 
     wxDECLARE_DYNAMIC_CLASS(wxWebViewEdge);
 

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1133,7 +1133,6 @@ wxWebViewEdge::~wxWebViewEdge()
     if (topLevelParent)
         topLevelParent->Unbind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
     Unbind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
-    GetParent()->Unbind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
     delete m_impl;
 }
 
@@ -1162,7 +1161,6 @@ bool wxWebViewEdge::Create(wxWindow* parent,
     if (topLevelParent)
         topLevelParent->Bind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
     Bind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
-    GetParent()->Bind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
 
     LoadURL(url);
     return true;

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1161,8 +1161,7 @@ bool wxWebViewEdge::Create(wxWindow* parent,
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
     if (topLevelParent)
         topLevelParent->Bind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
-    if (GetParent())
-        GetParent()->Bind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
+    GetParent()->Bind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
 
     LoadURL(url);
     return true;

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1132,7 +1132,8 @@ wxWebViewEdge::~wxWebViewEdge()
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
     if (topLevelParent)
         topLevelParent->Unbind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
-    GetParent()->Unbind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
+    Unbind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
+    GetParent()->Unbind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
     delete m_impl;
 }
 
@@ -1160,7 +1161,8 @@ bool wxWebViewEdge::Create(wxWindow* parent,
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
     if (topLevelParent)
         topLevelParent->Bind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
-    GetParent()->Bind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
+    Bind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
+    GetParent()->Bind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
 
     LoadURL(url);
     return true;
@@ -1186,7 +1188,7 @@ void wxWebViewEdge::OnTopLevelParentIconized(wxIconizeEvent& event)
     event.Skip();
 }
 
-void wxWebViewEdge::OnParentShow(wxShowEvent& event)
+void wxWebViewEdge::OnShow(wxShowEvent& event)
 {
     if ( m_impl && m_impl->m_webViewController )
     {

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1132,8 +1132,7 @@ wxWebViewEdge::~wxWebViewEdge()
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
     if (topLevelParent)
         topLevelParent->Unbind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
-    if (GetParent())
-        GetParent()->Unbind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
+    GetParent()->Unbind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
     delete m_impl;
 }
 

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1193,6 +1193,7 @@ void wxWebViewEdge::OnParentShow(wxShowEvent& event)
     if ( m_impl && m_impl->m_webViewController )
     {
         m_impl->m_webViewController->put_IsVisible(event.IsShown());
+        // Force a refresh by refreshing its paint area
         if ( event.IsShown() )
         {
             // put_Bounds is a no-op when the rect is unchanged, so collapse to

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1127,9 +1127,13 @@ wxWebViewEdge::wxWebViewEdge(wxWindow* parent,
 
 wxWebViewEdge::~wxWebViewEdge()
 {
+    Unbind(wxEVT_SIZE, &wxWebViewEdge::OnSize, this);
+    Unbind(wxEVT_SET_FOCUS, &wxWebViewEdge::OnSetFocus, this);
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
     if (topLevelParent)
         topLevelParent->Unbind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
+    if (GetParent())
+        GetParent()->Unbind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
     delete m_impl;
 }
 
@@ -1157,6 +1161,8 @@ bool wxWebViewEdge::Create(wxWindow* parent,
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
     if (topLevelParent)
         topLevelParent->Bind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
+    if (GetParent())
+        GetParent()->Bind(wxEVT_SHOW, &wxWebViewEdge::OnParentShow, this);
 
     LoadURL(url);
     return true;
@@ -1179,6 +1185,26 @@ void wxWebViewEdge::OnTopLevelParentIconized(wxIconizeEvent& event)
 {
     if (m_impl && m_impl->m_webViewController)
         m_impl->m_webViewController->put_IsVisible(!event.IsIconized());
+    event.Skip();
+}
+
+void wxWebViewEdge::OnParentShow(wxShowEvent& event)
+{
+    if ( m_impl && m_impl->m_webViewController )
+    {
+        m_impl->m_webViewController->put_IsVisible(event.IsShown());
+        if ( event.IsShown() )
+        {
+            // put_Bounds is a no-op when the rect is unchanged, so collapse to
+            // zero first to guarantee a bounds change that forces a repaint
+            m_impl->m_webViewController->put_Bounds(RECT{});
+            CallAfter([this]
+            {
+                if ( m_impl && m_impl->m_webViewController )
+                    m_impl->UpdateBounds();
+            });
+        }
+    }
     event.Skip();
 }
 


### PR DESCRIPTION
When an Edge WebView is hidden and then reshown, artifacts from the old window will appear in the `wxWebView`. This fixes it by calling `put_IsVisible` when the control (or its parent) is shown or hidden and also forces a repaint by updating the painting rect (this is the necessary part and the closest I could come to emulating an async refresh).

Here is an example of what I see with a `wxWebView` in a composite control inside of a split window when I select a different window and come back:

<img width="829" height="293" alt="image" src="https://github.com/user-attachments/assets/574e8d3a-9213-4864-a446-c0daea4ecb34" />

What it should look like:

<img width="800" height="161" alt="image" src="https://github.com/user-attachments/assets/2cf03f58-8a8b-4656-9e50-67370cd46154" />

Here is a reference to parent visibility issues with WebView2:

https://github.com/MicrosoftEdge/WebView2Feedback/issues/1094

and maybe related:

https://groups.google.com/g/wx-dev/c/NoVbVMODDB4

P.S.

I have to use `CallAfter` here because of the async nature of WebView.