### PR TITLE
Apply  wx coding standards to ribbon source

### DIFF
--- a/include/wx/ribbon/art.h
+++ b/include/wx/ribbon/art.h
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        wx/ribbon/art.h
 // Purpose:     Art providers for ribbon-bar-style interface
 // Author:      Peter Cawley
@@ -217,11 +217,11 @@ public:
     virtual void SetFlags(long flags) = 0;
     virtual long GetFlags() const = 0;
 
-    virtual int GetMetric(int id)  const = 0;
-    virtual void SetMetric(int id, int new_val) = 0;
+    virtual int GetMetric(int id) const = 0;
+    virtual void SetMetric(int id, int newVal) = 0;
     virtual void SetFont(int id, const wxFont& font) = 0;
-    virtual wxFont GetFont(int id)  const = 0;
-    virtual wxColour GetColour(int id)  const = 0;
+    virtual wxFont GetFont(int id) const = 0;
+    virtual wxColour GetColour(int id) const = 0;
     virtual void SetColour(int id, const wxColor& colour) = 0;
     wxColour GetColor(int id) const { return GetColour(id); }
     void SetColor(int id, const wxColour& color) { SetColour(id, color); }
@@ -291,8 +291,8 @@ public:
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small) = 0;
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall) = 0;
 
     virtual void DrawToolBarBackground(
                         wxDC& dc,
@@ -329,8 +329,8 @@ public:
                         const wxString& label,
                         const wxBitmap& bitmap,
                         int* ideal,
-                        int* small_begin_need_separator,
-                        int* small_must_have_separator,
+                        int* smallBeginNeedSeparator,
+                        int* smallMustHaveSeparator,
                         int* minimum) = 0;
 
     virtual int GetTabCtrlHeight(
@@ -346,14 +346,14 @@ public:
     virtual wxSize GetPanelSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize client_size,
-                        wxPoint* client_offset) = 0;
+                        wxSize clientSize,
+                        wxPoint* clientOffset) = 0;
 
     virtual wxSize GetPanelClientSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
-                        wxPoint* client_offset) = 0;
+                        wxPoint* clientOffset) = 0;
 
     virtual wxRect GetPanelExtButtonArea(
                         wxReadOnlyDC& dc,
@@ -363,22 +363,22 @@ public:
     virtual wxSize GetGallerySize(
                         wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
-                        wxSize client_size) = 0;
+                        wxSize clientSize) = 0;
 
     virtual wxSize GetGalleryClientSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
                         wxSize size,
-                        wxPoint* client_offset,
-                        wxRect* scroll_up_button,
-                        wxRect* scroll_down_button,
-                        wxRect* extension_button) = 0;
+                        wxPoint* clientOffset,
+                        wxRect* scrollUpButton,
+                        wxRect* scrollDownButton,
+                        wxRect* extensionButton) = 0;
 
     virtual wxRect GetPageBackgroundRedrawArea(
                         wxReadOnlyDC& dc,
                         const wxRibbonPage* wnd,
-                        wxSize page_old_size,
-                        wxSize page_new_size) = 0;
+                        wxSize pageOldSize,
+                        wxSize pageNewSize) = 0;
 
     virtual bool GetButtonBarButtonSize(
                         wxReadOnlyDC& dc,
@@ -386,12 +386,12 @@ public:
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
                         const wxString& label,
-                        wxCoord text_min_width,
-                        wxSize bitmap_size_large,
-                        wxSize bitmap_size_small,
-                        wxSize* button_size,
-                        wxRect* normal_region,
-                        wxRect* dropdown_region) = 0;
+                        wxCoord textMinWidth,
+                        wxSize bitmapSizeLarge,
+                        wxSize bitmapSizeSmall,
+                        wxSize* buttonSize,
+                        wxRect* normalRegion,
+                        wxRect* dropdownRegion) = 0;
 
     virtual wxCoord GetButtonBarButtonTextWidth(
                         wxReadOnlyDC& dc, const wxString& label,
@@ -401,17 +401,17 @@ public:
     virtual wxSize GetMinimisedPanelMinimumSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize* desired_bitmap_size,
-                        wxDirection* expanded_panel_direction) = 0;
+                        wxSize* desiredBitmapSize,
+                        wxDirection* expandedPanelDirection) = 0;
 
     virtual wxSize GetToolSize(
                         wxReadOnlyDC& dc,
                         wxWindow* wnd,
-                        wxSize bitmap_size,
+                        wxSize bitmapSize,
                         wxRibbonButtonKind kind,
-                        bool is_first,
-                        bool is_last,
-                        wxRect* dropdown_region) = 0;
+                        bool isFirst,
+                        bool isLast,
+                        wxRect* dropdownRegion) = 0;
 
     virtual wxRect GetBarToggleButtonArea(const wxRect& rect)= 0;
 
@@ -429,7 +429,7 @@ public:
     long GetFlags() const override;
 
     int GetMetric(int id) const override;
-    void SetMetric(int id, int new_val) override;
+    void SetMetric(int id, int newVal) override;
     void SetFont(int id, const wxFont& font) override;
     wxFont GetFont(int id) const override;
     wxColour GetColour(int id) const override;
@@ -506,8 +506,8 @@ public:
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small) override;
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall) override;
 
     void DrawToolBarBackground(
                         wxDC& dc,
@@ -543,8 +543,8 @@ public:
                         const wxString& label,
                         const wxBitmap& bitmap,
                         int* ideal,
-                        int* small_begin_need_separator,
-                        int* small_must_have_separator,
+                        int* smallBeginNeedSeparator,
+                        int* smallMustHaveSeparator,
                         int* minimum) override;
 
     wxSize GetScrollButtonMinimumSize(
@@ -555,14 +555,14 @@ public:
     wxSize GetPanelSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize client_size,
-                        wxPoint* client_offset) override;
+                        wxSize clientSize,
+                        wxPoint* clientOffset) override;
 
     wxSize GetPanelClientSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
-                        wxPoint* client_offset) override;
+                        wxPoint* clientOffset) override;
 
     wxRect GetPanelExtButtonArea(
                         wxReadOnlyDC& dc,
@@ -572,22 +572,22 @@ public:
     wxSize GetGallerySize(
                         wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
-                        wxSize client_size) override;
+                        wxSize clientSize) override;
 
     wxSize GetGalleryClientSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
                         wxSize size,
-                        wxPoint* client_offset,
-                        wxRect* scroll_up_button,
-                        wxRect* scroll_down_button,
-                        wxRect* extension_button) override;
+                        wxPoint* clientOffset,
+                        wxRect* scrollUpButton,
+                        wxRect* scrollDownButton,
+                        wxRect* extensionButton) override;
 
     wxRect GetPageBackgroundRedrawArea(
                         wxReadOnlyDC& dc,
                         const wxRibbonPage* wnd,
-                        wxSize page_old_size,
-                        wxSize page_new_size) override;
+                        wxSize pageOldSize,
+                        wxSize pageNewSize) override;
 
     bool GetButtonBarButtonSize(
                         wxReadOnlyDC& dc,
@@ -595,12 +595,12 @@ public:
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
                         const wxString& label,
-                        wxCoord text_min_width,
-                        wxSize bitmap_size_large,
-                        wxSize bitmap_size_small,
-                        wxSize* button_size,
-                        wxRect* normal_region,
-                        wxRect* dropdown_region) override;
+                        wxCoord textMinWidth,
+                        wxSize bitmapSizeLarge,
+                        wxSize bitmapSizeSmall,
+                        wxSize* buttonSize,
+                        wxRect* normalRegion,
+                        wxRect* dropdownRegion) override;
 
     wxCoord GetButtonBarButtonTextWidth(
                         wxReadOnlyDC& dc, const wxString& label,
@@ -610,17 +610,17 @@ public:
     wxSize GetMinimisedPanelMinimumSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize* desired_bitmap_size,
-                        wxDirection* expanded_panel_direction) override;
+                        wxSize* desiredBitmapSize,
+                        wxDirection* expandedPanelDirection) override;
 
     wxSize GetToolSize(
                         wxReadOnlyDC& dc,
                         wxWindow* wnd,
-                        wxSize bitmap_size,
+                        wxSize bitmapSize,
                         wxRibbonButtonKind kind,
-                        bool is_first,
-                        bool is_last,
-                        wxRect* dropdown_region) override;
+                        bool isFirst,
+                        bool isLast,
+                        wxRect* dropdownRegion) override;
 
     wxRect GetBarToggleButtonArea(const wxRect& rect) override;
 
@@ -629,11 +629,11 @@ public:
 protected:
     void ReallyDrawTabSeparator(wxWindow* wnd, const wxRect& rect, double visibility);
     void DrawPartialPageBackground(wxDC& dc, wxWindow* wnd, const wxRect& rect,
-        bool allow_hovered = true);
+        bool allowHovered = true);
     void DrawPartialPageBackground(wxDC& dc, wxWindow* wnd, const wxRect& rect,
          wxRibbonPage* page, wxPoint offset, bool hovered = false);
-    void DrawPanelBorder(wxDC& dc, const wxRect& rect, wxPen& primary_colour,
-        wxPen& secondary_colour);
+    void DrawPanelBorder(wxDC& dc, const wxRect& rect, wxPen& primaryColour,
+        wxPen& secondaryColour);
     void RemovePanelPadding(wxRect* rect);
     void DrawDropdownArrow(wxDC& dc, int x, int y, const wxColour& colour);
     void DrawGalleryBackgroundCommon(wxDC& dc, wxRibbonGallery* wnd,
@@ -646,149 +646,149 @@ protected:
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small);
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall);
     void DrawMinimisedPanelCommon(
                         wxDC& dc,
                         wxRibbonPanel* wnd,
                         const wxRect& rect,
-                        wxRect* preview_rect);
+                        wxRect* previewRect);
     void CloneTo(wxRibbonMSWArtProvider* copy) const;
 
-    wxBitmap m_cached_tab_separator;
-    wxBitmapBundle m_gallery_up_bundle[4];
-    wxBitmapBundle m_gallery_down_bundle[4];
-    wxBitmapBundle m_gallery_extension_bundle[4];
-    wxBitmapBundle m_toolbar_drop_bundle;
-    wxBitmapBundle m_panel_extension_bundle[2];
-    wxBitmapBundle m_ribbon_toggle_up_bundle[2];
-    wxBitmapBundle m_ribbon_toggle_down_bundle[2];
-    wxBitmapBundle m_ribbon_toggle_pin_bundle[2];
-    wxBitmapBundle m_ribbon_bar_help_button_bundle[2];
+    wxBitmap m_cachedTabSeparator;
+    wxBitmapBundle m_galleryUpBundle[4];
+    wxBitmapBundle m_galleryDownBundle[4];
+    wxBitmapBundle m_galleryExtensionBundle[4];
+    wxBitmapBundle m_toolbarDropBundle;
+    wxBitmapBundle m_panelExtensionBundle[2];
+    wxBitmapBundle m_ribbonToggleUpBundle[2];
+    wxBitmapBundle m_ribbonToggleDownBundle[2];
+    wxBitmapBundle m_ribbonTogglePinBundle[2];
+    wxBitmapBundle m_ribbonBarHelpButtonBundle[2];
 
-    wxColour m_primary_scheme_colour;
-    wxColour m_secondary_scheme_colour;
-    wxColour m_tertiary_scheme_colour;
+    wxColour m_primarySchemeColour;
+    wxColour m_secondarySchemeColour;
+    wxColour m_tertiarySchemeColour;
 
-    wxColour m_button_bar_label_colour;
-    wxColour m_button_bar_label_disabled_colour;
-    wxColour m_tab_label_colour;
-    wxColour m_tab_active_label_colour;
-    wxColour m_tab_hover_label_colour;
-    wxColour m_tab_separator_colour;
-    wxColour m_tab_separator_gradient_colour;
-    wxColour m_tab_active_background_colour;
-    wxColour m_tab_active_background_gradient_colour;
-    wxColour m_tab_hover_background_colour;
-    wxColour m_tab_hover_background_gradient_colour;
-    wxColour m_tab_hover_background_top_colour;
-    wxColour m_tab_hover_background_top_gradient_colour;
-    wxColour m_tab_highlight_top_colour;
-    wxColour m_tab_highlight_top_gradient_colour;
-    wxColour m_tab_highlight_colour;
-    wxColour m_tab_highlight_gradient_colour;
-    wxColour m_panel_label_colour;
-    wxColour m_panel_minimised_label_colour;
-    wxColour m_panel_hover_label_colour;
-    wxColour m_panel_active_background_colour;
-    wxColour m_panel_active_background_gradient_colour;
-    wxColour m_panel_active_background_top_colour;
-    wxColour m_panel_active_background_top_gradient_colour;
-    wxColour m_panel_button_face_colour;
-    wxColour m_panel_button_hover_face_colour;
-    wxColour m_page_toggle_face_colour;
-    wxColour m_page_toggle_hover_face_colour;
-    wxColour m_page_background_colour;
-    wxColour m_page_background_gradient_colour;
-    wxColour m_page_background_top_colour;
-    wxColour m_page_background_top_gradient_colour;
-    wxColour m_page_hover_background_colour;
-    wxColour m_page_hover_background_gradient_colour;
-    wxColour m_page_hover_background_top_colour;
-    wxColour m_page_hover_background_top_gradient_colour;
-    wxColour m_button_bar_hover_background_colour;
-    wxColour m_button_bar_hover_background_gradient_colour;
-    wxColour m_button_bar_hover_background_top_colour;
-    wxColour m_button_bar_hover_background_top_gradient_colour;
-    wxColour m_button_bar_active_background_colour;
-    wxColour m_button_bar_active_background_gradient_colour;
-    wxColour m_button_bar_active_background_top_colour;
-    wxColour m_button_bar_active_background_top_gradient_colour;
-    wxColour m_gallery_button_background_colour;
-    wxColour m_gallery_button_background_gradient_colour;
-    wxColour m_gallery_button_hover_background_colour;
-    wxColour m_gallery_button_hover_background_gradient_colour;
-    wxColour m_gallery_button_active_background_colour;
-    wxColour m_gallery_button_active_background_gradient_colour;
-    wxColour m_gallery_button_disabled_background_colour;
-    wxColour m_gallery_button_disabled_background_gradient_colour;
-    wxColour m_gallery_button_face_colour;
-    wxColour m_gallery_button_hover_face_colour;
-    wxColour m_gallery_button_active_face_colour;
-    wxColour m_gallery_button_disabled_face_colour;
+    wxColour m_buttonBarLabelColour;
+    wxColour m_buttonBarLabelDisabledColour;
+    wxColour m_tabLabelColour;
+    wxColour m_tabActiveLabelColour;
+    wxColour m_tabHoverLabelColour;
+    wxColour m_tabSeparatorColour;
+    wxColour m_tabSeparatorGradientColour;
+    wxColour m_tabActiveBackgroundColour;
+    wxColour m_tabActiveBackgroundGradientColour;
+    wxColour m_tabHoverBackgroundColour;
+    wxColour m_tabHoverBackgroundGradientColour;
+    wxColour m_tabHoverBackgroundTopColour;
+    wxColour m_tabHoverBackgroundTopGradientColour;
+    wxColour m_tabHighlightTopColour;
+    wxColour m_tabHighlightTopGradientColour;
+    wxColour m_tabHighlightColour;
+    wxColour m_tabHighlightGradientColour;
+    wxColour m_panelLabelColour;
+    wxColour m_panelMinimisedLabelColour;
+    wxColour m_panelHoverLabelColour;
+    wxColour m_panelActiveBackgroundColour;
+    wxColour m_panelActiveBackgroundGradientColour;
+    wxColour m_panelActiveBackgroundTopColour;
+    wxColour m_panelActiveBackgroundTopGradientColour;
+    wxColour m_panelButtonFaceColour;
+    wxColour m_panelButtonHoverFaceColour;
+    wxColour m_pageToggleFaceColour;
+    wxColour m_pageToggleHoverFaceColour;
+    wxColour m_pageBackgroundColour;
+    wxColour m_pageBackgroundGradientColour;
+    wxColour m_pageBackgroundTopColour;
+    wxColour m_pageBackgroundTopGradientColour;
+    wxColour m_pageHoverBackgroundColour;
+    wxColour m_pageHoverBackgroundGradientColour;
+    wxColour m_pageHoverBackgroundTopColour;
+    wxColour m_pageHoverBackgroundTopGradientColour;
+    wxColour m_buttonBarHoverBackgroundColour;
+    wxColour m_buttonBarHoverBackgroundGradientColour;
+    wxColour m_buttonBarHoverBackgroundTopColour;
+    wxColour m_buttonBarHoverBackgroundTopGradientColour;
+    wxColour m_buttonBarActiveBackgroundColour;
+    wxColour m_buttonBarActiveBackgroundGradientColour;
+    wxColour m_buttonBarActiveBackgroundTopColour;
+    wxColour m_buttonBarActiveBackgroundTopGradientColour;
+    wxColour m_galleryButtonBackgroundColour;
+    wxColour m_galleryButtonBackgroundGradientColour;
+    wxColour m_galleryButtonHoverBackgroundColour;
+    wxColour m_galleryButtonHoverBackgroundGradientColour;
+    wxColour m_galleryButtonActiveBackgroundColour;
+    wxColour m_galleryButtonActiveBackgroundGradientColour;
+    wxColour m_galleryButtonDisabledBackgroundColour;
+    wxColour m_galleryButtonDisabledBackgroundGradientColour;
+    wxColour m_galleryButtonFaceColour;
+    wxColour m_galleryButtonHoverFaceColour;
+    wxColour m_galleryButtonActiveFaceColour;
+    wxColour m_galleryButtonDisabledFaceColour;
 
-    wxColour m_tool_face_colour;
-    wxColour m_tool_background_top_colour;
-    wxColour m_tool_background_top_gradient_colour;
-    wxColour m_tool_background_colour;
-    wxColour m_tool_background_gradient_colour;
-    wxColour m_tool_hover_background_top_colour;
-    wxColour m_tool_hover_background_top_gradient_colour;
-    wxColour m_tool_hover_background_colour;
-    wxColour m_tool_hover_background_gradient_colour;
-    wxColour m_tool_active_background_top_colour;
-    wxColour m_tool_active_background_top_gradient_colour;
-    wxColour m_tool_active_background_colour;
-    wxColour m_tool_active_background_gradient_colour;
+    wxColour m_toolFaceColour;
+    wxColour m_toolBackgroundTopColour;
+    wxColour m_toolBackgroundTopGradientColour;
+    wxColour m_toolBackgroundColour;
+    wxColour m_toolBackgroundGradientColour;
+    wxColour m_toolHoverBackgroundTopColour;
+    wxColour m_toolHoverBackgroundTopGradientColour;
+    wxColour m_toolHoverBackgroundColour;
+    wxColour m_toolHoverBackgroundGradientColour;
+    wxColour m_toolActiveBackgroundTopColour;
+    wxColour m_toolActiveBackgroundTopGradientColour;
+    wxColour m_toolActiveBackgroundColour;
+    wxColour m_toolActiveBackgroundGradientColour;
 
-    wxBrush m_tab_ctrl_background_brush;
-    wxBrush m_panel_label_background_brush;
-    wxBrush m_panel_hover_label_background_brush;
-    wxBrush m_panel_hover_button_background_brush;
-    wxBrush m_gallery_hover_background_brush;
-    wxBrush m_gallery_button_background_top_brush;
-    wxBrush m_gallery_button_hover_background_top_brush;
-    wxBrush m_gallery_button_active_background_top_brush;
-    wxBrush m_gallery_button_disabled_background_top_brush;
-    wxBrush m_ribbon_toggle_brush;
+    wxBrush m_tabCtrlBackgroundBrush;
+    wxBrush m_panelLabelBackgroundBrush;
+    wxBrush m_panelHoverLabelBackgroundBrush;
+    wxBrush m_panelHoverButtonBackgroundBrush;
+    wxBrush m_galleryHoverBackgroundBrush;
+    wxBrush m_galleryButtonBackgroundTopBrush;
+    wxBrush m_galleryButtonHoverBackgroundTopBrush;
+    wxBrush m_galleryButtonActiveBackgroundTopBrush;
+    wxBrush m_galleryButtonDisabledBackgroundTopBrush;
+    wxBrush m_ribbonToggleBrush;
 
-    wxFont m_tab_label_font;
-    wxFont m_panel_label_font;
-    wxFont m_button_bar_label_font;
+    wxFont m_tabLabelFont;
+    wxFont m_panelLabelFont;
+    wxFont m_buttonBarLabelFont;
 
-    wxPen m_page_border_pen;
-    wxPen m_panel_border_pen;
-    wxPen m_panel_border_gradient_pen;
-    wxPen m_panel_hover_border_pen;
-    wxPen m_panel_hover_border_gradient_pen;
-    wxPen m_panel_minimised_border_pen;
-    wxPen m_panel_minimised_border_gradient_pen;
-    wxPen m_panel_hover_button_border_pen;
-    wxPen m_tab_border_pen;
-    wxPen m_button_bar_hover_border_pen;
-    wxPen m_button_bar_active_border_pen;
-    wxPen m_gallery_border_pen;
-    wxPen m_gallery_item_border_pen;
-    wxPen m_toolbar_border_pen;
-    wxPen m_ribbon_toggle_pen;
+    wxPen m_pageBorderPen;
+    wxPen m_panelBorderPen;
+    wxPen m_panelBorderGradientPen;
+    wxPen m_panelHoverBorderPen;
+    wxPen m_panelHoverBorderGradientPen;
+    wxPen m_panelMinimisedBorderPen;
+    wxPen m_panelMinimisedBorderGradientPen;
+    wxPen m_panelHoverButtonBorderPen;
+    wxPen m_tabBorderPen;
+    wxPen m_buttonBarHoverBorderPen;
+    wxPen m_buttonBarActiveBorderPen;
+    wxPen m_galleryBorderPen;
+    wxPen m_galleryItemBorderPen;
+    wxPen m_toolbarBorderPen;
+    wxPen m_ribbonTogglePen;
 
-    double m_cached_tab_separator_visibility;
+    double m_cachedTabSeparatorVisibility;
     long m_flags;
 
-    int m_tab_separation_size;
-    int m_page_border_left;
-    int m_page_border_top;
-    int m_page_border_right;
-    int m_page_border_bottom;
-    int m_panel_x_separation_size;
-    int m_panel_y_separation_size;
-    int m_tool_group_separation_size;
-    int m_gallery_bitmap_padding_left_size;
-    int m_gallery_bitmap_padding_right_size;
-    int m_gallery_bitmap_padding_top_size;
-    int m_gallery_bitmap_padding_bottom_size;
-    int m_toggle_button_offset;
-    int m_help_button_offset;
+    int m_tabSeparationSize;
+    int m_pageBorderLeft;
+    int m_pageBorderTop;
+    int m_pageBorderRight;
+    int m_pageBorderBottom;
+    int m_panelXSeparationSize;
+    int m_panelYSeparationSize;
+    int m_toolGroupSeparationSize;
+    int m_galleryBitmapPaddingLeftSize;
+    int m_galleryBitmapPaddingRightSize;
+    int m_galleryBitmapPaddingTopSize;
+    int m_galleryBitmapPaddingBottomSize;
+    int m_toggleButtonOffset;
+    int m_helpButtonOffset;
 };
 
 class WXDLLIMPEXP_RIBBON wxRibbonMSWFlatArtProvider : public wxRibbonMSWArtProvider
@@ -854,8 +854,8 @@ public:
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small) override;
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall) override;
 
     void DrawToolBarBackground(
                         wxDC& dc,
@@ -884,11 +884,11 @@ protected:
     void DrawPartialPageBackground(wxDC& dc, wxWindow* wnd, const wxRect& r,
         wxRibbonPage* page, wxPoint offset, bool hovered = false);
     void DrawPartialPageBackground(wxDC& dc, wxWindow* wnd,
-        const wxRect& rect, bool allow_hovered = true);
+        const wxRect& rect, bool allowHovered = true);
     void DrawGalleryButton(wxDC& dc, wxRect rect,
         wxRibbonGalleryButtonState state, wxBitmapBundle* bundles, wxWindow* wnd) override;
-    void DrawPanelBorder(wxDC& dc, const wxRect& rect, wxPen& primary_colour,
-        wxPen& secondary_colour);
+    void DrawPanelBorder(wxDC& dc, const wxRect& rect, wxPen& primaryColour,
+        wxPen& secondaryColour);
     void ReallyDrawTabSeparator(wxWindow* wnd, const wxRect& rect,
         double visibility);
 };
@@ -922,14 +922,14 @@ public:
     wxSize GetPanelSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize client_size,
-                        wxPoint* client_offset) override;
+                        wxSize clientSize,
+                        wxPoint* clientOffset) override;
 
     wxSize GetPanelClientSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
-                        wxPoint* client_offset) override;
+                        wxPoint* clientOffset) override;
 
     wxRect GetPanelExtButtonArea(
                         wxReadOnlyDC& dc,
@@ -952,8 +952,8 @@ public:
                         const wxString& label,
                         const wxBitmap& bitmap,
                         int* ideal,
-                        int* small_begin_need_separator,
-                        int* small_must_have_separator,
+                        int* smallBeginNeedSeparator,
+                        int* smallMustHaveSeparator,
                         int* minimum) override;
 
     void DrawTab(wxDC& dc,
@@ -1005,8 +1005,8 @@ public:
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small) override;
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall) override;
 
     void DrawToolBarBackground(
                         wxDC& dc,
@@ -1032,27 +1032,27 @@ protected:
     void DrawGalleryButton(wxDC& dc, wxRect rect,
         wxRibbonGalleryButtonState state, wxBitmapBundle* bundles, wxWindow* wnd) override;
 
-    wxColour m_tab_ctrl_background_colour;
-    wxColour m_tab_ctrl_background_gradient_colour;
-    wxColour m_panel_label_background_colour;
-    wxColour m_panel_label_background_gradient_colour;
-    wxColour m_panel_hover_label_background_colour;
-    wxColour m_panel_hover_label_background_gradient_colour;
+    wxColour m_tabCtrlBackgroundColour;
+    wxColour m_tabCtrlBackgroundGradientColour;
+    wxColour m_panelLabelBackgroundColour;
+    wxColour m_panelLabelBackgroundGradientColour;
+    wxColour m_panelHoverLabelBackgroundColour;
+    wxColour m_panelHoverLabelBackgroundGradientColour;
 
-    wxBrush m_background_brush;
-    wxBrush m_tab_active_top_background_brush;
-    wxBrush m_tab_hover_background_brush;
-    wxBrush m_button_bar_hover_background_brush;
-    wxBrush m_button_bar_active_background_brush;
-    wxBrush m_gallery_button_active_background_brush;
-    wxBrush m_gallery_button_hover_background_brush;
-    wxBrush m_gallery_button_disabled_background_brush;
-    wxBrush m_tool_hover_background_brush;
-    wxBrush m_tool_active_background_brush;
+    wxBrush m_backgroundBrush;
+    wxBrush m_tabActiveTopBackgroundBrush;
+    wxBrush m_tabHoverBackgroundBrush;
+    wxBrush m_buttonBarHoverBackgroundBrush;
+    wxBrush m_buttonBarActiveBackgroundBrush;
+    wxBrush m_galleryButtonActiveBackgroundBrush;
+    wxBrush m_galleryButtonHoverBackgroundBrush;
+    wxBrush m_galleryButtonDisabledBackgroundBrush;
+    wxBrush m_toolHoverBackgroundBrush;
+    wxBrush m_toolActiveBackgroundBrush;
 
-    wxPen m_toolbar_hover_borden_pen;
+    wxPen m_toolbarHoverBordenPen;
 
-    wxFont m_tab_active_label_font;
+    wxFont m_tabActiveLabelFont;
 };
 
 #if defined(__WXMSW__)

--- a/include/wx/ribbon/art_internal.h
+++ b/include/wx/ribbon/art_internal.h
@@ -17,11 +17,11 @@
 #include "wx/settings.h"
 
 WXDLLIMPEXP_RIBBON wxColour wxRibbonInterpolateColour(
-                                const wxColour& start_colour,
-                                const wxColour& end_colour,
+                                const wxColour& startColour,
+                                const wxColour& endColour,
                                 int position,
-                                int start_position,
-                                int end_position);
+                                int startPosition,
+                                int endPosition);
 
 WXDLLIMPEXP_RIBBON bool wxRibbonCanLabelBreakAtPosition(
                                 const wxString& label,
@@ -29,15 +29,15 @@ WXDLLIMPEXP_RIBBON bool wxRibbonCanLabelBreakAtPosition(
 
 WXDLLIMPEXP_RIBBON void wxRibbonDrawParallelGradientLines(
                                 wxDC& dc,
-                                int nlines,
-                                const wxPoint* line_origins,
-                                int stepx,
-                                int stepy,
-                                int numsteps,
-                                int offset_x,
-                                int offset_y,
-                                const wxColour& start_colour,
-                                const wxColour& end_colour);
+                                int nLines,
+                                const wxPoint* lineOrigins,
+                                int stepX,
+                                int stepY,
+                                int numSteps,
+                                int offsetX,
+                                int offsetY,
+                                const wxColour& startColour,
+                                const wxColour& endColour);
 
 WXDLLIMPEXP_RIBBON wxBitmap wxRibbonLoadPixmap(
                                 const char* const* bits,
@@ -56,30 +56,30 @@ WXDLLIMPEXP_RIBBON wxBitmap wxRibbonLoadPixmap(
 class WXDLLIMPEXP_RIBBON wxRibbonHSLColour
 {
 public:
-   wxRibbonHSLColour()
-       : hue(0.0), saturation(0.0), luminance(0.0) {}
-   wxRibbonHSLColour(float H, float S, float L)
-       : hue(H), saturation(S), luminance(L) { }
-   wxRibbonHSLColour(const wxColour& C);
+    wxRibbonHSLColour()
+        : m_hue(0.0), m_saturation(0.0), m_luminance(0.0) { }
+    wxRibbonHSLColour(float h, float s, float l)
+        : m_hue(h), m_saturation(s), m_luminance(l) { }
+    wxRibbonHSLColour(const wxColour& col);
 
-   wxColour    ToRGB() const;
+    wxColour ToRGB() const;
 
-   // In dark mode, makes the colour darker, while in light mode make it
-   // lighter.
-   wxRibbonHSLColour AdjustLuminance(float delta)
-   {
-       return wxSystemSettings::GetAppearance().IsDark()
-           ? Darker(delta)
-           : Lighter(delta);
-   }
+    // In dark mode, makes the colour darker, while in light mode make it
+    // lighter.
+    wxRibbonHSLColour AdjustLuminance(float delta)
+    {
+        return wxSystemSettings::GetAppearance().IsDark()
+            ? Darker(delta)
+            : Lighter(delta);
+    }
 
-   wxRibbonHSLColour Darker(float delta) const;
-   wxRibbonHSLColour Lighter(float delta) const;
-   wxRibbonHSLColour Saturated(float delta) const;
-   wxRibbonHSLColour Desaturated(float delta) const;
-   wxRibbonHSLColour ShiftHue(float delta) const;
+    wxRibbonHSLColour Darker(float delta) const;
+    wxRibbonHSLColour Lighter(float delta) const;
+    wxRibbonHSLColour Saturated(float delta) const;
+    wxRibbonHSLColour Desaturated(float delta) const;
+    wxRibbonHSLColour ShiftHue(float delta) const;
 
-   float       hue, saturation, luminance;
+    float m_hue, m_saturation, m_luminance;
 };
 
 WXDLLIMPEXP_RIBBON wxRibbonHSLColour wxRibbonShiftLuminance(

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -55,10 +55,10 @@ enum wxRibbonDisplayMode
 class WXDLLIMPEXP_RIBBON wxRibbonBarEvent : public wxNotifyEvent
 {
 public:
-    wxRibbonBarEvent(wxEventType command_type = wxEVT_NULL,
-                       int win_id = 0,
+    wxRibbonBarEvent(wxEventType commandType = wxEVT_NULL,
+                       int winId = 0,
                        wxRibbonPage* page = nullptr)
-        : wxNotifyEvent(command_type, win_id)
+        : wxNotifyEvent(commandType, winId)
         , m_page(page)
     {
     }
@@ -66,8 +66,8 @@ public:
     wxRibbonBarEvent(const wxRibbonBarEvent& e) = default;
     wxNODISCARD wxEvent *Clone() const override { return new wxRibbonBarEvent(*this); }
 
-    wxRibbonPage* GetPage() {return m_page;}
-    void SetPage(wxRibbonPage* page) {m_page = page;}
+    wxRibbonPage* GetPage() { return m_page; }
+    void SetPage(wxRibbonPage* page) { m_page = page; }
 
 protected:
     wxRibbonPage* m_page = nullptr;
@@ -81,16 +81,16 @@ private:
 class WXDLLIMPEXP_RIBBON wxRibbonPageTabInfo
 {
 public:
-    wxRect rect;
-    wxRibbonPage* page = nullptr;
-    int ideal_width;
-    int small_begin_need_separator_width;
-    int small_must_have_separator_width;
-    int minimum_width;
-    bool active;
-    bool hovered;
-    bool highlight;
-    bool shown;
+    wxRect m_rect;
+    wxRibbonPage* m_page = nullptr;
+    int m_idealWidth;
+    int m_smallBeginNeedSeparatorWidth;
+    int m_smallMustHaveSeparatorWidth;
+    int m_minimumWidth;
+    bool m_active;
+    bool m_hovered;
+    bool m_highlight;
+    bool m_shown;
 };
 
 // This must be a class because it's forward declared.
@@ -147,7 +147,7 @@ public:
     void ShowPanels(bool show = true);
     void HidePanels() { ShowPanels(wxRIBBON_BAR_MINIMIZED); }
     bool ArePanelsShown() const { return m_arePanelsShown; }
-    wxRibbonDisplayMode GetDisplayMode() const { return m_ribbon_state; }
+    wxRibbonDisplayMode GetDisplayMode() const { return m_ribbonState; }
 
     virtual bool HasMultiplePages() const override { return true; }
 
@@ -156,8 +156,8 @@ public:
     virtual bool Realize() override;
 
     // Implementation only.
-    bool IsToggleButtonHovered() const { return m_toggle_button_hovered; }
-    bool IsHelpButtonHovered() const { return m_help_button_hovered; }
+    bool IsToggleButtonHovered() const { return m_toggleButtonHovered; }
+    bool IsHelpButtonHovered() const { return m_helpButtonHovered; }
 
     void HideIfExpanded();
 
@@ -173,7 +173,7 @@ protected:
     virtual wxSize DoGetBestSize() const override;
     wxBorder GetDefaultBorder() const override { return wxBORDER_NONE; }
     wxRibbonPageTabInfo* HitTestTabs(wxPoint position, int* index = nullptr);
-    void HitTestRibbonButton(const wxRect& rect, const wxPoint& position, bool &hover_flag);
+    void HitTestRibbonButton(const wxRect& rect, const wxPoint& position, bool &hoverFlag);
 
     void CommonInit(long style);
     void AddPage(wxRibbonPage *page);
@@ -197,34 +197,34 @@ protected:
     void OnMouseMove(wxMouseEvent& evt);
     void OnMouseLeave(wxMouseEvent& evt);
     void OnMouseDoubleClick(wxMouseEvent& evt);
-    void DoMouseButtonCommon(wxMouseEvent& evt, wxEventType tab_event_type);
+    void DoMouseButtonCommon(wxMouseEvent& evt, wxEventType tabEventType);
     void OnKillFocus(wxFocusEvent& evt);
 
     wxRibbonPageTabInfoArray m_pages;
-    wxRect m_tab_scroll_left_button_rect;
-    wxRect m_tab_scroll_right_button_rect;
-    wxRect m_toggle_button_rect;
-    wxRect m_help_button_rect;
+    wxRect m_tabScrollLeftButtonRect;
+    wxRect m_tabScrollRightButtonRect;
+    wxRect m_toggleButtonRect;
+    wxRect m_helpButtonRect;
     long m_flags;
-    int m_tabs_total_width_ideal;
-    int m_tabs_total_width_minimum;
-    int m_tab_margin_left;
-    int m_tab_margin_right;
-    int m_tab_height;
-    int m_tab_scroll_amount;
-    int m_current_page;
-    int m_current_hovered_page;
-    int m_tab_scroll_left_button_state;
-    int m_tab_scroll_right_button_state;
-    bool m_tab_scroll_buttons_shown;
+    int m_tabsTotalWidthIdeal;
+    int m_tabsTotalWidthMinimum;
+    int m_tabMarginLeft;
+    int m_tabMarginRight;
+    int m_tabHeight;
+    int m_tabScrollAmount;
+    int m_currentPage;
+    int m_currentHoveredPage;
+    int m_tabScrollLeftButtonState;
+    int m_tabScrollRightButtonState;
+    bool m_tabScrollButtonsShown;
     bool m_arePanelsShown;
-    bool m_bar_hovered;
-    bool m_toggle_button_hovered;
-    bool m_help_button_hovered;
+    bool m_barHovered;
+    bool m_toggleButtonHovered;
+    bool m_helpButtonHovered;
 
-    wxRibbonDisplayMode m_ribbon_state;
+    wxRibbonDisplayMode m_ribbonState;
 
-    wxVector<wxImageList*> m_image_lists;
+    wxVector<wxImageList*> m_imageLists;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonBar);

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -46,82 +46,82 @@ public:
                 long style = 0);
 
     virtual wxRibbonButtonBarButtonBase* AddButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL);
-    // NB: help_string cannot be optional as that would cause the signature
+    // NB: helpString cannot be optional as that would cause the signature
     // to be identical to the full version of AddButton when 3 arguments are
     // given.
 
     virtual wxRibbonButtonBarButtonBase* AddDropdownButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonButtonBarButtonBase* AddHybridButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonButtonBarButtonBase* AddToggleButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonButtonBarButtonBase* AddButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_small = wxBitmapBundle(),
-                const wxBitmapBundle& bitmap_disabled = wxBitmapBundle(),
-                const wxBitmapBundle& bitmap_small_disabled = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapSmall = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapDisabled = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapSmallDisabled = wxBitmapBundle(),
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonButtonBarButtonBase* InsertButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL);
 
     virtual wxRibbonButtonBarButtonBase* InsertDropdownButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonButtonBarButtonBase* InsertHybridButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonButtonBarButtonBase* InsertToggleButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonButtonBarButtonBase* InsertButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_small = wxBitmapBundle(),
-                const wxBitmapBundle& bitmap_disabled = wxBitmapBundle(),
-                const wxBitmapBundle& bitmap_small_disabled = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapSmall = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapDisabled = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapSmallDisabled = wxBitmapBundle(),
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     void SetItemClientObject(wxRibbonButtonBarButtonBase* item, wxClientData* data);
     wxClientData* GetItemClientObject(const wxRibbonButtonBarButtonBase* item) const;
@@ -132,30 +132,30 @@ public:
     virtual wxRibbonButtonBarButtonBase *GetItem(size_t n) const;
     virtual wxRibbonButtonBarButtonBase *GetItemById(int id) const;
     virtual int GetItemId(wxRibbonButtonBarButtonBase *button) const;
-    virtual wxRect GetItemRect(int button_id) const;
+    virtual wxRect GetItemRect(int buttonId) const;
 
 
     virtual bool Realize() override;
     virtual void ClearButtons();
-    virtual bool DeleteButton(int button_id);
-    virtual void EnableButton(int button_id, bool enable = true);
-    virtual void ToggleButton(int button_id, bool checked);
+    virtual bool DeleteButton(int buttonId);
+    virtual void EnableButton(int buttonId, bool enable = true);
+    virtual void ToggleButton(int buttonId, bool checked);
 
     virtual void SetButtonIcon(
-                int button_id,
+                int buttonId,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_small = wxBitmapBundle(),
-                const wxBitmapBundle& bitmap_disabled = wxBitmapBundle(),
-                const wxBitmapBundle& bitmap_small_disabled = wxBitmapBundle());
+                const wxBitmapBundle& bitmapSmall = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapDisabled = wxBitmapBundle(),
+                const wxBitmapBundle& bitmapSmallDisabled = wxBitmapBundle());
 
-    virtual void SetButtonText(int button_id, const wxString& label);
-    virtual void SetButtonTextMinWidth(int button_id,
-                int min_width_medium, int min_width_large);
-    virtual void SetButtonTextMinWidth(int button_id, const wxString& label);
-    virtual void SetButtonMinSizeClass(int button_id,
-                wxRibbonButtonBarButtonState min_size_class);
-    virtual void SetButtonMaxSizeClass(int button_id,
-                wxRibbonButtonBarButtonState max_size_class);
+    virtual void SetButtonText(int buttonId, const wxString& label);
+    virtual void SetButtonTextMinWidth(int buttonId,
+                int minWidthMedium, int minWidthLarge);
+    virtual void SetButtonTextMinWidth(int buttonId, const wxString& label);
+    virtual void SetButtonMinSizeClass(int buttonId,
+                wxRibbonButtonBarButtonState minSizeClass);
+    virtual void SetButtonMaxSizeClass(int buttonId,
+                wxRibbonButtonBarButtonState maxSizeClass);
 
     virtual wxRibbonButtonBarButtonBase *GetActiveItem() const;
     virtual wxRibbonButtonBarButtonBase *GetHoveredItem() const;
@@ -187,31 +187,31 @@ protected:
     void OnDPIChanged(wxDPIChangedEvent& evt);
 
     virtual wxSize DoGetNextSmallerSize(wxOrientation direction,
-                                      wxSize relative_to) const override;
+                                      wxSize relativeTo) const override;
     virtual wxSize DoGetNextLargerSize(wxOrientation direction,
-                                     wxSize relative_to) const override;
+                                     wxSize relativeTo) const override;
 
     void CommonInit(long style);
     void MakeLayouts();
     void TryCollapseLayout(wxRibbonButtonBarLayout* original,
-                     size_t first_btn, size_t* last_button,
-                     wxRibbonButtonBarButtonState target_size);
+                     size_t firstBtn, size_t* lastButton,
+                     wxRibbonButtonBarButtonState targetSize);
     void FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,
         wxRibbonButtonBarButtonState size, wxReadOnlyDC& dc);
     virtual void UpdateWindowUI(long flags) override;
 
     wxArrayRibbonButtonBarLayout m_layouts;
     wxArrayRibbonButtonBarButtonBase m_buttons;
-    wxRibbonButtonBarButtonInstance* m_hovered_button = nullptr;
-    wxRibbonButtonBarButtonInstance* m_active_button = nullptr;
+    wxRibbonButtonBarButtonInstance* m_hoveredButton = nullptr;
+    wxRibbonButtonBarButtonInstance* m_activeButton = nullptr;
 
-    wxPoint m_layout_offset;
-    wxSize m_bitmap_size_large;
-    wxSize m_bitmap_size_small;
-    int m_current_layout;
-    bool m_layouts_valid;
-    bool m_lock_active_state;
-    bool m_show_tooltips_for_disabled;
+    wxPoint m_layoutOffset;
+    wxSize m_bitmapSizeLarge;
+    wxSize m_bitmapSizeSmall;
+    int m_currentLayout;
+    bool m_layoutsValid;
+    bool m_lockActiveState;
+    bool m_showTooltipsForDisabled;
 
     std::vector<wxBitmapBundle> m_bundlesLarge;         // Large button icons
     std::vector<wxBitmapBundle> m_bundlesSmall;         // Small button icons
@@ -231,11 +231,11 @@ private:
 class WXDLLIMPEXP_RIBBON wxRibbonButtonBarEvent : public wxCommandEvent
 {
 public:
-    wxRibbonButtonBarEvent(wxEventType command_type = wxEVT_NULL,
-                       int win_id = 0,
+    wxRibbonButtonBarEvent(wxEventType commandType = wxEVT_NULL,
+                       int winId = 0,
                        wxRibbonButtonBar* bar = nullptr,
                        wxRibbonButtonBarButtonBase* button = nullptr)
-        : wxCommandEvent(command_type, win_id)
+        : wxCommandEvent(commandType, winId)
         , m_bar(bar), m_button(button)
     {
     }
@@ -243,9 +243,9 @@ public:
     wxRibbonButtonBarEvent(const wxRibbonButtonBarEvent& e) = default;
     wxNODISCARD wxEvent *Clone() const override { return new wxRibbonButtonBarEvent(*this); }
 
-    wxRibbonButtonBar* GetBar() {return m_bar;}
+    wxRibbonButtonBar* GetBar() { return m_bar; }
     wxRibbonButtonBarButtonBase *GetButton() { return m_button; }
-    void SetBar(wxRibbonButtonBar* bar) {m_bar = bar;}
+    void SetBar(wxRibbonButtonBar* bar) { m_bar = bar; }
     void SetButton(wxRibbonButtonBarButtonBase* button) { m_button = button; }
     bool PopupMenu(wxMenu* menu);
 

--- a/include/wx/ribbon/control.h
+++ b/include/wx/ribbon/control.h
@@ -43,18 +43,18 @@ public:
             const wxString& name = wxASCII_STR(wxControlNameStr));
 
     virtual void SetArtProvider(wxRibbonArtProvider* art);
-    wxRibbonArtProvider* GetArtProvider() const {return m_art;}
+    wxRibbonArtProvider* GetArtProvider() const { return m_art; }
 
-    virtual bool IsSizingContinuous() const {return true;}
-    wxSize GetNextSmallerSize(wxOrientation direction, wxSize relative_to) const;
-    wxSize GetNextLargerSize(wxOrientation direction, wxSize relative_to) const;
+    virtual bool IsSizingContinuous() const { return true; }
+    wxSize GetNextSmallerSize(wxOrientation direction, wxSize relativeTo) const;
+    wxSize GetNextLargerSize(wxOrientation direction, wxSize relativeTo) const;
     wxSize GetNextSmallerSize(wxOrientation direction) const;
     wxSize GetNextLargerSize(wxOrientation direction) const;
 
     virtual bool Realize();
-    bool Realise() {return Realize();}
+    bool Realise() { return Realize(); }
 
-    virtual wxRibbonBar* GetAncestorRibbonBar()const;
+    virtual wxRibbonBar* GetAncestorRibbonBar() const;
 
     // Finds the best width and height given the parent's width and height
     virtual wxSize GetBestSizeForParentSize(const wxSize& WXUNUSED(parentSize)) const { return GetBestSize(); }
@@ -63,9 +63,9 @@ protected:
     wxRibbonArtProvider* m_art;
 
     virtual wxSize DoGetNextSmallerSize(wxOrientation direction,
-                                        wxSize relative_to) const;
+                                        wxSize relativeTo) const;
     virtual wxSize DoGetNextLargerSize(wxOrientation direction,
-                                       wxSize relative_to) const;
+                                       wxSize relativeTo) const;
 
 private:
     void Init() { m_art = nullptr; }

--- a/include/wx/ribbon/gallery.h
+++ b/include/wx/ribbon/gallery.h
@@ -27,10 +27,10 @@ public:
     wxRibbonGallery();
 
     wxRibbonGallery(wxWindow* parent,
-                  wxWindowID id = wxID_ANY,
-                  const wxPoint& pos = wxDefaultPosition,
-                  const wxSize& size = wxDefaultSize,
-                  long style = 0);
+                    wxWindowID id = wxID_ANY,
+                    const wxPoint& pos = wxDefaultPosition,
+                    const wxSize& size = wxDefaultSize,
+                    long style = 0);
 
     virtual ~wxRibbonGallery();
 
@@ -92,29 +92,29 @@ protected:
 
     virtual wxSize DoGetBestSize() const override;
     virtual wxSize DoGetNextSmallerSize(wxOrientation direction,
-                                        wxSize relative_to) const override;
+                                        wxSize relativeTo) const override;
     virtual wxSize DoGetNextLargerSize(wxOrientation direction,
-                                       wxSize relative_to) const override;
+                                       wxSize relativeTo) const override;
 
     wxArrayRibbonGalleryItem m_items;
-    wxRibbonGalleryItem* m_selected_item;
-    wxRibbonGalleryItem* m_hovered_item;
-    wxRibbonGalleryItem* m_active_item;
-    wxSize m_bitmap_size;
-    wxSize m_bitmap_padded_size;
-    wxSize m_best_size;
-    wxRect m_client_rect;
-    wxRect m_scroll_up_button_rect;
-    wxRect m_scroll_down_button_rect;
-    wxRect m_extension_button_rect;
-    const wxRect* m_mouse_active_rect = nullptr;
-    int m_item_separation_x;
-    int m_item_separation_y;
-    int m_scroll_amount;
-    int m_scroll_limit;
-    wxRibbonGalleryButtonState m_up_button_state;
-    wxRibbonGalleryButtonState m_down_button_state;
-    wxRibbonGalleryButtonState m_extension_button_state;
+    wxRibbonGalleryItem* m_selectedItem;
+    wxRibbonGalleryItem* m_hoveredItem;
+    wxRibbonGalleryItem* m_activeItem;
+    wxSize m_bitmapSize;
+    wxSize m_bitmapPaddedSize;
+    wxSize m_bestSize;
+    wxRect m_clientRect;
+    wxRect m_scrollUpButtonRect;
+    wxRect m_scrollDownButtonRect;
+    wxRect m_extensionButtonRect;
+    const wxRect* m_mouseActiveRect = nullptr;
+    int m_itemSeparationX;
+    int m_itemSeparationY;
+    int m_scrollAmount;
+    int m_scrollLimit;
+    wxRibbonGalleryButtonState m_upButtonState;
+    wxRibbonGalleryButtonState m_downButtonState;
+    wxRibbonGalleryButtonState m_extensionButtonState;
     bool m_hovered;
 
 #ifndef SWIG
@@ -126,11 +126,11 @@ protected:
 class WXDLLIMPEXP_RIBBON wxRibbonGalleryEvent : public wxCommandEvent
 {
 public:
-    wxRibbonGalleryEvent(wxEventType command_type = wxEVT_NULL,
-                       int win_id = 0,
+    wxRibbonGalleryEvent(wxEventType commandType = wxEVT_NULL,
+                       int winId = 0,
                        wxRibbonGallery* gallery = nullptr,
                        wxRibbonGalleryItem* item = nullptr)
-        : wxCommandEvent(command_type, win_id)
+        : wxCommandEvent(commandType, winId)
         , m_gallery(gallery), m_item(item)
     {
     }

--- a/include/wx/ribbon/page.h
+++ b/include/wx/ribbon/page.h
@@ -42,8 +42,8 @@ public:
 
     void SetArtProvider(wxRibbonArtProvider* art) override;
 
-    wxBitmap GetIcon() {return m_icon.GetBitmapFor(this);}
-    const wxBitmapBundle& GetIconBundle() const {return m_icon;}
+    wxBitmap GetIcon() { return m_icon.GetBitmapFor(this); }
+    const wxBitmapBundle& GetIconBundle() const { return m_icon; }
     virtual wxSize GetMinSize() const override;
     void SetSizeWithScrollButtonAdjustment(int x, int y, int width, int height);
     void AdjustRectToIncludeScrollButtons(wxRect* rect) const;
@@ -78,26 +78,26 @@ protected:
     void OnSize(wxSizeEvent& evt);
     void OnDPIChanged(wxDPIChangedEvent& evt);
 
-    bool ExpandPanels(wxOrientation direction, int maximum_amount);
-    bool CollapsePanels(wxOrientation direction, int minimum_amount);
+    bool ExpandPanels(wxOrientation direction, int maximumAmount);
+    bool CollapsePanels(wxOrientation direction, int minimumAmount);
     bool ShowScrollButtons();
     void HideScrollButtons();
 
     void CommonInit(const wxString& label, const wxBitmapBundle& icon);
-    void PopulateSizeCalcArray(wxSize (wxWindow::*get_size)(void) const);
+    void PopulateSizeCalcArray(wxSize (wxWindow::*getSize)(void) const);
 
-    wxArrayRibbonControl m_collapse_stack;
+    wxArrayRibbonControl m_collapseStack;
     wxBitmapBundle m_icon;
-    wxSize m_old_size;
+    wxSize m_oldSize;
     // NB: Scroll button windows are siblings rather than children (to get correct clipping of children)
-    wxRibbonPageScrollButton* m_scroll_left_btn = nullptr;
-    wxRibbonPageScrollButton* m_scroll_right_btn = nullptr;
-    wxSize* m_size_calc_array = nullptr;
-    size_t m_size_calc_array_size;
-    int m_scroll_amount;
-    int m_scroll_amount_limit;
-    int m_size_in_major_axis_for_children;
-    bool m_scroll_buttons_visible;
+    wxRibbonPageScrollButton* m_scrollLeftBtn = nullptr;
+    wxRibbonPageScrollButton* m_scrollRightBtn = nullptr;
+    wxSize* m_sizeCalcArray = nullptr;
+    size_t m_sizeCalcArraySize;
+    int m_scrollAmount;
+    int m_scrollAmountLimit;
+    int m_sizeInMajorAxisForChildren;
+    bool m_scrollButtonsVisible;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonPage);

--- a/include/wx/ribbon/panel.h
+++ b/include/wx/ribbon/panel.h
@@ -35,7 +35,7 @@ public:
     wxRibbonPanel(wxWindow* parent,
                   wxWindowID id = wxID_ANY,
                   const wxString& label = wxEmptyString,
-                  const wxBitmapBundle& minimised_icon = wxBitmapBundle(),
+                  const wxBitmapBundle& minimisedIcon = wxBitmapBundle(),
                   const wxPoint& pos = wxDefaultPosition,
                   const wxSize& size = wxDefaultSize,
                   long style = wxRIBBON_PANEL_DEFAULT_STYLE);
@@ -50,10 +50,10 @@ public:
                 const wxSize& size = wxDefaultSize,
                 long style = wxRIBBON_PANEL_DEFAULT_STYLE);
 
-    wxBitmap GetMinimisedIcon() {return m_minimised_icon.GetBitmapFor(this);}
-    const wxBitmapBundle& GetMinimisedIconBundle() const {return m_minimised_icon;}
+    wxBitmap GetMinimisedIcon() { return m_minimisedIcon.GetBitmapFor(this); }
+    const wxBitmapBundle& GetMinimisedIconBundle() const { return m_minimisedIcon; }
     bool IsMinimised() const;
-    bool IsMinimised(wxSize at_size) const;
+    bool IsMinimised(wxSize atSize) const;
     bool IsHovered() const;
     bool IsExtButtonHovered() const;
     bool CanAutoMinimise() const;
@@ -92,9 +92,9 @@ protected:
     wxSize GetMinNotMinimisedSize() const;
 
     virtual wxSize DoGetNextSmallerSize(wxOrientation direction,
-                                      wxSize relative_to) const override;
+                                      wxSize relativeTo) const override;
     virtual wxSize DoGetNextLargerSize(wxOrientation direction,
-                                     wxSize relative_to) const override;
+                                     wxSize relativeTo) const override;
 
     void DoSetSize(int x, int y, int width, int height, int sizeFlags = wxSIZE_AUTO) override;
     void OnSize(wxSizeEvent& evt);
@@ -116,22 +116,22 @@ protected:
 
     void CommonInit(const wxString& label, const wxBitmapBundle& icon, long style);
     static wxRect GetExpandedPosition(wxRect panel,
-                                      wxSize expanded_size,
+                                      wxSize expandedSize,
                                       wxDirection direction);
 
-    wxBitmapBundle m_minimised_icon;
-    wxBitmap m_minimised_icon_resized;
-    wxSize m_smallest_unminimised_size;
-    wxSize m_minimised_size;
-    wxDirection m_preferred_expand_direction;
-    wxRibbonPanel* m_expanded_dummy;
-    wxRibbonPanel* m_expanded_panel;
-    wxWindow* m_child_with_focus;
+    wxBitmapBundle m_minimisedIcon;
+    wxBitmap m_minimisedIconResized;
+    wxSize m_smallestUnminimisedSize;
+    wxSize m_minimisedSize;
+    wxDirection m_preferredExpandDirection;
+    wxRibbonPanel* m_expandedDummy;
+    wxRibbonPanel* m_expandedPanel;
+    wxWindow* m_childWithFocus;
     long m_flags;
     bool m_minimised;
     bool m_hovered;
-    bool m_ext_button_hovered;
-    wxRect m_ext_button_rect;
+    bool m_extButtonHovered;
+    wxRect m_extButtonRect;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonPanel);
@@ -143,10 +143,10 @@ protected:
 class WXDLLIMPEXP_RIBBON wxRibbonPanelEvent : public wxCommandEvent
 {
 public:
-    wxRibbonPanelEvent(wxEventType command_type = wxEVT_NULL,
-                       int win_id = 0,
+    wxRibbonPanelEvent(wxEventType commandType = wxEVT_NULL,
+                       int winId = 0,
                        wxRibbonPanel* panel = nullptr)
-        : wxCommandEvent(command_type, win_id)
+        : wxCommandEvent(commandType, winId)
         , m_panel(panel)
     {
     }
@@ -154,8 +154,8 @@ public:
     wxRibbonPanelEvent(const wxRibbonPanelEvent& e) = default;
     wxNODISCARD wxEvent *Clone() const override { return new wxRibbonPanelEvent(*this); }
 
-    wxRibbonPanel* GetPanel() {return m_panel;}
-    void SetPanel(wxRibbonPanel* panel) {m_panel = panel;}
+    wxRibbonPanel* GetPanel() { return m_panel; }
+    void SetPanel(wxRibbonPanel* panel) { m_panel = panel; }
 
 protected:
     wxRibbonPanel* m_panel;

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -59,104 +59,104 @@ public:
                 long style = 0);
 
     virtual wxRibbonToolBarToolBase* AddTool(
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL);
 
     virtual wxRibbonToolBarToolBase* AddDropdownTool(
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonToolBarToolBase* AddHybridTool(
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonToolBarToolBase* AddToggleTool(
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonToolBarToolBase* AddTool(
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_disabled = wxBitmapBundle(),
-                const wxString& help_string = wxEmptyString,
+                const wxBitmapBundle& bitmapDisabled = wxBitmapBundle(),
+                const wxString& helpString = wxEmptyString,
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL,
-                wxObject* client_data = nullptr);
+                wxObject* clientData = nullptr);
 
     virtual wxRibbonToolBarToolBase* AddSeparator();
 
     virtual wxRibbonToolBarToolBase* InsertTool(
                 size_t pos,
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL);
 
     virtual wxRibbonToolBarToolBase* InsertDropdownTool(
                 size_t pos,
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonToolBarToolBase* InsertHybridTool(
                 size_t pos,
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonToolBarToolBase* InsertToggleTool(
                 size_t pos,
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string = wxEmptyString);
+                const wxString& helpString = wxEmptyString);
 
     virtual wxRibbonToolBarToolBase* InsertTool(
                 size_t pos,
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_disabled = wxBitmapBundle(),
-                const wxString& help_string = wxEmptyString,
+                const wxBitmapBundle& bitmapDisabled = wxBitmapBundle(),
+                const wxString& helpString = wxEmptyString,
                 wxRibbonButtonKind kind = wxRIBBON_BUTTON_NORMAL,
-                wxObject* client_data = nullptr);
+                wxObject* clientData = nullptr);
 
     virtual wxRibbonToolBarToolBase* InsertSeparator(size_t pos);
 
     virtual void ClearTools();
-    virtual bool DeleteTool(int tool_id);
+    virtual bool DeleteTool(int toolId);
     virtual bool DeleteToolByPos(size_t pos);
 
-    virtual wxRibbonToolBarToolBase* FindById(int tool_id)const;
-    virtual wxRibbonToolBarToolBase* GetToolByPos(size_t pos)const;
-    virtual wxRibbonToolBarToolBase* GetToolByPos(wxCoord x, wxCoord y)const;
+    virtual wxRibbonToolBarToolBase* FindById(int toolId) const;
+    virtual wxRibbonToolBarToolBase* GetToolByPos(size_t pos) const;
+    virtual wxRibbonToolBarToolBase* GetToolByPos(wxCoord x, wxCoord y) const;
     virtual size_t GetToolCount() const;
-    virtual int GetToolId(const wxRibbonToolBarToolBase* tool)const;
+    virtual int GetToolId(const wxRibbonToolBarToolBase* tool) const;
     virtual wxRibbonToolBarToolBase* GetActiveTool() const;
 
 
-    virtual wxObject* GetToolClientData(int tool_id)const;
-    virtual bool GetToolEnabled(int tool_id)const;
-    virtual wxString GetToolHelpString(int tool_id)const;
-    virtual wxRibbonButtonKind GetToolKind(int tool_id)const;
-    virtual int GetToolPos(int tool_id)const;
-    virtual wxRect GetToolRect(int tool_id)const;
-    virtual bool GetToolState(int tool_id)const;
+    virtual wxObject* GetToolClientData(int toolId) const;
+    virtual bool GetToolEnabled(int toolId) const;
+    virtual wxString GetToolHelpString(int toolId) const;
+    virtual wxRibbonButtonKind GetToolKind(int toolId) const;
+    virtual int GetToolPos(int toolId) const;
+    virtual wxRect GetToolRect(int toolId) const;
+    virtual bool GetToolState(int toolId) const;
 
     virtual bool Realize() override;
     virtual void SetRows(int nMin, int nMax = -1);
 
-    virtual void SetToolClientData(int tool_id, wxObject* clientData);
-    virtual void SetToolDisabledBitmap(int tool_id, const wxBitmapBundle &bitmap);
-    virtual void SetToolHelpString(int tool_id, const wxString& helpString);
-    virtual void SetToolNormalBitmap(int tool_id, const wxBitmapBundle &bitmap);
+    virtual void SetToolClientData(int toolId, wxObject* clientData);
+    virtual void SetToolDisabledBitmap(int toolId, const wxBitmapBundle &bitmap);
+    virtual void SetToolHelpString(int toolId, const wxString& helpString);
+    virtual void SetToolNormalBitmap(int toolId, const wxBitmapBundle &bitmap);
 
     virtual bool IsSizingContinuous() const override;
 
-    virtual void EnableTool(int tool_id, bool enable = true);
-    virtual void ToggleTool(int tool_id, bool checked);
+    virtual void EnableTool(int toolId, bool enable = true);
+    virtual void ToggleTool(int toolId, bool checked);
 
     // Finds the best width and height given the parent's width and height
     virtual wxSize GetBestSizeForParentSize(const wxSize& parentSize) const override;
@@ -177,9 +177,9 @@ protected:
     void OnDPIChanged(wxDPIChangedEvent& evt);
 
     virtual wxSize DoGetNextSmallerSize(wxOrientation direction,
-                                      wxSize relative_to) const override;
+                                      wxSize relativeTo) const override;
     virtual wxSize DoGetNextLargerSize(wxOrientation direction,
-                                     wxSize relative_to) const override;
+                                     wxSize relativeTo) const override;
 
     void CommonInit(long style);
     void AppendGroup();
@@ -189,11 +189,11 @@ protected:
     static wxBitmap MakeDisabledBitmap(const wxBitmap& original);
 
     wxArrayRibbonToolBarToolGroup m_groups;
-    wxRibbonToolBarToolBase* m_hover_tool;
-    wxRibbonToolBarToolBase* m_active_tool;
+    wxRibbonToolBarToolBase* m_hoverTool;
+    wxRibbonToolBarToolBase* m_activeTool;
     wxSize* m_sizes;
-    int m_nrows_min;
-    int m_nrows_max;
+    int m_nrowsMin;
+    int m_nrowsMax;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonToolBar);
@@ -205,10 +205,10 @@ protected:
 class WXDLLIMPEXP_RIBBON wxRibbonToolBarEvent : public wxCommandEvent
 {
 public:
-    wxRibbonToolBarEvent(wxEventType command_type = wxEVT_NULL,
-                       int win_id = 0,
+    wxRibbonToolBarEvent(wxEventType commandType = wxEVT_NULL,
+                       int winId = 0,
                        wxRibbonToolBar* bar = nullptr)
-        : wxCommandEvent(command_type, win_id)
+        : wxCommandEvent(commandType, winId)
         , m_bar(bar)
     {
     }
@@ -216,8 +216,8 @@ public:
     wxRibbonToolBarEvent(const wxRibbonToolBarEvent& e) = default;
     wxNODISCARD wxEvent *Clone() const override { return new wxRibbonToolBarEvent(*this); }
 
-    wxRibbonToolBar* GetBar() {return m_bar;}
-    void SetBar(wxRibbonToolBar* bar) {m_bar = bar;}
+    wxRibbonToolBar* GetBar() { return m_bar; }
+    void SetBar(wxRibbonToolBar* bar) { m_bar = bar; }
     bool PopupMenu(wxMenu* menu);
 
 protected:

--- a/src/ribbon/art_aui.cpp
+++ b/src/ribbon/art_aui.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/art_aui.cpp
 // Purpose:     AUI style art provider for ribbon interface
 // Author:      Peter Cawley
@@ -20,41 +20,41 @@
 #include "wx/ribbon/toolbar.h"
 
 #ifndef WX_PRECOMP
-#include "wx/dc.h"
+    #include "wx/dc.h"
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #elif defined(__WXOSX__)
-#include "wx/osx/private.h"
+    #include "wx/osx/private.h"
 #endif
 
 wxRibbonAUIArtProvider::wxRibbonAUIArtProvider()
     : wxRibbonMSWArtProvider(false)
 {
 #ifdef __WXOSX__
-    wxColor base_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    wxColor baseColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
 #else
-    wxColor base_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE);
+    wxColor baseColour = wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE);
 #endif
 
-    SetColourScheme(base_colour,
+    SetColourScheme(baseColour,
         wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT),
         wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 
-    m_tab_active_label_font = m_tab_label_font;
-    m_tab_active_label_font.SetWeight(wxFONTWEIGHT_BOLD);
+    m_tabActiveLabelFont = m_tabLabelFont;
+    m_tabActiveLabelFont.SetWeight(wxFONTWEIGHT_BOLD);
 
-    m_page_border_left = 1;
-    m_page_border_right = 1;
-    m_page_border_top = 1;
-    m_page_border_bottom = 2;
-    m_tab_separation_size = 0;
+    m_pageBorderLeft = 1;
+    m_pageBorderRight = 1;
+    m_pageBorderTop = 1;
+    m_pageBorderBottom = 2;
+    m_tabSeparationSize = 0;
 
-    m_gallery_bitmap_padding_left_size = 3;
-    m_gallery_bitmap_padding_right_size = 3;
-    m_gallery_bitmap_padding_top_size = 3;
-    m_gallery_bitmap_padding_bottom_size = 3;
+    m_galleryBitmapPaddingLeftSize = 3;
+    m_galleryBitmapPaddingRightSize = 3;
+    m_galleryBitmapPaddingTopSize = 3;
+    m_galleryBitmapPaddingBottomSize = 3;
 }
 
 wxRibbonAUIArtProvider::~wxRibbonAUIArtProvider()
@@ -66,30 +66,30 @@ wxRibbonArtProvider* wxRibbonAUIArtProvider::Clone() const
     wxRibbonAUIArtProvider *copy = new wxRibbonAUIArtProvider();
     CloneTo(copy);
 
-    copy->m_tab_ctrl_background_colour = m_tab_ctrl_background_colour;
-    copy->m_tab_ctrl_background_gradient_colour = m_tab_ctrl_background_gradient_colour;
-    copy->m_panel_label_background_colour = m_panel_label_background_colour;
-    copy->m_panel_label_background_gradient_colour = m_panel_label_background_gradient_colour;
-    copy->m_panel_hover_label_background_colour = m_panel_hover_label_background_colour;
-    copy->m_panel_hover_label_background_gradient_colour = m_panel_hover_label_background_gradient_colour;
+    copy->m_tabCtrlBackgroundColour = m_tabCtrlBackgroundColour;
+    copy->m_tabCtrlBackgroundGradientColour = m_tabCtrlBackgroundGradientColour;
+    copy->m_panelLabelBackgroundColour = m_panelLabelBackgroundColour;
+    copy->m_panelLabelBackgroundGradientColour = m_panelLabelBackgroundGradientColour;
+    copy->m_panelHoverLabelBackgroundColour = m_panelHoverLabelBackgroundColour;
+    copy->m_panelHoverLabelBackgroundGradientColour = m_panelHoverLabelBackgroundGradientColour;
 
-    copy->m_background_brush = m_background_brush;
-    copy->m_tab_active_top_background_brush = m_tab_active_top_background_brush;
-    copy->m_tab_hover_background_brush = m_tab_hover_background_brush;
-    copy->m_button_bar_hover_background_brush = m_button_bar_hover_background_brush;
-    copy->m_button_bar_active_background_brush = m_button_bar_active_background_brush;
-    copy->m_gallery_button_active_background_brush = m_gallery_button_active_background_brush;
-    copy->m_gallery_button_hover_background_brush = m_gallery_button_hover_background_brush;
-    copy->m_gallery_button_disabled_background_brush = m_gallery_button_disabled_background_brush;
+    copy->m_backgroundBrush = m_backgroundBrush;
+    copy->m_tabActiveTopBackgroundBrush = m_tabActiveTopBackgroundBrush;
+    copy->m_tabHoverBackgroundBrush = m_tabHoverBackgroundBrush;
+    copy->m_buttonBarHoverBackgroundBrush = m_buttonBarHoverBackgroundBrush;
+    copy->m_buttonBarActiveBackgroundBrush = m_buttonBarActiveBackgroundBrush;
+    copy->m_galleryButtonActiveBackgroundBrush = m_galleryButtonActiveBackgroundBrush;
+    copy->m_galleryButtonHoverBackgroundBrush = m_galleryButtonHoverBackgroundBrush;
+    copy->m_galleryButtonDisabledBackgroundBrush = m_galleryButtonDisabledBackgroundBrush;
 
-    copy->m_tab_highlight_top_colour = m_tab_highlight_top_colour;
-    copy->m_tab_highlight_top_gradient_colour = m_tab_highlight_top_gradient_colour;
-    copy->m_tab_highlight_colour = m_tab_highlight_colour;
-    copy->m_tab_highlight_gradient_colour = m_tab_highlight_gradient_colour;
+    copy->m_tabHighlightTopColour = m_tabHighlightTopColour;
+    copy->m_tabHighlightTopGradientColour = m_tabHighlightTopGradientColour;
+    copy->m_tabHighlightColour = m_tabHighlightColour;
+    copy->m_tabHighlightGradientColour = m_tabHighlightGradientColour;
 
-    copy->m_toolbar_hover_borden_pen = m_toolbar_hover_borden_pen;
-    copy->m_tool_hover_background_brush = m_tool_hover_background_brush;
-    copy->m_tool_active_background_brush = m_tool_active_background_brush;
+    copy->m_toolbarHoverBordenPen = m_toolbarHoverBordenPen;
+    copy->m_toolHoverBackgroundBrush = m_toolHoverBackgroundBrush;
+    copy->m_toolActiveBackgroundBrush = m_toolActiveBackgroundBrush;
 
     return copy;
 }
@@ -97,58 +97,58 @@ wxRibbonArtProvider* wxRibbonAUIArtProvider::Clone() const
 void wxRibbonAUIArtProvider::SetFont(int id, const wxFont& font)
 {
     wxRibbonMSWArtProvider::SetFont(id, font);
-    if(id == wxRIBBON_ART_TAB_LABEL_FONT)
+    if ( id == wxRIBBON_ART_TAB_LABEL_FONT )
     {
-        m_tab_active_label_font = m_tab_label_font;
-        m_tab_active_label_font.SetWeight(wxFONTWEIGHT_BOLD);
+        m_tabActiveLabelFont = m_tabLabelFont;
+        m_tabActiveLabelFont.SetWeight(wxFONTWEIGHT_BOLD);
     }
 }
 
 wxColour wxRibbonAUIArtProvider::GetColour(int id) const
 {
-    switch(id)
+    switch ( id )
     {
     case wxRIBBON_ART_PAGE_BACKGROUND_COLOUR:
     case wxRIBBON_ART_PAGE_BACKGROUND_GRADIENT_COLOUR:
-        return m_background_brush.GetColour();
+        return m_backgroundBrush.GetColour();
     case wxRIBBON_ART_TAB_CTRL_BACKGROUND_COLOUR:
-        return m_tab_ctrl_background_colour;
+        return m_tabCtrlBackgroundColour;
     case wxRIBBON_ART_TAB_CTRL_BACKGROUND_GRADIENT_COLOUR:
-        return m_tab_ctrl_background_gradient_colour;
+        return m_tabCtrlBackgroundGradientColour;
     case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_COLOUR:
     case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-        return m_tab_active_top_background_brush.GetColour();
+        return m_tabActiveTopBackgroundBrush.GetColour();
     case wxRIBBON_ART_TAB_HOVER_BACKGROUND_COLOUR:
     case wxRIBBON_ART_TAB_HOVER_BACKGROUND_GRADIENT_COLOUR:
-        return m_tab_hover_background_brush.GetColour();
+        return m_tabHoverBackgroundBrush.GetColour();
     case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_COLOUR:
-        return m_panel_label_background_colour;
+        return m_panelLabelBackgroundColour;
     case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_GRADIENT_COLOUR:
-        return m_panel_label_background_gradient_colour;
+        return m_panelLabelBackgroundGradientColour;
     case wxRIBBON_ART_PANEL_HOVER_LABEL_BACKGROUND_COLOUR:
-        return m_panel_hover_label_background_colour;
+        return m_panelHoverLabelBackgroundColour;
     case wxRIBBON_ART_PANEL_HOVER_LABEL_BACKGROUND_GRADIENT_COLOUR:
-        return m_panel_hover_label_background_gradient_colour;
+        return m_panelHoverLabelBackgroundGradientColour;
     case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_COLOUR:
     case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_GRADIENT_COLOUR:
-        return m_button_bar_hover_background_brush.GetColour();
+        return m_buttonBarHoverBackgroundBrush.GetColour();
     case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_COLOUR:
     case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_GRADIENT_COLOUR:
-        return m_gallery_button_hover_background_brush.GetColour();
+        return m_galleryButtonHoverBackgroundBrush.GetColour();
     case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_COLOUR:
     case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-        return m_gallery_button_active_background_brush.GetColour();
+        return m_galleryButtonActiveBackgroundBrush.GetColour();
     case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_COLOUR:
     case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_GRADIENT_COLOUR:
-        return m_gallery_button_disabled_background_brush.GetColour();
+        return m_galleryButtonDisabledBackgroundBrush.GetColour();
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_TOP_COLOUR:
-       return m_tab_highlight_top_colour;
+       return m_tabHighlightTopColour;
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_TOP_COLOUR:
-       return m_tab_highlight_top_gradient_colour;
+       return m_tabHighlightTopGradientColour;
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_COLOUR:
-       return m_tab_highlight_colour;
+       return m_tabHighlightColour;
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_COLOUR:
-       return m_tab_highlight_gradient_colour;
+       return m_tabHighlightGradientColour;
     default:
         return wxRibbonMSWArtProvider::GetColour(id);
     }
@@ -156,59 +156,59 @@ wxColour wxRibbonAUIArtProvider::GetColour(int id) const
 
 void wxRibbonAUIArtProvider::SetColour(int id, const wxColor& colour)
 {
-    switch(id)
+    switch ( id )
     {
     case wxRIBBON_ART_PAGE_BACKGROUND_COLOUR:
     case wxRIBBON_ART_PAGE_BACKGROUND_GRADIENT_COLOUR:
-        m_background_brush.SetColour(colour);
+        m_backgroundBrush.SetColour(colour);
         break;
     case wxRIBBON_ART_TAB_CTRL_BACKGROUND_COLOUR:
-        m_tab_ctrl_background_colour = colour;
+        m_tabCtrlBackgroundColour = colour;
         break;
     case wxRIBBON_ART_TAB_CTRL_BACKGROUND_GRADIENT_COLOUR:
-        m_tab_ctrl_background_gradient_colour = colour;
+        m_tabCtrlBackgroundGradientColour = colour;
         break;
     case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_COLOUR:
     case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-        m_tab_active_top_background_brush.SetColour(colour);
+        m_tabActiveTopBackgroundBrush.SetColour(colour);
         break;
     case wxRIBBON_ART_TAB_HOVER_BACKGROUND_COLOUR:
     case wxRIBBON_ART_TAB_HOVER_BACKGROUND_GRADIENT_COLOUR:
-        m_tab_hover_background_brush.SetColour(colour);
+        m_tabHoverBackgroundBrush.SetColour(colour);
         break;
     case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_COLOUR:
-        m_panel_label_background_colour = colour;
+        m_panelLabelBackgroundColour = colour;
         break;
     case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_GRADIENT_COLOUR:
-        m_panel_label_background_gradient_colour = colour;
+        m_panelLabelBackgroundGradientColour = colour;
         break;
     case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_COLOUR:
     case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_GRADIENT_COLOUR:
-        m_button_bar_hover_background_brush.SetColour(colour);
+        m_buttonBarHoverBackgroundBrush.SetColour(colour);
         break;
     case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_COLOUR:
     case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_GRADIENT_COLOUR:
-        m_gallery_button_hover_background_brush.SetColour(colour);
+        m_galleryButtonHoverBackgroundBrush.SetColour(colour);
         break;
     case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_COLOUR:
     case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-        m_gallery_button_active_background_brush.SetColour(colour);
+        m_galleryButtonActiveBackgroundBrush.SetColour(colour);
         break;
     case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_COLOUR:
     case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_GRADIENT_COLOUR:
-        m_gallery_button_disabled_background_brush.SetColour(colour);
+        m_galleryButtonDisabledBackgroundBrush.SetColour(colour);
         break;
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_TOP_COLOUR:
-       m_tab_highlight_top_colour = colour;
+       m_tabHighlightTopColour = colour;
        break;
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_TOP_COLOUR:
-       m_tab_highlight_top_gradient_colour = colour;
+       m_tabHighlightTopGradientColour = colour;
        break;
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_COLOUR:
-       m_tab_highlight_colour = colour;
+       m_tabHighlightColour = colour;
        break;
     case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_COLOUR:
-       m_tab_highlight_gradient_colour = colour;
+       m_tabHighlightGradientColour = colour;
        break;
     default:
         wxRibbonMSWArtProvider::SetColour(id, colour);
@@ -221,111 +221,111 @@ void wxRibbonAUIArtProvider::SetColourScheme(
                          const wxColour& secondary,
                          const wxColour& tertiary)
 {
-    wxRibbonHSLColour primary_hsl(primary);
-    wxRibbonHSLColour secondary_hsl(secondary);
-    wxRibbonHSLColour tertiary_hsl(tertiary);
+    wxRibbonHSLColour primaryHsl(primary);
+    wxRibbonHSLColour secondaryHsl(secondary);
+    wxRibbonHSLColour tertiaryHsl(tertiary);
 
     // Map primary & secondary luminance from [0, 1] to [0.15, 0.85]
-    primary_hsl.luminance   = std::cos(primary_hsl.luminance   * float(M_PI)) * -0.35f + 0.5f;
-    secondary_hsl.luminance = std::cos(secondary_hsl.luminance * float(M_PI)) * -0.35f + 0.5f;
+    primaryHsl.m_luminance   = std::cos(primaryHsl.m_luminance   * float(M_PI)) * -0.35f + 0.5f;
+    secondaryHsl.m_luminance = std::cos(secondaryHsl.m_luminance * float(M_PI)) * -0.35f + 0.5f;
 
     // TODO: Remove next line once this provider stops piggybacking MSW
     wxRibbonMSWArtProvider::SetColourScheme(primary, secondary, tertiary);
 
-    const auto LikePrimary = [primary_hsl](double luminance)
+    const auto LikePrimary = [primaryHsl](double luminance)
         {
-            return wxRibbonShiftLuminance(primary_hsl, luminance).ToRGB();
+            return wxRibbonShiftLuminance(primaryHsl, luminance).ToRGB();
         };
-    const auto LikeSecondary = [secondary_hsl](double luminance)
+    const auto LikeSecondary = [secondaryHsl](double luminance)
         {
-            return wxRibbonShiftLuminance(secondary_hsl, luminance).ToRGB();
+            return wxRibbonShiftLuminance(secondaryHsl, luminance).ToRGB();
         };
 
-    m_tab_ctrl_background_colour = LikePrimary(0.9);
+    m_tabCtrlBackgroundColour = LikePrimary(0.9);
 #ifdef __WXOSX__
-    m_tab_ctrl_background_gradient_colour = m_tab_ctrl_background_colour;
+    m_tabCtrlBackgroundGradientColour = m_tabCtrlBackgroundColour;
 #else
-    m_tab_ctrl_background_gradient_colour = LikePrimary(1.7);
+    m_tabCtrlBackgroundGradientColour = LikePrimary(1.7);
 #endif
-    m_tab_border_pen = LikePrimary(0.75);
+    m_tabBorderPen = LikePrimary(0.75);
 #ifdef __WXOSX__
-    m_tab_label_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
+    m_tabLabelColour = wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
 #else
-    m_tab_label_colour = wxSystemSettings::SelectLightDark(
+    m_tabLabelColour = wxSystemSettings::SelectLightDark(
                             LikePrimary(0.1),
                             wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT));
 #endif
-    m_tab_active_label_colour = m_tab_label_colour;
-    m_tab_hover_label_colour = m_tab_label_colour;
-    m_tab_hover_background_top_colour =  primary_hsl.ToRGB();
+    m_tabActiveLabelColour = m_tabLabelColour;
+    m_tabHoverLabelColour = m_tabLabelColour;
+    m_tabHoverBackgroundTopColour = primaryHsl.ToRGB();
 #ifdef __WXOSX__
-    m_tab_hover_background_top_gradient_colour = m_tab_hover_background_top_colour;
+    m_tabHoverBackgroundTopGradientColour = m_tabHoverBackgroundTopColour;
 #else
-    m_tab_hover_background_top_gradient_colour = LikePrimary(1.6);
+    m_tabHoverBackgroundTopGradientColour = LikePrimary(1.6);
 #endif
-    m_tab_hover_background_brush = m_tab_hover_background_top_colour;
-    m_tab_active_background_colour = m_tab_ctrl_background_gradient_colour;
+    m_tabHoverBackgroundBrush = m_tabHoverBackgroundTopColour;
+    m_tabActiveBackgroundColour = m_tabCtrlBackgroundGradientColour;
 #ifdef __WXOSX__
-    m_tab_active_background_gradient_colour = m_tab_active_background_colour;
+    m_tabActiveBackgroundGradientColour = m_tabActiveBackgroundColour;
 #else
-    m_tab_active_background_gradient_colour = primary_hsl.ToRGB();
+    m_tabActiveBackgroundGradientColour = primaryHsl.ToRGB();
 #endif
-    m_tab_active_top_background_brush = m_tab_active_background_colour;
-    m_panel_label_colour = m_tab_label_colour;
-    m_panel_minimised_label_colour = m_panel_label_colour;
-    m_panel_hover_label_colour = tertiary_hsl.ToRGB();
-    m_page_border_pen = m_tab_border_pen;
-    m_panel_border_pen = m_tab_border_pen;
-    m_background_brush = primary_hsl.ToRGB();
-    m_page_hover_background_colour = LikePrimary(1.5);
-    m_page_hover_background_gradient_colour = LikePrimary(0.9);
-    m_panel_label_background_colour = LikePrimary(0.85);
-    m_panel_label_background_gradient_colour = LikePrimary(0.97);
-    m_panel_hover_label_background_gradient_colour = secondary_hsl.ToRGB();
-    m_panel_hover_label_background_colour = secondary_hsl.AdjustLuminance(0.2f).ToRGB();
-    m_button_bar_hover_border_pen = secondary_hsl.ToRGB();
-    m_button_bar_hover_background_brush = LikeSecondary(1.7);
-    m_button_bar_active_background_brush = LikeSecondary(1.4);
-    m_button_bar_label_colour = m_tab_label_colour;
+    m_tabActiveTopBackgroundBrush = m_tabActiveBackgroundColour;
+    m_panelLabelColour = m_tabLabelColour;
+    m_panelMinimisedLabelColour = m_panelLabelColour;
+    m_panelHoverLabelColour = tertiaryHsl.ToRGB();
+    m_pageBorderPen = m_tabBorderPen;
+    m_panelBorderPen = m_tabBorderPen;
+    m_backgroundBrush = primaryHsl.ToRGB();
+    m_pageHoverBackgroundColour = LikePrimary(1.5);
+    m_pageHoverBackgroundGradientColour = LikePrimary(0.9);
+    m_panelLabelBackgroundColour = LikePrimary(0.85);
+    m_panelLabelBackgroundGradientColour = LikePrimary(0.97);
+    m_panelHoverLabelBackgroundGradientColour = secondaryHsl.ToRGB();
+    m_panelHoverLabelBackgroundColour = secondaryHsl.AdjustLuminance(0.2f).ToRGB();
+    m_buttonBarHoverBorderPen = secondaryHsl.ToRGB();
+    m_buttonBarHoverBackgroundBrush = LikeSecondary(1.7);
+    m_buttonBarActiveBackgroundBrush = LikeSecondary(1.4);
+    m_buttonBarLabelColour = m_tabLabelColour;
 #ifdef __WXOSX__
-    m_button_bar_label_disabled_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT);
+    m_buttonBarLabelDisabledColour = wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT);
 #else
-    m_button_bar_label_disabled_colour = m_tab_label_colour;
+    m_buttonBarLabelDisabledColour = m_tabLabelColour;
 #endif
-    m_gallery_border_pen = m_tab_border_pen;
-    m_gallery_item_border_pen = m_button_bar_hover_border_pen;
-    m_gallery_hover_background_brush = LikePrimary(1.2);
-    m_gallery_button_background_colour = m_page_hover_background_colour;
-    m_gallery_button_background_gradient_colour = m_page_hover_background_gradient_colour;
-    m_gallery_button_hover_background_brush = m_button_bar_hover_background_brush;
-    m_gallery_button_active_background_brush = m_button_bar_active_background_brush;
-    m_gallery_button_disabled_background_brush = primary_hsl.Desaturated(0.15f).ToRGB();
+    m_galleryBorderPen = m_tabBorderPen;
+    m_galleryItemBorderPen = m_buttonBarHoverBorderPen;
+    m_galleryHoverBackgroundBrush = LikePrimary(1.2);
+    m_galleryButtonBackgroundColour = m_pageHoverBackgroundColour;
+    m_galleryButtonBackgroundGradientColour = m_pageHoverBackgroundGradientColour;
+    m_galleryButtonHoverBackgroundBrush = m_buttonBarHoverBackgroundBrush;
+    m_galleryButtonActiveBackgroundBrush = m_buttonBarActiveBackgroundBrush;
+    m_galleryButtonDisabledBackgroundBrush = primaryHsl.Desaturated(0.15f).ToRGB();
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_FACE_COLOUR, LikePrimary(0.1));
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_DISABLED_FACE_COLOUR, wxColour(128, 128, 128));
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_FACE_COLOUR, LikeSecondary(0.1));
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_HOVER_FACE_COLOUR, LikeSecondary(0.1));
-    m_toolbar_border_pen = m_tab_border_pen;
+    m_toolbarBorderPen = m_tabBorderPen;
     SetColour(wxRIBBON_ART_TOOLBAR_FACE_COLOUR, LikePrimary(0.1));
-    m_tool_background_colour = m_page_hover_background_colour;
-    m_tool_background_gradient_colour = m_page_hover_background_gradient_colour;
-    m_toolbar_hover_borden_pen = m_button_bar_hover_border_pen;
-    m_tool_hover_background_brush = m_button_bar_hover_background_brush;
-    m_tool_active_background_brush = m_button_bar_active_background_brush;
+    m_toolBackgroundColour = m_pageHoverBackgroundColour;
+    m_toolBackgroundGradientColour = m_pageHoverBackgroundGradientColour;
+    m_toolbarHoverBordenPen = m_buttonBarHoverBorderPen;
+    m_toolHoverBackgroundBrush = m_buttonBarHoverBackgroundBrush;
+    m_toolActiveBackgroundBrush = m_buttonBarActiveBackgroundBrush;
 
-    //For highlight pages
-    wxColour top_colour1((m_tab_active_background_colour.Red()   + m_tab_hover_background_top_colour.Red())/2,
-                         (m_tab_active_background_colour.Green() + m_tab_hover_background_top_colour.Green())/2,
-                         (m_tab_active_background_colour.Blue()  + m_tab_hover_background_top_colour.Blue())/2);
+    // For highlight pages
+    wxColour topColour1((m_tabActiveBackgroundColour.Red()   + m_tabHoverBackgroundTopColour.Red())/2,
+                         (m_tabActiveBackgroundColour.Green() + m_tabHoverBackgroundTopColour.Green())/2,
+                         (m_tabActiveBackgroundColour.Blue()  + m_tabHoverBackgroundTopColour.Blue())/2);
 
-    wxColour bottom_colour1((m_tab_active_background_gradient_colour.Red()   + m_tab_hover_background_top_gradient_colour.Red())/2,
-                            (m_tab_active_background_gradient_colour.Green() + m_tab_hover_background_top_gradient_colour.Green())/2,
-                            (m_tab_active_background_gradient_colour.Blue()  + m_tab_hover_background_top_gradient_colour.Blue())/2);
+    wxColour bottomColour1((m_tabActiveBackgroundGradientColour.Red()   + m_tabHoverBackgroundTopGradientColour.Red())/2,
+                            (m_tabActiveBackgroundGradientColour.Green() + m_tabHoverBackgroundTopGradientColour.Green())/2,
+                            (m_tabActiveBackgroundGradientColour.Blue()  + m_tabHoverBackgroundTopGradientColour.Blue())/2);
 
-    m_tab_highlight_top_colour = top_colour1;
-    m_tab_highlight_top_gradient_colour = bottom_colour1;
+    m_tabHighlightTopColour = topColour1;
+    m_tabHighlightTopGradientColour = bottomColour1;
 
-    m_tab_highlight_colour = top_colour1;
-    m_tab_highlight_gradient_colour = bottom_colour1;
+    m_tabHighlightColour = topColour1;
+    m_tabHighlightGradientColour = bottomColour1;
 }
 
 void wxRibbonAUIArtProvider::DrawTabCtrlBackground(
@@ -333,11 +333,11 @@ void wxRibbonAUIArtProvider::DrawTabCtrlBackground(
                         wxWindow* WXUNUSED(wnd),
                         const wxRect& rect)
 {
-    wxRect gradient_rect(rect);
-    gradient_rect.height--;
-    dc.GradientFillLinear(gradient_rect, m_tab_ctrl_background_colour,
-        m_tab_ctrl_background_gradient_colour, wxSOUTH);
-    dc.SetPen(m_tab_border_pen);
+    wxRect gradientRect(rect);
+    gradientRect.height--;
+    dc.GradientFillLinear(gradientRect, m_tabCtrlBackgroundColour,
+        m_tabCtrlBackgroundGradientColour, wxSOUTH);
+    dc.SetPen(m_tabBorderPen);
     dc.DrawLine(rect.x, rect.GetBottom(), rect.GetRight()+1, rect.GetBottom());
 }
 
@@ -346,163 +346,163 @@ int wxRibbonAUIArtProvider::GetTabCtrlHeight(
                         wxWindow* WXUNUSED(wnd),
                         const wxRibbonPageTabInfoArray& pages)
 {
-    int text_height = 0;
-    int icon_height = 0;
+    int textHeight = 0;
+    int iconHeight = 0;
 
-    if(pages.GetCount() <= 1 && (m_flags & wxRIBBON_BAR_ALWAYS_SHOW_TABS) == 0)
+    if ( pages.GetCount() <= 1 && (m_flags & wxRIBBON_BAR_ALWAYS_SHOW_TABS) == 0 )
     {
         // To preserve space, a single tab need not be displayed. We still need
         // one pixel of border though.
         return 1;
     }
 
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS )
     {
-        dc.SetFont(m_tab_active_label_font);
-        text_height = dc.GetTextExtent("ABCDEFXj").GetHeight();
+        dc.SetFont(m_tabActiveLabelFont);
+        textHeight = dc.GetTextExtent("ABCDEFXj").GetHeight();
     }
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
     {
-        size_t numpages = pages.GetCount();
-        for(size_t i = 0; i < numpages; ++i)
+        size_t numPages = pages.GetCount();
+        for ( size_t i = 0; i < numPages; ++i )
         {
             const wxRibbonPageTabInfo& info = pages.Item(i);
-            if(info.page->GetIcon().IsOk())
+            if ( info.m_page->GetIcon().IsOk() )
             {
-                icon_height = wxMax(icon_height, info.page->GetIcon().GetLogicalHeight());
+                iconHeight = wxMax(iconHeight, info.m_page->GetIcon().GetLogicalHeight());
             }
         }
     }
 
-    return wxMax(text_height, icon_height) + 10;
+    return wxMax(textHeight, iconHeight) + 10;
 }
 
 void wxRibbonAUIArtProvider::DrawTab(wxDC& dc,
                  wxWindow* WXUNUSED(wnd),
                  const wxRibbonPageTabInfo& tab)
 {
-    if(tab.rect.height <= 1)
+    if ( tab.m_rect.height <= 1 )
         return;
 
-    dc.SetFont(m_tab_label_font);
+    dc.SetFont(m_tabLabelFont);
     dc.SetPen(*wxTRANSPARENT_PEN);
-    if(tab.active || tab.hovered || tab.highlight)
+    if ( tab.m_active || tab.m_hovered || tab.m_highlight )
     {
-        if(tab.active)
+        if ( tab.m_active )
         {
-            dc.SetFont(m_tab_active_label_font);
-            dc.SetBrush(m_background_brush);
-            dc.DrawRectangle(tab.rect.x, tab.rect.y + tab.rect.height - 1,
-                tab.rect.width - 1, 1);
+            dc.SetFont(m_tabActiveLabelFont);
+            dc.SetBrush(m_backgroundBrush);
+            dc.DrawRectangle(tab.m_rect.x, tab.m_rect.y + tab.m_rect.height - 1,
+                tab.m_rect.width - 1, 1);
         }
-        wxRect grad_rect(tab.rect);
-        grad_rect.height -= 4;
-        grad_rect.width -= 1;
-        grad_rect.height /= 2;
-        grad_rect.y = grad_rect.y + tab.rect.height - grad_rect.height - 1;
-        dc.SetBrush(m_tab_active_top_background_brush);
-        dc.DrawRectangle(tab.rect.x, tab.rect.y + 3, tab.rect.width - 1,
-            grad_rect.y - tab.rect.y - 3);
-        if(tab.highlight)
+        wxRect gradRect(tab.m_rect);
+        gradRect.height -= 4;
+        gradRect.width -= 1;
+        gradRect.height /= 2;
+        gradRect.y = gradRect.y + tab.m_rect.height - gradRect.height - 1;
+        dc.SetBrush(m_tabActiveTopBackgroundBrush);
+        dc.DrawRectangle(tab.m_rect.x, tab.m_rect.y + 3, tab.m_rect.width - 1,
+            gradRect.y - tab.m_rect.y - 3);
+        if ( tab.m_highlight )
         {
-            dc.GradientFillLinear(grad_rect, m_tab_highlight_top_colour, m_tab_highlight_top_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(gradRect, m_tabHighlightTopColour, m_tabHighlightTopGradientColour, wxSOUTH);
         }
         else
         {
-            dc.GradientFillLinear(grad_rect, m_tab_active_background_colour,
-                m_tab_active_background_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(gradRect, m_tabActiveBackgroundColour,
+                m_tabActiveBackgroundGradientColour, wxSOUTH);
         }
     }
     else
     {
-        wxRect btm_rect(tab.rect);
-        btm_rect.height -= 4;
-        btm_rect.width -= 1;
-        btm_rect.height /= 2;
-        btm_rect.y = btm_rect.y + tab.rect.height - btm_rect.height - 1;
-        dc.SetBrush(m_tab_hover_background_brush);
-        dc.DrawRectangle(btm_rect.x, btm_rect.y, btm_rect.width,
-            btm_rect.height);
-        wxRect grad_rect(tab.rect);
-        grad_rect.width -= 1;
-        grad_rect.y += 3;
-        grad_rect.height = btm_rect.y - grad_rect.y;
-        dc.GradientFillLinear(grad_rect, m_tab_hover_background_top_colour,
-            m_tab_hover_background_top_gradient_colour, wxSOUTH);
+        wxRect btmRect(tab.m_rect);
+        btmRect.height -= 4;
+        btmRect.width -= 1;
+        btmRect.height /= 2;
+        btmRect.y = btmRect.y + tab.m_rect.height - btmRect.height - 1;
+        dc.SetBrush(m_tabHoverBackgroundBrush);
+        dc.DrawRectangle(btmRect.x, btmRect.y, btmRect.width,
+            btmRect.height);
+        wxRect gradRect(tab.m_rect);
+        gradRect.width -= 1;
+        gradRect.y += 3;
+        gradRect.height = btmRect.y - gradRect.y;
+        dc.GradientFillLinear(gradRect, m_tabHoverBackgroundTopColour,
+            m_tabHoverBackgroundTopGradientColour, wxSOUTH);
     }
 
-    wxPoint border_points[5];
-    border_points[0] = wxPoint(0, 3);
-    border_points[1] = wxPoint(1, 2);
-    border_points[2] = wxPoint(tab.rect.width - 3, 2);
-    border_points[3] = wxPoint(tab.rect.width - 1, 4);
-    border_points[4] = wxPoint(tab.rect.width - 1, tab.rect.height - 1);
+    wxPoint borderPoints[5];
+    borderPoints[0] = wxPoint(0, 3);
+    borderPoints[1] = wxPoint(1, 2);
+    borderPoints[2] = wxPoint(tab.m_rect.width - 3, 2);
+    borderPoints[3] = wxPoint(tab.m_rect.width - 1, 4);
+    borderPoints[4] = wxPoint(tab.m_rect.width - 1, tab.m_rect.height - 1);
 
-    dc.SetPen(m_tab_border_pen);
-    dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points, tab.rect.x, tab.rect.y);
+    dc.SetPen(m_tabBorderPen);
+    dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints, tab.m_rect.x, tab.m_rect.y);
 
-    wxRect old_clip;
-    dc.GetClippingBox(old_clip);
-    bool is_first_tab = false;
-    wxRibbonBar* bar = wxDynamicCast(tab.page->GetParent(), wxRibbonBar);
-    if(bar && bar->GetPage(0) == tab.page)
-        is_first_tab = true;
+    wxRect oldClip;
+    dc.GetClippingBox(oldClip);
+    bool isFirstTab = false;
+    wxRibbonBar* bar = wxDynamicCast(tab.m_page->GetParent(), wxRibbonBar);
+    if ( bar && bar->GetPage(0) == tab.m_page )
+        isFirstTab = true;
 
     wxBitmap icon;
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
     {
-        icon = tab.page->GetIcon();
-        if((m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) == 0)
+        icon = tab.m_page->GetIcon();
+        if ( (m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) == 0 )
         {
-            if(icon.IsOk())
+            if ( icon.IsOk() )
             {
-            int x = tab.rect.x + (tab.rect.width - icon.GetLogicalWidth()) / 2;
-            dc.DrawBitmap(icon, x, tab.rect.y + 1 + (tab.rect.height - 1 -
+            int x = tab.m_rect.x + (tab.m_rect.width - icon.GetLogicalWidth()) / 2;
+            dc.DrawBitmap(icon, x, tab.m_rect.y + 1 + (tab.m_rect.height - 1 -
                 icon.GetLogicalHeight()) / 2, true);
             }
         }
     }
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS )
     {
-        wxString label = tab.page->GetLabel();
-        if(!label.empty())
+        wxString label = tab.m_page->GetLabel();
+        if ( !label.empty() )
         {
-            if (tab.active)
+            if ( tab.m_active )
             {
-                dc.SetTextForeground(m_tab_active_label_colour);
+                dc.SetTextForeground(m_tabActiveLabelColour);
             }
-            else if (tab.hovered)
+            else if ( tab.m_hovered )
             {
-                dc.SetTextForeground(m_tab_hover_label_colour);
+                dc.SetTextForeground(m_tabHoverLabelColour);
             }
             else
             {
-                dc.SetTextForeground(m_tab_label_colour);
+                dc.SetTextForeground(m_tabLabelColour);
             }
 
             dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
             int offset = 0;
-            if(icon.IsOk())
+            if ( icon.IsOk() )
                 offset += icon.GetLogicalWidth() + 2;
-            int text_height;
-            int text_width;
-            dc.GetTextExtent(label, &text_width, &text_height);
-            int x = (tab.rect.width - 2 - text_width - offset) / 2;
-            if(x > 8)
+            int textHeight;
+            int textWidth;
+            dc.GetTextExtent(label, &textWidth, &textHeight);
+            int x = (tab.m_rect.width - 2 - textWidth - offset) / 2;
+            if ( x > 8 )
                 x = 8;
-            else if(x < 1)
+            else if ( x < 1 )
                 x = 1;
-            int width = tab.rect.width - x - 2;
-            x += tab.rect.x + offset;
-            int y = tab.rect.y + (tab.rect.height - text_height) / 2;
-            if(icon.IsOk())
+            int width = tab.m_rect.width - x - 2;
+            x += tab.m_rect.x + offset;
+            int y = tab.m_rect.y + (tab.m_rect.height - textHeight) / 2;
+            if ( icon.IsOk() )
             {
-                dc.DrawBitmap(icon, x - offset, tab.rect.y + (tab.rect.height -
+                dc.DrawBitmap(icon, x - offset, tab.m_rect.y + (tab.m_rect.height -
                     icon.GetLogicalHeight()) / 2, true);
             }
             {
-                wxDCClipper clip(dc, x, tab.rect.y, width, tab.rect.height);
+                wxDCClipper clip(dc, x, tab.m_rect.y, width, tab.m_rect.height);
                 dc.DrawText(label, x, y);
             }
         }
@@ -513,12 +513,12 @@ void wxRibbonAUIArtProvider::DrawTab(wxDC& dc,
     // outside the rectangle for the tab, only draw it if the leftmost part of
     // the tab is within the clip rectangle (the clip region has to be cleared
     // to draw outside the tab).
-    if(is_first_tab && old_clip.x <= tab.rect.x
-        && tab.rect.x < old_clip.x + old_clip.width)
+    if ( isFirstTab && oldClip.x <= tab.m_rect.x
+        && tab.m_rect.x < oldClip.x + oldClip.width )
     {
         dc.DestroyClippingRegion();
-        dc.DrawLine(tab.rect.x - 1, tab.rect.y + 4, tab.rect.x - 1,
-            tab.rect.y + tab.rect.height - 1);
+        dc.DrawLine(tab.m_rect.x - 1, tab.m_rect.y + 4, tab.m_rect.x - 1,
+            tab.m_rect.y + tab.m_rect.height - 1);
     }
 }
 
@@ -528,43 +528,43 @@ void wxRibbonAUIArtProvider::GetBarTabWidth(
                         const wxString& label,
                         const wxBitmap& bitmap,
                         int* ideal,
-                        int* small_begin_need_separator,
-                        int* small_must_have_separator,
+                        int* smallBeginNeedSeparator,
+                        int* smallMustHaveSeparator,
                         int* minimum)
 {
     int width = 0;
     int min = 0;
-    if((m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) && !label.empty())
+    if ( (m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) && !label.empty() )
     {
-        dc.SetFont(m_tab_active_label_font);
+        dc.SetFont(m_tabActiveLabelFont);
         width += dc.GetTextExtent(label).GetWidth();
         min += wxMin(30, width); // enough for a few chars
-        if(bitmap.IsOk())
+        if ( bitmap.IsOk() )
         {
             // gap between label and bitmap
             width += 4;
             min += 2;
         }
     }
-    if((m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS) && bitmap.IsOk())
+    if ( (m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS) && bitmap.IsOk() )
     {
         width += bitmap.GetLogicalWidth();
         min += bitmap.GetLogicalWidth();
     }
 
-    if(ideal != nullptr)
+    if ( ideal != nullptr )
     {
         *ideal = width + 16;
     }
-    if(small_begin_need_separator != nullptr)
+    if ( smallBeginNeedSeparator != nullptr )
     {
-        *small_begin_need_separator = min;
+        *smallBeginNeedSeparator = min;
     }
-    if(small_must_have_separator != nullptr)
+    if ( smallMustHaveSeparator != nullptr )
     {
-        *small_must_have_separator = min;
+        *smallMustHaveSeparator = min;
     }
-    if(minimum != nullptr)
+    if ( minimum != nullptr )
     {
         *minimum = min;
     }
@@ -585,12 +585,12 @@ void wxRibbonAUIArtProvider::DrawPageBackground(
                         const wxRect& rect)
 {
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(m_background_brush);
+    dc.SetBrush(m_backgroundBrush);
     dc.DrawRectangle(rect.x + 1, rect.y, rect.width - 2, rect.height - 1);
 
-    dc.SetPen(m_page_border_pen);
+    dc.SetPen(m_pageBorderPen);
     dc.DrawLine(rect.x, rect.y, rect.x, rect.y + rect.height);
-    dc.DrawLine(rect.GetRight(), rect.y, rect.GetRight(), rect.y +rect.height);
+    dc.DrawLine(rect.GetRight(), rect.y, rect.GetRight(), rect.y + rect.height);
     dc.DrawLine(rect.x, rect.GetBottom(), rect.GetRight()+1, rect.GetBottom());
 }
 
@@ -608,52 +608,52 @@ void wxRibbonAUIArtProvider::DrawScrollButton(
                         const wxRect& rect,
                         long style)
 {
-    wxRect true_rect(rect);
-    wxPoint arrow_points[3];
+    wxRect trueRect(rect);
+    wxPoint arrowPoints[3];
 
-    if((style & wxRIBBON_SCROLL_BTN_FOR_MASK) == wxRIBBON_SCROLL_BTN_FOR_TABS)
+    if ( (style & wxRIBBON_SCROLL_BTN_FOR_MASK) == wxRIBBON_SCROLL_BTN_FOR_TABS )
     {
-        true_rect.y += 2;
-        true_rect.height -= 2;
-        dc.SetPen(m_tab_border_pen);
+        trueRect.y += 2;
+        trueRect.height -= 2;
+        dc.SetPen(m_tabBorderPen);
     }
     else
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_background_brush);
+        dc.SetBrush(m_backgroundBrush);
         dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
-        dc.SetPen(m_page_border_pen);
+        dc.SetPen(m_pageBorderPen);
     }
 
-    switch(style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK)
+    switch ( style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
     {
     case wxRIBBON_SCROLL_BTN_LEFT:
-        dc.DrawLine(true_rect.GetRight(), true_rect.y, true_rect.GetRight(),
-            true_rect.y + true_rect.height);
-        arrow_points[0] = wxPoint(rect.width / 2 - 2, rect.height / 2);
-        arrow_points[1] = arrow_points[0] + wxPoint(5, -5);
-        arrow_points[2] = arrow_points[0] + wxPoint(5,  5);
+        dc.DrawLine(trueRect.GetRight(), trueRect.y, trueRect.GetRight(),
+            trueRect.y + trueRect.height);
+        arrowPoints[0] = wxPoint(rect.width / 2 - 2, rect.height / 2);
+        arrowPoints[1] = arrowPoints[0] + wxPoint(5, -5);
+        arrowPoints[2] = arrowPoints[0] + wxPoint(5,  5);
         break;
     case wxRIBBON_SCROLL_BTN_RIGHT:
-        dc.DrawLine(true_rect.x, true_rect.y, true_rect.x,
-            true_rect.y + true_rect.height);
-        arrow_points[0] = wxPoint(rect.width / 2 + 3, rect.height / 2);
-        arrow_points[1] = arrow_points[0] - wxPoint(5, -5);
-        arrow_points[2] = arrow_points[0] - wxPoint(5,  5);
+        dc.DrawLine(trueRect.x, trueRect.y, trueRect.x,
+            trueRect.y + trueRect.height);
+        arrowPoints[0] = wxPoint(rect.width / 2 + 3, rect.height / 2);
+        arrowPoints[1] = arrowPoints[0] - wxPoint(5, -5);
+        arrowPoints[2] = arrowPoints[0] - wxPoint(5,  5);
         break;
     case wxRIBBON_SCROLL_BTN_DOWN:
-        dc.DrawLine(true_rect.x, true_rect.y, true_rect.x + true_rect.width,
-            true_rect.y);
-        arrow_points[0] = wxPoint(rect.width / 2, rect.height / 2 + 3);
-        arrow_points[1] = arrow_points[0] - wxPoint( 5, 5);
-        arrow_points[2] = arrow_points[0] - wxPoint(-5, 5);
+        dc.DrawLine(trueRect.x, trueRect.y, trueRect.x + trueRect.width,
+            trueRect.y);
+        arrowPoints[0] = wxPoint(rect.width / 2, rect.height / 2 + 3);
+        arrowPoints[1] = arrowPoints[0] - wxPoint( 5, 5);
+        arrowPoints[2] = arrowPoints[0] - wxPoint(-5, 5);
         break;
     case wxRIBBON_SCROLL_BTN_UP:
-        dc.DrawLine(true_rect.x, true_rect.GetBottom(),
-            true_rect.x + true_rect.width, true_rect.GetBottom());
-        arrow_points[0] = wxPoint(rect.width / 2, rect.height / 2 - 2);
-        arrow_points[1] = arrow_points[0] + wxPoint( 5, 5);
-        arrow_points[2] = arrow_points[0] + wxPoint(-5, 5);
+        dc.DrawLine(trueRect.x, trueRect.GetBottom(),
+            trueRect.x + trueRect.width, trueRect.GetBottom());
+        arrowPoints[0] = wxPoint(rect.width / 2, rect.height / 2 - 2);
+        arrowPoints[1] = arrowPoints[0] + wxPoint( 5, 5);
+        arrowPoints[2] = arrowPoints[0] + wxPoint(-5, 5);
         break;
     default:
         return;
@@ -661,64 +661,66 @@ void wxRibbonAUIArtProvider::DrawScrollButton(
 
     int x = rect.x;
     int y = rect.y;
-    if(style & wxRIBBON_SCROLL_BTN_ACTIVE)
+    if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
     {
         ++x;
         ++y;
     }
 
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(wxBrush(m_tab_label_colour));
-    dc.DrawPolygon(WXSIZEOF(arrow_points), arrow_points, x, y);
+    dc.SetBrush(wxBrush(m_tabLabelColour));
+    dc.DrawPolygon(WXSIZEOF(arrowPoints), arrowPoints, x, y);
 }
 
 wxSize wxRibbonAUIArtProvider::GetPanelSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize client_size,
-                        wxPoint* client_offset)
+                        wxSize clientSize,
+                        wxPoint* clientOffset)
 {
-    dc.SetFont(m_panel_label_font);
-    wxSize label_size = dc.GetTextExtent(wnd->GetLabel());
-    int label_height = label_size.GetHeight() + 5;
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    dc.SetFont(m_panelLabelFont);
+    wxSize labelSize = dc.GetTextExtent(wnd->GetLabel());
+    int labelHeight = labelSize.GetHeight() + 5;
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
-        client_size.IncBy(4, label_height + 6);
-        if(client_offset)
-            *client_offset = wxPoint(2, label_height + 3);
+        clientSize.IncBy(4, labelHeight + 6);
+        if ( clientOffset )
+            *clientOffset = wxPoint(2, labelHeight + 3);
     }
     else
     {
-        client_size.IncBy(6, label_height + 4);
-        if(client_offset)
-            *client_offset = wxPoint(3, label_height + 2);
+        clientSize.IncBy(6, labelHeight + 4);
+        if ( clientOffset )
+            *clientOffset = wxPoint(3, labelHeight + 2);
     }
-    return client_size;
+    return clientSize;
 }
 
 wxSize wxRibbonAUIArtProvider::GetPanelClientSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
-                        wxPoint* client_offset)
+                        wxPoint* clientOffset)
 {
-    dc.SetFont(m_panel_label_font);
-    wxSize label_size = dc.GetTextExtent(wnd->GetLabel());
-    int label_height = label_size.GetHeight() + 5;
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    dc.SetFont(m_panelLabelFont);
+    wxSize labelSize = dc.GetTextExtent(wnd->GetLabel());
+    int labelHeight = labelSize.GetHeight() + 5;
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
-        size.DecBy(4, label_height + 6);
-        if(client_offset)
-            *client_offset = wxPoint(2, label_height + 3);
+        size.DecBy(4, labelHeight + 6);
+        if ( clientOffset )
+            *clientOffset = wxPoint(2, labelHeight + 3);
     }
     else
     {
-        size.DecBy(6, label_height + 4);
-        if(client_offset)
-            *client_offset = wxPoint(3, label_height + 2);
+        size.DecBy(6, labelHeight + 4);
+        if ( clientOffset )
+            *clientOffset = wxPoint(3, labelHeight + 2);
     }
-    if (size.x < 0) size.x = 0;
-    if (size.y < 0) size.y = 0;
+    if ( size.x < 0 )
+        size.x = 0;
+    if ( size.y < 0 )
+        size.y = 0;
     return size;
 }
 
@@ -726,20 +728,20 @@ wxRect wxRibbonAUIArtProvider::GetPanelExtButtonArea(wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxRect rect)
 {
-    wxRect true_rect(rect);
-    RemovePanelPadding(&true_rect);
+    wxRect trueRect(rect);
+    RemovePanelPadding(&trueRect);
 
-    true_rect.x++;
-    true_rect.width -= 2;
-    true_rect.y++;
+    trueRect.x++;
+    trueRect.width -= 2;
+    trueRect.y++;
 
-    dc.SetFont(m_panel_label_font);
-    wxSize label_size = dc.GetTextExtent(wnd->GetLabel());
-    int label_height = label_size.GetHeight() + 5;
-    wxRect label_rect(true_rect);
-    label_rect.height = label_height - 1;
+    dc.SetFont(m_panelLabelFont);
+    wxSize labelSize = dc.GetTextExtent(wnd->GetLabel());
+    int labelHeight = labelSize.GetHeight() + 5;
+    wxRect labelRect(trueRect);
+    labelRect.height = labelHeight - 1;
 
-    rect = wxRect(label_rect.GetRight()-13, label_rect.GetBottom()-13, 13, 13);
+    rect = wxRect(labelRect.GetRight()-13, labelRect.GetBottom()-13, 13, 13);
     return rect;
 }
 
@@ -749,75 +751,75 @@ void wxRibbonAUIArtProvider::DrawPanelBackground(
                         const wxRect& rect)
 {
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(m_background_brush);
+    dc.SetBrush(m_backgroundBrush);
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
-    wxRect true_rect(rect);
-    RemovePanelPadding(&true_rect);
+    wxRect trueRect(rect);
+    RemovePanelPadding(&trueRect);
 
-    dc.SetPen(m_panel_border_pen);
+    dc.SetPen(m_panelBorderPen);
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
-    dc.DrawRectangle(true_rect.x, true_rect.y, true_rect.width, true_rect.height);
+    dc.DrawRectangle(trueRect.x, trueRect.y, trueRect.width, trueRect.height);
 
-    true_rect.x++;
-    true_rect.width -= 2;
-    true_rect.y++;
+    trueRect.x++;
+    trueRect.width -= 2;
+    trueRect.y++;
 
-    dc.SetFont(m_panel_label_font);
-    wxSize label_size = dc.GetTextExtent(wnd->GetLabel());
-    int label_height = label_size.GetHeight() + 5;
-    wxRect label_rect(true_rect);
-    label_rect.height = label_height - 1;
-    dc.DrawLine(label_rect.x, label_rect.y + label_rect.height,
-        label_rect.x + label_rect.width, label_rect.y + label_rect.height);
+    dc.SetFont(m_panelLabelFont);
+    wxSize labelSize = dc.GetTextExtent(wnd->GetLabel());
+    int labelHeight = labelSize.GetHeight() + 5;
+    wxRect labelRect(trueRect);
+    labelRect.height = labelHeight - 1;
+    dc.DrawLine(labelRect.x, labelRect.y + labelRect.height,
+        labelRect.x + labelRect.width, labelRect.y + labelRect.height);
 
-    wxColour label_bg_colour = m_panel_label_background_colour;
-    wxColour label_bg_grad_colour = m_panel_label_background_gradient_colour;
-    if(wnd->IsHovered())
+    wxColour labelBgColour = m_panelLabelBackgroundColour;
+    wxColour labelBgGradColour = m_panelLabelBackgroundGradientColour;
+    if ( wnd->IsHovered() )
     {
-        label_bg_colour = m_panel_hover_label_background_colour;
-        label_bg_grad_colour = m_panel_hover_label_background_gradient_colour;
-        dc.SetTextForeground(m_panel_hover_label_colour);
+        labelBgColour = m_panelHoverLabelBackgroundColour;
+        labelBgGradColour = m_panelHoverLabelBackgroundGradientColour;
+        dc.SetTextForeground(m_panelHoverLabelColour);
     }
     else
     {
-        dc.SetTextForeground(m_panel_label_colour);
+        dc.SetTextForeground(m_panelLabelColour);
     }
-    dc.GradientFillLinear(label_rect,
+    dc.GradientFillLinear(labelRect,
 #ifdef __WXOSX__
-        label_bg_grad_colour, label_bg_colour, wxSOUTH);
+        labelBgGradColour, labelBgColour, wxSOUTH);
 #else
-        label_bg_colour, label_bg_grad_colour, wxSOUTH);
+        labelBgColour, labelBgGradColour, wxSOUTH);
 #endif
-    dc.SetFont(m_panel_label_font);
-    dc.DrawText(wnd->GetLabel(), label_rect.x + 3, label_rect.y + 2);
+    dc.SetFont(m_panelLabelFont);
+    dc.DrawText(wnd->GetLabel(), labelRect.x + 3, labelRect.y + 2);
 
-    if(wnd->IsHovered())
+    if ( wnd->IsHovered() )
     {
-        wxRect gradient_rect(true_rect);
-        gradient_rect.y += label_rect.height + 1;
-        gradient_rect.height = true_rect.height - label_rect.height - 3;
+        wxRect gradientRect(trueRect);
+        gradientRect.y += labelRect.height + 1;
+        gradientRect.height = trueRect.height - labelRect.height - 3;
 #ifdef __WXOSX__
-        wxColour colour = m_page_hover_background_gradient_colour;
-        wxColour gradient = m_page_hover_background_colour;
+        wxColour colour = m_pageHoverBackgroundGradientColour;
+        wxColour gradient = m_pageHoverBackgroundColour;
 #else
-        wxColour colour = m_page_hover_background_colour;
-        wxColour gradient = m_page_hover_background_gradient_colour;
+        wxColour colour = m_pageHoverBackgroundColour;
+        wxColour gradient = m_pageHoverBackgroundGradientColour;
 #endif
-        dc.GradientFillLinear(gradient_rect, colour, gradient, wxSOUTH);
+        dc.GradientFillLinear(gradientRect, colour, gradient, wxSOUTH);
     }
 
-    if(wnd->HasExtButton())
+    if ( wnd->HasExtButton() )
     {
-        if(wnd->IsExtButtonHovered())
+        if ( wnd->IsExtButtonHovered() )
         {
-            dc.SetPen(m_panel_hover_button_border_pen);
-            dc.SetBrush(m_panel_hover_button_background_brush);
-            dc.DrawRoundedRectangle(label_rect.GetRight() - 13, label_rect.GetBottom() - 13, 13, 13, 1.0);
-            dc.DrawBitmap(m_panel_extension_bundle[1].GetBitmapFor(wnd), label_rect.GetRight() - 10, label_rect.GetBottom() - 10, true);
+            dc.SetPen(m_panelHoverButtonBorderPen);
+            dc.SetBrush(m_panelHoverButtonBackgroundBrush);
+            dc.DrawRoundedRectangle(labelRect.GetRight() - 13, labelRect.GetBottom() - 13, 13, 13, 1.0);
+            dc.DrawBitmap(m_panelExtensionBundle[1].GetBitmapFor(wnd), labelRect.GetRight() - 10, labelRect.GetBottom() - 10, true);
         }
         else
-            dc.DrawBitmap(m_panel_extension_bundle[0].GetBitmapFor(wnd), label_rect.GetRight() - 10, label_rect.GetBottom() - 10, true);
+            dc.DrawBitmap(m_panelExtensionBundle[0].GetBitmapFor(wnd), labelRect.GetRight() - 10, labelRect.GetBottom() - 10, true);
     }
 }
 
@@ -828,62 +830,62 @@ void wxRibbonAUIArtProvider::DrawMinimisedPanel(
                         wxBitmap& bitmap)
 {
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(m_background_brush);
+    dc.SetBrush(m_backgroundBrush);
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
-    wxRect true_rect(rect);
-    RemovePanelPadding(&true_rect);
+    wxRect trueRect(rect);
+    RemovePanelPadding(&trueRect);
 
-    dc.SetPen(m_panel_border_pen);
+    dc.SetPen(m_panelBorderPen);
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
-    dc.DrawRectangle(true_rect.x, true_rect.y, true_rect.width, true_rect.height);
-    true_rect.Deflate(1);
+    dc.DrawRectangle(trueRect.x, trueRect.y, trueRect.width, trueRect.height);
+    trueRect.Deflate(1);
 
-    if(wnd->IsHovered() || wnd->GetExpandedPanel())
+    if ( wnd->IsHovered() || wnd->GetExpandedPanel() )
     {
-        wxColour colour = m_page_hover_background_colour;
-        wxColour gradient = m_page_hover_background_gradient_colour;
+        wxColour colour = m_pageHoverBackgroundColour;
+        wxColour gradient = m_pageHoverBackgroundGradientColour;
 #ifdef __WXOSX__
-        if(!wnd->GetExpandedPanel())
+        if ( !wnd->GetExpandedPanel() )
 #else
-        if(wnd->GetExpandedPanel())
+        if ( wnd->GetExpandedPanel() )
 #endif
         {
             wxColour temp = colour;
             colour = gradient;
             gradient = temp;
         }
-        dc.GradientFillLinear(true_rect, colour, gradient, wxSOUTH);
+        dc.GradientFillLinear(trueRect, colour, gradient, wxSOUTH);
     }
 
     wxRect preview;
-    DrawMinimisedPanelCommon(dc, wnd, true_rect, &preview);
+    DrawMinimisedPanelCommon(dc, wnd, trueRect, &preview);
 
-    dc.SetPen(m_panel_border_pen);
+    dc.SetPen(m_panelBorderPen);
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
     dc.DrawRectangle(preview.x, preview.y, preview.width, preview.height);
     preview.Deflate(1);
-    wxRect preview_caption_rect(preview);
-    preview_caption_rect.height = 7;
-    preview.y += preview_caption_rect.height;
-    preview.height -= preview_caption_rect.height;
+    wxRect previewCaptionRect(preview);
+    previewCaptionRect.height = 7;
+    preview.y += previewCaptionRect.height;
+    preview.height -= previewCaptionRect.height;
 #ifdef __WXOSX__
-    dc.GradientFillLinear(preview_caption_rect,
-        m_panel_hover_label_background_gradient_colour,
-        m_panel_hover_label_background_colour, wxSOUTH);
+    dc.GradientFillLinear(previewCaptionRect,
+        m_panelHoverLabelBackgroundGradientColour,
+        m_panelHoverLabelBackgroundColour, wxSOUTH);
     dc.GradientFillLinear(preview,
-        m_page_hover_background_gradient_colour,
-        m_page_hover_background_colour, wxSOUTH);
+        m_pageHoverBackgroundGradientColour,
+        m_pageHoverBackgroundColour, wxSOUTH);
 #else
-    dc.GradientFillLinear(preview_caption_rect,
-        m_panel_hover_label_background_colour,
-        m_panel_hover_label_background_gradient_colour, wxSOUTH);
+    dc.GradientFillLinear(previewCaptionRect,
+        m_panelHoverLabelBackgroundColour,
+        m_panelHoverLabelBackgroundGradientColour, wxSOUTH);
     dc.GradientFillLinear(preview,
-        m_page_hover_background_colour,
-        m_page_hover_background_gradient_colour, wxSOUTH);
+        m_pageHoverBackgroundColour,
+        m_pageHoverBackgroundGradientColour, wxSOUTH);
 #endif
 
-    if(bitmap.IsOk())
+    if ( bitmap.IsOk() )
     {
         dc.DrawBitmap(bitmap, preview.x + (preview.width - bitmap.GetLogicalWidth()) / 2,
             preview.y + (preview.height - bitmap.GetLogicalHeight()) / 2, true);
@@ -894,61 +896,60 @@ void wxRibbonAUIArtProvider::DrawPartialPanelBackground(wxDC& dc,
         wxWindow* wnd, const wxRect& rect)
 {
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(m_background_brush);
+    dc.SetBrush(m_backgroundBrush);
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
     wxPoint offset(wnd->GetPosition());
     wxWindow* parent = wnd->GetParent();
     wxRibbonPanel* panel = nullptr;
 
-    for(; parent; parent = parent->GetParent())
+    for ( ; parent; parent = parent->GetParent() )
     {
         panel = wxDynamicCast(parent, wxRibbonPanel);
-        if(panel != nullptr)
+        if ( panel != nullptr )
         {
-            if(!panel->IsHovered())
+            if ( !panel->IsHovered() )
                 return;
             break;
         }
         offset += parent->GetPosition();
     }
-    if(panel == nullptr)
+    if ( panel == nullptr )
         return;
 
     wxRect background(panel->GetSize());
     RemovePanelPadding(&background);
     background.x++;
     background.width -= 2;
-    dc.SetFont(m_panel_label_font);
-    int caption_height = dc.GetTextExtent(panel->GetLabel()).GetHeight() + 7;
-    background.y += caption_height - 1;
-    background.height -= caption_height;
+    dc.SetFont(m_panelLabelFont);
+    int captionHeight = dc.GetTextExtent(panel->GetLabel()).GetHeight() + 7;
+    background.y += captionHeight - 1;
+    background.height -= captionHeight;
 
-    wxRect paint_rect(rect);
-    paint_rect.x += offset.x;
-    paint_rect.y += offset.y;
+    wxRect paintRect(rect);
+    paintRect.x += offset.x;
+    paintRect.y += offset.y;
 
-    wxColour bg_clr, bg_grad_clr;
+    wxColour bgClr, bgGradClr;
 #ifdef __WXOSX__
-    bg_grad_clr = m_page_hover_background_colour;
-    bg_clr = m_page_hover_background_gradient_colour;
+    bgGradClr = m_pageHoverBackgroundColour;
+    bgClr = m_pageHoverBackgroundGradientColour;
 #else
-    bg_clr = m_page_hover_background_colour;
-    bg_grad_clr = m_page_hover_background_gradient_colour;
+    bgClr = m_pageHoverBackgroundColour;
+    bgGradClr = m_pageHoverBackgroundGradientColour;
 #endif
 
-    paint_rect.Intersect(background);
-    if(!paint_rect.IsEmpty())
+    paintRect.Intersect(background);
+    if ( !paintRect.IsEmpty() )
     {
-        wxColour starting_colour(wxRibbonInterpolateColour(bg_clr, bg_grad_clr,
-            paint_rect.y, background.y, background.y + background.height));
-        wxColour ending_colour(wxRibbonInterpolateColour(bg_clr, bg_grad_clr,
-            paint_rect.y + paint_rect.height, background.y,
+        wxColour startingColour(wxRibbonInterpolateColour(bgClr, bgGradClr,
+            paintRect.y, background.y, background.y + background.height));
+        wxColour endingColour(wxRibbonInterpolateColour(bgClr, bgGradClr,
+            paintRect.y + paintRect.height, background.y,
             background.y + background.height));
-        paint_rect.x -= offset.x;
-        paint_rect.y -= offset.y;
-        dc.GradientFillLinear(paint_rect, starting_colour, ending_colour
-            , wxSOUTH);
+        paintRect.x -= offset.x;
+        paintRect.y -= offset.y;
+        dc.GradientFillLinear(paintRect, startingColour, endingColour, wxSOUTH);
     }
 }
 
@@ -959,11 +960,11 @@ void wxRibbonAUIArtProvider::DrawGalleryBackground(
 {
     DrawPartialPanelBackground(dc, wnd, rect);
 
-    if(wnd->IsHovered())
+    if ( wnd->IsHovered() )
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_gallery_hover_background_brush);
-        if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+        dc.SetBrush(m_galleryHoverBackgroundBrush);
+        if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
         {
             dc.DrawRectangle(rect.x + 1, rect.y + 1, rect.width - 2,
                 rect.height - 16);
@@ -975,7 +976,7 @@ void wxRibbonAUIArtProvider::DrawGalleryBackground(
         }
     }
 
-    dc.SetPen(m_gallery_border_pen);
+    dc.SetPen(m_galleryBorderPen);
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
@@ -985,54 +986,54 @@ void wxRibbonAUIArtProvider::DrawGalleryBackground(
 void wxRibbonAUIArtProvider::DrawGalleryButton(wxDC& dc, wxRect rect,
         wxRibbonGalleryButtonState state, wxBitmapBundle* bundles, wxWindow* wnd)
 {
-    int extra_height = 0;
-    int extra_width = 0;
-    wxRect reduced_rect(rect);
-    reduced_rect.Deflate(1);
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    int extraHeight = 0;
+    int extraWidth = 0;
+    wxRect reducedRect(rect);
+    reducedRect.Deflate(1);
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
-        reduced_rect.width++;
-        extra_width = 1;
+        reducedRect.width++;
+        extraWidth = 1;
     }
     else
     {
-        reduced_rect.height++;
-        extra_height = 1;
+        reducedRect.height++;
+        extraHeight = 1;
     }
 
-    wxBitmap btn_bitmap;
-    switch(state)
+    wxBitmap btnBitmap;
+    switch ( state )
     {
     case wxRIBBON_GALLERY_BUTTON_NORMAL:
-        dc.GradientFillLinear(reduced_rect,
-            m_gallery_button_background_colour,
-            m_gallery_button_background_gradient_colour, wxSOUTH);
-        btn_bitmap = bundles[0].GetBitmapFor(wnd);
+        dc.GradientFillLinear(reducedRect,
+            m_galleryButtonBackgroundColour,
+            m_galleryButtonBackgroundGradientColour, wxSOUTH);
+        btnBitmap = bundles[0].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_HOVERED:
-        dc.SetPen(m_gallery_item_border_pen);
-        dc.SetBrush(m_gallery_button_hover_background_brush);
-        dc.DrawRectangle(rect.x, rect.y, rect.width + extra_width,
-            rect.height + extra_height);
-        btn_bitmap = bundles[1].GetBitmapFor(wnd);
+        dc.SetPen(m_galleryItemBorderPen);
+        dc.SetBrush(m_galleryButtonHoverBackgroundBrush);
+        dc.DrawRectangle(rect.x, rect.y, rect.width + extraWidth,
+            rect.height + extraHeight);
+        btnBitmap = bundles[1].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_ACTIVE:
-        dc.SetPen(m_gallery_item_border_pen);
-        dc.SetBrush(m_gallery_button_active_background_brush);
-        dc.DrawRectangle(rect.x, rect.y, rect.width + extra_width,
-            rect.height + extra_height);
-        btn_bitmap = bundles[2].GetBitmapFor(wnd);
+        dc.SetPen(m_galleryItemBorderPen);
+        dc.SetBrush(m_galleryButtonActiveBackgroundBrush);
+        dc.DrawRectangle(rect.x, rect.y, rect.width + extraWidth,
+            rect.height + extraHeight);
+        btnBitmap = bundles[2].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_DISABLED:
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_gallery_button_disabled_background_brush);
-        dc.DrawRectangle(reduced_rect.x, reduced_rect.y, reduced_rect.width,
-            reduced_rect.height);
-        btn_bitmap = bundles[3].GetBitmapFor(wnd);
+        dc.SetBrush(m_galleryButtonDisabledBackgroundBrush);
+        dc.DrawRectangle(reducedRect.x, reducedRect.y, reducedRect.width,
+            reducedRect.height);
+        btnBitmap = bundles[3].GetBitmapFor(wnd);
         break;
     }
 
-    dc.DrawBitmap(btn_bitmap, reduced_rect.x + reduced_rect.width / 2 - 2,
+    dc.DrawBitmap(btnBitmap, reducedRect.x + reducedRect.width / 2 - 2,
         (rect.y + rect.height / 2) - 2, true);
 }
 
@@ -1042,15 +1043,15 @@ void wxRibbonAUIArtProvider::DrawGalleryItemBackground(
                         const wxRect& rect,
                         wxRibbonGalleryItem* item)
 {
-    if(wnd->GetHoveredItem() != item && wnd->GetActiveItem() != item &&
-        wnd->GetSelection() != item)
+    if ( wnd->GetHoveredItem() != item && wnd->GetActiveItem() != item &&
+         wnd->GetSelection() != item )
         return;
 
-    dc.SetPen(m_gallery_item_border_pen);
-    if(wnd->GetActiveItem() == item || wnd->GetSelection() == item)
-        dc.SetBrush(m_gallery_button_active_background_brush);
+    dc.SetPen(m_galleryItemBorderPen);
+    if ( wnd->GetActiveItem() == item || wnd->GetSelection() == item )
+        dc.SetBrush(m_galleryButtonActiveBackgroundBrush);
     else
-        dc.SetBrush(m_gallery_button_hover_background_brush);
+        dc.SetBrush(m_galleryButtonHoverBackgroundBrush);
 
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 }
@@ -1070,63 +1071,63 @@ void wxRibbonAUIArtProvider::DrawButtonBarButton(
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small)
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall)
 {
-    if(kind == wxRIBBON_BUTTON_TOGGLE)
+    if ( kind == wxRIBBON_BUTTON_TOGGLE )
     {
         kind = wxRIBBON_BUTTON_NORMAL;
-        if(state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED)
+        if ( state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED )
             state ^= wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
     }
 
-    if(state & (wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK
-        | wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK))
+    if ( state &
+         (wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK | wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK) )
     {
-        dc.SetPen(m_button_bar_hover_border_pen);
+        dc.SetPen(m_buttonBarHoverBorderPen);
 
-        wxRect bg_rect(rect);
-        bg_rect.Deflate(1);
+        wxRect bgRect(rect);
+        bgRect.Deflate(1);
 
-        if(kind == wxRIBBON_BUTTON_HYBRID)
+        if ( kind == wxRIBBON_BUTTON_HYBRID )
         {
-            switch(state & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
+            switch ( state & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK )
             {
             case wxRIBBON_BUTTONBAR_BUTTON_LARGE:
                 {
-                    int iYBorder = rect.y + bitmap_large.GetLogicalHeight() + 4;
-                    wxRect partial_bg(rect);
-                    if(state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED)
+                    int iYBorder = rect.y + bitmapLarge.GetLogicalHeight() + 4;
+                    wxRect partialBg(rect);
+                    if ( state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED )
                     {
-                        partial_bg.SetBottom(iYBorder - 1);
+                        partialBg.SetBottom(iYBorder - 1);
                     }
                     else
                     {
-                        partial_bg.height -= (iYBorder - partial_bg.y + 1);
-                        partial_bg.y = iYBorder + 1;
+                        partialBg.height -= (iYBorder - partialBg.y + 1);
+                        partialBg.y = iYBorder + 1;
                     }
                     dc.DrawLine(rect.x, iYBorder, rect.x + rect.width, iYBorder);
-                    bg_rect.Intersect(partial_bg);
+                    bgRect.Intersect(partialBg);
                 }
                 break;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
             case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 {
                     int iArrowWidth = 9;
-                    if(state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED)
+                    if ( state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED )
                     {
-                        bg_rect.width -= iArrowWidth;
-                        dc.DrawLine(bg_rect.x + bg_rect.width,
-                            rect.y, bg_rect.x + bg_rect.width,
+                        bgRect.width -= iArrowWidth;
+                        dc.DrawLine(bgRect.x + bgRect.width,
+                            rect.y, bgRect.x + bgRect.width,
                             rect.y + rect.height);
                     }
                     else
                     {
                         --iArrowWidth;
-                        bg_rect.x += bg_rect.width - iArrowWidth;
-                        bg_rect.width = iArrowWidth;
-                        dc.DrawLine(bg_rect.x - 1, rect.y,
-                            bg_rect.x - 1, rect.y + rect.height);
+                        bgRect.x += bgRect.width - iArrowWidth;
+                        bgRect.width = iArrowWidth;
+                        dc.DrawLine(bgRect.x - 1, rect.y,
+                            bgRect.x - 1, rect.y + rect.height);
                     }
                 }
                 break;
@@ -1137,19 +1138,19 @@ void wxRibbonAUIArtProvider::DrawButtonBarButton(
         dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
         dc.SetPen(*wxTRANSPARENT_PEN);
-        if(state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK)
-            dc.SetBrush(m_button_bar_active_background_brush);
+        if ( state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK )
+            dc.SetBrush(m_buttonBarActiveBackgroundBrush);
         else
-            dc.SetBrush(m_button_bar_hover_background_brush);
-        dc.DrawRectangle(bg_rect.x, bg_rect.y, bg_rect.width, bg_rect.height);
+            dc.SetBrush(m_buttonBarHoverBackgroundBrush);
+        dc.DrawRectangle(bgRect.x, bgRect.y, bgRect.width, bgRect.height);
     }
 
-    dc.SetFont(m_button_bar_label_font);
+    dc.SetFont(m_buttonBarLabelFont);
     dc.SetTextForeground(state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED
-                            ? m_button_bar_label_disabled_colour
-                            : m_button_bar_label_colour);
-    DrawButtonBarButtonForeground(dc, rect, kind, state, label, bitmap_large,
-        bitmap_small);
+                            ? m_buttonBarLabelDisabledColour
+                            : m_buttonBarLabelColour);
+    DrawButtonBarButtonForeground(dc, rect, kind, state, label, bitmapLarge,
+        bitmapSmall);
 }
 
 void wxRibbonAUIArtProvider::DrawToolBarBackground(
@@ -1165,13 +1166,13 @@ void wxRibbonAUIArtProvider::DrawToolGroupBackground(
                     wxWindow* WXUNUSED(wnd),
                     const wxRect& rect)
 {
-    dc.SetPen(m_toolbar_border_pen);
+    dc.SetPen(m_toolbarBorderPen);
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
-    wxRect bg_rect(rect);
-    bg_rect.Deflate(1);
-    dc.GradientFillLinear(bg_rect, m_tool_background_colour,
-        m_tool_background_gradient_colour, wxSOUTH);
+    wxRect bgRect(rect);
+    bgRect.Deflate(1);
+    dc.GradientFillLinear(bgRect, m_toolBackgroundColour,
+        m_toolBackgroundGradientColour, wxSOUTH);
 }
 
 void wxRibbonAUIArtProvider::DrawTool(
@@ -1182,83 +1183,83 @@ void wxRibbonAUIArtProvider::DrawTool(
             wxRibbonButtonKind kind,
             long state)
 {
-    if(kind == wxRIBBON_BUTTON_TOGGLE)
+    if ( kind == wxRIBBON_BUTTON_TOGGLE )
     {
-        if(state & wxRIBBON_TOOLBAR_TOOL_TOGGLED)
+        if ( state & wxRIBBON_TOOLBAR_TOOL_TOGGLED )
             state ^= wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
     }
 
-    wxRect bg_rect(rect);
-    bg_rect.Deflate(1);
-    if((state & wxRIBBON_TOOLBAR_TOOL_LAST) == 0)
-        bg_rect.width++;
-    bool is_custom_bg = (state & (wxRIBBON_TOOLBAR_TOOL_HOVER_MASK |
+    wxRect bgRect(rect);
+    bgRect.Deflate(1);
+    if ( (state & wxRIBBON_TOOLBAR_TOOL_LAST) == 0 )
+        bgRect.width++;
+    bool isCustomBg = (state & (wxRIBBON_TOOLBAR_TOOL_HOVER_MASK |
         wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK)) != 0;
-    bool is_split_hybrid = kind == wxRIBBON_BUTTON_HYBRID && is_custom_bg;
+    bool isSplitHybrid = kind == wxRIBBON_BUTTON_HYBRID && isCustomBg;
 
     // Background
-    if(is_custom_bg)
+    if ( isCustomBg )
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_tool_hover_background_brush);
-        dc.DrawRectangle(bg_rect.x, bg_rect.y, bg_rect.width, bg_rect.height);
-        if(state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK)
+        dc.SetBrush(m_toolHoverBackgroundBrush);
+        dc.DrawRectangle(bgRect.x, bgRect.y, bgRect.width, bgRect.height);
+        if ( state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK )
         {
-            wxRect active_rect(bg_rect);
-            if(kind == wxRIBBON_BUTTON_HYBRID)
+            wxRect activeRect(bgRect);
+            if ( kind == wxRIBBON_BUTTON_HYBRID )
             {
-                active_rect.width -= 8;
-                if(state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE)
+                activeRect.width -= 8;
+                if ( state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE )
                 {
-                    active_rect.x += active_rect.width;
-                    active_rect.width = 8;
+                    activeRect.x += activeRect.width;
+                    activeRect.width = 8;
                 }
             }
-            dc.SetBrush(m_tool_active_background_brush);
-            dc.DrawRectangle(active_rect.x, active_rect.y, active_rect.width,
-                active_rect.height);
+            dc.SetBrush(m_toolActiveBackgroundBrush);
+            dc.DrawRectangle(activeRect.x, activeRect.y, activeRect.width,
+                activeRect.height);
         }
     }
 
     // Border
-    if(is_custom_bg)
-        dc.SetPen(m_toolbar_hover_borden_pen);
+    if ( isCustomBg )
+        dc.SetPen(m_toolbarHoverBordenPen);
     else
-        dc.SetPen(m_toolbar_border_pen);
-    if((state & wxRIBBON_TOOLBAR_TOOL_FIRST) == 0)
+        dc.SetPen(m_toolbarBorderPen);
+    if ( (state & wxRIBBON_TOOLBAR_TOOL_FIRST) == 0 )
     {
         wxColour existing;
-        if(!dc.GetPixel(rect.x, rect.y + 1, &existing) ||
-            existing != m_toolbar_hover_borden_pen.GetColour())
+        if ( !dc.GetPixel(rect.x, rect.y + 1, &existing) ||
+             existing != m_toolbarHoverBordenPen.GetColour() )
         {
             dc.DrawLine(rect.x, rect.y + 1, rect.x, rect.y + rect.height - 1);
         }
     }
-    if(is_custom_bg)
+    if ( isCustomBg )
     {
-        wxRect border_rect(bg_rect);
-        border_rect.Inflate(1);
+        wxRect borderRect(bgRect);
+        borderRect.Inflate(1);
         dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawRectangle(border_rect.x, border_rect.y, border_rect.width,
-            border_rect.height);
+        dc.DrawRectangle(borderRect.x, borderRect.y, borderRect.width,
+            borderRect.height);
     }
 
     // Foreground
-    int avail_width = bg_rect.GetWidth();
-    if(kind & wxRIBBON_BUTTON_DROPDOWN)
+    int availWidth = bgRect.GetWidth();
+    if ( kind & wxRIBBON_BUTTON_DROPDOWN )
     {
-        avail_width -= 8;
-        if(is_split_hybrid)
+        availWidth -= 8;
+        if ( isSplitHybrid )
         {
-            dc.DrawLine(rect.x + avail_width + 1, rect.y,
-                rect.x + avail_width + 1, rect.y + rect.height);
+            dc.DrawLine(rect.x + availWidth + 1, rect.y,
+                rect.x + availWidth + 1, rect.y + rect.height);
         }
-        dc.DrawBitmap(m_toolbar_drop_bundle.GetBitmapFor(wnd), bg_rect.x + avail_width + 2,
-            bg_rect.y + (bg_rect.height / 2) - 2, true);
+        dc.DrawBitmap(m_toolbarDropBundle.GetBitmapFor(wnd), bgRect.x + availWidth + 2,
+            bgRect.y + (bgRect.height / 2) - 2, true);
     }
     if ( bitmap.IsOk() )
-        dc.DrawBitmap(bitmap, bg_rect.x + (avail_width - bitmap.GetLogicalWidth()) / 2,
-            bg_rect.y + (bg_rect.height - bitmap.GetLogicalHeight()) / 2, true);
+        dc.DrawBitmap(bitmap, bgRect.x + (availWidth - bitmap.GetLogicalWidth()) / 2,
+            bgRect.y + (bgRect.height - bitmap.GetLogicalHeight()) / 2, true);
 }
 
 #endif // wxUSE_RIBBON

--- a/src/ribbon/art_internal.cpp
+++ b/src/ribbon/art_internal.cpp
@@ -19,38 +19,39 @@
 #include "wx/ribbon/gallery.h"
 
 #ifndef WX_PRECOMP
-#include "wx/dc.h"
+    #include "wx/dc.h"
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 wxRibbonArtProvider::wxRibbonArtProvider() {}
 wxRibbonArtProvider::~wxRibbonArtProvider() {}
 
-wxColour wxRibbonInterpolateColour(const wxColour& start_colour,
-                                const wxColour& end_colour,
+wxColour wxRibbonInterpolateColour(const wxColour& startColour,
+                                const wxColour& endColour,
                                 int position,
-                                int start_position,
-                                int end_position)
+                                int startPosition,
+                                int endPosition)
 {
-    if(position <= start_position)
+    if ( position <= startPosition )
     {
-        return start_colour;
+        return startColour;
     }
-    if(position >= end_position)
+    if ( position >= endPosition )
     {
-        return end_colour;
+        return endColour;
     }
-    position -= start_position;
-    end_position -= start_position;
-    int r = end_colour.Red() - start_colour.Red();
-    int g = end_colour.Green() - start_colour.Green();
-    int b = end_colour.Blue() - start_colour.Blue();
-    r = start_colour.Red()   + (((r * position * 100) / end_position) / 100);
-    g = start_colour.Green() + (((g * position * 100) / end_position) / 100);
-    b = start_colour.Blue()  + (((b * position * 100) / end_position) / 100);
+    position -= startPosition;
+    endPosition -= startPosition;
+    int r = endColour.Red() - startColour.Red();
+    int g = endColour.Green() - startColour.Green();
+    int b = endColour.Blue() - startColour.Blue();
+    // Scale by 100 to avoid integer truncation during the interpolation.
+    r = startColour.Red()   + (((r * position * 100) / endPosition) / 100);
+    g = startColour.Green() + (((g * position * 100) / endPosition) / 100);
+    b = startColour.Blue()  + (((b * position * 100) / endPosition) / 100);
     return wxColour(r, g, b);
 }
 
@@ -60,54 +61,59 @@ bool wxRibbonCanLabelBreakAtPosition(const wxString& label, size_t pos)
 }
 
 void wxRibbonDrawParallelGradientLines(wxDC& dc,
-                                    int nlines,
-                                    const wxPoint* line_origins,
-                                    int stepx,
-                                    int stepy,
-                                    int numsteps,
-                                    int offset_x,
-                                    int offset_y,
-                                    const wxColour& start_colour,
-                                    const wxColour& end_colour)
+                                    int nLines,
+                                    const wxPoint* lineOrigins,
+                                    int stepX,
+                                    int stepY,
+                                    int numSteps,
+                                    int offsetX,
+                                    int offsetY,
+                                    const wxColour& startColour,
+                                    const wxColour& endColour)
 {
+    // Pre-compute per-channel deltas across the full gradient range.
     int rd, gd, bd;
-    rd = end_colour.Red() - start_colour.Red();
-    gd = end_colour.Green() - start_colour.Green();
-    bd = end_colour.Blue() - start_colour.Blue();
+    rd = endColour.Red() - startColour.Red();
+    gd = endColour.Green() - startColour.Green();
+    bd = endColour.Blue() - startColour.Blue();
 
-    for (int step = 0; step < numsteps; ++step)
+    for ( int step = 0; step < numSteps; ++step )
     {
-        int r,g,b;
+        int r, g, b;
 
-        r = start_colour.Red() + (((step*rd*100)/numsteps)/100);
-        g = start_colour.Green() + (((step*gd*100)/numsteps)/100);
-        b = start_colour.Blue() + (((step*bd*100)/numsteps)/100);
+        // Scale by 100 to avoid integer truncation during interpolation.
+        r = startColour.Red()   + (((step * rd * 100) / numSteps) / 100);
+        g = startColour.Green() + (((step * gd * 100) / numSteps) / 100);
+        b = startColour.Blue()  + (((step * bd * 100) / numSteps) / 100);
 
         wxPen p(wxColour((unsigned char)r,
-                        (unsigned char)g,
-                        (unsigned char)b));
+                         (unsigned char)g,
+                         (unsigned char)b));
         dc.SetPen(p);
 
-        for(int n = 0; n < nlines; ++n)
+        for ( int n = 0; n < nLines; ++n )
         {
-            dc.DrawLine(offset_x + line_origins[n].x, offset_y + line_origins[n].y,
-                        offset_x + line_origins[n].x + stepx, offset_y + line_origins[n].y + stepy);
+            dc.DrawLine(offsetX + lineOrigins[n].x,
+                        offsetY + lineOrigins[n].y,
+                        offsetX + lineOrigins[n].x + stepX,
+                        offsetY + lineOrigins[n].y + stepY);
         }
 
-        offset_x += stepx;
-        offset_y += stepy;
+        offsetX += stepX;
+        offsetY += stepY;
     }
 }
 
 wxRibbonHSLColour wxRibbonShiftLuminance(wxRibbonHSLColour colour,
                                                 float amount)
 {
-    if(amount <= 1.0f)
-        return colour.Darker(colour.luminance * (1.0f - amount));
-    else if (wxSystemSettings::GetAppearance().IsDark())
-        return colour.Darker(colour.luminance * (amount - 1.0f));
+    // amount < 1 darkens, amount > 1 lightens (inverted in dark mode).
+    if ( amount <= 1.0f )
+        return colour.Darker(colour.m_luminance * (1.0f - amount));
+    else if ( wxSystemSettings::GetAppearance().IsDark() )
+        return colour.Darker(colour.m_luminance * (amount - 1.0f));
     else
-        return colour.Lighter((1.0f - colour.luminance) * (amount - 1.0f));
+        return colour.Lighter((1.0f - colour.m_luminance) * (amount - 1.0f));
 }
 
 wxBitmap wxRibbonLoadPixmap(const char* const* bits, wxColour fore)
@@ -122,96 +128,100 @@ wxRibbonHSLColour::wxRibbonHSLColour(const wxColour& col)
     float red = col.Red() / 255.0f;
     float green = col.Green() / 255.0f;
     float blue = col.Blue() / 255.0f;
-    float Min = wxMin(red, wxMin(green, blue));
-    float Max = wxMax(red, wxMax(green, blue));
-    luminance = 0.5f * (Max + Min);
-    if (Min == Max)
+    float minComp = wxMin(red, wxMin(green, blue));
+    float maxComp = wxMax(red, wxMax(green, blue));
+    m_luminance = 0.5f * (maxComp + minComp);
+    if ( minComp == maxComp )
     {
         // colour is a shade of grey
-        hue = 0;
-        saturation = 0;
+        m_hue = 0;
+        m_saturation = 0;
     }
     else
     {
-        if (luminance <= 0.5f)
-            saturation = (Max - Min) / (Max + Min);
+        // HSL saturation formula differs above and below 0.5 luminance.
+        if ( m_luminance <= 0.5f )
+            m_saturation = (maxComp - minComp) / (maxComp + minComp);
         else
-            saturation = (Max - Min) / (2.0f - (Max + Min));
+            m_saturation = (maxComp - minComp) / (2.0f - (maxComp + minComp));
 
-        if(Max == red)
+        if ( maxComp == red )
         {
-            hue = 60.0f * (green - blue) / (Max - Min);
-            if (hue < 0)
-                hue += 360.0f;
+            m_hue = 60.0f * (green - blue) / (maxComp - minComp);
+            if ( m_hue < 0 )
+                m_hue += 360.0f;
         }
-        else if(Max == green)
+        else if ( maxComp == green )
         {
-            hue = 60.0f * (blue - red) / (Max - Min);
-            hue += 120.0f;
+            m_hue = 60.0f * (blue - red) / (maxComp - minComp);
+            m_hue += 120.0f;
         }
-        else // Max == blue
+        else // maxComp == blue
         {
-            hue = 60.0f * (red - green) / (Max - Min);
-            hue += 240.0f;
+            m_hue = 60.0f * (red - green) / (maxComp - minComp);
+            m_hue += 240.0f;
         }
     }
 }
 
 wxColour wxRibbonHSLColour::ToRGB() const
 {
-    float _hue = (hue - float(floor(hue / 360.0f)) * 360.0f);
-    float _saturation = saturation;
-    float _luminance = luminance;
-    if (_saturation > 1) _saturation = 1;
-    if (_saturation < 0) _saturation = 0;
-    if (_luminance > 1) _luminance = 1;
-    if (_luminance < 0) _luminance = 0;
+    // Normalise hue to [0, 360) and clamp saturation/luminance to [0, 1].
+    float hue = (m_hue - float(floor(m_hue / 360.0f)) * 360.0f);
+    float saturation = m_saturation;
+    float luminance = m_luminance;
+    if ( saturation > 1 ) saturation = 1;
+    if ( saturation < 0 ) saturation = 0;
+    if ( luminance > 1 ) luminance = 1;
+    if ( luminance < 0 ) luminance = 0;
 
     float red, blue, green;
-    if (_saturation == 0)
+    if ( saturation == 0 )
     {
         // colour is a shade of grey
-        red = blue = green = _luminance;
+        red = blue = green = luminance;
     }
     else
     {
-        float tmp2 = (_luminance < 0.5f)
-           ? _luminance * (1.0f + _saturation)
-           : (_luminance + _saturation) - (_luminance * _saturation);
-        float tmp1 = 2.0f * _luminance - tmp2;
+        // Standard HSL-to-RGB conversion using two temporary values.
+        float tmp2 = (luminance < 0.5f)
+            ? luminance * (1.0f + saturation)
+            : (luminance + saturation) - (luminance * saturation);
+        float tmp1 = 2.0f * luminance - tmp2;
 
-        float tmp3R = _hue + 120.0f;
-        if (tmp3R > 360)
+        // Each channel uses a hue offset: red +120, green +0, blue +240.
+        float tmp3R = hue + 120.0f;
+        if ( tmp3R > 360 )
             tmp3R -= 360.0f;
-        if (tmp3R < 60)
+        if ( tmp3R < 60 )
             red = tmp1 + (tmp2 - tmp1) * tmp3R / 60.0f;
-        else if (tmp3R < 180)
+        else if ( tmp3R < 180 )
             red = tmp2;
-        else if (tmp3R < 240)
+        else if ( tmp3R < 240 )
             red = tmp1 + (tmp2 - tmp1) * (240.0f - tmp3R) / 60.0f;
         else
             red = tmp1;
 
-        float tmp3G = _hue;
-        if (tmp3G > 360)
+        float tmp3G = hue;
+        if ( tmp3G > 360 )
             tmp3G -= 360.0f;
-        if (tmp3G < 60)
+        if ( tmp3G < 60 )
             green = tmp1 + (tmp2 - tmp1) * tmp3G / 60.0f;
-        else if (tmp3G < 180)
+        else if ( tmp3G < 180 )
             green = tmp2;
-        else if (tmp3G < 240)
+        else if ( tmp3G < 240 )
             green = tmp1 + (tmp2 - tmp1) * (240.0f - tmp3G) / 60.0f;
         else
             green = tmp1;
 
-        float tmp3B = _hue + 240.0f;
-        if (tmp3B > 360)
+        float tmp3B = hue + 240.0f;
+        if ( tmp3B > 360 )
             tmp3B -= 360.0f;
-        if (tmp3B < 60)
+        if ( tmp3B < 60 )
             blue = tmp1 + (tmp2 - tmp1) * tmp3B / 60.0f;
-        else if (tmp3B < 180)
+        else if ( tmp3B < 180 )
             blue = tmp2;
-        else if (tmp3B < 240)
+        else if ( tmp3B < 240 )
             blue = tmp1 + (tmp2 - tmp1) * (240.0f - tmp3B) / 60.0f;
         else
             blue = tmp1;
@@ -229,12 +239,12 @@ wxRibbonHSLColour wxRibbonHSLColour::Darker(float delta) const
 
 wxRibbonHSLColour wxRibbonHSLColour::Lighter(float delta) const
 {
-    return wxRibbonHSLColour(hue, saturation, luminance + delta);
+    return wxRibbonHSLColour(m_hue, m_saturation, m_luminance + delta);
 }
 
 wxRibbonHSLColour wxRibbonHSLColour::Saturated(float delta) const
 {
-    return wxRibbonHSLColour(hue, saturation + delta, luminance);
+    return wxRibbonHSLColour(m_hue, m_saturation + delta, m_luminance);
 }
 
 wxRibbonHSLColour wxRibbonHSLColour::Desaturated(float delta) const
@@ -244,7 +254,7 @@ wxRibbonHSLColour wxRibbonHSLColour::Desaturated(float delta) const
 
 wxRibbonHSLColour wxRibbonHSLColour::ShiftHue(float delta) const
 {
-    return wxRibbonHSLColour(hue + delta, saturation, luminance);
+    return wxRibbonHSLColour(m_hue + delta, m_saturation, m_luminance);
 }
 
 #endif // wxUSE_RIBBON

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/art_msw.cpp
 // Purpose:     MSW style art provider for ribbon interface
 // Author:      Peter Cawley
@@ -19,11 +19,11 @@
 #include "wx/ribbon/toolbar.h"
 
 #ifndef WX_PRECOMP
-#include "wx/dcmemory.h"
+    #include "wx/dcmemory.h"
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 static const char* const gallery_up_xpm[] = {
@@ -261,20 +261,20 @@ static const char * const ribbon_help_button_xpm[] = {
 "1.1.1.E N q f T @.1.1.1."
 };
 
-wxRibbonMSWArtProvider::wxRibbonMSWArtProvider(bool set_colour_scheme)
+wxRibbonMSWArtProvider::wxRibbonMSWArtProvider(bool setColourScheme)
 #if defined( __WXOSX__ )
-    : m_tab_label_font(*wxSMALL_FONT)
+    : m_tabLabelFont(*wxSMALL_FONT)
 #else
-    : m_tab_label_font(*wxNORMAL_FONT)
+    : m_tabLabelFont(*wxNORMAL_FONT)
 #endif
 {
     m_flags = 0;
-    m_button_bar_label_font = m_tab_label_font;
-    m_panel_label_font = m_tab_label_font;
+    m_buttonBarLabelFont = m_tabLabelFont;
+    m_panelLabelFont = m_tabLabelFont;
 
-    if(set_colour_scheme)
+    if ( setColourScheme )
     {
-        if (wxSystemSettings::GetAppearance().IsDark())
+        if ( wxSystemSettings::GetAppearance().IsDark() )
         {
             SetColourScheme(
                 wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE),
@@ -290,21 +290,21 @@ wxRibbonMSWArtProvider::wxRibbonMSWArtProvider(bool set_colour_scheme)
         }
     }
 
-    m_cached_tab_separator_visibility = -10.0; // valid visibilities are in range [0, 1]
-    m_tab_separation_size = 3;
-    m_page_border_left = 2;
-    m_page_border_top = 1;
-    m_page_border_right = 2;
-    m_page_border_bottom = 3;
-    m_panel_x_separation_size = 1;
-    m_panel_y_separation_size = 1;
-    m_tool_group_separation_size = 3;
-    m_gallery_bitmap_padding_left_size = 4;
-    m_gallery_bitmap_padding_right_size = 4;
-    m_gallery_bitmap_padding_top_size = 4;
-    m_gallery_bitmap_padding_bottom_size = 4;
-    m_toggle_button_offset = 22;
-    m_help_button_offset = 22;
+    m_cachedTabSeparatorVisibility = -10.0; // valid visibilities are in range [0, 1]
+    m_tabSeparationSize = 3;
+    m_pageBorderLeft = 2;
+    m_pageBorderTop = 1;
+    m_pageBorderRight = 2;
+    m_pageBorderBottom = 3;
+    m_panelXSeparationSize = 1;
+    m_panelYSeparationSize = 1;
+    m_toolGroupSeparationSize = 3;
+    m_galleryBitmapPaddingLeftSize = 4;
+    m_galleryBitmapPaddingRightSize = 4;
+    m_galleryBitmapPaddingTopSize = 4;
+    m_galleryBitmapPaddingBottomSize = 4;
+    m_toggleButtonOffset = 22;
+    m_helpButtonOffset = 22;
 }
 
 wxRibbonMSWArtProvider::~wxRibbonMSWArtProvider()
@@ -316,12 +316,12 @@ void wxRibbonMSWArtProvider::GetColourScheme(
                          wxColour* secondary,
                          wxColour* tertiary) const
 {
-    if(primary != nullptr)
-        *primary = m_primary_scheme_colour;
-    if(secondary != nullptr)
-        *secondary = m_secondary_scheme_colour;
-    if(tertiary != nullptr)
-        *tertiary = m_tertiary_scheme_colour;
+    if ( primary != nullptr )
+        *primary = m_primarySchemeColour;
+    if ( secondary != nullptr )
+        *secondary = m_secondarySchemeColour;
+    if ( tertiary != nullptr )
+        *tertiary = m_tertiarySchemeColour;
 }
 
 void wxRibbonMSWArtProvider::SetColourScheme(
@@ -329,178 +329,178 @@ void wxRibbonMSWArtProvider::SetColourScheme(
                          const wxColour& secondary,
                          const wxColour& tertiary)
 {
-    m_primary_scheme_colour = primary;
-    m_secondary_scheme_colour = secondary;
-    m_tertiary_scheme_colour = tertiary;
+    m_primarySchemeColour = primary;
+    m_secondarySchemeColour = secondary;
+    m_tertiarySchemeColour = tertiary;
 
-    wxRibbonHSLColour primary_hsl(primary);
-    wxRibbonHSLColour secondary_hsl(secondary);
+    wxRibbonHSLColour primaryHsl(primary);
+    wxRibbonHSLColour secondaryHsl(secondary);
     // tertiary not used for anything
 
     // Map primary saturation from [0, 1] to [.25, .75]
-    bool primary_is_gray = false;
-    static const float gray_saturation_threshold = 0.01f;
-    if(primary_hsl.saturation <= gray_saturation_threshold)
-        primary_is_gray = true;
+    bool primaryIsGray = false;
+    static const float graySaturationThreshold = 0.01f;
+    if ( primaryHsl.m_saturation <= graySaturationThreshold )
+        primaryIsGray = true;
     else
     {
-        primary_hsl.saturation = std::cos(primary_hsl.saturation * float(M_PI))
+        primaryHsl.m_saturation = std::cos(primaryHsl.m_saturation * float(M_PI))
             * -0.25f + 0.5f;
     }
 
     // Map primary luminance from [0, 1] to [.23, .83]
-    primary_hsl.luminance = std::cos(primary_hsl.luminance * float(M_PI)) * -0.3f + 0.53f;
+    primaryHsl.m_luminance = std::cos(primaryHsl.m_luminance * float(M_PI)) * -0.3f + 0.53f;
 
     // Map secondary saturation from [0, 1] to [0.16, 0.84]
-    bool secondary_is_gray = false;
-    if(secondary_hsl.saturation <= gray_saturation_threshold)
-        secondary_is_gray = true;
+    bool secondaryIsGray = false;
+    if ( secondaryHsl.m_saturation <= graySaturationThreshold )
+        secondaryIsGray = true;
     else
     {
-        secondary_hsl.saturation = std::cos(secondary_hsl.saturation * float(M_PI))
+        secondaryHsl.m_saturation = std::cos(secondaryHsl.m_saturation * float(M_PI))
             * -0.34f + 0.5f;
     }
 
     // Map secondary luminance from [0, 1] to [0.1, 0.9]
-    secondary_hsl.luminance = std::cos(secondary_hsl.luminance * float(M_PI)) * -0.4f + 0.5f;
+    secondaryHsl.m_luminance = std::cos(secondaryHsl.m_luminance * float(M_PI)) * -0.4f + 0.5f;
 
-    const auto LikePrimary = [primary_hsl, primary_is_gray]
+    const auto LikePrimary = [primaryHsl, primaryIsGray]
         (double h, double s, double l)
         {
-            return primary_hsl.ShiftHue(h).Saturated(primary_is_gray ? 0.0 : s)
+            return primaryHsl.ShiftHue(h).Saturated(primaryIsGray ? 0.0 : s)
                 .AdjustLuminance(l).ToRGB();
         };
-    const auto LikeSecondary = [secondary_hsl, secondary_is_gray]
+    const auto LikeSecondary = [secondaryHsl, secondaryIsGray]
         (double h, double s, double l)
         {
-            return secondary_hsl.ShiftHue(h).Saturated(secondary_is_gray ? 0.0 : s)
+            return secondaryHsl.ShiftHue(h).Saturated(secondaryIsGray ? 0.0 : s)
                 .AdjustLuminance(l).ToRGB();
         };
 
-    m_page_border_pen = LikePrimary(1.4, 0.00, -0.08);
+    m_pageBorderPen = LikePrimary(1.4, 0.00, -0.08);
 
-    m_page_background_top_colour = LikePrimary(-0.1, -0.03, 0.12);
-    m_page_hover_background_top_colour = LikePrimary(-2.8, 0.27, 0.17);
-    m_page_background_top_gradient_colour = LikePrimary(0.1, -0.10, 0.08);
-    m_page_hover_background_top_gradient_colour = LikePrimary(3.2, 0.16, 0.13);
-    m_page_background_colour = LikePrimary(0.4, -0.09, 0.05);
-    m_page_hover_background_colour = LikePrimary(0.1, 0.19, 0.10);
-    m_page_background_gradient_colour = LikePrimary(-3.2, 0.27, 0.10);
-    m_page_hover_background_gradient_colour = LikePrimary(1.8, 0.01, 0.15);
+    m_pageBackgroundTopColour = LikePrimary(-0.1, -0.03, 0.12);
+    m_pageHoverBackgroundTopColour = LikePrimary(-2.8, 0.27, 0.17);
+    m_pageBackgroundTopGradientColour = LikePrimary(0.1, -0.10, 0.08);
+    m_pageHoverBackgroundTopGradientColour = LikePrimary(3.2, 0.16, 0.13);
+    m_pageBackgroundColour = LikePrimary(0.4, -0.09, 0.05);
+    m_pageHoverBackgroundColour = LikePrimary(0.1, 0.19, 0.10);
+    m_pageBackgroundGradientColour = LikePrimary(-3.2, 0.27, 0.10);
+    m_pageHoverBackgroundGradientColour = LikePrimary(1.8, 0.01, 0.15);
 
-    m_tab_active_background_colour = LikePrimary(-0.1, -0.31, 0.16);
-    m_tab_active_background_gradient_colour = LikePrimary(-0.1, -0.03, 0.12);
-    m_tab_separator_colour = LikePrimary(0.9, 0.24, 0.05);
-    m_tab_ctrl_background_brush = LikePrimary(1.0, 0.39, 0.07);
-    m_tab_hover_background_colour = LikePrimary(1.3, 0.15, 0.10);
-    m_tab_hover_background_top_colour = LikePrimary(1.4, 0.36, 0.08);
-    m_tab_border_pen = LikePrimary(1.4, 0.03, -0.05);
-    m_tab_separator_gradient_colour = LikePrimary(1.7, -0.15, -0.18);
-    m_tab_hover_background_top_gradient_colour = LikePrimary(1.8, 0.34, 0.13);
-    m_tab_label_colour = LikePrimary(4.3, 0.13, -0.49);
-    m_tab_active_label_colour = m_tab_label_colour;
-    m_tab_hover_label_colour = m_tab_label_colour;
-    m_tab_hover_background_gradient_colour = LikeSecondary(-1.5, -0.34, 0.01);
+    m_tabActiveBackgroundColour = LikePrimary(-0.1, -0.31, 0.16);
+    m_tabActiveBackgroundGradientColour = LikePrimary(-0.1, -0.03, 0.12);
+    m_tabSeparatorColour = LikePrimary(0.9, 0.24, 0.05);
+    m_tabCtrlBackgroundBrush = LikePrimary(1.0, 0.39, 0.07);
+    m_tabHoverBackgroundColour = LikePrimary(1.3, 0.15, 0.10);
+    m_tabHoverBackgroundTopColour = LikePrimary(1.4, 0.36, 0.08);
+    m_tabBorderPen = LikePrimary(1.4, 0.03, -0.05);
+    m_tabSeparatorGradientColour = LikePrimary(1.7, -0.15, -0.18);
+    m_tabHoverBackgroundTopGradientColour = LikePrimary(1.8, 0.34, 0.13);
+    m_tabLabelColour = LikePrimary(4.3, 0.13, -0.49);
+    m_tabActiveLabelColour = m_tabLabelColour;
+    m_tabHoverLabelColour = m_tabLabelColour;
+    m_tabHoverBackgroundGradientColour = LikeSecondary(-1.5, -0.34, 0.01);
 
-    m_panel_minimised_border_gradient_pen = LikePrimary(-6.9, -0.17, -0.09);
-    m_panel_minimised_border_pen = LikePrimary(-5.3, -0.24, -0.06);
-    m_panel_hover_border_gradient_pen = m_panel_border_gradient_pen = LikePrimary(-5.2, -0.15, -0.06);
-    m_panel_hover_border_pen = m_panel_border_pen = LikePrimary(-2.8, -0.32, 0.02);
-    m_panel_label_background_brush = LikePrimary(-1.5, 0.03, 0.05);
-    m_panel_active_background_gradient_colour = LikePrimary(0.5, 0.34, 0.05);
-    m_panel_hover_label_background_brush = LikePrimary(1.0, 0.30, 0.09);
-    m_panel_active_background_top_gradient_colour = LikePrimary(1.4, -0.17, -0.13);
-    m_panel_active_background_colour = LikePrimary(1.6, -0.18, -0.18);
-    m_panel_active_background_top_colour = LikePrimary(1.7, -0.20, -0.03);
-    m_panel_label_colour = LikePrimary(2.8, -0.14, -0.35);
-    m_panel_hover_label_colour = m_panel_label_colour;
-    m_panel_minimised_label_colour = m_tab_label_colour;
-    m_panel_hover_button_background_brush = LikeSecondary(-0.9, 0.16, -0.07);
-    m_panel_hover_button_border_pen = LikeSecondary(-3.9, -0.16, -0.14);
+    m_panelMinimisedBorderGradientPen = LikePrimary(-6.9, -0.17, -0.09);
+    m_panelMinimisedBorderPen = LikePrimary(-5.3, -0.24, -0.06);
+    m_panelHoverBorderGradientPen = m_panelBorderGradientPen = LikePrimary(-5.2, -0.15, -0.06);
+    m_panelHoverBorderPen = m_panelBorderPen = LikePrimary(-2.8, -0.32, 0.02);
+    m_panelLabelBackgroundBrush = LikePrimary(-1.5, 0.03, 0.05);
+    m_panelActiveBackgroundGradientColour = LikePrimary(0.5, 0.34, 0.05);
+    m_panelHoverLabelBackgroundBrush = LikePrimary(1.0, 0.30, 0.09);
+    m_panelActiveBackgroundTopGradientColour = LikePrimary(1.4, -0.17, -0.13);
+    m_panelActiveBackgroundColour = LikePrimary(1.6, -0.18, -0.18);
+    m_panelActiveBackgroundTopColour = LikePrimary(1.7, -0.20, -0.03);
+    m_panelLabelColour = LikePrimary(2.8, -0.14, -0.35);
+    m_panelHoverLabelColour = m_panelLabelColour;
+    m_panelMinimisedLabelColour = m_tabLabelColour;
+    m_panelHoverButtonBackgroundBrush = LikeSecondary(-0.9, 0.16, -0.07);
+    m_panelHoverButtonBorderPen = LikeSecondary(-3.9, -0.16, -0.14);
     SetColour(wxRIBBON_ART_PANEL_BUTTON_FACE_COLOUR, LikePrimary(1.4, -0.21, -0.23));
     SetColour(wxRIBBON_ART_PANEL_BUTTON_HOVER_FACE_COLOUR, LikePrimary(1.5, -0.24, -0.29));
 
-    m_ribbon_toggle_brush = LikeSecondary(-0.9, 0.16, -0.07);
-    m_ribbon_toggle_pen = LikeSecondary(-3.9, -0.16, -0.14);
+    m_ribbonToggleBrush = LikeSecondary(-0.9, 0.16, -0.07);
+    m_ribbonTogglePen = LikeSecondary(-3.9, -0.16, -0.14);
     SetColour(wxRIBBON_ART_PAGE_TOGGLE_FACE_COLOUR, LikePrimary(1.7, -0.20, -0.15));
     SetColour(wxRIBBON_ART_PAGE_TOGGLE_HOVER_FACE_COLOUR, LikePrimary(1.8, -0.23, -0.21));
 
-    m_gallery_button_disabled_background_colour = LikePrimary(-2.8, -0.46, 0.09);
-    m_gallery_button_disabled_background_top_brush = LikePrimary(-2.8, -0.36, 0.15);
-    m_gallery_hover_background_brush = LikePrimary(-0.8, 0.05, 0.15);
-    m_gallery_border_pen = LikePrimary(0.7, -0.02, 0.03);
-    m_gallery_button_background_top_brush = LikePrimary(0.8, 0.34, 0.13);
-    m_gallery_button_background_colour = LikePrimary(1.3, 0.10, 0.08);
+    m_galleryButtonDisabledBackgroundColour = LikePrimary(-2.8, -0.46, 0.09);
+    m_galleryButtonDisabledBackgroundTopBrush = LikePrimary(-2.8, -0.36, 0.15);
+    m_galleryHoverBackgroundBrush = LikePrimary(-0.8, 0.05, 0.15);
+    m_galleryBorderPen = LikePrimary(0.7, -0.02, 0.03);
+    m_galleryButtonBackgroundTopBrush = LikePrimary(0.8, 0.34, 0.13);
+    m_galleryButtonBackgroundColour = LikePrimary(1.3, 0.10, 0.08);
     // SetColour used so that the relevant bitmaps are generated
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_FACE_COLOUR, LikePrimary(1.4, -0.21, -0.23));
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_HOVER_FACE_COLOUR, LikePrimary(1.5, -0.24, -0.29));
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_FACE_COLOUR, LikePrimary(1.5, -0.24, -0.29));
     SetColour(wxRIBBON_ART_GALLERY_BUTTON_DISABLED_FACE_COLOUR, LikePrimary(0.0, -1.0, 0.0));
-    m_gallery_button_disabled_background_gradient_colour = LikePrimary(1.5, -0.43, 0.12);
-    m_gallery_button_background_gradient_colour = LikePrimary(1.7, 0.11, 0.09);
-    m_gallery_item_border_pen = LikeSecondary(-3.9, -0.16, -0.14);
-    m_gallery_button_hover_background_colour = LikeSecondary(-0.9, 0.16, -0.07);
-    m_gallery_button_hover_background_gradient_colour = LikeSecondary(0.1, 0.12, 0.03);
-    m_gallery_button_hover_background_top_brush = LikeSecondary(4.3, 0.16, 0.17);
+    m_galleryButtonDisabledBackgroundGradientColour = LikePrimary(1.5, -0.43, 0.12);
+    m_galleryButtonBackgroundGradientColour = LikePrimary(1.7, 0.11, 0.09);
+    m_galleryItemBorderPen = LikeSecondary(-3.9, -0.16, -0.14);
+    m_galleryButtonHoverBackgroundColour = LikeSecondary(-0.9, 0.16, -0.07);
+    m_galleryButtonHoverBackgroundGradientColour = LikeSecondary(0.1, 0.12, 0.03);
+    m_galleryButtonHoverBackgroundTopBrush = LikeSecondary(4.3, 0.16, 0.17);
 
-    m_gallery_button_active_background_colour = LikeSecondary(-9.9, 0.03, -0.22);
-    m_gallery_button_active_background_gradient_colour = LikeSecondary(-9.5, 0.14, -0.11);
-    m_gallery_button_active_background_top_brush = LikeSecondary(-9.0, 0.15, -0.08);
+    m_galleryButtonActiveBackgroundColour = LikeSecondary(-9.9, 0.03, -0.22);
+    m_galleryButtonActiveBackgroundGradientColour = LikeSecondary(-9.5, 0.14, -0.11);
+    m_galleryButtonActiveBackgroundTopBrush = LikeSecondary(-9.0, 0.15, -0.08);
 
-    m_button_bar_label_colour = m_tab_label_colour;
-    m_button_bar_label_disabled_colour = m_tab_label_colour;
+    m_buttonBarLabelColour = m_tabLabelColour;
+    m_buttonBarLabelDisabledColour = m_tabLabelColour;
 
-    m_button_bar_hover_border_pen = LikeSecondary(-6.2, -0.47, -0.14);
-    m_button_bar_hover_background_gradient_colour = LikeSecondary(-0.6, 0.16, 0.04);
-    m_button_bar_hover_background_colour = LikeSecondary(-0.2, 0.16, -0.10);
-    m_button_bar_hover_background_top_gradient_colour = LikeSecondary(0.2, 0.16, 0.03);
-    m_button_bar_hover_background_top_colour = LikeSecondary(8.8, 0.16, 0.17);
-    m_button_bar_active_border_pen = LikeSecondary(-6.2, -0.47, -0.25);
-    m_button_bar_active_background_top_colour = LikeSecondary(-8.4, 0.08, 0.06);
-    m_button_bar_active_background_top_gradient_colour = LikeSecondary(-9.7, 0.13, -0.07);
-    m_button_bar_active_background_colour = LikeSecondary(-9.9, 0.14, -0.14);
-    m_button_bar_active_background_gradient_colour = LikeSecondary(-8.7, 0.17, -0.03);
+    m_buttonBarHoverBorderPen = LikeSecondary(-6.2, -0.47, -0.14);
+    m_buttonBarHoverBackgroundGradientColour = LikeSecondary(-0.6, 0.16, 0.04);
+    m_buttonBarHoverBackgroundColour = LikeSecondary(-0.2, 0.16, -0.10);
+    m_buttonBarHoverBackgroundTopGradientColour = LikeSecondary(0.2, 0.16, 0.03);
+    m_buttonBarHoverBackgroundTopColour = LikeSecondary(8.8, 0.16, 0.17);
+    m_buttonBarActiveBorderPen = LikeSecondary(-6.2, -0.47, -0.25);
+    m_buttonBarActiveBackgroundTopColour = LikeSecondary(-8.4, 0.08, 0.06);
+    m_buttonBarActiveBackgroundTopGradientColour = LikeSecondary(-9.7, 0.13, -0.07);
+    m_buttonBarActiveBackgroundColour = LikeSecondary(-9.9, 0.14, -0.14);
+    m_buttonBarActiveBackgroundGradientColour = LikeSecondary(-8.7, 0.17, -0.03);
 
-    m_toolbar_border_pen = LikePrimary(1.4, -0.21, -0.16);
+    m_toolbarBorderPen = LikePrimary(1.4, -0.21, -0.16);
     SetColour(wxRIBBON_ART_TOOLBAR_FACE_COLOUR, LikePrimary(1.4, -0.17, -0.22));
-    m_tool_background_top_colour = LikePrimary(-1.9, -0.07, 0.06);
-    m_tool_background_top_gradient_colour = LikePrimary(1.4, 0.12, 0.08);
-    m_tool_background_colour = LikePrimary(1.4, -0.09, 0.03);
-    m_tool_background_gradient_colour = LikePrimary(1.9, 0.11, 0.09);
-    m_tool_hover_background_top_colour = LikeSecondary(3.4, 0.11, 0.16);
-    m_tool_hover_background_top_gradient_colour = LikeSecondary(-1.4, 0.04, 0.08);
-    m_tool_hover_background_colour = LikeSecondary(-1.8, 0.16, -0.12);
-    m_tool_hover_background_gradient_colour = LikeSecondary(-2.6, 0.16, 0.05);
-    m_tool_active_background_top_colour = LikeSecondary(-9.9, -0.12, -0.09);
-    m_tool_active_background_top_gradient_colour = LikeSecondary(-8.5, 0.16, -0.12);
-    m_tool_active_background_colour = LikeSecondary(-7.9, 0.16, -0.20);
-    m_tool_active_background_gradient_colour = LikeSecondary(-6.6, 0.16, -0.10);
+    m_toolBackgroundTopColour = LikePrimary(-1.9, -0.07, 0.06);
+    m_toolBackgroundTopGradientColour = LikePrimary(1.4, 0.12, 0.08);
+    m_toolBackgroundColour = LikePrimary(1.4, -0.09, 0.03);
+    m_toolBackgroundGradientColour = LikePrimary(1.9, 0.11, 0.09);
+    m_toolHoverBackgroundTopColour = LikeSecondary(3.4, 0.11, 0.16);
+    m_toolHoverBackgroundTopGradientColour = LikeSecondary(-1.4, 0.04, 0.08);
+    m_toolHoverBackgroundColour = LikeSecondary(-1.8, 0.16, -0.12);
+    m_toolHoverBackgroundGradientColour = LikeSecondary(-2.6, 0.16, 0.05);
+    m_toolActiveBackgroundTopColour = LikeSecondary(-9.9, -0.12, -0.09);
+    m_toolActiveBackgroundTopGradientColour = LikeSecondary(-8.5, 0.16, -0.12);
+    m_toolActiveBackgroundColour = LikeSecondary(-7.9, 0.16, -0.20);
+    m_toolActiveBackgroundGradientColour = LikeSecondary(-6.6, 0.16, -0.10);
 
-    //For highlight pages we show a colour between the active page and for a hovered page:
-    wxColour top_colour1((m_tab_active_background_colour.Red()   + m_tab_hover_background_top_colour.Red())/2,
-                         (m_tab_active_background_colour.Green() + m_tab_hover_background_top_colour.Green())/2,
-                         (m_tab_active_background_colour.Blue()  + m_tab_hover_background_top_colour.Blue())/2);
+    // For highlight pages we show a colour between the active page and for a hovered page:
+    wxColour topColour1((m_tabActiveBackgroundColour.Red()   + m_tabHoverBackgroundTopColour.Red())/2,
+                         (m_tabActiveBackgroundColour.Green() + m_tabHoverBackgroundTopColour.Green())/2,
+                         (m_tabActiveBackgroundColour.Blue()  + m_tabHoverBackgroundTopColour.Blue())/2);
 
-    wxColour bottom_colour1((m_tab_active_background_gradient_colour.Red()   + m_tab_hover_background_top_gradient_colour.Red())/2,
-                            (m_tab_active_background_gradient_colour.Green() + m_tab_hover_background_top_gradient_colour.Green())/2,
-                            (m_tab_active_background_gradient_colour.Blue()  + m_tab_hover_background_top_gradient_colour.Blue())/2);
+    wxColour bottomColour1((m_tabActiveBackgroundGradientColour.Red()   + m_tabHoverBackgroundTopGradientColour.Red())/2,
+                            (m_tabActiveBackgroundGradientColour.Green() + m_tabHoverBackgroundTopGradientColour.Green())/2,
+                            (m_tabActiveBackgroundGradientColour.Blue()  + m_tabHoverBackgroundTopGradientColour.Blue())/2);
 
-    m_tab_highlight_top_colour = top_colour1;
-    m_tab_highlight_top_gradient_colour = bottom_colour1;
+    m_tabHighlightTopColour = topColour1;
+    m_tabHighlightTopGradientColour = bottomColour1;
 
-    wxColour top_colour2((m_tab_active_background_colour.Red()   + m_tab_hover_background_colour.Red())/2,
-                         (m_tab_active_background_colour.Green() + m_tab_hover_background_colour.Green())/2,
-                         (m_tab_active_background_colour.Blue()  + m_tab_hover_background_colour.Blue())/2);
+    wxColour topColour2((m_tabActiveBackgroundColour.Red()   + m_tabHoverBackgroundColour.Red())/2,
+                         (m_tabActiveBackgroundColour.Green() + m_tabHoverBackgroundColour.Green())/2,
+                         (m_tabActiveBackgroundColour.Blue()  + m_tabHoverBackgroundColour.Blue())/2);
 
-    wxColour bottom_colour2((m_tab_active_background_gradient_colour.Red()   + m_tab_hover_background_gradient_colour.Red())/2,
-                            (m_tab_active_background_gradient_colour.Green() + m_tab_hover_background_gradient_colour.Green())/2,
-                            (m_tab_active_background_gradient_colour.Blue()  + m_tab_hover_background_gradient_colour.Blue())/2);
+    wxColour bottomColour2((m_tabActiveBackgroundGradientColour.Red()   + m_tabHoverBackgroundGradientColour.Red())/2,
+                            (m_tabActiveBackgroundGradientColour.Green() + m_tabHoverBackgroundGradientColour.Green())/2,
+                            (m_tabActiveBackgroundGradientColour.Blue()  + m_tabHoverBackgroundGradientColour.Blue())/2);
 
-    m_tab_highlight_colour = top_colour2;
-    m_tab_highlight_gradient_colour = bottom_colour2;
+    m_tabHighlightColour = topColour2;
+    m_tabHighlightGradientColour = bottomColour2;
 
     // Invalidate cached tab separator
-    m_cached_tab_separator_visibility = -1.0;
+    m_cachedTabSeparatorVisibility = -1.0;
 }
 
 wxRibbonArtProvider* wxRibbonMSWArtProvider::Clone() const
@@ -513,128 +513,128 @@ wxRibbonArtProvider* wxRibbonMSWArtProvider::Clone() const
 void wxRibbonMSWArtProvider::CloneTo(wxRibbonMSWArtProvider* copy) const
 {
     int i;
-    for(i = 0; i < 4; ++i)
+    for ( i = 0; i < 4; ++i )
     {
-        copy->m_gallery_up_bundle[i] = m_gallery_up_bundle[i];
-        copy->m_gallery_down_bundle[i] = m_gallery_down_bundle[i];
-        copy->m_gallery_extension_bundle[i] = m_gallery_extension_bundle[i];
+        copy->m_galleryUpBundle[i] = m_galleryUpBundle[i];
+        copy->m_galleryDownBundle[i] = m_galleryDownBundle[i];
+        copy->m_galleryExtensionBundle[i] = m_galleryExtensionBundle[i];
     }
-    for(i = 0; i < 2; ++i)
+    for ( i = 0; i < 2; ++i )
     {
-        copy->m_panel_extension_bundle[i] = m_panel_extension_bundle[i];
-        copy->m_ribbon_toggle_up_bundle[i] = m_ribbon_toggle_up_bundle[i];
-        copy->m_ribbon_toggle_down_bundle[i] = m_ribbon_toggle_down_bundle[i];
-        copy->m_ribbon_toggle_pin_bundle[i] = m_ribbon_toggle_pin_bundle[i];
-        copy->m_ribbon_bar_help_button_bundle[i] = m_ribbon_bar_help_button_bundle[i];
+        copy->m_panelExtensionBundle[i] = m_panelExtensionBundle[i];
+        copy->m_ribbonToggleUpBundle[i] = m_ribbonToggleUpBundle[i];
+        copy->m_ribbonToggleDownBundle[i] = m_ribbonToggleDownBundle[i];
+        copy->m_ribbonTogglePinBundle[i] = m_ribbonTogglePinBundle[i];
+        copy->m_ribbonBarHelpButtonBundle[i] = m_ribbonBarHelpButtonBundle[i];
     }
-    copy->m_toolbar_drop_bundle = m_toolbar_drop_bundle;
+    copy->m_toolbarDropBundle = m_toolbarDropBundle;
 
-    copy->m_primary_scheme_colour = m_primary_scheme_colour;
-    copy->m_secondary_scheme_colour = m_secondary_scheme_colour;
-    copy->m_tertiary_scheme_colour = m_tertiary_scheme_colour;
+    copy->m_primarySchemeColour = m_primarySchemeColour;
+    copy->m_secondarySchemeColour = m_secondarySchemeColour;
+    copy->m_tertiarySchemeColour = m_tertiarySchemeColour;
 
-    copy->m_page_toggle_face_colour = m_page_toggle_face_colour;
-    copy->m_page_toggle_hover_face_colour = m_page_toggle_hover_face_colour;
+    copy->m_pageToggleFaceColour = m_pageToggleFaceColour;
+    copy->m_pageToggleHoverFaceColour = m_pageToggleHoverFaceColour;
 
-    copy->m_button_bar_label_colour = m_button_bar_label_colour;
-    copy->m_button_bar_label_disabled_colour = m_button_bar_label_disabled_colour;
-    copy->m_tab_label_colour = m_tab_label_colour;
-    copy->m_tab_active_label_colour = m_tab_active_label_colour;
-    copy->m_tab_hover_label_colour = m_tab_hover_label_colour;
-    copy->m_tab_separator_colour = m_tab_separator_colour;
-    copy->m_tab_separator_gradient_colour = m_tab_separator_gradient_colour;
-    copy->m_tab_active_background_colour = m_tab_active_background_colour;
-    copy->m_tab_active_background_gradient_colour = m_tab_active_background_gradient_colour;
-    copy->m_tab_hover_background_colour = m_tab_hover_background_colour;
-    copy->m_tab_hover_background_gradient_colour = m_tab_hover_background_gradient_colour;
-    copy->m_tab_hover_background_top_colour = m_tab_hover_background_top_colour;
-    copy->m_tab_hover_background_top_gradient_colour = m_tab_hover_background_top_gradient_colour;
-    copy->m_panel_label_colour = m_panel_label_colour;
-    copy->m_panel_hover_label_colour = m_panel_hover_label_colour;
-    copy->m_panel_minimised_label_colour = m_panel_minimised_label_colour;
-    copy->m_panel_button_face_colour = m_panel_button_face_colour;
-    copy->m_panel_button_hover_face_colour = m_panel_button_hover_face_colour;
-    copy->m_panel_active_background_colour = m_panel_active_background_colour;
-    copy->m_panel_active_background_gradient_colour = m_panel_active_background_gradient_colour;
-    copy->m_panel_active_background_top_colour = m_panel_active_background_top_colour;
-    copy->m_panel_active_background_top_gradient_colour = m_panel_active_background_top_gradient_colour;
-    copy->m_page_background_colour = m_page_background_colour;
-    copy->m_page_background_gradient_colour = m_page_background_gradient_colour;
-    copy->m_page_background_top_colour = m_page_background_top_colour;
-    copy->m_page_background_top_gradient_colour = m_page_background_top_gradient_colour;
-    copy->m_page_hover_background_colour = m_page_hover_background_colour;
-    copy->m_page_hover_background_gradient_colour = m_page_hover_background_gradient_colour;
-    copy->m_page_hover_background_top_colour = m_page_hover_background_top_colour;
-    copy->m_page_hover_background_top_gradient_colour = m_page_hover_background_top_gradient_colour;
-    copy->m_button_bar_hover_background_colour = m_button_bar_hover_background_colour;
-    copy->m_button_bar_hover_background_gradient_colour = m_button_bar_hover_background_gradient_colour;
-    copy->m_button_bar_hover_background_top_colour = m_button_bar_hover_background_top_colour;
-    copy->m_button_bar_hover_background_top_gradient_colour = m_button_bar_hover_background_top_gradient_colour;
-    copy->m_button_bar_active_background_colour = m_button_bar_active_background_colour;
-    copy->m_button_bar_active_background_gradient_colour = m_button_bar_active_background_gradient_colour;
-    copy->m_button_bar_active_background_top_colour = m_button_bar_active_background_top_colour;
-    copy->m_button_bar_active_background_top_gradient_colour = m_button_bar_active_background_top_gradient_colour;
-    copy->m_gallery_button_background_colour = m_gallery_button_background_colour;
-    copy->m_gallery_button_background_gradient_colour = m_gallery_button_background_gradient_colour;
-    copy->m_gallery_button_hover_background_colour = m_gallery_button_hover_background_colour;
-    copy->m_gallery_button_hover_background_gradient_colour = m_gallery_button_hover_background_gradient_colour;
-    copy->m_gallery_button_active_background_colour = m_gallery_button_active_background_colour;
-    copy->m_gallery_button_active_background_gradient_colour = m_gallery_button_active_background_gradient_colour;
-    copy->m_gallery_button_disabled_background_colour = m_gallery_button_disabled_background_colour;
-    copy->m_gallery_button_disabled_background_gradient_colour = m_gallery_button_disabled_background_gradient_colour;
-    copy->m_gallery_button_face_colour = m_gallery_button_face_colour;
-    copy->m_gallery_button_hover_face_colour = m_gallery_button_hover_face_colour;
-    copy->m_gallery_button_active_face_colour = m_gallery_button_active_face_colour;
-    copy->m_gallery_button_disabled_face_colour = m_gallery_button_disabled_face_colour;
+    copy->m_buttonBarLabelColour = m_buttonBarLabelColour;
+    copy->m_buttonBarLabelDisabledColour = m_buttonBarLabelDisabledColour;
+    copy->m_tabLabelColour = m_tabLabelColour;
+    copy->m_tabActiveLabelColour = m_tabActiveLabelColour;
+    copy->m_tabHoverLabelColour = m_tabHoverLabelColour;
+    copy->m_tabSeparatorColour = m_tabSeparatorColour;
+    copy->m_tabSeparatorGradientColour = m_tabSeparatorGradientColour;
+    copy->m_tabActiveBackgroundColour = m_tabActiveBackgroundColour;
+    copy->m_tabActiveBackgroundGradientColour = m_tabActiveBackgroundGradientColour;
+    copy->m_tabHoverBackgroundColour = m_tabHoverBackgroundColour;
+    copy->m_tabHoverBackgroundGradientColour = m_tabHoverBackgroundGradientColour;
+    copy->m_tabHoverBackgroundTopColour = m_tabHoverBackgroundTopColour;
+    copy->m_tabHoverBackgroundTopGradientColour = m_tabHoverBackgroundTopGradientColour;
+    copy->m_panelLabelColour = m_panelLabelColour;
+    copy->m_panelHoverLabelColour = m_panelHoverLabelColour;
+    copy->m_panelMinimisedLabelColour = m_panelMinimisedLabelColour;
+    copy->m_panelButtonFaceColour = m_panelButtonFaceColour;
+    copy->m_panelButtonHoverFaceColour = m_panelButtonHoverFaceColour;
+    copy->m_panelActiveBackgroundColour = m_panelActiveBackgroundColour;
+    copy->m_panelActiveBackgroundGradientColour = m_panelActiveBackgroundGradientColour;
+    copy->m_panelActiveBackgroundTopColour = m_panelActiveBackgroundTopColour;
+    copy->m_panelActiveBackgroundTopGradientColour = m_panelActiveBackgroundTopGradientColour;
+    copy->m_pageBackgroundColour = m_pageBackgroundColour;
+    copy->m_pageBackgroundGradientColour = m_pageBackgroundGradientColour;
+    copy->m_pageBackgroundTopColour = m_pageBackgroundTopColour;
+    copy->m_pageBackgroundTopGradientColour = m_pageBackgroundTopGradientColour;
+    copy->m_pageHoverBackgroundColour = m_pageHoverBackgroundColour;
+    copy->m_pageHoverBackgroundGradientColour = m_pageHoverBackgroundGradientColour;
+    copy->m_pageHoverBackgroundTopColour = m_pageHoverBackgroundTopColour;
+    copy->m_pageHoverBackgroundTopGradientColour = m_pageHoverBackgroundTopGradientColour;
+    copy->m_buttonBarHoverBackgroundColour = m_buttonBarHoverBackgroundColour;
+    copy->m_buttonBarHoverBackgroundGradientColour = m_buttonBarHoverBackgroundGradientColour;
+    copy->m_buttonBarHoverBackgroundTopColour = m_buttonBarHoverBackgroundTopColour;
+    copy->m_buttonBarHoverBackgroundTopGradientColour = m_buttonBarHoverBackgroundTopGradientColour;
+    copy->m_buttonBarActiveBackgroundColour = m_buttonBarActiveBackgroundColour;
+    copy->m_buttonBarActiveBackgroundGradientColour = m_buttonBarActiveBackgroundGradientColour;
+    copy->m_buttonBarActiveBackgroundTopColour = m_buttonBarActiveBackgroundTopColour;
+    copy->m_buttonBarActiveBackgroundTopGradientColour = m_buttonBarActiveBackgroundTopGradientColour;
+    copy->m_galleryButtonBackgroundColour = m_galleryButtonBackgroundColour;
+    copy->m_galleryButtonBackgroundGradientColour = m_galleryButtonBackgroundGradientColour;
+    copy->m_galleryButtonHoverBackgroundColour = m_galleryButtonHoverBackgroundColour;
+    copy->m_galleryButtonHoverBackgroundGradientColour = m_galleryButtonHoverBackgroundGradientColour;
+    copy->m_galleryButtonActiveBackgroundColour = m_galleryButtonActiveBackgroundColour;
+    copy->m_galleryButtonActiveBackgroundGradientColour = m_galleryButtonActiveBackgroundGradientColour;
+    copy->m_galleryButtonDisabledBackgroundColour = m_galleryButtonDisabledBackgroundColour;
+    copy->m_galleryButtonDisabledBackgroundGradientColour = m_galleryButtonDisabledBackgroundGradientColour;
+    copy->m_galleryButtonFaceColour = m_galleryButtonFaceColour;
+    copy->m_galleryButtonHoverFaceColour = m_galleryButtonHoverFaceColour;
+    copy->m_galleryButtonActiveFaceColour = m_galleryButtonActiveFaceColour;
+    copy->m_galleryButtonDisabledFaceColour = m_galleryButtonDisabledFaceColour;
 
-    copy->m_tab_highlight_top_colour = m_tab_highlight_top_colour;
-    copy->m_tab_highlight_top_gradient_colour = m_tab_highlight_top_gradient_colour;
-    copy->m_tab_highlight_colour = m_tab_highlight_colour;
-    copy->m_tab_highlight_gradient_colour = m_tab_highlight_gradient_colour;
+    copy->m_tabHighlightTopColour = m_tabHighlightTopColour;
+    copy->m_tabHighlightTopGradientColour = m_tabHighlightTopGradientColour;
+    copy->m_tabHighlightColour = m_tabHighlightColour;
+    copy->m_tabHighlightGradientColour = m_tabHighlightGradientColour;
 
-    copy->m_tab_ctrl_background_brush = m_tab_ctrl_background_brush;
-    copy->m_panel_label_background_brush = m_panel_label_background_brush;
-    copy->m_panel_hover_label_background_brush = m_panel_hover_label_background_brush;
-    copy->m_panel_hover_button_background_brush = m_panel_hover_button_background_brush;
-    copy->m_gallery_hover_background_brush = m_gallery_hover_background_brush;
-    copy->m_gallery_button_background_top_brush = m_gallery_button_background_top_brush;
-    copy->m_gallery_button_hover_background_top_brush = m_gallery_button_hover_background_top_brush;
-    copy->m_gallery_button_active_background_top_brush = m_gallery_button_active_background_top_brush;
-    copy->m_gallery_button_disabled_background_top_brush = m_gallery_button_disabled_background_top_brush;
-    copy->m_ribbon_toggle_brush = m_ribbon_toggle_brush;
+    copy->m_tabCtrlBackgroundBrush = m_tabCtrlBackgroundBrush;
+    copy->m_panelLabelBackgroundBrush = m_panelLabelBackgroundBrush;
+    copy->m_panelHoverLabelBackgroundBrush = m_panelHoverLabelBackgroundBrush;
+    copy->m_panelHoverButtonBackgroundBrush = m_panelHoverButtonBackgroundBrush;
+    copy->m_galleryHoverBackgroundBrush = m_galleryHoverBackgroundBrush;
+    copy->m_galleryButtonBackgroundTopBrush = m_galleryButtonBackgroundTopBrush;
+    copy->m_galleryButtonHoverBackgroundTopBrush = m_galleryButtonHoverBackgroundTopBrush;
+    copy->m_galleryButtonActiveBackgroundTopBrush = m_galleryButtonActiveBackgroundTopBrush;
+    copy->m_galleryButtonDisabledBackgroundTopBrush = m_galleryButtonDisabledBackgroundTopBrush;
+    copy->m_ribbonToggleBrush = m_ribbonToggleBrush;
 
-    copy->m_tab_label_font = m_tab_label_font;
-    copy->m_button_bar_label_font = m_button_bar_label_font;
-    copy->m_panel_label_font = m_panel_label_font;
+    copy->m_tabLabelFont = m_tabLabelFont;
+    copy->m_buttonBarLabelFont = m_buttonBarLabelFont;
+    copy->m_panelLabelFont = m_panelLabelFont;
 
-    copy->m_page_border_pen = m_page_border_pen;
-    copy->m_panel_border_pen = m_panel_border_pen;
-    copy->m_panel_border_gradient_pen = m_panel_border_gradient_pen;
-    copy->m_panel_hover_border_pen = m_panel_hover_border_pen;
-    copy->m_panel_hover_border_gradient_pen = m_panel_hover_border_gradient_pen;
-    copy->m_panel_minimised_border_pen = m_panel_minimised_border_pen;
-    copy->m_panel_minimised_border_gradient_pen = m_panel_minimised_border_gradient_pen;
-    copy->m_panel_hover_button_border_pen = m_panel_hover_button_border_pen;
-    copy->m_tab_border_pen = m_tab_border_pen;
-    copy->m_gallery_border_pen = m_gallery_border_pen;
-    copy->m_button_bar_hover_border_pen = m_button_bar_hover_border_pen;
-    copy->m_button_bar_active_border_pen = m_button_bar_active_border_pen;
-    copy->m_gallery_item_border_pen = m_gallery_item_border_pen;
-    copy->m_toolbar_border_pen = m_toolbar_border_pen;
-    copy->m_ribbon_toggle_pen = m_ribbon_toggle_pen;
+    copy->m_pageBorderPen = m_pageBorderPen;
+    copy->m_panelBorderPen = m_panelBorderPen;
+    copy->m_panelBorderGradientPen = m_panelBorderGradientPen;
+    copy->m_panelHoverBorderPen = m_panelHoverBorderPen;
+    copy->m_panelHoverBorderGradientPen = m_panelHoverBorderGradientPen;
+    copy->m_panelMinimisedBorderPen = m_panelMinimisedBorderPen;
+    copy->m_panelMinimisedBorderGradientPen = m_panelMinimisedBorderGradientPen;
+    copy->m_panelHoverButtonBorderPen = m_panelHoverButtonBorderPen;
+    copy->m_tabBorderPen = m_tabBorderPen;
+    copy->m_galleryBorderPen = m_galleryBorderPen;
+    copy->m_buttonBarHoverBorderPen = m_buttonBarHoverBorderPen;
+    copy->m_buttonBarActiveBorderPen = m_buttonBarActiveBorderPen;
+    copy->m_galleryItemBorderPen = m_galleryItemBorderPen;
+    copy->m_toolbarBorderPen = m_toolbarBorderPen;
+    copy->m_ribbonTogglePen = m_ribbonTogglePen;
 
     copy->m_flags = m_flags;
-    copy->m_tab_separation_size = m_tab_separation_size;
-    copy->m_page_border_left = m_page_border_left;
-    copy->m_page_border_top = m_page_border_top;
-    copy->m_page_border_right = m_page_border_right;
-    copy->m_page_border_bottom = m_page_border_bottom;
-    copy->m_panel_x_separation_size = m_panel_x_separation_size;
-    copy->m_panel_y_separation_size = m_panel_y_separation_size;
-    copy->m_gallery_bitmap_padding_left_size = m_gallery_bitmap_padding_left_size;
-    copy->m_gallery_bitmap_padding_right_size = m_gallery_bitmap_padding_right_size;
-    copy->m_gallery_bitmap_padding_top_size = m_gallery_bitmap_padding_top_size;
-    copy->m_gallery_bitmap_padding_bottom_size = m_gallery_bitmap_padding_bottom_size;
+    copy->m_tabSeparationSize = m_tabSeparationSize;
+    copy->m_pageBorderLeft = m_pageBorderLeft;
+    copy->m_pageBorderTop = m_pageBorderTop;
+    copy->m_pageBorderRight = m_pageBorderRight;
+    copy->m_pageBorderBottom = m_pageBorderBottom;
+    copy->m_panelXSeparationSize = m_panelXSeparationSize;
+    copy->m_panelYSeparationSize = m_panelYSeparationSize;
+    copy->m_galleryBitmapPaddingLeftSize = m_galleryBitmapPaddingLeftSize;
+    copy->m_galleryBitmapPaddingRightSize = m_galleryBitmapPaddingRightSize;
+    copy->m_galleryBitmapPaddingTopSize = m_galleryBitmapPaddingTopSize;
+    copy->m_galleryBitmapPaddingBottomSize = m_galleryBitmapPaddingBottomSize;
 }
 
 long wxRibbonMSWArtProvider::GetFlags() const
@@ -644,21 +644,21 @@ long wxRibbonMSWArtProvider::GetFlags() const
 
 void wxRibbonMSWArtProvider::SetFlags(long flags)
 {
-    if((flags ^ m_flags) & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( (flags ^ m_flags) & wxRIBBON_BAR_FLOW_VERTICAL )
     {
-        if(flags & wxRIBBON_BAR_FLOW_VERTICAL)
+        if ( flags & wxRIBBON_BAR_FLOW_VERTICAL )
         {
-            m_page_border_left++;
-            m_page_border_right++;
-            m_page_border_top--;
-            m_page_border_bottom--;
+            m_pageBorderLeft++;
+            m_pageBorderRight++;
+            m_pageBorderTop--;
+            m_pageBorderBottom--;
         }
         else
         {
-            m_page_border_left--;
-            m_page_border_right--;
-            m_page_border_top++;
-            m_page_border_bottom++;
+            m_pageBorderLeft--;
+            m_pageBorderRight--;
+            m_pageBorderTop++;
+            m_pageBorderBottom++;
         }
     }
     m_flags = flags;
@@ -676,32 +676,32 @@ void wxRibbonMSWArtProvider::SetFlags(long flags)
 
 int wxRibbonMSWArtProvider::GetMetric(int id) const
 {
-    switch(id)
+    switch ( id )
     {
         case wxRIBBON_ART_TAB_SEPARATION_SIZE:
-            return m_tab_separation_size;
+            return m_tabSeparationSize;
         case wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE:
-            return m_page_border_left;
+            return m_pageBorderLeft;
         case wxRIBBON_ART_PAGE_BORDER_TOP_SIZE:
-            return m_page_border_top;
+            return m_pageBorderTop;
         case wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE:
-            return m_page_border_right;
+            return m_pageBorderRight;
         case wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE:
-            return m_page_border_bottom;
+            return m_pageBorderBottom;
         case wxRIBBON_ART_PANEL_X_SEPARATION_SIZE:
-            return m_panel_x_separation_size;
+            return m_panelXSeparationSize;
         case wxRIBBON_ART_PANEL_Y_SEPARATION_SIZE:
-            return m_panel_y_separation_size;
+            return m_panelYSeparationSize;
         case wxRIBBON_ART_TOOL_GROUP_SEPARATION_SIZE:
-            return m_tool_group_separation_size;
+            return m_toolGroupSeparationSize;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_LEFT_SIZE:
-            return m_gallery_bitmap_padding_left_size;
+            return m_galleryBitmapPaddingLeftSize;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_RIGHT_SIZE:
-            return m_gallery_bitmap_padding_right_size;
+            return m_galleryBitmapPaddingRightSize;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_TOP_SIZE:
-            return m_gallery_bitmap_padding_top_size;
+            return m_galleryBitmapPaddingTopSize;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_BOTTOM_SIZE:
-            return m_gallery_bitmap_padding_bottom_size;
+            return m_galleryBitmapPaddingBottomSize;
         default:
             wxFAIL_MSG("Invalid Metric Ordinal");
             break;
@@ -710,45 +710,45 @@ int wxRibbonMSWArtProvider::GetMetric(int id) const
     return 0;
 }
 
-void wxRibbonMSWArtProvider::SetMetric(int id, int new_val)
+void wxRibbonMSWArtProvider::SetMetric(int id, int newVal)
 {
-    switch(id)
+    switch ( id )
     {
         case wxRIBBON_ART_TAB_SEPARATION_SIZE:
-            m_tab_separation_size = new_val;
+            m_tabSeparationSize = newVal;
             break;
         case wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE:
-            m_page_border_left = new_val;
+            m_pageBorderLeft = newVal;
             break;
         case wxRIBBON_ART_PAGE_BORDER_TOP_SIZE:
-            m_page_border_top = new_val;
+            m_pageBorderTop = newVal;
             break;
         case wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE:
-            m_page_border_right = new_val;
+            m_pageBorderRight = newVal;
             break;
         case wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE:
-            m_page_border_bottom = new_val;
+            m_pageBorderBottom = newVal;
             break;
         case wxRIBBON_ART_PANEL_X_SEPARATION_SIZE:
-            m_panel_x_separation_size = new_val;
+            m_panelXSeparationSize = newVal;
             break;
         case wxRIBBON_ART_PANEL_Y_SEPARATION_SIZE:
-            m_panel_y_separation_size = new_val;
+            m_panelYSeparationSize = newVal;
             break;
         case wxRIBBON_ART_TOOL_GROUP_SEPARATION_SIZE:
-            m_tool_group_separation_size = new_val;
+            m_toolGroupSeparationSize = newVal;
             break;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_LEFT_SIZE:
-            m_gallery_bitmap_padding_left_size = new_val;
+            m_galleryBitmapPaddingLeftSize = newVal;
             break;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_RIGHT_SIZE:
-            m_gallery_bitmap_padding_right_size = new_val;
+            m_galleryBitmapPaddingRightSize = newVal;
             break;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_TOP_SIZE:
-            m_gallery_bitmap_padding_top_size = new_val;
+            m_galleryBitmapPaddingTopSize = newVal;
             break;
         case wxRIBBON_ART_GALLERY_BITMAP_PADDING_BOTTOM_SIZE:
-            m_gallery_bitmap_padding_bottom_size = new_val;
+            m_galleryBitmapPaddingBottomSize = newVal;
             break;
         default:
             wxFAIL_MSG("Invalid Metric Ordinal");
@@ -758,16 +758,16 @@ void wxRibbonMSWArtProvider::SetMetric(int id, int new_val)
 
 void wxRibbonMSWArtProvider::SetFont(int id, const wxFont& font)
 {
-    switch(id)
+    switch ( id )
     {
         case wxRIBBON_ART_TAB_LABEL_FONT:
-            m_tab_label_font = font;
+            m_tabLabelFont = font;
             break;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_FONT:
-            m_button_bar_label_font = font;
+            m_buttonBarLabelFont = font;
             break;
         case wxRIBBON_ART_PANEL_LABEL_FONT:
-            m_panel_label_font = font;
+            m_panelLabelFont = font;
             break;
         default:
             wxFAIL_MSG("Invalid Metric Ordinal");
@@ -777,14 +777,14 @@ void wxRibbonMSWArtProvider::SetFont(int id, const wxFont& font)
 
 wxFont wxRibbonMSWArtProvider::GetFont(int id) const
 {
-    switch(id)
+    switch ( id )
     {
         case wxRIBBON_ART_TAB_LABEL_FONT:
-            return m_tab_label_font;
+            return m_tabLabelFont;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_FONT:
-            return m_button_bar_label_font;
+            return m_buttonBarLabelFont;
         case wxRIBBON_ART_PANEL_LABEL_FONT:
-            return m_panel_label_font;
+            return m_panelLabelFont;
         default:
             wxFAIL_MSG("Invalid Metric Ordinal");
             break;
@@ -795,195 +795,195 @@ wxFont wxRibbonMSWArtProvider::GetFont(int id) const
 
 wxColour wxRibbonMSWArtProvider::GetColour(int id) const
 {
-    switch(id)
+    switch ( id )
     {
         case wxRIBBON_ART_BUTTON_BAR_LABEL_COLOUR:
-            return m_button_bar_label_colour;
+            return m_buttonBarLabelColour;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_DISABLED_COLOUR:
-            return m_button_bar_label_disabled_colour;
+            return m_buttonBarLabelDisabledColour;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BORDER_COLOUR:
-            return m_button_bar_hover_border_pen.GetColour();
+            return m_buttonBarHoverBorderPen.GetColour();
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_TOP_COLOUR:
-            return m_button_bar_hover_background_top_colour;
+            return m_buttonBarHoverBackgroundTopColour;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_button_bar_hover_background_top_gradient_colour;
+            return m_buttonBarHoverBackgroundTopGradientColour;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_COLOUR:
-            return m_button_bar_hover_background_colour;
+            return m_buttonBarHoverBackgroundColour;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            return m_button_bar_hover_background_gradient_colour;
+            return m_buttonBarHoverBackgroundGradientColour;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BORDER_COLOUR:
-            return m_button_bar_active_border_pen.GetColour();
+            return m_buttonBarActiveBorderPen.GetColour();
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_TOP_COLOUR:
-            return m_button_bar_active_background_top_colour;
+            return m_buttonBarActiveBackgroundTopColour;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_button_bar_active_background_top_gradient_colour;
+            return m_buttonBarActiveBackgroundTopGradientColour;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_COLOUR:
-            return m_button_bar_active_background_colour;
+            return m_buttonBarActiveBackgroundColour;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            return m_button_bar_active_background_gradient_colour;
+            return m_buttonBarActiveBackgroundGradientColour;
         case wxRIBBON_ART_GALLERY_BORDER_COLOUR:
-            return m_gallery_border_pen.GetColour();
+            return m_galleryBorderPen.GetColour();
         case wxRIBBON_ART_GALLERY_HOVER_BACKGROUND_COLOUR:
-            return m_gallery_hover_background_brush.GetColour();
+            return m_galleryHoverBackgroundBrush.GetColour();
         case wxRIBBON_ART_GALLERY_BUTTON_BACKGROUND_COLOUR:
-            return m_gallery_button_background_colour;
+            return m_galleryButtonBackgroundColour;
         case wxRIBBON_ART_GALLERY_BUTTON_BACKGROUND_GRADIENT_COLOUR:
-            return m_gallery_button_background_gradient_colour;
+            return m_galleryButtonBackgroundGradientColour;
         case wxRIBBON_ART_GALLERY_BUTTON_BACKGROUND_TOP_COLOUR:
-            return m_gallery_button_background_top_brush.GetColour();
+            return m_galleryButtonBackgroundTopBrush.GetColour();
         case wxRIBBON_ART_GALLERY_BUTTON_FACE_COLOUR:
-            return m_gallery_button_face_colour;
+            return m_galleryButtonFaceColour;
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_COLOUR:
-            return m_gallery_button_hover_background_colour;
+            return m_galleryButtonHoverBackgroundColour;
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            return m_gallery_button_hover_background_gradient_colour;
+            return m_galleryButtonHoverBackgroundGradientColour;
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_TOP_COLOUR:
-            return m_gallery_button_hover_background_top_brush.GetColour();
+            return m_galleryButtonHoverBackgroundTopBrush.GetColour();
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_FACE_COLOUR:
-            return m_gallery_button_hover_face_colour;
+            return m_galleryButtonHoverFaceColour;
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_COLOUR:
-            return m_gallery_button_active_background_colour;
+            return m_galleryButtonActiveBackgroundColour;
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            return m_gallery_button_active_background_gradient_colour;
+            return m_galleryButtonActiveBackgroundGradientColour;
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_TOP_COLOUR:
-            return m_gallery_button_background_top_brush.GetColour();
+            return m_galleryButtonBackgroundTopBrush.GetColour();
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_FACE_COLOUR:
-            return m_gallery_button_active_face_colour;
+            return m_galleryButtonActiveFaceColour;
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_COLOUR:
-            return m_gallery_button_disabled_background_colour;
+            return m_galleryButtonDisabledBackgroundColour;
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_GRADIENT_COLOUR:
-            return m_gallery_button_disabled_background_gradient_colour;
+            return m_galleryButtonDisabledBackgroundGradientColour;
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_TOP_COLOUR:
-            return m_gallery_button_disabled_background_top_brush.GetColour();
+            return m_galleryButtonDisabledBackgroundTopBrush.GetColour();
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_FACE_COLOUR:
-            return m_gallery_button_disabled_face_colour;
+            return m_galleryButtonDisabledFaceColour;
         case wxRIBBON_ART_GALLERY_ITEM_BORDER_COLOUR:
-            return m_gallery_item_border_pen.GetColour();
+            return m_galleryItemBorderPen.GetColour();
         case wxRIBBON_ART_TAB_CTRL_BACKGROUND_COLOUR:
         case wxRIBBON_ART_TAB_CTRL_BACKGROUND_GRADIENT_COLOUR:
-            return m_tab_ctrl_background_brush.GetColour();
+            return m_tabCtrlBackgroundBrush.GetColour();
         case wxRIBBON_ART_TAB_LABEL_COLOUR:
-            return m_tab_label_colour;
+            return m_tabLabelColour;
         case wxRIBBON_ART_TAB_ACTIVE_LABEL_COLOUR:
-            return m_tab_active_label_colour;
+            return m_tabActiveLabelColour;
         case wxRIBBON_ART_TAB_HOVER_LABEL_COLOUR:
-            return m_tab_hover_label_colour;
+            return m_tabHoverLabelColour;
         case wxRIBBON_ART_TAB_SEPARATOR_COLOUR:
-            return m_tab_separator_colour;
+            return m_tabSeparatorColour;
         case wxRIBBON_ART_TAB_SEPARATOR_GRADIENT_COLOUR:
-            return m_tab_separator_gradient_colour;
+            return m_tabSeparatorGradientColour;
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_COLOUR:
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
             return wxColour(0, 0, 0);
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_COLOUR:
-            return m_tab_active_background_colour;
+            return m_tabActiveBackgroundColour;
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            return m_tab_active_background_gradient_colour;
+            return m_tabActiveBackgroundGradientColour;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_TOP_COLOUR:
-            return m_tab_hover_background_top_colour;
+            return m_tabHoverBackgroundTopColour;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_tab_hover_background_top_gradient_colour;
+            return m_tabHoverBackgroundTopGradientColour;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_COLOUR:
-            return m_tab_hover_background_colour;
+            return m_tabHoverBackgroundColour;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            return m_tab_hover_background_gradient_colour;
+            return m_tabHoverBackgroundGradientColour;
         case wxRIBBON_ART_TAB_BORDER_COLOUR:
-            return m_tab_border_pen.GetColour();
+            return m_tabBorderPen.GetColour();
         case wxRIBBON_ART_PANEL_BORDER_COLOUR:
-            return m_panel_border_pen.GetColour();
+            return m_panelBorderPen.GetColour();
         case wxRIBBON_ART_PANEL_BORDER_GRADIENT_COLOUR:
-            return m_panel_border_gradient_pen.GetColour();
+            return m_panelBorderGradientPen.GetColour();
         case wxRIBBON_ART_PANEL_HOVER_BORDER_COLOUR:
-            return m_panel_hover_border_pen.GetColour();
+            return m_panelHoverBorderPen.GetColour();
         case wxRIBBON_ART_PANEL_HOVER_BORDER_GRADIENT_COLOUR:
-            return m_panel_hover_border_gradient_pen.GetColour();
+            return m_panelHoverBorderGradientPen.GetColour();
         case wxRIBBON_ART_PANEL_MINIMISED_BORDER_COLOUR:
-            return m_panel_minimised_border_pen.GetColour();
+            return m_panelMinimisedBorderPen.GetColour();
         case wxRIBBON_ART_PANEL_MINIMISED_BORDER_GRADIENT_COLOUR:
-            return m_panel_minimised_border_gradient_pen.GetColour();
+            return m_panelMinimisedBorderGradientPen.GetColour();
         case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_COLOUR:
         case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_GRADIENT_COLOUR:
-            return m_panel_label_background_brush.GetColour();
+            return m_panelLabelBackgroundBrush.GetColour();
         case wxRIBBON_ART_PANEL_LABEL_COLOUR:
-            return m_panel_label_colour;
+            return m_panelLabelColour;
         case wxRIBBON_ART_PANEL_MINIMISED_LABEL_COLOUR:
-            return m_panel_minimised_label_colour;
+            return m_panelMinimisedLabelColour;
         case wxRIBBON_ART_PANEL_HOVER_LABEL_BACKGROUND_COLOUR:
         case wxRIBBON_ART_PANEL_HOVER_LABEL_BACKGROUND_GRADIENT_COLOUR:
-            return m_panel_hover_label_background_brush.GetColour();
+            return m_panelHoverLabelBackgroundBrush.GetColour();
         case wxRIBBON_ART_PANEL_HOVER_LABEL_COLOUR:
-            return m_panel_hover_label_colour;
+            return m_panelHoverLabelColour;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_TOP_COLOUR:
-            return m_panel_active_background_top_colour;
+            return m_panelActiveBackgroundTopColour;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_panel_active_background_top_gradient_colour;
+            return m_panelActiveBackgroundTopGradientColour;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_COLOUR:
-            return m_panel_active_background_colour;
+            return m_panelActiveBackgroundColour;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            return m_panel_active_background_gradient_colour;
+            return m_panelActiveBackgroundGradientColour;
         case wxRIBBON_ART_PANEL_BUTTON_FACE_COLOUR:
-            return m_panel_button_face_colour;
+            return m_panelButtonFaceColour;
         case wxRIBBON_ART_PANEL_BUTTON_HOVER_FACE_COLOUR:
-            return m_panel_button_hover_face_colour;
+            return m_panelButtonHoverFaceColour;
         case wxRIBBON_ART_PAGE_BORDER_COLOUR:
-            return m_page_border_pen.GetColour();
+            return m_pageBorderPen.GetColour();
         case wxRIBBON_ART_PAGE_BACKGROUND_TOP_COLOUR:
-            return m_page_background_top_colour;
+            return m_pageBackgroundTopColour;
         case wxRIBBON_ART_PAGE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_page_background_top_gradient_colour;
+            return m_pageBackgroundTopGradientColour;
         case wxRIBBON_ART_PAGE_BACKGROUND_COLOUR:
-            return m_page_background_colour;
+            return m_pageBackgroundColour;
         case wxRIBBON_ART_PAGE_BACKGROUND_GRADIENT_COLOUR:
-            return m_page_background_gradient_colour;
+            return m_pageBackgroundGradientColour;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_TOP_COLOUR:
-            return m_page_hover_background_top_colour;
+            return m_pageHoverBackgroundTopColour;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_page_hover_background_top_gradient_colour;
+            return m_pageHoverBackgroundTopGradientColour;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_COLOUR:
-            return m_page_hover_background_colour;
+            return m_pageHoverBackgroundColour;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            return m_page_hover_background_gradient_colour;
+            return m_pageHoverBackgroundGradientColour;
         case wxRIBBON_ART_TOOLBAR_BORDER_COLOUR:
         case wxRIBBON_ART_TOOLBAR_HOVER_BORDER_COLOUR:
-            return m_toolbar_border_pen.GetColour();
+            return m_toolbarBorderPen.GetColour();
         case wxRIBBON_ART_TOOLBAR_FACE_COLOUR:
-            return m_tool_face_colour;
+            return m_toolFaceColour;
         case wxRIBBON_ART_PAGE_TOGGLE_FACE_COLOUR:
-            return m_page_toggle_face_colour;
+            return m_pageToggleFaceColour;
         case wxRIBBON_ART_PAGE_TOGGLE_HOVER_FACE_COLOUR:
-            return m_page_toggle_hover_face_colour;
+            return m_pageToggleHoverFaceColour;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_TOP_COLOUR:
-           return m_tab_highlight_top_colour;
+           return m_tabHighlightTopColour;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_TOP_COLOUR:
-           return m_tab_highlight_top_gradient_colour;
+           return m_tabHighlightTopGradientColour;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_COLOUR:
-           return m_tab_highlight_colour;
+           return m_tabHighlightColour;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_COLOUR:
-           return m_tab_highlight_gradient_colour;
+           return m_tabHighlightGradientColour;
         case wxRIBBON_ART_TOOL_BACKGROUND_TOP_COLOUR:
-            return m_tool_background_top_colour;
+            return m_toolBackgroundTopColour;
         case wxRIBBON_ART_TOOL_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_tool_background_top_gradient_colour;
+            return m_toolBackgroundTopGradientColour;
         case wxRIBBON_ART_TOOL_BACKGROUND_COLOUR:
-            return m_tool_background_colour;
+            return m_toolBackgroundColour;
         case wxRIBBON_ART_TOOL_BACKGROUND_GRADIENT_COLOUR:
-            return m_tool_background_gradient_colour;
+            return m_toolBackgroundGradientColour;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_COLOUR:
-            return m_tool_hover_background_top_colour;
+            return m_toolHoverBackgroundTopColour;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_tool_hover_background_top_gradient_colour;
+            return m_toolHoverBackgroundTopGradientColour;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_COLOUR:
-            return m_tool_hover_background_colour;
+            return m_toolHoverBackgroundColour;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            return m_tool_hover_background_gradient_colour;
+            return m_toolHoverBackgroundGradientColour;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_COLOUR:
-            return m_tool_active_background_top_colour;
+            return m_toolActiveBackgroundTopColour;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            return m_tool_active_background_top_gradient_colour;
+            return m_toolActiveBackgroundTopGradientColour;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_COLOUR:
-            return m_tool_active_background_colour;
+            return m_toolActiveBackgroundColour;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            return m_tool_active_background_gradient_colour;
+            return m_toolActiveBackgroundGradientColour;
         default:
             wxFAIL_MSG("Invalid Metric Ordinal");
             break;
@@ -994,342 +994,342 @@ wxColour wxRibbonMSWArtProvider::GetColour(int id) const
 
 void wxRibbonMSWArtProvider::SetColour(int id, const wxColor& colour)
 {
-    switch(id)
+    switch ( id )
     {
         case wxRIBBON_ART_BUTTON_BAR_LABEL_COLOUR:
-            m_button_bar_label_colour = colour;
+            m_buttonBarLabelColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_DISABLED_COLOUR:
-            m_button_bar_label_disabled_colour = colour;
+            m_buttonBarLabelDisabledColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BORDER_COLOUR:
-            m_button_bar_hover_border_pen.SetColour(colour);
+            m_buttonBarHoverBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_TOP_COLOUR:
-            m_button_bar_hover_background_top_colour = colour;
+            m_buttonBarHoverBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_button_bar_hover_background_top_gradient_colour = colour;
+            m_buttonBarHoverBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_COLOUR:
-            m_button_bar_hover_background_colour = colour;
+            m_buttonBarHoverBackgroundColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            m_button_bar_hover_background_gradient_colour = colour;
+            m_buttonBarHoverBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BORDER_COLOUR:
-            m_button_bar_active_border_pen.SetColour(colour);
+            m_buttonBarActiveBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_TOP_COLOUR:
-            m_button_bar_active_background_top_colour = colour;
+            m_buttonBarActiveBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_button_bar_active_background_top_gradient_colour = colour;
+            m_buttonBarActiveBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_COLOUR:
-            m_button_bar_active_background_colour = colour;
+            m_buttonBarActiveBackgroundColour = colour;
             break;
         case wxRIBBON_ART_BUTTON_BAR_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            m_button_bar_active_background_gradient_colour = colour;
+            m_buttonBarActiveBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BORDER_COLOUR:
-            m_gallery_border_pen.SetColour(colour);
+            m_galleryBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_GALLERY_HOVER_BACKGROUND_COLOUR:
-            m_gallery_hover_background_brush.SetColour(colour);
+            m_galleryHoverBackgroundBrush.SetColour(colour);
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_BACKGROUND_COLOUR:
-            m_gallery_button_background_colour = colour;
+            m_galleryButtonBackgroundColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_BACKGROUND_GRADIENT_COLOUR:
-            m_gallery_button_background_gradient_colour = colour;
+            m_galleryButtonBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_BACKGROUND_TOP_COLOUR:
-            m_gallery_button_background_top_brush.SetColour(colour);
+            m_galleryButtonBackgroundTopBrush.SetColour(colour);
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_FACE_COLOUR:
-            m_gallery_button_face_colour = colour;
-            if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+            m_galleryButtonFaceColour = colour;
+            if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
             {
-                m_gallery_up_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
-                m_gallery_down_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
+                m_galleryUpBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
+                m_galleryDownBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
             }
             else
             {
-                m_gallery_up_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
-                m_gallery_down_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
+                m_galleryUpBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
+                m_galleryDownBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
             }
-            m_gallery_extension_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
+            m_galleryExtensionBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_COLOUR:
-            m_gallery_button_hover_background_colour = colour;
+            m_galleryButtonHoverBackgroundColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            m_gallery_button_hover_background_gradient_colour = colour;
+            m_galleryButtonHoverBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_BACKGROUND_TOP_COLOUR:
-            m_gallery_button_hover_background_top_brush.SetColour(colour);
+            m_galleryButtonHoverBackgroundTopBrush.SetColour(colour);
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_HOVER_FACE_COLOUR:
-            m_gallery_button_hover_face_colour = colour;
-            if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+            m_galleryButtonHoverFaceColour = colour;
+            if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
             {
-                m_gallery_up_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
-                m_gallery_down_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
+                m_galleryUpBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
+                m_galleryDownBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
             }
             else
             {
-                m_gallery_up_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
-                m_gallery_down_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
+                m_galleryUpBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
+                m_galleryDownBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
             }
-            m_gallery_extension_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
+            m_galleryExtensionBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_COLOUR:
-            m_gallery_button_active_background_colour = colour;
+            m_galleryButtonActiveBackgroundColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            m_gallery_button_active_background_gradient_colour = colour;
+            m_galleryButtonActiveBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_BACKGROUND_TOP_COLOUR:
-            m_gallery_button_active_background_top_brush.SetColour(colour);
+            m_galleryButtonActiveBackgroundTopBrush.SetColour(colour);
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_ACTIVE_FACE_COLOUR:
-            m_gallery_button_active_face_colour = colour;
-            if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+            m_galleryButtonActiveFaceColour = colour;
+            if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
             {
-                m_gallery_up_bundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
-                m_gallery_down_bundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
+                m_galleryUpBundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
+                m_galleryDownBundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
             }
             else
             {
-                m_gallery_up_bundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
-                m_gallery_down_bundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
+                m_galleryUpBundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
+                m_galleryDownBundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
             }
-            m_gallery_extension_bundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
+            m_galleryExtensionBundle[2] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_COLOUR:
-            m_gallery_button_disabled_background_colour = colour;
+            m_galleryButtonDisabledBackgroundColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_GRADIENT_COLOUR:
-            m_gallery_button_disabled_background_gradient_colour = colour;
+            m_galleryButtonDisabledBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_BACKGROUND_TOP_COLOUR:
-            m_gallery_button_disabled_background_top_brush.SetColour(colour);
+            m_galleryButtonDisabledBackgroundTopBrush.SetColour(colour);
             break;
         case wxRIBBON_ART_GALLERY_BUTTON_DISABLED_FACE_COLOUR:
-            m_gallery_button_disabled_face_colour = colour;
-            if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+            m_galleryButtonDisabledFaceColour = colour;
+            if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
             {
-                m_gallery_up_bundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
-                m_gallery_down_bundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
+                m_galleryUpBundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_left_xpm, colour));
+                m_galleryDownBundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_right_xpm, colour));
             }
             else
             {
-                m_gallery_up_bundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
-                m_gallery_down_bundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
+                m_galleryUpBundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_up_xpm, colour));
+                m_galleryDownBundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
             }
-            m_gallery_extension_bundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
+            m_galleryExtensionBundle[3] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_extension_xpm, colour));
             break;
         case wxRIBBON_ART_GALLERY_ITEM_BORDER_COLOUR:
-            m_gallery_item_border_pen.SetColour(colour);
+            m_galleryItemBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_TAB_CTRL_BACKGROUND_COLOUR:
         case wxRIBBON_ART_TAB_CTRL_BACKGROUND_GRADIENT_COLOUR:
-            m_tab_ctrl_background_brush.SetColour(colour);
-            m_cached_tab_separator_visibility = -1.0;
+            m_tabCtrlBackgroundBrush.SetColour(colour);
+            m_cachedTabSeparatorVisibility = -1.0;
             break;
         case wxRIBBON_ART_TAB_LABEL_COLOUR:
-            m_tab_label_colour = colour;
+            m_tabLabelColour = colour;
             break;
         case wxRIBBON_ART_TAB_ACTIVE_LABEL_COLOUR:
-            m_tab_active_label_colour = colour;
+            m_tabActiveLabelColour = colour;
             break;
         case wxRIBBON_ART_TAB_HOVER_LABEL_COLOUR:
-            m_tab_hover_label_colour = colour;
+            m_tabHoverLabelColour = colour;
             break;
         case wxRIBBON_ART_TAB_SEPARATOR_COLOUR:
-            m_tab_separator_colour = colour;
-            m_cached_tab_separator_visibility = -1.0;
+            m_tabSeparatorColour = colour;
+            m_cachedTabSeparatorVisibility = -1.0;
             break;
         case wxRIBBON_ART_TAB_SEPARATOR_GRADIENT_COLOUR:
-            m_tab_separator_gradient_colour = colour;
-            m_cached_tab_separator_visibility = -1.0;
+            m_tabSeparatorGradientColour = colour;
+            m_cachedTabSeparatorVisibility = -1.0;
             break;
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_COLOUR:
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
             break;
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_COLOUR:
-            m_tab_active_background_colour = colour;
+            m_tabActiveBackgroundColour = colour;
             break;
         case wxRIBBON_ART_TAB_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            m_tab_active_background_gradient_colour = colour;
+            m_tabActiveBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_TOP_COLOUR:
-            m_tab_hover_background_top_colour = colour;
+            m_tabHoverBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_tab_hover_background_top_gradient_colour = colour;
+            m_tabHoverBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_COLOUR:
-            m_tab_hover_background_colour = colour;
+            m_tabHoverBackgroundColour = colour;
             break;
         case wxRIBBON_ART_TAB_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            m_tab_hover_background_gradient_colour = colour;
+            m_tabHoverBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_TAB_BORDER_COLOUR:
-            m_tab_border_pen.SetColour(colour);
+            m_tabBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_BORDER_COLOUR:
-            m_panel_border_pen.SetColour(colour);
+            m_panelBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_BORDER_GRADIENT_COLOUR:
-            m_panel_border_gradient_pen.SetColour(colour);
+            m_panelBorderGradientPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_HOVER_BORDER_COLOUR:
-            m_panel_hover_border_pen.SetColour(colour);
+            m_panelHoverBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_HOVER_BORDER_GRADIENT_COLOUR:
-            m_panel_hover_border_gradient_pen.SetColour(colour);
+            m_panelHoverBorderGradientPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_MINIMISED_BORDER_COLOUR:
-            m_panel_minimised_border_pen.SetColour(colour);
+            m_panelMinimisedBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_MINIMISED_BORDER_GRADIENT_COLOUR:
-            m_panel_minimised_border_gradient_pen.SetColour(colour);
+            m_panelMinimisedBorderGradientPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_COLOUR:
         case wxRIBBON_ART_PANEL_LABEL_BACKGROUND_GRADIENT_COLOUR:
-            m_panel_label_background_brush.SetColour(colour);
+            m_panelLabelBackgroundBrush.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_LABEL_COLOUR:
-            m_panel_label_colour = colour;
+            m_panelLabelColour = colour;
             break;
         case wxRIBBON_ART_PANEL_HOVER_LABEL_BACKGROUND_COLOUR:
         case wxRIBBON_ART_PANEL_HOVER_LABEL_BACKGROUND_GRADIENT_COLOUR:
-            m_panel_hover_label_background_brush.SetColour(colour);
+            m_panelHoverLabelBackgroundBrush.SetColour(colour);
             break;
         case wxRIBBON_ART_PANEL_HOVER_LABEL_COLOUR:
-            m_panel_hover_label_colour = colour;
+            m_panelHoverLabelColour = colour;
             break;
         case wxRIBBON_ART_PANEL_MINIMISED_LABEL_COLOUR:
-            m_panel_minimised_label_colour = colour;
+            m_panelMinimisedLabelColour = colour;
             break;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_TOP_COLOUR:
-            m_panel_active_background_top_colour = colour;
+            m_panelActiveBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_panel_active_background_top_gradient_colour = colour;
+            m_panelActiveBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_COLOUR:
-            m_panel_active_background_colour = colour;
+            m_panelActiveBackgroundColour = colour;
             break;
         case wxRIBBON_ART_PANEL_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            m_panel_active_background_gradient_colour = colour;
+            m_panelActiveBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_PANEL_BUTTON_FACE_COLOUR:
-            m_panel_button_face_colour = colour;
-            m_panel_extension_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_extension_xpm, colour));
+            m_panelButtonFaceColour = colour;
+            m_panelExtensionBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_extension_xpm, colour));
             break;
         case wxRIBBON_ART_PANEL_BUTTON_HOVER_FACE_COLOUR:
-            m_panel_button_hover_face_colour = colour;
-            m_panel_extension_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_extension_xpm, colour));
+            m_panelButtonHoverFaceColour = colour;
+            m_panelExtensionBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_extension_xpm, colour));
             break;
         case wxRIBBON_ART_PAGE_BORDER_COLOUR:
-            m_page_border_pen.SetColour(colour);
+            m_pageBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_PAGE_BACKGROUND_TOP_COLOUR:
-            m_page_background_top_colour = colour;
+            m_pageBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_PAGE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_page_background_top_gradient_colour = colour;
+            m_pageBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_PAGE_BACKGROUND_COLOUR:
-            m_page_background_colour = colour;
+            m_pageBackgroundColour = colour;
             break;
         case wxRIBBON_ART_PAGE_BACKGROUND_GRADIENT_COLOUR:
-            m_page_background_gradient_colour = colour;
+            m_pageBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_TOP_COLOUR:
-            m_page_hover_background_top_colour = colour;
+            m_pageHoverBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_page_hover_background_top_gradient_colour = colour;
+            m_pageHoverBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_COLOUR:
-            m_page_hover_background_colour = colour;
+            m_pageHoverBackgroundColour = colour;
             break;
         case wxRIBBON_ART_PAGE_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            m_page_hover_background_gradient_colour = colour;
+            m_pageHoverBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_TOOLBAR_BORDER_COLOUR:
         case wxRIBBON_ART_TOOLBAR_HOVER_BORDER_COLOUR:
-            m_toolbar_border_pen.SetColour(colour);
+            m_toolbarBorderPen.SetColour(colour);
             break;
         case wxRIBBON_ART_TOOLBAR_FACE_COLOUR:
-            m_tool_face_colour = colour;
-            m_toolbar_drop_bundle = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
+            m_toolFaceColour = colour;
+            m_toolbarDropBundle = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(gallery_down_xpm, colour));
             break;
         case wxRIBBON_ART_PAGE_TOGGLE_FACE_COLOUR:
-            m_page_toggle_face_colour = colour;
-            m_ribbon_toggle_down_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_down_xpm, colour));
-            m_ribbon_toggle_up_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_up_xpm, colour));
-            m_ribbon_toggle_pin_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_toggle_pin_xpm, colour));
-            m_ribbon_bar_help_button_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_help_button_xpm, colour));
+            m_pageToggleFaceColour = colour;
+            m_ribbonToggleDownBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_down_xpm, colour));
+            m_ribbonToggleUpBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_up_xpm, colour));
+            m_ribbonTogglePinBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_toggle_pin_xpm, colour));
+            m_ribbonBarHelpButtonBundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_help_button_xpm, colour));
             break;
         case wxRIBBON_ART_PAGE_TOGGLE_HOVER_FACE_COLOUR:
-            m_page_toggle_hover_face_colour = colour;
-            m_ribbon_toggle_down_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_down_xpm, colour));
-            m_ribbon_toggle_up_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_up_xpm, colour));
-            m_ribbon_toggle_pin_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_toggle_pin_xpm, colour));
-            m_ribbon_bar_help_button_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_help_button_xpm, colour));
+            m_pageToggleHoverFaceColour = colour;
+            m_ribbonToggleDownBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_down_xpm, colour));
+            m_ribbonToggleUpBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_up_xpm, colour));
+            m_ribbonTogglePinBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_toggle_pin_xpm, colour));
+            m_ribbonBarHelpButtonBundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_help_button_xpm, colour));
             break;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_TOP_COLOUR:
-           m_tab_highlight_top_colour = colour;
+           m_tabHighlightTopColour = colour;
            break;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_TOP_COLOUR:
-           m_tab_highlight_top_gradient_colour = colour;
+           m_tabHighlightTopGradientColour = colour;
            break;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_COLOUR:
-           m_tab_highlight_colour = colour;
+           m_tabHighlightColour = colour;
            break;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_COLOUR:
-           m_tab_highlight_gradient_colour = colour;
+           m_tabHighlightGradientColour = colour;
            break;
         case wxRIBBON_ART_TOOL_BACKGROUND_TOP_COLOUR:
-            m_tool_background_top_colour = colour;
+            m_toolBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_TOOL_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_tool_background_top_gradient_colour = colour;
+            m_toolBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_TOOL_BACKGROUND_COLOUR:
-            m_tool_background_colour = colour;
+            m_toolBackgroundColour = colour;
             break;
         case wxRIBBON_ART_TOOL_BACKGROUND_GRADIENT_COLOUR:
-            m_tool_background_gradient_colour = colour;
+            m_toolBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_COLOUR:
-            m_tool_hover_background_top_colour = colour;
+            m_toolHoverBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_tool_hover_background_top_gradient_colour = colour;
+            m_toolHoverBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_COLOUR:
-            m_tool_hover_background_colour = colour;
+            m_toolHoverBackgroundColour = colour;
             break;
         case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_GRADIENT_COLOUR:
-            m_tool_hover_background_gradient_colour = colour;
+            m_toolHoverBackgroundGradientColour = colour;
             break;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_COLOUR:
-            m_tool_active_background_top_colour = colour;
+            m_toolActiveBackgroundTopColour = colour;
             break;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
-            m_tool_active_background_top_gradient_colour = colour;
+            m_toolActiveBackgroundTopGradientColour = colour;
             break;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_COLOUR:
-            m_tool_active_background_colour = colour;
+            m_toolActiveBackgroundColour = colour;
             break;
         case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
-            m_tool_active_background_gradient_colour = colour;
+            m_toolActiveBackgroundGradientColour = colour;
             break;
         default:
             wxFAIL_MSG("Invalid Metric Ordinal");
@@ -1343,11 +1343,11 @@ void wxRibbonMSWArtProvider::DrawTabCtrlBackground(
                         const wxRect& rect)
 {
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(m_tab_ctrl_background_brush);
+    dc.SetBrush(m_tabCtrlBackgroundBrush);
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
-    dc.SetPen(m_page_border_pen);
-    if(rect.width > 6)
+    dc.SetPen(m_pageBorderPen);
+    if ( rect.width > 6 )
     {
         dc.DrawLine(rect.x + 3, rect.y + rect.height - 1, rect.x + rect.width - 3, rect.y + rect.height - 1);
     }
@@ -1362,28 +1362,28 @@ void wxRibbonMSWArtProvider::DrawTab(
                  wxWindow* WXUNUSED(wnd),
                  const wxRibbonPageTabInfo& tab)
 {
-    if(tab.rect.height <= 2)
+    if ( tab.m_rect.height <= 2 )
         return;
 
-    if(tab.active || tab.hovered || tab.highlight)
+    if ( tab.m_active || tab.m_hovered || tab.m_highlight )
     {
-        if(tab.active)
+        if ( tab.m_active )
         {
-            wxRect background(tab.rect);
+            wxRect background(tab.m_rect);
 
             background.x += 2;
             background.y += 2;
             background.width -= 4;
             background.height -= 2;
 
-            dc.GradientFillLinear(background, m_tab_active_background_colour,
-                m_tab_active_background_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(background, m_tabActiveBackgroundColour,
+                m_tabActiveBackgroundGradientColour, wxSOUTH);
 
             // TODO: active and hovered
         }
-        else if(tab.hovered)
+        else if ( tab.m_hovered )
         {
-            wxRect background(tab.rect);
+            wxRect background(tab.m_rect);
 
             background.x += 2;
             background.y += 2;
@@ -1392,17 +1392,17 @@ void wxRibbonMSWArtProvider::DrawTab(
             int h = background.height;
             background.height /= 2;
             dc.GradientFillLinear(background,
-                m_tab_hover_background_top_colour,
-                m_tab_hover_background_top_gradient_colour, wxSOUTH);
+                m_tabHoverBackgroundTopColour,
+                m_tabHoverBackgroundTopGradientColour, wxSOUTH);
 
             background.y += background.height;
             background.height = h - background.height;
-            dc.GradientFillLinear(background, m_tab_hover_background_colour,
-                m_tab_hover_background_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(background, m_tabHoverBackgroundColour,
+                m_tabHoverBackgroundGradientColour, wxSOUTH);
         }
-        else if(tab.highlight)
+        else if ( tab.m_highlight )
         {
-            wxRect background(tab.rect);
+            wxRect background(tab.m_rect);
 
             background.x += 2;
             background.y += 2;
@@ -1411,106 +1411,106 @@ void wxRibbonMSWArtProvider::DrawTab(
             int h = background.height;
             background.height /= 2;
 
-            dc.GradientFillLinear(background, m_tab_highlight_top_colour, m_tab_highlight_top_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(background, m_tabHighlightTopColour, m_tabHighlightTopGradientColour, wxSOUTH);
 
             background.y += background.height;
             background.height = h - background.height;
 
-            dc.GradientFillLinear(background, m_tab_highlight_colour, m_tab_highlight_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(background, m_tabHighlightColour, m_tabHighlightGradientColour, wxSOUTH);
         }
 
-        wxPoint border_points[6];
-        border_points[0] = wxPoint(1, tab.rect.height - 2);
-        border_points[1] = wxPoint(1, 3);
-        border_points[2] = wxPoint(3, 1);
-        border_points[3] = wxPoint(tab.rect.width - 4, 1);
-        border_points[4] = wxPoint(tab.rect.width - 2, 3);
-        border_points[5] = wxPoint(tab.rect.width - 2, tab.rect.height - 1);
+        wxPoint borderPoints[6];
+        borderPoints[0] = wxPoint(1, tab.m_rect.height - 2);
+        borderPoints[1] = wxPoint(1, 3);
+        borderPoints[2] = wxPoint(3, 1);
+        borderPoints[3] = wxPoint(tab.m_rect.width - 4, 1);
+        borderPoints[4] = wxPoint(tab.m_rect.width - 2, 3);
+        borderPoints[5] = wxPoint(tab.m_rect.width - 2, tab.m_rect.height - 1);
 
-        dc.SetPen(m_tab_border_pen);
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points, tab.rect.x, tab.rect.y);
+        dc.SetPen(m_tabBorderPen);
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints, tab.m_rect.x, tab.m_rect.y);
 
-        if(tab.active)
+        if ( tab.m_active )
         {
             // Give the tab a curved outward border at the bottom
-            dc.DrawPoint(tab.rect.x, tab.rect.y + tab.rect.height - 2);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 1, tab.rect.y + tab.rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x, tab.m_rect.y + tab.m_rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 1, tab.m_rect.y + tab.m_rect.height - 2);
 
-            wxPen p(m_tab_active_background_gradient_colour);
+            wxPen p(m_tabActiveBackgroundGradientColour);
             dc.SetPen(p);
 
             // Technically the first two points are the wrong colour, but they're near enough
-            dc.DrawPoint(tab.rect.x + 1, tab.rect.y + tab.rect.height - 2);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 2, tab.rect.y + tab.rect.height - 2);
-            dc.DrawPoint(tab.rect.x + 1, tab.rect.y + tab.rect.height - 1);
-            dc.DrawPoint(tab.rect.x, tab.rect.y + tab.rect.height - 1);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 2, tab.rect.y + tab.rect.height - 1);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 1, tab.rect.y + tab.rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x + 1, tab.m_rect.y + tab.m_rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 2, tab.m_rect.y + tab.m_rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x + 1, tab.m_rect.y + tab.m_rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x, tab.m_rect.y + tab.m_rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 2, tab.m_rect.y + tab.m_rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 1, tab.m_rect.y + tab.m_rect.height - 1);
         }
     }
 
-    if ( tab.page == nullptr )
+    if ( tab.m_page == nullptr )
         return;
 
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
     {
-        wxBitmap icon = tab.page->GetIcon();
-        if(icon.IsOk())
+        wxBitmap icon = tab.m_page->GetIcon();
+        if ( icon.IsOk() )
         {
-        int x = tab.rect.x + 4;
-        if((m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) == 0)
-            x = tab.rect.x + (tab.rect.width - icon.GetLogicalWidth()) / 2;
-        dc.DrawBitmap(icon, x, tab.rect.y + 1 + (tab.rect.height - 1 -
+        int x = tab.m_rect.x + 4;
+        if ( (m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) == 0 )
+            x = tab.m_rect.x + (tab.m_rect.width - icon.GetLogicalWidth()) / 2;
+        dc.DrawBitmap(icon, x, tab.m_rect.y + 1 + (tab.m_rect.height - 1 -
             icon.GetLogicalHeight()) / 2, true);
         }
     }
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS )
     {
-        wxString label = tab.page->GetLabel();
-        if(!label.empty())
+        wxString label = tab.m_page->GetLabel();
+        if ( !label.empty() )
         {
-            dc.SetFont(m_tab_label_font);
+            dc.SetFont(m_tabLabelFont);
 
-            if (tab.active)
+            if ( tab.m_active )
             {
-                dc.SetTextForeground(m_tab_active_label_colour);
+                dc.SetTextForeground(m_tabActiveLabelColour);
             }
-            else if (tab.hovered)
+            else if ( tab.m_hovered )
             {
-                dc.SetTextForeground(m_tab_hover_label_colour);
+                dc.SetTextForeground(m_tabHoverLabelColour);
             }
             else
             {
-                dc.SetTextForeground(m_tab_label_colour);
+                dc.SetTextForeground(m_tabLabelColour);
             }
 
             dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
-            int text_height;
-            int text_width;
-            dc.GetTextExtent(label, &text_width, &text_height);
-            int width = tab.rect.width - 5;
-            int x = tab.rect.x + 3;
-            if(m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS)
+            int textHeight;
+            int textWidth;
+            dc.GetTextExtent(label, &textWidth, &textHeight);
+            int width = tab.m_rect.width - 5;
+            int x = tab.m_rect.x + 3;
+            if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
             {
-                const wxBitmap& icon = tab.page->GetIcon();
-                if (icon.IsOk())
+                const wxBitmap& icon = tab.m_page->GetIcon();
+                if ( icon.IsOk() )
                 {
                     const int iconWidth = icon.GetLogicalWidth();
                     x += 3 + iconWidth;
                     width -= 3 + iconWidth;
                 }
             }
-            int y = tab.rect.y + (tab.rect.height - text_height) / 2;
+            int y = tab.m_rect.y + (tab.m_rect.height - textHeight) / 2;
 
-            if(width <= text_width)
+            if ( width <= textWidth )
             {
-                wxDCClipper clip(dc, x, tab.rect.y, width, tab.rect.height);
+                wxDCClipper clip(dc, x, tab.m_rect.y, width, tab.m_rect.height);
                 dc.DrawText(label, x, y);
             }
             else
             {
-                dc.DrawText(label, x + (width - text_width) / 2 + 1, y);
+                dc.DrawText(label, x + (width - textWidth) / 2 + 1, y);
             }
         }
     }
@@ -1522,11 +1522,11 @@ void wxRibbonMSWArtProvider::DrawTabSeparator(
                         const wxRect& rect,
                         double visibility)
 {
-    if(visibility <= 0.0)
+    if ( visibility <= 0.0 )
     {
         return;
     }
-    if(visibility > 1.0)
+    if ( visibility > 1.0 )
     {
         visibility = 1.0;
     }
@@ -1534,38 +1534,38 @@ void wxRibbonMSWArtProvider::DrawTabSeparator(
     // The tab separator is relatively expensive to draw (for its size), and is
     // usually drawn multiple times sequentially (in different positions), so it
     // makes sense to draw it once and cache it.
-    if(!m_cached_tab_separator.IsOk() || m_cached_tab_separator.GetLogicalSize() != rect.GetSize() || visibility != m_cached_tab_separator_visibility)
+    if ( !m_cachedTabSeparator.IsOk() || m_cachedTabSeparator.GetLogicalSize() != rect.GetSize() || visibility != m_cachedTabSeparatorVisibility )
     {
         wxRect size(rect.GetSize());
         ReallyDrawTabSeparator(wnd, size, visibility);
     }
-    dc.DrawBitmap(m_cached_tab_separator, rect.x, rect.y, false);
+    dc.DrawBitmap(m_cachedTabSeparator, rect.x, rect.y, false);
 }
 
 void wxRibbonMSWArtProvider::ReallyDrawTabSeparator(wxWindow* wnd, const wxRect& rect, double visibility)
 {
-    if(!m_cached_tab_separator.IsOk() || m_cached_tab_separator.GetLogicalSize() != rect.GetSize())
+    if ( !m_cachedTabSeparator.IsOk() || m_cachedTabSeparator.GetLogicalSize() != rect.GetSize() )
     {
-        m_cached_tab_separator = wxBitmap(rect.GetSize());
+        m_cachedTabSeparator = wxBitmap(rect.GetSize());
     }
 
-    wxMemoryDC dc(m_cached_tab_separator);
+    wxMemoryDC dc(m_cachedTabSeparator);
     DrawTabCtrlBackground(dc, wnd, rect);
 
     wxCoord x = rect.x + rect.width / 2;
     double h = (double)(rect.height - 1);
 
-    double r1 = m_tab_ctrl_background_brush.GetColour().Red() * (1.0 - visibility) + 0.5;
-    double g1 = m_tab_ctrl_background_brush.GetColour().Green() * (1.0 - visibility) + 0.5;
-    double b1 = m_tab_ctrl_background_brush.GetColour().Blue() * (1.0 - visibility) + 0.5;
-    double r2 = m_tab_separator_colour.Red();
-    double g2 = m_tab_separator_colour.Green();
-    double b2 = m_tab_separator_colour.Blue();
-    double r3 = m_tab_separator_gradient_colour.Red();
-    double g3 = m_tab_separator_gradient_colour.Green();
-    double b3 = m_tab_separator_gradient_colour.Blue();
+    double r1 = m_tabCtrlBackgroundBrush.GetColour().Red() * (1.0 - visibility) + 0.5;
+    double g1 = m_tabCtrlBackgroundBrush.GetColour().Green() * (1.0 - visibility) + 0.5;
+    double b1 = m_tabCtrlBackgroundBrush.GetColour().Blue() * (1.0 - visibility) + 0.5;
+    double r2 = m_tabSeparatorColour.Red();
+    double g2 = m_tabSeparatorColour.Green();
+    double b2 = m_tabSeparatorColour.Blue();
+    double r3 = m_tabSeparatorGradientColour.Red();
+    double g3 = m_tabSeparatorGradientColour.Green();
+    double b3 = m_tabSeparatorGradientColour.Blue();
 
-    for(int i = 0; i < rect.height - 1; ++i)
+    for ( int i = 0; i < rect.height - 1; ++i )
     {
         double p = ((double)i)/h;
 
@@ -1578,7 +1578,7 @@ void wxRibbonMSWArtProvider::ReallyDrawTabSeparator(wxWindow* wnd, const wxRect&
         dc.DrawPoint(x, rect.y + i);
     }
 
-    m_cached_tab_separator_visibility = visibility;
+    m_cachedTabSeparatorVisibility = visibility;
 }
 
 void wxRibbonMSWArtProvider::DrawPartialPageBackground(wxDC& dc,
@@ -1592,7 +1592,7 @@ void wxRibbonMSWArtProvider::DrawPartialPageBackground(wxDC& dc,
     // because it paints the panel without reference to its parent's size.
     // Expanded panels use a wxFrame as parent (not a wxRibbonPage).
 
-    if(wnd->GetSizer() && wnd->GetParent() != page)
+    if ( wnd->GetSizer() && wnd->GetParent() != page )
     {
         background = wnd->GetParent()->GetSize();
         offset = wxPoint(0,0);
@@ -1611,60 +1611,60 @@ void wxRibbonMSWArtProvider::DrawPartialPageBackground(wxDC& dc,
     background.x = 0;
     background.width = INT_MAX;
 
-    // upper_rect, lower_rect, paint_rect are all in page co-ordinates
-    wxRect upper_rect(background);
-    upper_rect.height /= 5;
+    // upperRect, lowerRect, paintRect are all in page co-ordinates
+    wxRect upperRect(background);
+    upperRect.height /= 5;
 
-    wxRect lower_rect(background);
-    lower_rect.y += upper_rect.height;
-    lower_rect.height -= upper_rect.height;
+    wxRect lowerRect(background);
+    lowerRect.y += upperRect.height;
+    lowerRect.height -= upperRect.height;
 
-    wxRect paint_rect(r);
-    paint_rect.x += offset.x;
-    paint_rect.y += offset.y;
+    wxRect paintRect(r);
+    paintRect.x += offset.x;
+    paintRect.y += offset.y;
 
-    wxColour bg_top, bg_top_grad, bg_btm, bg_btm_grad;
-    if(hovered)
+    wxColour bgTop, bgTopGrad, bgBtm, bgBtmGrad;
+    if ( hovered )
     {
-        bg_top = m_page_hover_background_top_colour;
-        bg_top_grad = m_page_hover_background_top_gradient_colour;
-        bg_btm = m_page_hover_background_colour;
-        bg_btm_grad = m_page_hover_background_gradient_colour;
+        bgTop = m_pageHoverBackgroundTopColour;
+        bgTopGrad = m_pageHoverBackgroundTopGradientColour;
+        bgBtm = m_pageHoverBackgroundColour;
+        bgBtmGrad = m_pageHoverBackgroundGradientColour;
     }
     else
     {
-        bg_top = m_page_background_top_colour;
-        bg_top_grad = m_page_background_top_gradient_colour;
-        bg_btm = m_page_background_colour;
-        bg_btm_grad = m_page_background_gradient_colour;
+        bgTop = m_pageBackgroundTopColour;
+        bgTopGrad = m_pageBackgroundTopGradientColour;
+        bgBtm = m_pageBackgroundColour;
+        bgBtmGrad = m_pageBackgroundGradientColour;
     }
 
-    if(paint_rect.Intersects(upper_rect))
+    if ( paintRect.Intersects(upperRect) )
     {
-        wxRect rect(upper_rect);
-        rect.Intersect(paint_rect);
+        wxRect rect(upperRect);
+        rect.Intersect(paintRect);
         rect.x -= offset.x;
         rect.y -= offset.y;
-        wxColour starting_colour(wxRibbonInterpolateColour(bg_top, bg_top_grad,
-            paint_rect.y, upper_rect.y, upper_rect.y + upper_rect.height));
-        wxColour ending_colour(wxRibbonInterpolateColour(bg_top, bg_top_grad,
-            paint_rect.y + paint_rect.height, upper_rect.y,
-            upper_rect.y + upper_rect.height));
-        dc.GradientFillLinear(rect, starting_colour, ending_colour, wxSOUTH);
+        wxColour startingColour(wxRibbonInterpolateColour(bgTop, bgTopGrad,
+            paintRect.y, upperRect.y, upperRect.y + upperRect.height));
+        wxColour endingColour(wxRibbonInterpolateColour(bgTop, bgTopGrad,
+            paintRect.y + paintRect.height, upperRect.y,
+            upperRect.y + upperRect.height));
+        dc.GradientFillLinear(rect, startingColour, endingColour, wxSOUTH);
     }
 
-    if(paint_rect.Intersects(lower_rect))
+    if ( paintRect.Intersects(lowerRect) )
     {
-        wxRect rect(lower_rect);
-        rect.Intersect(paint_rect);
+        wxRect rect(lowerRect);
+        rect.Intersect(paintRect);
         rect.x -= offset.x;
         rect.y -= offset.y;
-        wxColour starting_colour(wxRibbonInterpolateColour(bg_btm, bg_btm_grad,
-            paint_rect.y, lower_rect.y, lower_rect.y + lower_rect.height));
-        wxColour ending_colour(wxRibbonInterpolateColour(bg_btm, bg_btm_grad,
-            paint_rect.y + paint_rect.height,
-            lower_rect.y, lower_rect.y + lower_rect.height));
-        dc.GradientFillLinear(rect, starting_colour, ending_colour, wxSOUTH);
+        wxColour startingColour(wxRibbonInterpolateColour(bgBtm, bgBtmGrad,
+            paintRect.y, lowerRect.y, lowerRect.y + lowerRect.height));
+        wxColour endingColour(wxRibbonInterpolateColour(bgBtm, bgBtmGrad,
+            paintRect.y + paintRect.height,
+            lowerRect.y, lowerRect.y + lowerRect.height));
+        dc.GradientFillLinear(rect, startingColour, endingColour, wxSOUTH);
     }
 }
 
@@ -1674,7 +1674,7 @@ void wxRibbonMSWArtProvider::DrawPageBackground(
                         const wxRect& rect)
 {
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(m_tab_ctrl_background_brush);
+    dc.SetBrush(m_tabCtrlBackgroundBrush);
 
     {
         wxRect edge(rect);
@@ -1698,28 +1698,28 @@ void wxRibbonMSWArtProvider::DrawPageBackground(
         background.height -= 2;
 
         background.height /= 5;
-        dc.GradientFillLinear(background, m_page_background_top_colour,
-            m_page_background_top_gradient_colour, wxSOUTH);
+        dc.GradientFillLinear(background, m_pageBackgroundTopColour,
+            m_pageBackgroundTopGradientColour, wxSOUTH);
 
         background.y += background.height;
         background.height = rect.height - 2 - background.height;
-        dc.GradientFillLinear(background, m_page_background_colour,
-            m_page_background_gradient_colour, wxSOUTH);
+        dc.GradientFillLinear(background, m_pageBackgroundColour,
+            m_pageBackgroundGradientColour, wxSOUTH);
     }
 
     {
-        wxPoint border_points[8];
-        border_points[0] = wxPoint(2, 0);
-        border_points[1] = wxPoint(1, 1);
-        border_points[2] = wxPoint(1, rect.height - 4);
-        border_points[3] = wxPoint(3, rect.height - 2);
-        border_points[4] = wxPoint(rect.width - 4, rect.height - 2);
-        border_points[5] = wxPoint(rect.width - 2, rect.height - 4);
-        border_points[6] = wxPoint(rect.width - 2, 1);
-        border_points[7] = wxPoint(rect.width - 4, -1);
+        wxPoint borderPoints[8];
+        borderPoints[0] = wxPoint(2, 0);
+        borderPoints[1] = wxPoint(1, 1);
+        borderPoints[2] = wxPoint(1, rect.height - 4);
+        borderPoints[3] = wxPoint(3, rect.height - 2);
+        borderPoints[4] = wxPoint(rect.width - 4, rect.height - 2);
+        borderPoints[5] = wxPoint(rect.width - 2, rect.height - 4);
+        borderPoints[6] = wxPoint(rect.width - 2, 1);
+        borderPoints[7] = wxPoint(rect.width - 4, -1);
 
-        dc.SetPen(m_page_border_pen);
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points, rect.x, rect.y);
+        dc.SetPen(m_pageBorderPen);
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints, rect.x, rect.y);
     }
 }
 
@@ -1731,16 +1731,16 @@ void wxRibbonMSWArtProvider::DrawScrollButton(
 {
     wxRect rect(rect_);
 
-    if((style & wxRIBBON_SCROLL_BTN_FOR_MASK) == wxRIBBON_SCROLL_BTN_FOR_PAGE)
+    if ( (style & wxRIBBON_SCROLL_BTN_FOR_MASK) == wxRIBBON_SCROLL_BTN_FOR_PAGE )
     {
         // Page scroll buttons do not have the luxury of rendering on top of anything
         // else, and their size includes some padding, hence the background painting
         // and size adjustment.
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_tab_ctrl_background_brush);
+        dc.SetBrush(m_tabCtrlBackgroundBrush);
         dc.DrawRectangle(rect);
         dc.SetClippingRegion(rect);
-        switch(style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK)
+        switch ( style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
         {
         case wxRIBBON_SCROLL_BTN_LEFT:
             rect.x++;
@@ -1770,119 +1770,119 @@ void wxRibbonMSWArtProvider::DrawScrollButton(
         background.width -= 2;
         background.height -= 2;
 
-        if(style & wxRIBBON_SCROLL_BTN_UP)
+        if ( style & wxRIBBON_SCROLL_BTN_UP )
             background.height /= 2;
         else
             background.height /= 5;
-        dc.GradientFillLinear(background, m_page_background_top_colour,
-            m_page_background_top_gradient_colour, wxSOUTH);
+        dc.GradientFillLinear(background, m_pageBackgroundTopColour,
+            m_pageBackgroundTopGradientColour, wxSOUTH);
 
         background.y += background.height;
         background.height = rect.height - 2 - background.height;
-        dc.GradientFillLinear(background, m_page_background_colour,
-            m_page_background_gradient_colour, wxSOUTH);
+        dc.GradientFillLinear(background, m_pageBackgroundColour,
+            m_pageBackgroundGradientColour, wxSOUTH);
     }
 
     {
-        wxPoint border_points[7];
-        switch(style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK)
+        wxPoint borderPoints[7];
+        switch ( style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
         {
         case wxRIBBON_SCROLL_BTN_LEFT:
-            border_points[0] = wxPoint(2, 0);
-            border_points[1] = wxPoint(rect.width - 1, 0);
-            border_points[2] = wxPoint(rect.width - 1, rect.height - 1);
-            border_points[3] = wxPoint(2, rect.height - 1);
-            border_points[4] = wxPoint(0, rect.height - 3);
-            border_points[5] = wxPoint(0, 2);
+            borderPoints[0] = wxPoint(2, 0);
+            borderPoints[1] = wxPoint(rect.width - 1, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, rect.height - 1);
+            borderPoints[3] = wxPoint(2, rect.height - 1);
+            borderPoints[4] = wxPoint(0, rect.height - 3);
+            borderPoints[5] = wxPoint(0, 2);
             break;
         case wxRIBBON_SCROLL_BTN_RIGHT:
-            border_points[0] = wxPoint(0, 0);
-            border_points[1] = wxPoint(rect.width - 3, 0);
-            border_points[2] = wxPoint(rect.width - 1, 2);
-            border_points[3] = wxPoint(rect.width - 1, rect.height - 3);
-            border_points[4] = wxPoint(rect.width - 3, rect.height - 1);
-            border_points[5] = wxPoint(0, rect.height - 1);
+            borderPoints[0] = wxPoint(0, 0);
+            borderPoints[1] = wxPoint(rect.width - 3, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, 2);
+            borderPoints[3] = wxPoint(rect.width - 1, rect.height - 3);
+            borderPoints[4] = wxPoint(rect.width - 3, rect.height - 1);
+            borderPoints[5] = wxPoint(0, rect.height - 1);
             break;
         case wxRIBBON_SCROLL_BTN_UP:
-            border_points[0] = wxPoint(2, 0);
-            border_points[1] = wxPoint(rect.width - 3, 0);
-            border_points[2] = wxPoint(rect.width - 1, 2);
-            border_points[3] = wxPoint(rect.width - 1, rect.height - 1);
-            border_points[4] = wxPoint(0, rect.height - 1);
-            border_points[5] = wxPoint(0, 2);
+            borderPoints[0] = wxPoint(2, 0);
+            borderPoints[1] = wxPoint(rect.width - 3, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, 2);
+            borderPoints[3] = wxPoint(rect.width - 1, rect.height - 1);
+            borderPoints[4] = wxPoint(0, rect.height - 1);
+            borderPoints[5] = wxPoint(0, 2);
             break;
         case wxRIBBON_SCROLL_BTN_DOWN:
-            border_points[0] = wxPoint(0, 0);
-            border_points[1] = wxPoint(rect.width - 1, 0);
-            border_points[2] = wxPoint(rect.width - 1, rect.height - 3);
-            border_points[3] = wxPoint(rect.width - 3, rect.height - 1);
-            border_points[4] = wxPoint(2, rect.height - 1);
-            border_points[5] = wxPoint(0, rect.height - 3);
+            borderPoints[0] = wxPoint(0, 0);
+            borderPoints[1] = wxPoint(rect.width - 1, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, rect.height - 3);
+            borderPoints[3] = wxPoint(rect.width - 3, rect.height - 1);
+            borderPoints[4] = wxPoint(2, rect.height - 1);
+            borderPoints[5] = wxPoint(0, rect.height - 3);
             break;
         }
-        border_points[6] = border_points[0];
+        borderPoints[6] = borderPoints[0];
 
-        dc.SetPen(m_page_border_pen);
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points, rect.x, rect.y);
+        dc.SetPen(m_pageBorderPen);
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints, rect.x, rect.y);
     }
 
     {
         // NB: Code for handling hovered/active state is temporary
-        wxPoint arrow_points[3];
-        switch(style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK)
+        wxPoint arrowPoints[3];
+        switch ( style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
         {
         case wxRIBBON_SCROLL_BTN_LEFT:
-            arrow_points[0] = wxPoint(rect.width / 2 - 2, rect.height / 2);
-            if(style & wxRIBBON_SCROLL_BTN_ACTIVE)
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] + wxPoint(3, -3);
-            arrow_points[2] = arrow_points[0] + wxPoint(3,  3);
+            arrowPoints[0] = wxPoint(rect.width / 2 - 2, rect.height / 2);
+            if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] + wxPoint(3, -3);
+            arrowPoints[2] = arrowPoints[0] + wxPoint(3,  3);
             break;
         case wxRIBBON_SCROLL_BTN_RIGHT:
-            arrow_points[0] = wxPoint(rect.width / 2 + 2, rect.height / 2);
-            if(style & wxRIBBON_SCROLL_BTN_ACTIVE)
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] - wxPoint(3,  3);
-            arrow_points[2] = arrow_points[0] - wxPoint(3, -3);
+            arrowPoints[0] = wxPoint(rect.width / 2 + 2, rect.height / 2);
+            if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] - wxPoint(3,  3);
+            arrowPoints[2] = arrowPoints[0] - wxPoint(3, -3);
             break;
         case wxRIBBON_SCROLL_BTN_UP:
-            arrow_points[0] = wxPoint(rect.width / 2, rect.height / 2 - 2);
-            if(style & wxRIBBON_SCROLL_BTN_ACTIVE)
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] + wxPoint( 3, 3);
-            arrow_points[2] = arrow_points[0] + wxPoint(-3, 3);
+            arrowPoints[0] = wxPoint(rect.width / 2, rect.height / 2 - 2);
+            if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] + wxPoint( 3, 3);
+            arrowPoints[2] = arrowPoints[0] + wxPoint(-3, 3);
             break;
         case wxRIBBON_SCROLL_BTN_DOWN:
-            arrow_points[0] = wxPoint(rect.width / 2, rect.height / 2 + 2);
-            if(style & wxRIBBON_SCROLL_BTN_ACTIVE)
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] - wxPoint( 3, 3);
-            arrow_points[2] = arrow_points[0] - wxPoint(-3, 3);
+            arrowPoints[0] = wxPoint(rect.width / 2, rect.height / 2 + 2);
+            if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] - wxPoint( 3, 3);
+            arrowPoints[2] = arrowPoints[0] - wxPoint(-3, 3);
             break;
         }
 
         dc.SetPen(*wxTRANSPARENT_PEN);
-        wxBrush B(style & wxRIBBON_SCROLL_BTN_HOVERED ? m_tab_active_background_colour : m_tab_label_colour);
+        wxBrush B(style & wxRIBBON_SCROLL_BTN_HOVERED ? m_tabActiveBackgroundColour : m_tabLabelColour);
         dc.SetBrush(B);
-        dc.DrawPolygon(sizeof(arrow_points)/sizeof(wxPoint), arrow_points, rect.x, rect.y);
+        dc.DrawPolygon(sizeof(arrowPoints)/sizeof(wxPoint), arrowPoints, rect.x, rect.y);
     }
 }
 
 void wxRibbonMSWArtProvider::DrawDropdownArrow(wxDC& dc, int x, int y, const wxColour& colour)
 {
-    wxPoint arrow_points[3];
+    wxPoint arrowPoints[3];
     wxBrush brush(colour);
-    arrow_points[0] = wxPoint(1, 2);
-    arrow_points[1] = arrow_points[0] + wxPoint(-3, -3);
-    arrow_points[2] = arrow_points[0] + wxPoint( 3, -3);
+    arrowPoints[0] = wxPoint(1, 2);
+    arrowPoints[1] = arrowPoints[0] + wxPoint(-3, -3);
+    arrowPoints[2] = arrowPoints[0] + wxPoint( 3, -3);
     dc.SetPen(*wxTRANSPARENT_PEN);
     dc.SetBrush(brush);
-    dc.DrawPolygon(sizeof(arrow_points)/sizeof(wxPoint), arrow_points, x, y);
+    dc.DrawPolygon(sizeof(arrowPoints)/sizeof(wxPoint), arrowPoints, x, y);
 }
 
 void wxRibbonMSWArtProvider::RemovePanelPadding(wxRect* rect)
 {
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         rect->y += 1;
         rect->height -= 2;
@@ -1901,112 +1901,112 @@ void wxRibbonMSWArtProvider::DrawPanelBackground(
 {
     DrawPartialPageBackground(dc, wnd, rect, false);
 
-    wxRect true_rect(rect);
-    RemovePanelPadding(&true_rect);
-    bool has_ext_button = wnd->HasExtButton();
+    wxRect trueRect(rect);
+    RemovePanelPadding(&trueRect);
+    bool hasExtButton = wnd->HasExtButton();
 
-    int label_height;
+    int labelHeight;
     {
-        dc.SetFont(m_panel_label_font);
+        dc.SetFont(m_panelLabelFont);
         dc.SetPen(*wxTRANSPARENT_PEN);
-        if(wnd->IsHovered())
+        if ( wnd->IsHovered() )
         {
-            dc.SetBrush(m_panel_hover_label_background_brush);
-            dc.SetTextForeground(m_panel_hover_label_colour);
+            dc.SetBrush(m_panelHoverLabelBackgroundBrush);
+            dc.SetTextForeground(m_panelHoverLabelColour);
         }
         else
         {
-            dc.SetBrush(m_panel_label_background_brush);
-            dc.SetTextForeground(m_panel_label_colour);
+            dc.SetBrush(m_panelLabelBackgroundBrush);
+            dc.SetTextForeground(m_panelLabelColour);
         }
 
-        wxRect label_rect(true_rect);
+        wxRect labelRect(trueRect);
         wxString label = wnd->GetLabel();
-        bool clip_label = false;
-        wxSize label_size(dc.GetTextExtent(label));
+        bool clipLabel = false;
+        wxSize labelSize(dc.GetTextExtent(label));
 
-        label_rect.SetX(label_rect.GetX() + 1);
-        label_rect.SetWidth(label_rect.GetWidth() - 2);
-        label_rect.SetHeight(label_size.GetHeight() + 2);
-        label_rect.SetY(true_rect.GetBottom() - label_rect.GetHeight());
-        label_height = label_rect.GetHeight();
+        labelRect.SetX(labelRect.GetX() + 1);
+        labelRect.SetWidth(labelRect.GetWidth() - 2);
+        labelRect.SetHeight(labelSize.GetHeight() + 2);
+        labelRect.SetY(trueRect.GetBottom() - labelRect.GetHeight());
+        labelHeight = labelRect.GetHeight();
 
-        wxRect label_bg_rect = label_rect;
+        wxRect labelBgRect = labelRect;
 
-        if(has_ext_button)
-            label_rect.SetWidth(label_rect.GetWidth() - 13);
+        if ( hasExtButton )
+            labelRect.SetWidth(labelRect.GetWidth() - 13);
 
-        if(label_size.GetWidth() > label_rect.GetWidth())
+        if ( labelSize.GetWidth() > labelRect.GetWidth() )
         {
             // Test if there is enough length for 3 letters and ...
-            wxString new_label = label.Mid(0, 3) + "...";
-            label_size = dc.GetTextExtent(new_label);
-            if(label_size.GetWidth() > label_rect.GetWidth())
+            wxString newLabel = label.Mid(0, 3) + "...";
+            labelSize = dc.GetTextExtent(newLabel);
+            if ( labelSize.GetWidth() > labelRect.GetWidth() )
             {
                 // Not enough room for three characters and ...
                 // Display the entire label and just crop it
-                clip_label = true;
+                clipLabel = true;
             }
             else
             {
                 // Room for some characters and ...
                 // Display as many characters as possible and append ...
-                for( int len = wxSsize(label) - 1; len >= 3; --len )
+                for ( int len = wxSsize(label) - 1; len >= 3; --len )
                 {
-                    new_label = label.Mid(0, len) + "...";
-                    label_size = dc.GetTextExtent(new_label);
-                    if(label_size.GetWidth() <= label_rect.GetWidth())
+                    newLabel = label.Mid(0, len) + "...";
+                    labelSize = dc.GetTextExtent(newLabel);
+                    if ( labelSize.GetWidth() <= labelRect.GetWidth() )
                     {
-                        label = new_label;
+                        label = newLabel;
                         break;
                     }
                 }
             }
         }
 
-        dc.DrawRectangle(label_bg_rect);
-        if(clip_label)
+        dc.DrawRectangle(labelBgRect);
+        if ( clipLabel )
         {
-            wxDCClipper clip(dc, label_rect);
-            dc.DrawText(label, label_rect.x, label_rect.y +
-                (label_rect.GetHeight() - label_size.GetHeight()) / 2);
+            wxDCClipper clip(dc, labelRect);
+            dc.DrawText(label, labelRect.x, labelRect.y +
+                (labelRect.GetHeight() - labelSize.GetHeight()) / 2);
         }
         else
         {
-            dc.DrawText(label, label_rect.x +
-                (label_rect.GetWidth() - label_size.GetWidth()) / 2,
-                label_rect.y +
-                (label_rect.GetHeight() - label_size.GetHeight()) / 2);
+            dc.DrawText(label, labelRect.x +
+                (labelRect.GetWidth() - labelSize.GetWidth()) / 2,
+                labelRect.y +
+                (labelRect.GetHeight() - labelSize.GetHeight()) / 2);
         }
 
-        if(has_ext_button)
+        if ( hasExtButton )
         {
-            if(wnd->IsExtButtonHovered())
+            if ( wnd->IsExtButtonHovered() )
             {
-                dc.SetPen(m_panel_hover_button_border_pen);
-                dc.SetBrush(m_panel_hover_button_background_brush);
-                dc.DrawRoundedRectangle(label_rect.GetRight(), label_rect.GetBottom() - 13, 13, 13, 1.0);
-                dc.DrawBitmap(m_panel_extension_bundle[1].GetBitmapFor(wnd), label_rect.GetRight() + 3, label_rect.GetBottom() - 10, true);
+                dc.SetPen(m_panelHoverButtonBorderPen);
+                dc.SetBrush(m_panelHoverButtonBackgroundBrush);
+                dc.DrawRoundedRectangle(labelRect.GetRight(), labelRect.GetBottom() - 13, 13, 13, 1.0);
+                dc.DrawBitmap(m_panelExtensionBundle[1].GetBitmapFor(wnd), labelRect.GetRight() + 3, labelRect.GetBottom() - 10, true);
             }
             else
-                dc.DrawBitmap(m_panel_extension_bundle[0].GetBitmapFor(wnd), label_rect.GetRight() + 3, label_rect.GetBottom() - 10, true);
+                dc.DrawBitmap(m_panelExtensionBundle[0].GetBitmapFor(wnd), labelRect.GetRight() + 3, labelRect.GetBottom() - 10, true);
         }
     }
 
-    if(wnd->IsHovered())
+    if ( wnd->IsHovered() )
     {
-        wxRect client_rect(true_rect);
-        client_rect.x++;
-        client_rect.width -= 2;
-        client_rect.y++;
-        client_rect.height -= 2 + label_height;
-        DrawPartialPageBackground(dc, wnd, client_rect, true);
+        wxRect clientRect(trueRect);
+        clientRect.x++;
+        clientRect.width -= 2;
+        clientRect.y++;
+        clientRect.height -= 2 + labelHeight;
+        DrawPartialPageBackground(dc, wnd, clientRect, true);
     }
 
-    if(!wnd->IsHovered())
-        DrawPanelBorder(dc, true_rect, m_panel_border_pen, m_panel_border_gradient_pen);
+    if ( !wnd->IsHovered() )
+        DrawPanelBorder(dc, trueRect, m_panelBorderPen, m_panelBorderGradientPen);
     else
-        DrawPanelBorder(dc, true_rect, m_panel_hover_border_pen, m_panel_hover_border_gradient_pen);
+        DrawPanelBorder(dc, trueRect, m_panelHoverBorderPen, m_panelHoverBorderGradientPen);
 }
 
 wxRect wxRibbonMSWArtProvider::GetPanelExtButtonArea(wxReadOnlyDC& WXUNUSED(dc),
@@ -2025,11 +2025,11 @@ void wxRibbonMSWArtProvider::DrawGalleryBackground(
 {
     DrawPartialPageBackground(dc, wnd, rect);
 
-    if(wnd->IsHovered())
+    if ( wnd->IsHovered() )
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_gallery_hover_background_brush);
-        if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+        dc.SetBrush(m_galleryHoverBackgroundBrush);
+        if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
         {
             dc.DrawRectangle(rect.x + 1, rect.y + 1, rect.width - 2,
                 rect.height - 16);
@@ -2041,7 +2041,7 @@ void wxRibbonMSWArtProvider::DrawGalleryBackground(
         }
     }
 
-    dc.SetPen(m_gallery_border_pen);
+    dc.SetPen(m_galleryBorderPen);
     // Outline
     dc.DrawLine(rect.x + 1, rect.y, rect.x + rect.width - 1, rect.y);
     dc.DrawLine(rect.x, rect.y + 1, rect.x, rect.y + rect.height - 1);
@@ -2057,25 +2057,25 @@ void wxRibbonMSWArtProvider::DrawGalleryBackgroundCommon(wxDC& dc,
                         wxRibbonGallery* wnd,
                         const wxRect& rect)
 {
-    wxRect up_btn, down_btn, ext_btn;
+    wxRect upBtn, downBtn, extBtn;
 
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         // Divider between items and buttons
         dc.DrawLine(rect.x, rect.y + rect.height - 15, rect.x + rect.width,
             rect.y + rect.height - 15);
 
-        up_btn = wxRect(rect.x, rect.y + rect.height - 15, rect.width / 3, 15);
+        upBtn = wxRect(rect.x, rect.y + rect.height - 15, rect.width / 3, 15);
 
-        down_btn = wxRect(up_btn.GetRight() + 1, up_btn.GetTop(),
-            up_btn.GetWidth(), up_btn.GetHeight());
-        dc.DrawLine(down_btn.GetLeft(), down_btn.GetTop(), down_btn.GetLeft(),
-            down_btn.GetBottom());
+        downBtn = wxRect(upBtn.GetRight() + 1, upBtn.GetTop(),
+            upBtn.GetWidth(), upBtn.GetHeight());
+        dc.DrawLine(downBtn.GetLeft(), downBtn.GetTop(), downBtn.GetLeft(),
+            downBtn.GetBottom());
 
-        ext_btn = wxRect(down_btn.GetRight() + 1, up_btn.GetTop(), rect.width -
-            up_btn.GetWidth() - down_btn.GetWidth() - 1, up_btn.GetHeight());
-        dc.DrawLine(ext_btn.GetLeft(), ext_btn.GetTop(), ext_btn.GetLeft(),
-            ext_btn.GetBottom());
+        extBtn = wxRect(downBtn.GetRight() + 1, upBtn.GetTop(), rect.width -
+            upBtn.GetWidth() - downBtn.GetWidth() - 1, upBtn.GetHeight());
+        dc.DrawLine(extBtn.GetLeft(), extBtn.GetTop(), extBtn.GetLeft(),
+            extBtn.GetBottom());
     }
     else
     {
@@ -2083,25 +2083,25 @@ void wxRibbonMSWArtProvider::DrawGalleryBackgroundCommon(wxDC& dc,
         dc.DrawLine(rect.x + rect.width - 15, rect.y, rect.x + rect.width - 15,
             rect.y + rect.height);
 
-        up_btn = wxRect(rect.x + rect.width - 15, rect.y, 15, rect.height / 3);
+        upBtn = wxRect(rect.x + rect.width - 15, rect.y, 15, rect.height / 3);
 
-        down_btn = wxRect(up_btn.GetLeft(), up_btn.GetBottom() + 1,
-            up_btn.GetWidth(), up_btn.GetHeight());
-        dc.DrawLine(down_btn.GetLeft(), down_btn.GetTop(), down_btn.GetRight(),
-            down_btn.GetTop());
+        downBtn = wxRect(upBtn.GetLeft(), upBtn.GetBottom() + 1,
+            upBtn.GetWidth(), upBtn.GetHeight());
+        dc.DrawLine(downBtn.GetLeft(), downBtn.GetTop(), downBtn.GetRight(),
+            downBtn.GetTop());
 
-        ext_btn = wxRect(up_btn.GetLeft(), down_btn.GetBottom() + 1, up_btn.GetWidth(),
-            rect.height - up_btn.GetHeight() - down_btn.GetHeight() - 1);
-        dc.DrawLine(ext_btn.GetLeft(), ext_btn.GetTop(), ext_btn.GetRight(),
-            ext_btn.GetTop());
+        extBtn = wxRect(upBtn.GetLeft(), downBtn.GetBottom() + 1, upBtn.GetWidth(),
+            rect.height - upBtn.GetHeight() - downBtn.GetHeight() - 1);
+        dc.DrawLine(extBtn.GetLeft(), extBtn.GetTop(), extBtn.GetRight(),
+            extBtn.GetTop());
     }
 
-    DrawGalleryButton(dc, up_btn, wnd->GetUpButtonState(),
-        m_gallery_up_bundle, wnd);
-    DrawGalleryButton(dc, down_btn, wnd->GetDownButtonState(),
-        m_gallery_down_bundle, wnd);
-    DrawGalleryButton(dc, ext_btn, wnd->GetExtensionButtonState(),
-        m_gallery_extension_bundle, wnd);
+    DrawGalleryButton(dc, upBtn, wnd->GetUpButtonState(),
+        m_galleryUpBundle, wnd);
+    DrawGalleryButton(dc, downBtn, wnd->GetDownButtonState(),
+        m_galleryDownBundle, wnd);
+    DrawGalleryButton(dc, extBtn, wnd->GetExtensionButtonState(),
+        m_galleryExtensionBundle, wnd);
 }
 
 void wxRibbonMSWArtProvider::DrawGalleryButton(wxDC& dc,
@@ -2110,41 +2110,41 @@ void wxRibbonMSWArtProvider::DrawGalleryButton(wxDC& dc,
                                             wxBitmapBundle* bundles,
                                             wxWindow* wnd)
 {
-    wxBitmap btn_bitmap;
-    wxBrush btn_top_brush;
-    wxColour btn_colour;
-    wxColour btn_grad_colour;
-    switch(state)
+    wxBitmap btnBitmap;
+    wxBrush btnTopBrush;
+    wxColour btnColour;
+    wxColour btnGradColour;
+    switch ( state )
     {
     case wxRIBBON_GALLERY_BUTTON_NORMAL:
-        btn_top_brush = m_gallery_button_background_top_brush;
-        btn_colour = m_gallery_button_background_colour;
-        btn_grad_colour = m_gallery_button_background_gradient_colour;
-        btn_bitmap = bundles[0].GetBitmapFor(wnd);
+        btnTopBrush = m_galleryButtonBackgroundTopBrush;
+        btnColour = m_galleryButtonBackgroundColour;
+        btnGradColour = m_galleryButtonBackgroundGradientColour;
+        btnBitmap = bundles[0].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_HOVERED:
-        btn_top_brush = m_gallery_button_hover_background_top_brush;
-        btn_colour = m_gallery_button_hover_background_colour;
-        btn_grad_colour = m_gallery_button_hover_background_gradient_colour;
-        btn_bitmap = bundles[1].GetBitmapFor(wnd);
+        btnTopBrush = m_galleryButtonHoverBackgroundTopBrush;
+        btnColour = m_galleryButtonHoverBackgroundColour;
+        btnGradColour = m_galleryButtonHoverBackgroundGradientColour;
+        btnBitmap = bundles[1].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_ACTIVE:
-        btn_top_brush = m_gallery_button_active_background_top_brush;
-        btn_colour = m_gallery_button_active_background_colour;
-        btn_grad_colour = m_gallery_button_active_background_gradient_colour;
-        btn_bitmap = bundles[2].GetBitmapFor(wnd);
+        btnTopBrush = m_galleryButtonActiveBackgroundTopBrush;
+        btnColour = m_galleryButtonActiveBackgroundColour;
+        btnGradColour = m_galleryButtonActiveBackgroundGradientColour;
+        btnBitmap = bundles[2].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_DISABLED:
-        btn_top_brush = m_gallery_button_disabled_background_top_brush;
-        btn_colour = m_gallery_button_disabled_background_colour;
-        btn_grad_colour = m_gallery_button_disabled_background_gradient_colour;
-        btn_bitmap = bundles[3].GetBitmapFor(wnd);
+        btnTopBrush = m_galleryButtonDisabledBackgroundTopBrush;
+        btnColour = m_galleryButtonDisabledBackgroundColour;
+        btnGradColour = m_galleryButtonDisabledBackgroundGradientColour;
+        btnBitmap = bundles[3].GetBitmapFor(wnd);
         break;
     }
 
     rect.x++;
     rect.y++;
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         rect.width--;
         rect.height -= 2;
@@ -2156,15 +2156,15 @@ void wxRibbonMSWArtProvider::DrawGalleryButton(wxDC& dc,
     }
 
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(btn_top_brush);
+    dc.SetBrush(btnTopBrush);
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height / 2);
 
     wxRect lower(rect);
     lower.height = (lower.height + 1) / 2;
     lower.y += rect.height - lower.height;
-    dc.GradientFillLinear(lower, btn_colour, btn_grad_colour, wxSOUTH);
+    dc.GradientFillLinear(lower, btnColour, btnGradColour, wxSOUTH);
 
-    dc.DrawBitmap(btn_bitmap, rect.x + rect.width / 2 - 2, lower.y - 2, true);
+    dc.DrawBitmap(btnBitmap, rect.x + rect.width / 2 - 2, lower.y - 2, true);
 }
 
 void wxRibbonMSWArtProvider::DrawGalleryItemBackground(
@@ -2173,11 +2173,11 @@ void wxRibbonMSWArtProvider::DrawGalleryItemBackground(
                         const wxRect& rect,
                         wxRibbonGalleryItem* item)
 {
-    if(wnd->GetHoveredItem() != item && wnd->GetActiveItem() != item &&
-        wnd->GetSelection() != item)
+    if ( wnd->GetHoveredItem() != item && wnd->GetActiveItem() != item &&
+        wnd->GetSelection() != item )
         return;
 
-    dc.SetPen(m_gallery_item_border_pen);
+    dc.SetPen(m_galleryItemBorderPen);
     dc.DrawLine(rect.x + 1, rect.y, rect.x + rect.width - 1, rect.y);
     dc.DrawLine(rect.x, rect.y + 1, rect.x, rect.y + rect.height - 1);
     dc.DrawLine(rect.x + 1, rect.y + rect.height - 1, rect.x + rect.width - 1,
@@ -2185,21 +2185,21 @@ void wxRibbonMSWArtProvider::DrawGalleryItemBackground(
     dc.DrawLine(rect.x + rect.width - 1, rect.y + 1, rect.x + rect.width - 1,
         rect.y + rect.height - 1);
 
-    wxBrush top_brush;
-    wxColour bg_colour;
-    wxColour bg_gradient_colour;
+    wxBrush topBrush;
+    wxColour bgColour;
+    wxColour bgGradientColour;
 
-    if(wnd->GetActiveItem() == item || wnd->GetSelection() == item)
+    if ( wnd->GetActiveItem() == item || wnd->GetSelection() == item )
     {
-        top_brush = m_gallery_button_active_background_top_brush;
-        bg_colour = m_gallery_button_active_background_colour;
-        bg_gradient_colour = m_gallery_button_active_background_gradient_colour;
+        topBrush = m_galleryButtonActiveBackgroundTopBrush;
+        bgColour = m_galleryButtonActiveBackgroundColour;
+        bgGradientColour = m_galleryButtonActiveBackgroundGradientColour;
     }
     else
     {
-        top_brush = m_gallery_button_hover_background_top_brush;
-        bg_colour = m_gallery_button_hover_background_colour;
-        bg_gradient_colour = m_gallery_button_hover_background_gradient_colour;
+        topBrush = m_galleryButtonHoverBackgroundTopBrush;
+        bgColour = m_galleryButtonHoverBackgroundColour;
+        bgGradientColour = m_galleryButtonHoverBackgroundGradientColour;
     }
 
     wxRect upper(rect);
@@ -2208,54 +2208,54 @@ void wxRibbonMSWArtProvider::DrawGalleryItemBackground(
     upper.y += 1;
     upper.height /= 3;
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(top_brush);
+    dc.SetBrush(topBrush);
     dc.DrawRectangle(upper.x, upper.y, upper.width, upper.height);
 
     wxRect lower(upper);
     lower.y += lower.height;
     lower.height = rect.height - 2 - lower.height;
-    dc.GradientFillLinear(lower, bg_colour, bg_gradient_colour, wxSOUTH);
+    dc.GradientFillLinear(lower, bgColour, bgGradientColour, wxSOUTH);
 }
 
 void wxRibbonMSWArtProvider::DrawPanelBorder(wxDC& dc, const wxRect& rect,
-                                             wxPen& primary_colour,
-                                             wxPen& secondary_colour)
+                                             wxPen& primaryColour,
+                                             wxPen& secondaryColour)
 {
-    wxPoint border_points[9];
-    border_points[0] = wxPoint(2, 0);
-    border_points[1] = wxPoint(rect.width - 3, 0);
-    border_points[2] = wxPoint(rect.width - 1, 2);
-    border_points[3] = wxPoint(rect.width - 1, rect.height - 3);
-    border_points[4] = wxPoint(rect.width - 3, rect.height - 1);
-    border_points[5] = wxPoint(2, rect.height - 1);
-    border_points[6] = wxPoint(0, rect.height - 3);
-    border_points[7] = wxPoint(0, 2);
+    wxPoint borderPoints[9];
+    borderPoints[0] = wxPoint(2, 0);
+    borderPoints[1] = wxPoint(rect.width - 3, 0);
+    borderPoints[2] = wxPoint(rect.width - 1, 2);
+    borderPoints[3] = wxPoint(rect.width - 1, rect.height - 3);
+    borderPoints[4] = wxPoint(rect.width - 3, rect.height - 1);
+    borderPoints[5] = wxPoint(2, rect.height - 1);
+    borderPoints[6] = wxPoint(0, rect.height - 3);
+    borderPoints[7] = wxPoint(0, 2);
 
-    if(primary_colour.GetColour() == secondary_colour.GetColour())
+    if ( primaryColour.GetColour() == secondaryColour.GetColour() )
     {
-        border_points[8] = border_points[0];
-        dc.SetPen(primary_colour);
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points, rect.x, rect.y);
+        borderPoints[8] = borderPoints[0];
+        dc.SetPen(primaryColour);
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints, rect.x, rect.y);
     }
     else
     {
-        dc.SetPen(primary_colour);
-        dc.DrawLines(3, border_points, rect.x, rect.y);
+        dc.SetPen(primaryColour);
+        dc.DrawLines(3, borderPoints, rect.x, rect.y);
 
 #define SingleLine(start, finish) \
         dc.DrawLine(start.x + rect.x, start.y + rect.y, finish.x + rect.x, finish.y + rect.y)
 
-        SingleLine(border_points[0], border_points[7]);
-        dc.SetPen(secondary_colour);
-        dc.DrawLines(3, border_points + 4, rect.x, rect.y);
-        SingleLine(border_points[4], border_points[3]);
+        SingleLine(borderPoints[0], borderPoints[7]);
+        dc.SetPen(secondaryColour);
+        dc.DrawLines(3, borderPoints + 4, rect.x, rect.y);
+        SingleLine(borderPoints[4], borderPoints[3]);
 
 #undef SingleLine
 
-        border_points[6] = border_points[2];
-        wxRibbonDrawParallelGradientLines(dc, 2, border_points + 6, 0, 1,
-            border_points[3].y - border_points[2].y + 1, rect.x, rect.y,
-            primary_colour.GetColour(), secondary_colour.GetColour());
+        borderPoints[6] = borderPoints[2];
+        wxRibbonDrawParallelGradientLines(dc, 2, borderPoints + 6, 0, 1,
+            borderPoints[3].y - borderPoints[2].y + 1, rect.x, rect.y,
+            primaryColour.GetColour(), secondaryColour.GetColour());
     }
 }
 
@@ -2267,157 +2267,157 @@ void wxRibbonMSWArtProvider::DrawMinimisedPanel(
 {
     DrawPartialPageBackground(dc, wnd, rect, false);
 
-    wxRect true_rect(rect);
-    RemovePanelPadding(&true_rect);
+    wxRect trueRect(rect);
+    RemovePanelPadding(&trueRect);
 
-    if(wnd->GetExpandedPanel() != nullptr)
+    if ( wnd->GetExpandedPanel() != nullptr )
     {
-        wxRect client_rect(true_rect);
-        client_rect.x++;
-        client_rect.width -= 2;
-        client_rect.y++;
-        client_rect.height = (rect.y + rect.height / 5) - client_rect.x;
-        dc.GradientFillLinear(client_rect,
-            m_panel_active_background_top_colour,
-            m_panel_active_background_top_gradient_colour, wxSOUTH);
+        wxRect clientRect(trueRect);
+        clientRect.x++;
+        clientRect.width -= 2;
+        clientRect.y++;
+        clientRect.height = (rect.y + rect.height / 5) - clientRect.x;
+        dc.GradientFillLinear(clientRect,
+            m_panelActiveBackgroundTopColour,
+            m_panelActiveBackgroundTopGradientColour, wxSOUTH);
 
-        client_rect.y += client_rect.height;
-        client_rect.height = (true_rect.y + true_rect.height) - client_rect.y;
-        dc.GradientFillLinear(client_rect,
-            m_panel_active_background_colour,
-            m_panel_active_background_gradient_colour, wxSOUTH);
+        clientRect.y += clientRect.height;
+        clientRect.height = (trueRect.y + trueRect.height) - clientRect.y;
+        dc.GradientFillLinear(clientRect,
+            m_panelActiveBackgroundColour,
+            m_panelActiveBackgroundGradientColour, wxSOUTH);
     }
-    else if(wnd->IsHovered())
+    else if ( wnd->IsHovered() )
     {
-        wxRect client_rect(true_rect);
-        client_rect.x++;
-        client_rect.width -= 2;
-        client_rect.y++;
-        client_rect.height -= 2;
-        DrawPartialPageBackground(dc, wnd, client_rect, true);
+        wxRect clientRect(trueRect);
+        clientRect.x++;
+        clientRect.width -= 2;
+        clientRect.y++;
+        clientRect.height -= 2;
+        DrawPartialPageBackground(dc, wnd, clientRect, true);
     }
 
     wxRect preview;
-    DrawMinimisedPanelCommon(dc, wnd, true_rect, &preview);
+    DrawMinimisedPanelCommon(dc, wnd, trueRect, &preview);
 
-    dc.SetBrush(m_panel_hover_label_background_brush);
+    dc.SetBrush(m_panelHoverLabelBackgroundBrush);
     dc.SetPen(*wxTRANSPARENT_PEN);
     dc.DrawRectangle(preview.x + 1, preview.y + preview.height - 8,
         preview.width - 2, 7);
 
-    int mid_pos = rect.y + rect.height / 5 - preview.y;
-    if(mid_pos < 0 || mid_pos >= preview.height)
+    int midPos = rect.y + rect.height / 5 - preview.y;
+    if ( midPos < 0 || midPos >= preview.height )
     {
-        wxRect full_rect(preview);
-        full_rect.x += 1;
-        full_rect.y += 1;
-        full_rect.width -= 2;
-        full_rect.height -= 9;
-        if(mid_pos < 0)
+        wxRect fullRect(preview);
+        fullRect.x += 1;
+        fullRect.y += 1;
+        fullRect.width -= 2;
+        fullRect.height -= 9;
+        if ( midPos < 0 )
         {
-            dc.GradientFillLinear(full_rect,
-                m_page_hover_background_colour,
-                m_page_hover_background_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(fullRect,
+                m_pageHoverBackgroundColour,
+                m_pageHoverBackgroundGradientColour, wxSOUTH);
         }
         else
         {
-            dc.GradientFillLinear(full_rect,
-                m_page_hover_background_top_colour,
-                m_page_hover_background_top_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(fullRect,
+                m_pageHoverBackgroundTopColour,
+                m_pageHoverBackgroundTopGradientColour, wxSOUTH);
         }
     }
     else
     {
-        wxRect top_rect(preview);
-        top_rect.x += 1;
-        top_rect.y += 1;
-        top_rect.width -= 2;
-        top_rect.height = mid_pos;
-        dc.GradientFillLinear(top_rect,
-            m_page_hover_background_top_colour,
-            m_page_hover_background_top_gradient_colour, wxSOUTH);
+        wxRect topRect(preview);
+        topRect.x += 1;
+        topRect.y += 1;
+        topRect.width -= 2;
+        topRect.height = midPos;
+        dc.GradientFillLinear(topRect,
+            m_pageHoverBackgroundTopColour,
+            m_pageHoverBackgroundTopGradientColour, wxSOUTH);
 
-        wxRect btm_rect(top_rect);
-        btm_rect.y = preview.y + mid_pos;
-        btm_rect.height = preview.y + preview.height - 7 - btm_rect.y;
-        dc.GradientFillLinear(btm_rect,
-            m_page_hover_background_colour,
-            m_page_hover_background_gradient_colour, wxSOUTH);
+        wxRect btmRect(topRect);
+        btmRect.y = preview.y + midPos;
+        btmRect.height = preview.y + preview.height - 7 - btmRect.y;
+        dc.GradientFillLinear(btmRect,
+            m_pageHoverBackgroundColour,
+            m_pageHoverBackgroundGradientColour, wxSOUTH);
     }
 
-    if(bitmap.IsOk())
+    if ( bitmap.IsOk() )
     {
         dc.DrawBitmap(bitmap, preview.x + (preview.width - bitmap.GetLogicalWidth()) / 2,
             preview.y + (preview.height - 7 - bitmap.GetLogicalHeight()) / 2, true);
     }
 
-    if (!wnd->IsHovered())
-        DrawPanelBorder(dc, preview, m_panel_border_pen, m_panel_border_gradient_pen);
+    if ( !wnd->IsHovered() )
+        DrawPanelBorder(dc, preview, m_panelBorderPen, m_panelBorderGradientPen);
     else
-        DrawPanelBorder(dc, preview, m_panel_hover_border_pen, m_panel_hover_border_gradient_pen);
+        DrawPanelBorder(dc, preview, m_panelHoverBorderPen, m_panelHoverBorderGradientPen);
 
-    DrawPanelBorder(dc, true_rect, m_panel_minimised_border_pen,
-        m_panel_minimised_border_gradient_pen);
+    DrawPanelBorder(dc, trueRect, m_panelMinimisedBorderPen,
+        m_panelMinimisedBorderGradientPen);
 }
 
 void wxRibbonMSWArtProvider::DrawMinimisedPanelCommon(
                         wxDC& dc,
                         wxRibbonPanel* wnd,
-                        const wxRect& true_rect,
-                        wxRect* preview_rect)
+                        const wxRect& trueRect,
+                        wxRect* previewRect)
 {
     wxRect preview(0, 0, 32, 32);
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
-        preview.x = true_rect.x + 4;
-        preview.y = true_rect.y + (true_rect.height - preview.height) / 2;
+        preview.x = trueRect.x + 4;
+        preview.y = trueRect.y + (trueRect.height - preview.height) / 2;
     }
     else
     {
-        preview.x = true_rect.x + (true_rect.width - preview.width) / 2;
-        preview.y = true_rect.y + 4;
+        preview.x = trueRect.x + (trueRect.width - preview.width) / 2;
+        preview.y = trueRect.y + 4;
     }
-    if(preview_rect)
-        *preview_rect = preview;
+    if ( previewRect )
+        *previewRect = preview;
 
-    wxCoord label_width, label_height;
-    dc.SetFont(m_panel_label_font);
-    dc.GetTextExtent(wnd->GetLabel(), &label_width, &label_height);
+    wxCoord label_width, labelHeight;
+    dc.SetFont(m_panelLabelFont);
+    dc.GetTextExtent(wnd->GetLabel(), &label_width, &labelHeight);
 
-    int xpos = true_rect.x + (true_rect.width - label_width + 1) / 2;
+    int xpos = trueRect.x + (trueRect.width - label_width + 1) / 2;
     int ypos = preview.y + preview.height + 5;
 
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         xpos = preview.x + preview.width + 5;
-        ypos = true_rect.y + (true_rect.height - label_height) / 2;
+        ypos = trueRect.y + (trueRect.height - labelHeight) / 2;
     }
 
-    dc.SetTextForeground(m_panel_minimised_label_colour);
+    dc.SetTextForeground(m_panelMinimisedLabelColour);
     dc.DrawText(wnd->GetLabel(), xpos, ypos);
 
 
-    wxPoint arrow_points[3];
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    wxPoint arrowPoints[3];
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         xpos += label_width;
-        arrow_points[0] = wxPoint(xpos + 5, ypos + label_height / 2);
-        arrow_points[1] = arrow_points[0] + wxPoint(-3,  3);
-        arrow_points[2] = arrow_points[0] + wxPoint(-3, -3);
+        arrowPoints[0] = wxPoint(xpos + 5, ypos + labelHeight / 2);
+        arrowPoints[1] = arrowPoints[0] + wxPoint(-3,  3);
+        arrowPoints[2] = arrowPoints[0] + wxPoint(-3, -3);
     }
     else
     {
-        ypos += label_height;
-        arrow_points[0] = wxPoint(true_rect.width / 2, ypos + 5);
-        arrow_points[1] = arrow_points[0] + wxPoint(-3, -3);
-        arrow_points[2] = arrow_points[0] + wxPoint( 3, -3);
+        ypos += labelHeight;
+        arrowPoints[0] = wxPoint(trueRect.width / 2, ypos + 5);
+        arrowPoints[1] = arrowPoints[0] + wxPoint(-3, -3);
+        arrowPoints[2] = arrowPoints[0] + wxPoint( 3, -3);
     }
 
     dc.SetPen(*wxTRANSPARENT_PEN);
-    wxBrush B(m_panel_minimised_label_colour);
+    wxBrush B(m_panelMinimisedLabelColour);
     dc.SetBrush(B);
-    dc.DrawPolygon(sizeof(arrow_points)/sizeof(wxPoint), arrow_points,
-        true_rect.x, true_rect.y);
+    dc.DrawPolygon(sizeof(arrowPoints)/sizeof(wxPoint), arrowPoints,
+        trueRect.x, trueRect.y);
 }
 
 void wxRibbonMSWArtProvider::DrawButtonBarBackground(
@@ -2432,7 +2432,7 @@ void wxRibbonMSWArtProvider::DrawPartialPageBackground(
                         wxDC& dc,
                         wxWindow* wnd,
                         const wxRect& rect,
-                        bool allow_hovered)
+                        bool allowHovered)
 {
     // Assume the window is a child of a ribbon page, and also check for a
     // hovered panel somewhere between the window and the page, as it causes
@@ -2443,37 +2443,37 @@ void wxRibbonMSWArtProvider::DrawPartialPageBackground(
     wxRibbonPanel* panel = wxDynamicCast(wnd, wxRibbonPanel);
     bool hovered = false;
 
-    if(panel != nullptr)
+    if ( panel != nullptr )
     {
-        hovered = allow_hovered && panel->IsHovered();
-        if(panel->GetExpandedDummy() != nullptr)
+        hovered = allowHovered && panel->IsHovered();
+        if ( panel->GetExpandedDummy() != nullptr )
         {
             offset = panel->GetExpandedDummy()->GetPosition();
             parent = panel->GetExpandedDummy()->GetParent();
         }
     }
-    for(; parent; parent = parent->GetParent())
+    for ( ; parent; parent = parent->GetParent() )
     {
-        if(panel == nullptr)
+        if ( panel == nullptr )
         {
             panel = wxDynamicCast(parent, wxRibbonPanel);
-            if(panel != nullptr)
+            if ( panel != nullptr )
             {
-                hovered = allow_hovered && panel->IsHovered();
-                if(panel->GetExpandedDummy() != nullptr)
+                hovered = allowHovered && panel->IsHovered();
+                if ( panel->GetExpandedDummy() != nullptr )
                 {
                     parent = panel->GetExpandedDummy();
                 }
             }
         }
         page = wxDynamicCast(parent, wxRibbonPage);
-        if(page != nullptr)
+        if ( page != nullptr )
         {
             break;
         }
         offset += parent->GetPosition();
     }
-    if(page != nullptr)
+    if ( page != nullptr )
     {
         DrawPartialPageBackground(dc, wnd, rect, page, offset, hovered);
         return;
@@ -2492,124 +2492,124 @@ void wxRibbonMSWArtProvider::DrawButtonBarButton(
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small)
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall)
 {
-    if(kind == wxRIBBON_BUTTON_TOGGLE)
+    if ( kind == wxRIBBON_BUTTON_TOGGLE )
     {
         kind = wxRIBBON_BUTTON_NORMAL;
-        if(state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED)
+        if ( state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED )
             state ^= wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
     }
 
-    if(state & (wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK |
-        wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK))
+    if ( state & (wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK |
+        wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK) )
     {
-        if(state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK)
-            dc.SetPen(m_button_bar_active_border_pen);
+        if ( state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK )
+            dc.SetPen(m_buttonBarActiveBorderPen);
         else
-            dc.SetPen(m_button_bar_hover_border_pen);
+            dc.SetPen(m_buttonBarHoverBorderPen);
 
-        wxRect bg_rect(rect);
-        bg_rect.x++;
-        bg_rect.y++;
-        bg_rect.width -= 2;
-        bg_rect.height -= 2;
+        wxRect bgRect(rect);
+        bgRect.x++;
+        bgRect.y++;
+        bgRect.width -= 2;
+        bgRect.height -= 2;
 
-        wxRect bg_rect_top(bg_rect);
-        bg_rect_top.height /= 3;
-        bg_rect.y += bg_rect_top.height;
-        bg_rect.height -= bg_rect_top.height;
+        wxRect bgRectTop(bgRect);
+        bgRectTop.height /= 3;
+        bgRect.y += bgRectTop.height;
+        bgRect.height -= bgRectTop.height;
 
-        if(kind == wxRIBBON_BUTTON_HYBRID)
+        if ( kind == wxRIBBON_BUTTON_HYBRID )
         {
-            switch(state & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
+            switch ( state & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK )
             {
             case wxRIBBON_BUTTONBAR_BUTTON_LARGE:
                 {
-                    int iYBorder = rect.y + bitmap_large.GetLogicalHeight() + 4;
-                    wxRect partial_bg(rect);
-                    if(state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED)
+                    int iYBorder = rect.y + bitmapLarge.GetLogicalHeight() + 4;
+                    wxRect partialBg(rect);
+                    if ( state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED )
                     {
-                        partial_bg.SetBottom(iYBorder - 1);
+                        partialBg.SetBottom(iYBorder - 1);
                     }
                     else
                     {
-                        partial_bg.height -= (iYBorder - partial_bg.y + 1);
-                        partial_bg.y = iYBorder + 1;
+                        partialBg.height -= (iYBorder - partialBg.y + 1);
+                        partialBg.y = iYBorder + 1;
                     }
                     dc.DrawLine(rect.x, iYBorder, rect.x + rect.width, iYBorder);
-                    bg_rect.Intersect(partial_bg);
-                    bg_rect_top.Intersect(partial_bg);
+                    bgRect.Intersect(partialBg);
+                    bgRectTop.Intersect(partialBg);
                 }
                 break;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
             case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
                 {
                     int iArrowWidth = 9;
-                    if(state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED)
+                    if ( state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED )
                     {
-                        bg_rect.width -= iArrowWidth;
-                        bg_rect_top.width -= iArrowWidth;
-                        dc.DrawLine(bg_rect_top.x + bg_rect_top.width,
-                            rect.y, bg_rect_top.x + bg_rect_top.width,
+                        bgRect.width -= iArrowWidth;
+                        bgRectTop.width -= iArrowWidth;
+                        dc.DrawLine(bgRectTop.x + bgRectTop.width,
+                            rect.y, bgRectTop.x + bgRectTop.width,
                             rect.y + rect.height);
                     }
                     else
                     {
                         --iArrowWidth;
-                        bg_rect.x += bg_rect.width - iArrowWidth;
-                        bg_rect_top.x += bg_rect_top.width - iArrowWidth;
-                        bg_rect.width = iArrowWidth;
-                        bg_rect_top.width = iArrowWidth;
-                        dc.DrawLine(bg_rect_top.x - 1, rect.y,
-                            bg_rect_top.x - 1, rect.y + rect.height);
+                        bgRect.x += bgRect.width - iArrowWidth;
+                        bgRectTop.x += bgRectTop.width - iArrowWidth;
+                        bgRect.width = iArrowWidth;
+                        bgRectTop.width = iArrowWidth;
+                        dc.DrawLine(bgRectTop.x - 1, rect.y,
+                            bgRectTop.x - 1, rect.y + rect.height);
                     }
                 }
                 break;
             }
         }
 
-        if(state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK)
+        if ( state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK )
         {
-            dc.GradientFillLinear(bg_rect_top,
-                m_button_bar_active_background_top_colour,
-                m_button_bar_active_background_top_gradient_colour, wxSOUTH);
-            dc.GradientFillLinear(bg_rect,
-                m_button_bar_active_background_colour,
-                m_button_bar_active_background_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(bgRectTop,
+                m_buttonBarActiveBackgroundTopColour,
+                m_buttonBarActiveBackgroundTopGradientColour, wxSOUTH);
+            dc.GradientFillLinear(bgRect,
+                m_buttonBarActiveBackgroundColour,
+                m_buttonBarActiveBackgroundGradientColour, wxSOUTH);
         }
         else
         {
-            dc.GradientFillLinear(bg_rect_top,
-                m_button_bar_hover_background_top_colour,
-                m_button_bar_hover_background_top_gradient_colour, wxSOUTH);
-            dc.GradientFillLinear(bg_rect,
-                m_button_bar_hover_background_colour,
-                m_button_bar_hover_background_gradient_colour, wxSOUTH);
+            dc.GradientFillLinear(bgRectTop,
+                m_buttonBarHoverBackgroundTopColour,
+                m_buttonBarHoverBackgroundTopGradientColour, wxSOUTH);
+            dc.GradientFillLinear(bgRect,
+                m_buttonBarHoverBackgroundColour,
+                m_buttonBarHoverBackgroundGradientColour, wxSOUTH);
         }
 
-        wxPoint border_points[9];
-        border_points[0] = wxPoint(2, 0);
-        border_points[1] = wxPoint(rect.width - 3, 0);
-        border_points[2] = wxPoint(rect.width - 1, 2);
-        border_points[3] = wxPoint(rect.width - 1, rect.height - 3);
-        border_points[4] = wxPoint(rect.width - 3, rect.height - 1);
-        border_points[5] = wxPoint(2, rect.height - 1);
-        border_points[6] = wxPoint(0, rect.height - 3);
-        border_points[7] = wxPoint(0, 2);
-        border_points[8] = border_points[0];
+        wxPoint borderPoints[9];
+        borderPoints[0] = wxPoint(2, 0);
+        borderPoints[1] = wxPoint(rect.width - 3, 0);
+        borderPoints[2] = wxPoint(rect.width - 1, 2);
+        borderPoints[3] = wxPoint(rect.width - 1, rect.height - 3);
+        borderPoints[4] = wxPoint(rect.width - 3, rect.height - 1);
+        borderPoints[5] = wxPoint(2, rect.height - 1);
+        borderPoints[6] = wxPoint(0, rect.height - 3);
+        borderPoints[7] = wxPoint(0, 2);
+        borderPoints[8] = borderPoints[0];
 
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points,
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints,
             rect.x, rect.y);
     }
 
-    dc.SetFont(m_button_bar_label_font);
+    dc.SetFont(m_buttonBarLabelFont);
     dc.SetTextForeground(state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED
-                            ? m_button_bar_label_disabled_colour
-                            : m_button_bar_label_colour);
-    DrawButtonBarButtonForeground(dc, rect, kind, state, label, bitmap_large,
-        bitmap_small);
+                            ? m_buttonBarLabelDisabledColour
+                            : m_buttonBarLabelColour);
+    DrawButtonBarButtonForeground(dc, rect, kind, state, label, bitmapLarge,
+        bitmapSmall);
 }
 
 void wxRibbonMSWArtProvider::DrawButtonBarButtonForeground(
@@ -2618,98 +2618,98 @@ void wxRibbonMSWArtProvider::DrawButtonBarButtonForeground(
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small)
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall)
 {
     const wxColour
         arrowColour(state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED
-                        ? m_button_bar_label_disabled_colour
-                        : m_button_bar_label_colour);
+                        ? m_buttonBarLabelDisabledColour
+                        : m_buttonBarLabelColour);
 
-    switch(state & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
+    switch ( state & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK )
     {
     case wxRIBBON_BUTTONBAR_BUTTON_LARGE:
         {
             const int padding = 2;
-            dc.DrawBitmap(bitmap_large,
-                rect.x + (rect.width - bitmap_large.GetLogicalWidth()) / 2,
+            dc.DrawBitmap(bitmapLarge,
+                rect.x + (rect.width - bitmapLarge.GetLogicalWidth()) / 2,
                 rect.y + padding, true);
-            int ypos = rect.y + padding + bitmap_large.GetLogicalHeight() + padding;
-            int arrow_width = kind == wxRIBBON_BUTTON_NORMAL ? 0 : 8;
-            wxCoord label_w, label_h;
-            dc.GetTextExtent(label, &label_w, &label_h);
-            if(label_w + 2 * padding <= rect.width)
+            int ypos = rect.y + padding + bitmapLarge.GetLogicalHeight() + padding;
+            int arrowWidth = kind == wxRIBBON_BUTTON_NORMAL ? 0 : 8;
+            wxCoord labelW, labelH;
+            dc.GetTextExtent(label, &labelW, &labelH);
+            if ( labelW + 2 * padding <= rect.width )
             {
-                dc.DrawText(label, rect.x + (rect.width - label_w) / 2, ypos);
-                if(arrow_width != 0)
+                dc.DrawText(label, rect.x + (rect.width - labelW) / 2, ypos);
+                if ( arrowWidth != 0 )
                 {
                     DrawDropdownArrow(dc, rect.x + rect.width / 2,
-                        ypos + (label_h * 3) / 2,
+                        ypos + (labelH * 3) / 2,
                         arrowColour);
                 }
             }
             else
             {
-                size_t breaki = label.Len();
+                size_t breakI = label.Len();
                 do
                 {
-                    --breaki;
-                    if(wxRibbonCanLabelBreakAtPosition(label, breaki))
+                    --breakI;
+                    if ( wxRibbonCanLabelBreakAtPosition(label, breakI) )
                     {
-                        wxString label_top = label.Mid(0, breaki);
-                        dc.GetTextExtent(label_top, &label_w, &label_h);
-                        if(label_w + 2 * padding <= rect.width)
+                        wxString labelTop = label.Mid(0, breakI);
+                        dc.GetTextExtent(labelTop, &labelW, &labelH);
+                        if ( labelW + 2 * padding <= rect.width )
                         {
-                            dc.DrawText(label_top,
-                                rect.x + (rect.width - label_w) / 2, ypos);
-                            ypos += label_h;
-                            wxString label_bottom = label.Mid(breaki + 1);
-                            dc.GetTextExtent(label_bottom, &label_w, &label_h);
-                            label_w += arrow_width;
-                            int iX = rect.x + (rect.width - label_w) / 2;
-                            dc.DrawText(label_bottom, iX, ypos);
-                            if(arrow_width != 0)
+                            dc.DrawText(labelTop,
+                                rect.x + (rect.width - labelW) / 2, ypos);
+                            ypos += labelH;
+                            wxString labelBottom = label.Mid(breakI + 1);
+                            dc.GetTextExtent(labelBottom, &labelW, &labelH);
+                            labelW += arrowWidth;
+                            int iX = rect.x + (rect.width - labelW) / 2;
+                            dc.DrawText(labelBottom, iX, ypos);
+                            if ( arrowWidth != 0 )
                             {
                                 DrawDropdownArrow(dc,
-                                    iX + 2 +label_w - arrow_width,
-                                    ypos + label_h / 2 + 1,
+                                    iX + 2 +labelW - arrowWidth,
+                                    ypos + labelH / 2 + 1,
                                     arrowColour);
                             }
                             break;
                         }
                     }
-                } while(breaki > 0);
+                } while ( breakI > 0 );
             }
         }
         break;
     case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
         {
-            int x_cursor = rect.x + 2;
-            dc.DrawBitmap(bitmap_small, x_cursor,
-                    rect.y + (rect.height - bitmap_small.GetLogicalHeight())/2, true);
-            x_cursor += bitmap_small.GetLogicalWidth() + 2;
-            wxCoord label_w, label_h;
-            dc.GetTextExtent(label, &label_w, &label_h);
-            dc.DrawText(label, x_cursor,
-                rect.y + (rect.height - label_h) / 2);
-            x_cursor += label_w + 3;
-            if(kind != wxRIBBON_BUTTON_NORMAL)
+            int xCursor = rect.x + 2;
+            dc.DrawBitmap(bitmapSmall, xCursor,
+                    rect.y + (rect.height - bitmapSmall.GetLogicalHeight())/2, true);
+            xCursor += bitmapSmall.GetLogicalWidth() + 2;
+            wxCoord labelW, labelH;
+            dc.GetTextExtent(label, &labelW, &labelH);
+            dc.DrawText(label, xCursor,
+                rect.y + (rect.height - labelH) / 2);
+            xCursor += labelW + 3;
+            if ( kind != wxRIBBON_BUTTON_NORMAL )
             {
-                DrawDropdownArrow(dc, x_cursor, rect.y + rect.height / 2, arrowColour);
+                DrawDropdownArrow(dc, xCursor, rect.y + rect.height / 2, arrowColour);
             }
             break;
         }
     case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
         {
-            int avail_width = rect.width;
-            if(kind != wxRIBBON_BUTTON_NORMAL)
+            int availWidth = rect.width;
+            if ( kind != wxRIBBON_BUTTON_NORMAL )
             {
-                avail_width -= 8;
-                DrawDropdownArrow(dc, rect.x + avail_width + 4, rect.y + rect.height / 2, arrowColour);
+                availWidth -= 8;
+                DrawDropdownArrow(dc, rect.x + availWidth + 4, rect.y + rect.height / 2, arrowColour);
             }
-            int x_cursor = rect.x + (avail_width - bitmap_small.GetLogicalWidth()) / 2;
-            dc.DrawBitmap(bitmap_small, x_cursor,
-                    rect.y + (rect.height - bitmap_small.GetLogicalHeight()) / 2, true);
+            int xCursor = rect.x + (availWidth - bitmapSmall.GetLogicalWidth()) / 2;
+            dc.DrawBitmap(bitmapSmall, xCursor,
+                    rect.y + (rect.height - bitmapSmall.GetLogicalHeight()) / 2, true);
             break;
         }
     default:
@@ -2730,7 +2730,7 @@ void wxRibbonMSWArtProvider::DrawToolGroupBackground(
                         wxWindow* WXUNUSED(wnd),
                         const wxRect& rect)
 {
-    dc.SetPen(m_toolbar_border_pen);
+    dc.SetPen(m_toolbarBorderPen);
     wxPoint outline[9];
     outline[0] = wxPoint(2, 0);
     outline[1] = wxPoint(rect.width - 3, 0);
@@ -2753,50 +2753,50 @@ void wxRibbonMSWArtProvider::DrawTool(
                 wxRibbonButtonKind kind,
                 long state)
 {
-    if(kind == wxRIBBON_BUTTON_TOGGLE)
+    if ( kind == wxRIBBON_BUTTON_TOGGLE )
     {
-        if(state & wxRIBBON_TOOLBAR_TOOL_TOGGLED)
+        if ( state & wxRIBBON_TOOLBAR_TOOL_TOGGLED )
             state ^= wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
     }
 
-    wxRect bg_rect(rect);
-    bg_rect.Deflate(1);
-    if((state & wxRIBBON_TOOLBAR_TOOL_LAST) == 0)
-        bg_rect.width++;
-    bool is_split_hybrid = (kind == wxRIBBON_BUTTON_HYBRID && (state &
+    wxRect bgRect(rect);
+    bgRect.Deflate(1);
+    if ( (state & wxRIBBON_TOOLBAR_TOOL_LAST) == 0 )
+        bgRect.width++;
+    bool isSplitHybrid = (kind == wxRIBBON_BUTTON_HYBRID && (state &
         (wxRIBBON_TOOLBAR_TOOL_HOVER_MASK | wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK)));
 
     // Background
-    wxRect bg_rect_top(bg_rect);
-    bg_rect_top.height = (bg_rect_top.height * 2) / 5;
-    wxRect bg_rect_btm(bg_rect);
-    bg_rect_btm.y += bg_rect_top.height;
-    bg_rect_btm.height -= bg_rect_top.height;
-    wxColour bg_top_colour = m_tool_background_top_colour;
-    wxColour bg_top_grad_colour = m_tool_background_top_gradient_colour;
-    wxColour bg_colour = m_tool_background_colour;
-    wxColour bg_grad_colour = m_tool_background_gradient_colour;
-    if(state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK)
+    wxRect bgRectTop(bgRect);
+    bgRectTop.height = (bgRectTop.height * 2) / 5;
+    wxRect bgRectBtm(bgRect);
+    bgRectBtm.y += bgRectTop.height;
+    bgRectBtm.height -= bgRectTop.height;
+    wxColour bgTopColour = m_toolBackgroundTopColour;
+    wxColour bgTopGradColour = m_toolBackgroundTopGradientColour;
+    wxColour bgColour = m_toolBackgroundColour;
+    wxColour bgGradColour = m_toolBackgroundGradientColour;
+    if ( state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK )
     {
-        bg_top_colour = m_tool_active_background_top_colour;
-        bg_top_grad_colour = m_tool_active_background_top_gradient_colour;
-        bg_colour = m_tool_active_background_colour;
-        bg_grad_colour = m_tool_active_background_gradient_colour;
+        bgTopColour = m_toolActiveBackgroundTopColour;
+        bgTopGradColour = m_toolActiveBackgroundTopGradientColour;
+        bgColour = m_toolActiveBackgroundColour;
+        bgGradColour = m_toolActiveBackgroundGradientColour;
     }
-    else if(state & wxRIBBON_TOOLBAR_TOOL_HOVER_MASK)
+    else if ( state & wxRIBBON_TOOLBAR_TOOL_HOVER_MASK )
     {
-        bg_top_colour = m_tool_hover_background_top_colour;
-        bg_top_grad_colour = m_tool_hover_background_top_gradient_colour;
-        bg_colour = m_tool_hover_background_colour;
-        bg_grad_colour = m_tool_hover_background_gradient_colour;
+        bgTopColour = m_toolHoverBackgroundTopColour;
+        bgTopGradColour = m_toolHoverBackgroundTopGradientColour;
+        bgColour = m_toolHoverBackgroundColour;
+        bgGradColour = m_toolHoverBackgroundGradientColour;
     }
-    dc.GradientFillLinear(bg_rect_top, bg_top_colour, bg_top_grad_colour, wxSOUTH);
-    dc.GradientFillLinear(bg_rect_btm, bg_colour, bg_grad_colour, wxSOUTH);
-    if(is_split_hybrid)
+    dc.GradientFillLinear(bgRectTop, bgTopColour, bgTopGradColour, wxSOUTH);
+    dc.GradientFillLinear(bgRectBtm, bgColour, bgGradColour, wxSOUTH);
+    if ( isSplitHybrid )
     {
-        wxRect nonrect(bg_rect);
-        if(state & (wxRIBBON_TOOLBAR_TOOL_DROPDOWN_HOVERED |
-            wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE))
+        wxRect nonrect(bgRect);
+        if ( state & (wxRIBBON_TOOLBAR_TOOL_DROPDOWN_HOVERED |
+            wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE) )
         {
             nonrect.width -= 8;
         }
@@ -2805,15 +2805,15 @@ void wxRibbonMSWArtProvider::DrawTool(
             nonrect.x += nonrect.width - 8;
             nonrect.width = 8;
         }
-        wxBrush B(m_tool_hover_background_top_colour);
+        wxBrush B(m_toolHoverBackgroundTopColour);
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(B);
         dc.DrawRectangle(nonrect.x, nonrect.y, nonrect.width, nonrect.height);
     }
 
     // Border
-    dc.SetPen(m_toolbar_border_pen);
-    if(state & wxRIBBON_TOOLBAR_TOOL_FIRST)
+    dc.SetPen(m_toolbarBorderPen);
+    if ( state & wxRIBBON_TOOLBAR_TOOL_FIRST )
     {
         dc.DrawPoint(rect.x + 1, rect.y + 1);
         dc.DrawPoint(rect.x + 1, rect.y + rect.height - 2);
@@ -2821,27 +2821,27 @@ void wxRibbonMSWArtProvider::DrawTool(
     else
         dc.DrawLine(rect.x, rect.y + 1, rect.x, rect.y + rect.height - 1);
 
-    if(state & wxRIBBON_TOOLBAR_TOOL_LAST)
+    if ( state & wxRIBBON_TOOLBAR_TOOL_LAST )
     {
         dc.DrawPoint(rect.x + rect.width - 2, rect.y + 1);
         dc.DrawPoint(rect.x + rect.width - 2, rect.y + rect.height - 2);
     }
 
     // Foreground
-    int avail_width = bg_rect.GetWidth();
-    if(kind & wxRIBBON_BUTTON_DROPDOWN)
+    int availWidth = bgRect.GetWidth();
+    if ( kind & wxRIBBON_BUTTON_DROPDOWN )
     {
-        avail_width -= 8;
-        if(is_split_hybrid)
+        availWidth -= 8;
+        if ( isSplitHybrid )
         {
-            dc.DrawLine(rect.x + avail_width + 1, rect.y,
-                rect.x + avail_width + 1, rect.y + rect.height);
+            dc.DrawLine(rect.x + availWidth + 1, rect.y,
+                rect.x + availWidth + 1, rect.y + rect.height);
         }
-        dc.DrawBitmap(m_toolbar_drop_bundle.GetBitmapFor(wnd), bg_rect.x + avail_width + 2,
-            bg_rect.y + (bg_rect.height / 2) - 2, true);
+        dc.DrawBitmap(m_toolbarDropBundle.GetBitmapFor(wnd), bgRect.x + availWidth + 2,
+            bgRect.y + (bgRect.height / 2) - 2, true);
     }
-    dc.DrawBitmap(bitmap, bg_rect.x + (avail_width - bitmap.GetLogicalWidth()) / 2,
-        bg_rect.y + (bg_rect.height - bitmap.GetLogicalHeight()) / 2, true);
+    dc.DrawBitmap(bitmap, bgRect.x + (availWidth - bitmap.GetLogicalWidth()) / 2,
+        bgRect.y + (bgRect.height - bitmap.GetLogicalHeight()) / 2, true);
 }
 
 void
@@ -2856,23 +2856,23 @@ wxRibbonMSWArtProvider::DrawToggleButton(wxDC& dc,
     dc.DestroyClippingRegion();
     dc.SetClippingRegion(rect);
 
-    if(wnd->IsToggleButtonHovered())
+    if ( wnd->IsToggleButtonHovered() )
     {
-        dc.SetPen(m_ribbon_toggle_pen);
-        dc.SetBrush(m_ribbon_toggle_brush);
+        dc.SetPen(m_ribbonTogglePen);
+        dc.SetBrush(m_ribbonToggleBrush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
         bindex = 1;
     }
-    switch(mode)
+    switch ( mode )
     {
         case wxRIBBON_BAR_PINNED:
-            dc.DrawBitmap(m_ribbon_toggle_up_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawBitmap(m_ribbonToggleUpBundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
             break;
         case wxRIBBON_BAR_MINIMIZED:
-            dc.DrawBitmap(m_ribbon_toggle_down_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawBitmap(m_ribbonToggleDownBundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
             break;
         case wxRIBBON_BAR_EXPANDED:
-            dc.DrawBitmap(m_ribbon_toggle_pin_bundle[bindex].GetBitmapFor(wnd), rect.GetX ()+4, rect.GetY ()+5, true);
+            dc.DrawBitmap(m_ribbonTogglePinBundle[bindex].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
             break;
     }
 }
@@ -2888,14 +2888,14 @@ void wxRibbonMSWArtProvider::DrawHelpButton(wxDC& dc,
 
     if ( wnd->IsHelpButtonHovered() )
     {
-        dc.SetPen(m_ribbon_toggle_pen);
-        dc.SetBrush(m_ribbon_toggle_brush);
+        dc.SetPen(m_ribbonTogglePen);
+        dc.SetBrush(m_ribbonToggleBrush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[1].GetBitmapFor(wnd), rect.GetX ()+4, rect.GetY()+5, true);
+        dc.DrawBitmap(m_ribbonBarHelpButtonBundle[1].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
     }
     else
     {
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[0].GetBitmapFor(wnd), rect.GetX ()+4, rect.GetY()+5, true);
+        dc.DrawBitmap(m_ribbonBarHelpButtonBundle[0].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
     }
 
 }
@@ -2906,43 +2906,43 @@ void wxRibbonMSWArtProvider::GetBarTabWidth(
                         const wxString& label,
                         const wxBitmap& bitmap,
                         int* ideal,
-                        int* small_begin_need_separator,
-                        int* small_must_have_separator,
+                        int* smallBeginNeedSeparator,
+                        int* smallMustHaveSeparator,
                         int* minimum)
 {
     int width = 0;
     int min = 0;
-    if((m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) && !label.empty())
+    if ( (m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) && !label.empty() )
     {
-        dc.SetFont(m_tab_label_font);
+        dc.SetFont(m_tabLabelFont);
         width += dc.GetTextExtent(label).GetWidth();
         min += wxMin(25, width); // enough for a few chars
-        if(bitmap.IsOk())
+        if ( bitmap.IsOk() )
         {
             // gap between label and bitmap
             width += 4;
             min += 2;
         }
     }
-    if((m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS) && bitmap.IsOk())
+    if ( (m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS) && bitmap.IsOk() )
     {
         width += bitmap.GetLogicalWidth();
         min += bitmap.GetLogicalWidth();
     }
 
-    if(ideal != nullptr)
+    if ( ideal != nullptr )
     {
         *ideal = width + 30;
     }
-    if(small_begin_need_separator != nullptr)
+    if ( smallBeginNeedSeparator != nullptr )
     {
-        *small_begin_need_separator = width + 20;
+        *smallBeginNeedSeparator = width + 20;
     }
-    if(small_must_have_separator != nullptr)
+    if ( smallMustHaveSeparator != nullptr )
     {
-        *small_must_have_separator = width + 10;
+        *smallMustHaveSeparator = width + 10;
     }
-    if(minimum != nullptr)
+    if ( minimum != nullptr )
     {
         *minimum = min;
     }
@@ -2953,35 +2953,35 @@ int wxRibbonMSWArtProvider::GetTabCtrlHeight(
                         wxWindow* WXUNUSED(wnd),
                         const wxRibbonPageTabInfoArray& pages)
 {
-    int text_height = 0;
-    int icon_height = 0;
+    int textHeight = 0;
+    int iconHeight = 0;
 
-    if(pages.GetCount() <= 1 && (m_flags & wxRIBBON_BAR_ALWAYS_SHOW_TABS) == 0)
+    if ( pages.GetCount() <= 1 && (m_flags & wxRIBBON_BAR_ALWAYS_SHOW_TABS) == 0 )
     {
         // To preserve space, a single tab need not be displayed. We still need
         // two pixels of border / padding though.
         return 2;
     }
 
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS )
     {
-        dc.SetFont(m_tab_label_font);
-        text_height = dc.GetTextExtent("ABCDEFXj").GetHeight() + 10;
+        dc.SetFont(m_tabLabelFont);
+        textHeight = dc.GetTextExtent("ABCDEFXj").GetHeight() + 10;
     }
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
     {
-        size_t numpages = pages.GetCount();
-        for(size_t i = 0; i < numpages; ++i)
+        size_t numPages = pages.GetCount();
+        for ( size_t i = 0; i < numPages; ++i )
         {
             const wxRibbonPageTabInfo& info = pages.Item(i);
-            if(info.page->GetIcon().IsOk())
+            if ( info.m_page->GetIcon().IsOk() )
             {
-                icon_height = wxMax(icon_height, info.page->GetIcon().GetLogicalHeight() + 4);
+                iconHeight = wxMax(iconHeight, info.m_page->GetIcon().GetLogicalHeight() + 4);
             }
         }
     }
 
-    return wxMax(text_height, icon_height);
+    return wxMax(textHeight, iconHeight);
 }
 
 wxSize wxRibbonMSWArtProvider::GetScrollButtonMinimumSize(
@@ -2995,53 +2995,53 @@ wxSize wxRibbonMSWArtProvider::GetScrollButtonMinimumSize(
 wxSize wxRibbonMSWArtProvider::GetPanelSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize client_size,
-                        wxPoint* client_offset)
+                        wxSize clientSize,
+                        wxPoint* clientOffset)
 {
-    dc.SetFont(m_panel_label_font);
-    wxSize label_size = dc.GetTextExtent(wnd->GetLabel());
+    dc.SetFont(m_panelLabelFont);
+    wxSize labelSize = dc.GetTextExtent(wnd->GetLabel());
 
-    client_size.IncBy(0, label_size.GetHeight());
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
-        client_size.IncBy(4, 8);
+    clientSize.IncBy(0, labelSize.GetHeight());
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
+        clientSize.IncBy(4, 8);
     else
-        client_size.IncBy(6, 6);
+        clientSize.IncBy(6, 6);
 
-    if(client_offset != nullptr)
+    if ( clientOffset != nullptr )
     {
-        if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
-            *client_offset = wxPoint(2, 3);
+        if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
+            *clientOffset = wxPoint(2, 3);
         else
-            *client_offset = wxPoint(3, 2);
+            *clientOffset = wxPoint(3, 2);
     }
 
-    return client_size;
+    return clientSize;
 }
 
 wxSize wxRibbonMSWArtProvider::GetPanelClientSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
-                        wxPoint* client_offset)
+                        wxPoint* clientOffset)
 {
-    dc.SetFont(m_panel_label_font);
-    wxSize label_size = dc.GetTextExtent(wnd->GetLabel());
+    dc.SetFont(m_panelLabelFont);
+    wxSize labelSize = dc.GetTextExtent(wnd->GetLabel());
 
-    size.DecBy(0, label_size.GetHeight());
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    size.DecBy(0, labelSize.GetHeight());
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
         size.DecBy(4, 8);
     else
         size.DecBy(6, 6);
 
-    if(client_offset != nullptr)
+    if ( clientOffset != nullptr )
     {
-        if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
-            *client_offset = wxPoint(2, 3);
+        if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
+            *clientOffset = wxPoint(2, 3);
         else
-            *client_offset = wxPoint(3, 2);
+            *clientOffset = wxPoint(3, 2);
     }
-    if (size.x < 0) size.x = 0;
-    if (size.y < 0) size.y = 0;
+    if ( size.x < 0 ) size.x = 0;
+    if ( size.y < 0 ) size.y = 0;
 
     return size;
 }
@@ -3049,73 +3049,73 @@ wxSize wxRibbonMSWArtProvider::GetPanelClientSize(
 wxSize wxRibbonMSWArtProvider::GetGallerySize(
                         wxReadOnlyDC& WXUNUSED(dc),
                         const wxRibbonGallery* WXUNUSED(wnd),
-                        wxSize client_size)
+                        wxSize clientSize)
 {
-    client_size.IncBy( 2, 1); // Left / top padding
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
-        client_size.IncBy(1, 16); // Right / bottom padding
+    clientSize.IncBy( 2, 1); // Left / top padding
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
+        clientSize.IncBy(1, 16); // Right / bottom padding
     else
-        client_size.IncBy(16, 1); // Right / bottom padding
-    return client_size;
+        clientSize.IncBy(16, 1); // Right / bottom padding
+    return clientSize;
 }
 
 wxSize wxRibbonMSWArtProvider::GetGalleryClientSize(
                         wxReadOnlyDC& WXUNUSED(dc),
                         const wxRibbonGallery* WXUNUSED(wnd),
                         wxSize size,
-                        wxPoint* client_offset,
-                        wxRect* scroll_up_button,
-                        wxRect* scroll_down_button,
-                        wxRect* extension_button)
+                        wxPoint* clientOffset,
+                        wxRect* scrollUpButton,
+                        wxRect* scrollDownButton,
+                        wxRect* extensionButton)
 {
-    wxRect scroll_up;
-    wxRect scroll_down;
+    wxRect scrollUp;
+    wxRect scrollDown;
     wxRect extension;
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         // Flow is vertical - put buttons on bottom
-        scroll_up.y = size.GetHeight() - 15;
-        scroll_up.height = 15;
-        scroll_up.x = 0;
-        scroll_up.width = (size.GetWidth() + 2) / 3;
-        scroll_down.y = scroll_up.y;
-        scroll_down.height = scroll_up.height;
-        scroll_down.x = scroll_up.x + scroll_up.width;
-        scroll_down.width = scroll_up.width;
-        extension.y = scroll_down.y;
-        extension.height = scroll_down.height;
-        extension.x = scroll_down.x + scroll_down.width;
-        extension.width = size.GetWidth() - scroll_up.width - scroll_down.width;
+        scrollUp.y = size.GetHeight() - 15;
+        scrollUp.height = 15;
+        scrollUp.x = 0;
+        scrollUp.width = (size.GetWidth() + 2) / 3;
+        scrollDown.y = scrollUp.y;
+        scrollDown.height = scrollUp.height;
+        scrollDown.x = scrollUp.x + scrollUp.width;
+        scrollDown.width = scrollUp.width;
+        extension.y = scrollDown.y;
+        extension.height = scrollDown.height;
+        extension.x = scrollDown.x + scrollDown.width;
+        extension.width = size.GetWidth() - scrollUp.width - scrollDown.width;
         size.DecBy(1, 16);
         size.DecBy( 2, 1);
     }
     else
     {
         // Flow is horizontal - put buttons on right
-        scroll_up.x = size.GetWidth() - 15;
-        scroll_up.width = 15;
-        scroll_up.y = 0;
-        scroll_up.height = (size.GetHeight() + 2) / 3;
-        scroll_down.x = scroll_up.x;
-        scroll_down.width = scroll_up.width;
-        scroll_down.y = scroll_up.y + scroll_up.height;
-        scroll_down.height = scroll_up.height;
-        extension.x = scroll_down.x;
-        extension.width = scroll_down.width;
-        extension.y = scroll_down.y + scroll_down.height;
-        extension.height = size.GetHeight() - scroll_up.height - scroll_down.height;
+        scrollUp.x = size.GetWidth() - 15;
+        scrollUp.width = 15;
+        scrollUp.y = 0;
+        scrollUp.height = (size.GetHeight() + 2) / 3;
+        scrollDown.x = scrollUp.x;
+        scrollDown.width = scrollUp.width;
+        scrollDown.y = scrollUp.y + scrollUp.height;
+        scrollDown.height = scrollUp.height;
+        extension.x = scrollDown.x;
+        extension.width = scrollDown.width;
+        extension.y = scrollDown.y + scrollDown.height;
+        extension.height = size.GetHeight() - scrollUp.height - scrollDown.height;
         size.DecBy(16, 1);
         size.DecBy( 2, 1);
     }
 
-    if(client_offset != nullptr)
-        *client_offset = wxPoint(2, 1);
-    if(scroll_up_button != nullptr)
-        *scroll_up_button = scroll_up;
-    if(scroll_down_button != nullptr)
-        *scroll_down_button = scroll_down;
-    if(extension_button != nullptr)
-        *extension_button = extension;
+    if ( clientOffset != nullptr )
+        *clientOffset = wxPoint(2, 1);
+    if ( scrollUpButton != nullptr )
+        *scrollUpButton = scrollUp;
+    if ( scrollDownButton != nullptr )
+        *scrollDownButton = scrollDown;
+    if ( extensionButton != nullptr )
+        *extensionButton = extension;
 
     return size;
 }
@@ -3123,30 +3123,30 @@ wxSize wxRibbonMSWArtProvider::GetGalleryClientSize(
 wxRect wxRibbonMSWArtProvider::GetPageBackgroundRedrawArea(
                         wxReadOnlyDC& WXUNUSED(dc),
                         const wxRibbonPage* WXUNUSED(wnd),
-                        wxSize page_old_size,
-                        wxSize page_new_size)
+                        wxSize pageOldSize,
+                        wxSize pageNewSize)
 {
-    wxRect new_rect, old_rect;
+    wxRect newRect, oldRect;
 
-    if(page_new_size.GetWidth() != page_old_size.GetWidth())
+    if ( pageNewSize.GetWidth() != pageOldSize.GetWidth() )
     {
-        if(page_new_size.GetHeight() != page_old_size.GetHeight())
+        if ( pageNewSize.GetHeight() != pageOldSize.GetHeight() )
         {
             // Width and height both changed - redraw everything
-            return wxRect(page_new_size);
+            return wxRect(pageNewSize);
         }
         else
         {
             // Only width changed - redraw right hand side
             const int right_edge_width = 4;
 
-            new_rect = wxRect(page_new_size.GetWidth() - right_edge_width, 0, right_edge_width, page_new_size.GetHeight());
-            old_rect = wxRect(page_old_size.GetWidth() - right_edge_width, 0, right_edge_width, page_old_size.GetHeight());
+            newRect = wxRect(pageNewSize.GetWidth() - right_edge_width, 0, right_edge_width, pageNewSize.GetHeight());
+            oldRect = wxRect(pageOldSize.GetWidth() - right_edge_width, 0, right_edge_width, pageOldSize.GetHeight());
         }
     }
     else
     {
-        if(page_new_size.GetHeight() == page_old_size.GetHeight())
+        if ( pageNewSize.GetHeight() == pageOldSize.GetHeight() )
         {
             // Nothing changed (should never happen) - redraw nothing
             return wxRect(0, 0, 0, 0);
@@ -3155,13 +3155,13 @@ wxRect wxRibbonMSWArtProvider::GetPageBackgroundRedrawArea(
         {
             // Height changed - need to redraw everything (as the background
             // gradient is done vertically).
-            return page_new_size;
+            return pageNewSize;
         }
     }
 
-    new_rect.Union(old_rect);
-    new_rect.Intersect(wxRect(page_new_size));
-    return new_rect;
+    newRect.Union(oldRect);
+    newRect.Intersect(wxRect(pageNewSize));
+    return newRect;
 }
 
 bool wxRibbonMSWArtProvider::GetButtonBarButtonSize(
@@ -3170,38 +3170,38 @@ bool wxRibbonMSWArtProvider::GetButtonBarButtonSize(
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
                         const wxString& label,
-                        wxCoord text_min_width,
-                        wxSize bitmap_size_large,
-                        wxSize bitmap_size_small,
-                        wxSize* button_size,
-                        wxRect* normal_region,
-                        wxRect* dropdown_region)
+                        wxCoord textMinWidth,
+                        wxSize bitmapSizeLarge,
+                        wxSize bitmapSizeSmall,
+                        wxSize* buttonSize,
+                        wxRect* normalRegion,
+                        wxRect* dropdownRegion)
 {
     const int drop_button_width = 8;
 
-    dc.SetFont(m_button_bar_label_font);
-    switch(size & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
+    dc.SetFont(m_buttonBarLabelFont);
+    switch ( size & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK )
     {
     case wxRIBBON_BUTTONBAR_BUTTON_SMALL:
         // Small bitmap, no label
-        *button_size = bitmap_size_small + wxSize(6, 4);
-        switch(kind)
+        *buttonSize = bitmapSizeSmall + wxSize(6, 4);
+        switch ( kind )
         {
         case wxRIBBON_BUTTON_NORMAL:
         case wxRIBBON_BUTTON_TOGGLE:
-            *normal_region = wxRect(*button_size);
-            *dropdown_region = wxRect(0, 0, 0, 0);
+            *normalRegion = wxRect(*buttonSize);
+            *dropdownRegion = wxRect(0, 0, 0, 0);
             break;
         case wxRIBBON_BUTTON_DROPDOWN:
-            *button_size += wxSize(drop_button_width, 0);
-            *dropdown_region = wxRect(*button_size);
-            *normal_region = wxRect(0, 0, 0, 0);
+            *buttonSize += wxSize(drop_button_width, 0);
+            *dropdownRegion = wxRect(*buttonSize);
+            *normalRegion = wxRect(0, 0, 0, 0);
             break;
         case wxRIBBON_BUTTON_HYBRID:
-            *normal_region = wxRect(*button_size);
-            *dropdown_region = wxRect(button_size->GetWidth(), 0,
-                drop_button_width, button_size->GetHeight());
-            *button_size += wxSize(drop_button_width, 0);
+            *normalRegion = wxRect(*buttonSize);
+            *dropdownRegion = wxRect(buttonSize->GetWidth(), 0,
+                drop_button_width, buttonSize->GetHeight());
+            *buttonSize += wxSize(drop_button_width, 0);
             break;
         }
         break;
@@ -3209,23 +3209,23 @@ bool wxRibbonMSWArtProvider::GetButtonBarButtonSize(
         // Small bitmap, with label to the right
         {
             GetButtonBarButtonSize(dc, wnd, kind, wxRIBBON_BUTTONBAR_BUTTON_SMALL,
-                label, text_min_width, bitmap_size_large, bitmap_size_small,
-                button_size, normal_region, dropdown_region);
-            int text_size = dc.GetTextExtent(label).GetWidth();
-            if(text_size < text_min_width)
-                text_size = text_min_width;
-            button_size->SetWidth(button_size->GetWidth() + text_size);
-            switch(kind)
+                label, textMinWidth, bitmapSizeLarge, bitmapSizeSmall,
+                buttonSize, normalRegion, dropdownRegion);
+            int textSize = dc.GetTextExtent(label).GetWidth();
+            if ( textSize < textMinWidth )
+                textSize = textMinWidth;
+            buttonSize->SetWidth(buttonSize->GetWidth() + textSize);
+            switch ( kind )
             {
             case wxRIBBON_BUTTON_DROPDOWN:
-                dropdown_region->SetWidth(dropdown_region->GetWidth() + text_size);
+                dropdownRegion->SetWidth(dropdownRegion->GetWidth() + textSize);
                 break;
             case wxRIBBON_BUTTON_HYBRID:
-                dropdown_region->SetX(dropdown_region->GetX() + text_size);
+                dropdownRegion->SetX(dropdownRegion->GetX() + textSize);
                 wxFALLTHROUGH;// no break
             case wxRIBBON_BUTTON_NORMAL:
             case wxRIBBON_BUTTON_TOGGLE:
-                normal_region->SetWidth(normal_region->GetWidth() + text_size);
+                normalRegion->SetWidth(normalRegion->GetWidth() + textSize);
                 break;
             }
             break;
@@ -3233,55 +3233,55 @@ bool wxRibbonMSWArtProvider::GetButtonBarButtonSize(
     case wxRIBBON_BUTTONBAR_BUTTON_LARGE:
         // Large bitmap, with label below (possibly split over 2 lines)
         {
-            wxSize icon_size(bitmap_size_large);
-            icon_size += wxSize(4, 4);
-            wxCoord label_height;
-            wxCoord best_width;
-            dc.GetTextExtent(label, &best_width, &label_height);
-            if(best_width < text_min_width)
-                best_width = text_min_width;
-            int last_line_extra_width = 0;
-            if(kind != wxRIBBON_BUTTON_NORMAL && kind != wxRIBBON_BUTTON_TOGGLE)
+            wxSize iconSize(bitmapSizeLarge);
+            iconSize += wxSize(4, 4);
+            wxCoord labelHeight;
+            wxCoord bestWidth;
+            dc.GetTextExtent(label, &bestWidth, &labelHeight);
+            if ( bestWidth < textMinWidth )
+                bestWidth = textMinWidth;
+            int lastLineExtraWidth = 0;
+            if ( kind != wxRIBBON_BUTTON_NORMAL && kind != wxRIBBON_BUTTON_TOGGLE )
             {
-                last_line_extra_width += 8;
+                lastLineExtraWidth += 8;
             }
             size_t i;
-            for(i = 0; i < label.Len(); ++i)
+            for ( i = 0; i < label.Len(); ++i )
             {
-                if(wxRibbonCanLabelBreakAtPosition(label, i))
+                if ( wxRibbonCanLabelBreakAtPosition(label, i) )
                 {
                     int width = wxMax(
                         dc.GetTextExtent(label.Left(i)).GetWidth(),
-                        dc.GetTextExtent(label.Mid(i + 1)).GetWidth() + last_line_extra_width);
-                    if(best_width < text_min_width)
-                        best_width = text_min_width;
-                    if(width < best_width)
+                        dc.GetTextExtent(label.Mid(i + 1)).GetWidth() + lastLineExtraWidth);
+                    if ( bestWidth < textMinWidth )
+                        bestWidth = textMinWidth;
+                    if ( width < bestWidth )
                     {
-                        best_width = width;
+                        bestWidth = width;
                     }
                 }
             }
-            label_height *= 2; // Assume two lines even when only one is used
+            labelHeight *= 2; // Assume two lines even when only one is used
                                // (to give all buttons a consistent height)
-            icon_size.SetWidth(wxMax(icon_size.GetWidth(), best_width) + 6);
-            icon_size.SetHeight(icon_size.GetHeight() + label_height);
-            *button_size = icon_size;
-            switch(kind)
+            iconSize.SetWidth(wxMax(iconSize.GetWidth(), bestWidth) + 6);
+            iconSize.SetHeight(iconSize.GetHeight() + labelHeight);
+            *buttonSize = iconSize;
+            switch ( kind )
             {
             case wxRIBBON_BUTTON_DROPDOWN:
-                *dropdown_region = wxRect(icon_size);
+                *dropdownRegion = wxRect(iconSize);
                 break;
             case wxRIBBON_BUTTON_HYBRID:
-                *normal_region = wxRect(icon_size);
-                normal_region->height -= 2 + label_height;
-                dropdown_region->x = 0;
-                dropdown_region->y = normal_region->height;
-                dropdown_region->width = icon_size.GetWidth();
-                dropdown_region->height = icon_size.GetHeight() - normal_region->height;
+                *normalRegion = wxRect(iconSize);
+                normalRegion->height -= 2 + labelHeight;
+                dropdownRegion->x = 0;
+                dropdownRegion->y = normalRegion->height;
+                dropdownRegion->width = iconSize.GetWidth();
+                dropdownRegion->height = iconSize.GetHeight() - normalRegion->height;
                 break;
             case wxRIBBON_BUTTON_NORMAL:
             case wxRIBBON_BUTTON_TOGGLE:
-                *normal_region = wxRect(icon_size);
+                *normalRegion = wxRect(iconSize);
                 break;
             }
             break;
@@ -3295,109 +3295,109 @@ wxCoord wxRibbonMSWArtProvider::GetButtonBarButtonTextWidth(
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size)
 {
-    wxCoord best_width = 0;
-    dc.SetFont(m_button_bar_label_font);
+    wxCoord bestWidth = 0;
+    dc.SetFont(m_buttonBarLabelFont);
 
-    if((size & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
-       == wxRIBBON_BUTTONBAR_BUTTON_LARGE)
+    if ( (size & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
+       == wxRIBBON_BUTTONBAR_BUTTON_LARGE )
     {
-        best_width = dc.GetTextExtent(label).GetWidth();
-        int last_line_extra_width = 0;
-        if(kind != wxRIBBON_BUTTON_NORMAL && kind != wxRIBBON_BUTTON_TOGGLE)
+        bestWidth = dc.GetTextExtent(label).GetWidth();
+        int lastLineExtraWidth = 0;
+        if ( kind != wxRIBBON_BUTTON_NORMAL && kind != wxRIBBON_BUTTON_TOGGLE )
         {
-            last_line_extra_width += 8;
+            lastLineExtraWidth += 8;
         }
         size_t i;
-        for(i = 0; i < label.Len(); ++i)
+        for ( i = 0; i < label.Len(); ++i )
         {
-            if(wxRibbonCanLabelBreakAtPosition(label, i))
+            if ( wxRibbonCanLabelBreakAtPosition(label, i) )
             {
                 int width = wxMax(
                     dc.GetTextExtent(label.Left(i)).GetWidth(),
-                    dc.GetTextExtent(label.Mid(i + 1)).GetWidth() + last_line_extra_width);
-                if(width < best_width)
+                    dc.GetTextExtent(label.Mid(i + 1)).GetWidth() + lastLineExtraWidth);
+                if ( width < bestWidth )
                 {
-                    best_width = width;
+                    bestWidth = width;
                 }
             }
         }
     }
-    else if((size & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
-       == wxRIBBON_BUTTONBAR_BUTTON_MEDIUM)
+    else if ( (size & wxRIBBON_BUTTONBAR_BUTTON_SIZE_MASK)
+       == wxRIBBON_BUTTONBAR_BUTTON_MEDIUM )
     {
-        best_width = dc.GetTextExtent(label).GetWidth();
+        bestWidth = dc.GetTextExtent(label).GetWidth();
     }
 
-    return best_width;
+    return bestWidth;
 }
 
 wxSize wxRibbonMSWArtProvider::GetMinimisedPanelMinimumSize(
                         wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
-                        wxSize* desired_bitmap_size,
-                        wxDirection* expanded_panel_direction)
+                        wxSize* desiredBitmapSize,
+                        wxDirection* expandedPanelDirection)
 {
-    if(desired_bitmap_size != nullptr)
+    if ( desiredBitmapSize != nullptr )
     {
-        *desired_bitmap_size = wxSize(16, 16);
+        *desiredBitmapSize = wxSize(16, 16);
     }
-    if(expanded_panel_direction != nullptr)
+    if ( expandedPanelDirection != nullptr )
     {
-        if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
-            *expanded_panel_direction = wxEAST;
+        if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
+            *expandedPanelDirection = wxEAST;
         else
-            *expanded_panel_direction = wxSOUTH;
+            *expandedPanelDirection = wxSOUTH;
     }
     wxSize base_size(42, 42);
 
-    dc.SetFont(m_panel_label_font);
-    wxSize label_size(dc.GetTextExtent(wnd->GetLabel()));
-    label_size.IncBy(2, 2); // Allow for differences between this DC and a paint DC
-    label_size.IncBy(6, 0); // Padding
-    label_size.y *= 2; // Second line for dropdown button
+    dc.SetFont(m_panelLabelFont);
+    wxSize labelSize(dc.GetTextExtent(wnd->GetLabel()));
+    labelSize.IncBy(2, 2); // Allow for differences between this DC and a paint DC
+    labelSize.IncBy(6, 0); // Padding
+    labelSize.y *= 2; // Second line for dropdown button
 
-    if(m_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         // Label alongside icon
-        return wxSize(base_size.x + label_size.x,
-            wxMax(base_size.y, label_size.y));
+        return wxSize(base_size.x + labelSize.x,
+            wxMax(base_size.y, labelSize.y));
     }
     else
     {
         // Label beneath icon
-        return wxSize(wxMax(base_size.x, label_size.x),
-            base_size.y + label_size.y);
+        return wxSize(wxMax(base_size.x, labelSize.x),
+            base_size.y + labelSize.y);
     }
 }
 
 wxSize wxRibbonMSWArtProvider::GetToolSize(
                         wxReadOnlyDC& WXUNUSED(dc),
                         wxWindow* WXUNUSED(wnd),
-                        wxSize bitmap_size,
+                        wxSize bitmapSize,
                         wxRibbonButtonKind kind,
-                        bool WXUNUSED(is_first),
-                        bool is_last,
-                        wxRect* dropdown_region)
+                        bool WXUNUSED(isFirst),
+                        bool isLast,
+                        wxRect* dropdownRegion)
 {
-    wxSize size(bitmap_size);
+    wxSize size(bitmapSize);
     size.IncBy(7, 6);
-    if(is_last)
+    if ( isLast )
         size.IncBy(1, 0);
-    if(kind & wxRIBBON_BUTTON_DROPDOWN)
+    if ( kind & wxRIBBON_BUTTON_DROPDOWN )
     {
         size.IncBy(8, 0);
-        if(dropdown_region)
+        if ( dropdownRegion )
         {
-            if(kind == wxRIBBON_BUTTON_DROPDOWN)
-                *dropdown_region = size;
+            if ( kind == wxRIBBON_BUTTON_DROPDOWN )
+                *dropdownRegion = size;
             else
-                *dropdown_region = wxRect(size.GetWidth() - 8, 0, 8, size.GetHeight());
+                *dropdownRegion = wxRect(size.GetWidth() - 8, 0, 8, size.GetHeight());
         }
     }
     else
     {
-        if(dropdown_region)
-            *dropdown_region = wxRect(0, 0, 0, 0);
+        if ( dropdownRegion )
+            *dropdownRegion = wxRect(0, 0, 0, 0);
     }
     return size;
 }
@@ -3405,18 +3405,18 @@ wxSize wxRibbonMSWArtProvider::GetToolSize(
 wxRect
 wxRibbonMSWArtProvider::GetBarToggleButtonArea(const wxRect& rect)
 {
-    wxRect rectOut = wxRect(rect.GetWidth()-m_toggle_button_offset, 2, 20, 20);
-    if ( (m_toggle_button_offset==22) && (m_help_button_offset==22) )
-        m_help_button_offset += 22;
+    wxRect rectOut = wxRect(rect.GetWidth()-m_toggleButtonOffset, 2, 20, 20);
+    if ( (m_toggleButtonOffset==22) && (m_helpButtonOffset==22) )
+        m_helpButtonOffset += 22;
     return rectOut;
 }
 
 wxRect
 wxRibbonMSWArtProvider::GetRibbonHelpButtonArea(const wxRect& rect)
 {
-    wxRect rectOut = wxRect(rect.GetWidth()-m_help_button_offset, 2, 20, 20);
-    if ( (m_toggle_button_offset==22) && (m_help_button_offset==22) )
-        m_toggle_button_offset += 22;
+    wxRect rectOut = wxRect(rect.GetWidth()-m_helpButtonOffset, 2, 20, 20);
+    if ( (m_toggleButtonOffset==22) && (m_helpButtonOffset==22) )
+        m_toggleButtonOffset += 22;
     return rectOut;
 }
 

--- a/src/ribbon/art_msw_flat.cpp
+++ b/src/ribbon/art_msw_flat.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/art_msw_flat.cpp
 // Purpose:     Flat MSW style art provider for ribbon interface
 // Author:      wxWidgets team
@@ -20,11 +20,11 @@
 #include "wx/ribbon/toolbar.h"
 
 #ifndef WX_PRECOMP
-#include "wx/dcmemory.h"
+    #include "wx/dcmemory.h"
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 wxRibbonMSWFlatArtProvider::wxRibbonMSWFlatArtProvider()
@@ -48,14 +48,14 @@ void wxRibbonMSWFlatArtProvider::DrawTab(
                  wxWindow* WXUNUSED(wnd),
                  const wxRibbonPageTabInfo& tab)
 {
-    if ( tab.rect.height <= 2 )
+    if ( tab.m_rect.height <= 2 )
         return;
 
-    if ( tab.active || tab.hovered || tab.highlight )
+    if ( tab.m_active || tab.m_hovered || tab.m_highlight )
     {
-        if ( tab.active )
+        if ( tab.m_active )
         {
-            wxRect background(tab.rect);
+            wxRect background(tab.m_rect);
 
             background.x += 2;
             background.y += 2;
@@ -65,14 +65,14 @@ void wxRibbonMSWFlatArtProvider::DrawTab(
             if ( background.width > 0 && background.height > 0 )
             {
                 dc.SetPen(*wxTRANSPARENT_PEN);
-                dc.SetBrush(wxBrush(m_tab_active_background_colour));
+                dc.SetBrush(wxBrush(m_tabActiveBackgroundColour));
                 dc.DrawRectangle(background.x, background.y,
                     background.width, background.height);
             }
         }
-        else if ( tab.hovered )
+        else if ( tab.m_hovered )
         {
-            wxRect background(tab.rect);
+            wxRect background(tab.m_rect);
 
             background.x += 2;
             background.y += 2;
@@ -82,14 +82,14 @@ void wxRibbonMSWFlatArtProvider::DrawTab(
             if ( background.width > 0 && background.height > 0 )
             {
                 dc.SetPen(*wxTRANSPARENT_PEN);
-                dc.SetBrush(wxBrush(m_tab_hover_background_colour));
+                dc.SetBrush(wxBrush(m_tabHoverBackgroundColour));
                 dc.DrawRectangle(background.x, background.y,
                     background.width, background.height);
             }
         }
-        else if ( tab.highlight )
+        else if ( tab.m_highlight )
         {
-            wxRect background(tab.rect);
+            wxRect background(tab.m_rect);
 
             background.x += 2;
             background.y += 2;
@@ -99,90 +99,90 @@ void wxRibbonMSWFlatArtProvider::DrawTab(
             if ( background.width > 0 && background.height > 0 )
             {
                 dc.SetPen(*wxTRANSPARENT_PEN);
-                dc.SetBrush(wxBrush(m_tab_highlight_colour));
+                dc.SetBrush(wxBrush(m_tabHighlightColour));
                 dc.DrawRectangle(background.x, background.y,
                     background.width, background.height);
             }
         }
 
-        wxPoint border_points[6];
-        border_points[0] = wxPoint(1, tab.rect.height - 2);
-        border_points[1] = wxPoint(1, 3);
-        border_points[2] = wxPoint(3, 1);
-        border_points[3] = wxPoint(tab.rect.width - 4, 1);
-        border_points[4] = wxPoint(tab.rect.width - 2, 3);
-        border_points[5] = wxPoint(tab.rect.width - 2, tab.rect.height - 1);
+        wxPoint borderPoints[6];
+        borderPoints[0] = wxPoint(1, tab.m_rect.height - 2);
+        borderPoints[1] = wxPoint(1, 3);
+        borderPoints[2] = wxPoint(3, 1);
+        borderPoints[3] = wxPoint(tab.m_rect.width - 4, 1);
+        borderPoints[4] = wxPoint(tab.m_rect.width - 2, 3);
+        borderPoints[5] = wxPoint(tab.m_rect.width - 2, tab.m_rect.height - 1);
 
-        dc.SetPen(m_tab_border_pen);
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points,
-            tab.rect.x, tab.rect.y);
+        dc.SetPen(m_tabBorderPen);
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints,
+            tab.m_rect.x, tab.m_rect.y);
 
-        if ( tab.active )
+        if ( tab.m_active )
         {
             // Give the tab a curved outward border at the bottom
-            dc.DrawPoint(tab.rect.x, tab.rect.y + tab.rect.height - 2);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 1,
-                tab.rect.y + tab.rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x, tab.m_rect.y + tab.m_rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 1,
+                tab.m_rect.y + tab.m_rect.height - 2);
 
-            dc.SetPen(wxPen(m_tab_active_background_colour));
+            dc.SetPen(wxPen(m_tabActiveBackgroundColour));
 
-            dc.DrawPoint(tab.rect.x + 1, tab.rect.y + tab.rect.height - 2);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 2,
-                tab.rect.y + tab.rect.height - 2);
-            dc.DrawPoint(tab.rect.x + 1, tab.rect.y + tab.rect.height - 1);
-            dc.DrawPoint(tab.rect.x, tab.rect.y + tab.rect.height - 1);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 2,
-                tab.rect.y + tab.rect.height - 1);
-            dc.DrawPoint(tab.rect.x + tab.rect.width - 1,
-                tab.rect.y + tab.rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x + 1, tab.m_rect.y + tab.m_rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 2,
+                tab.m_rect.y + tab.m_rect.height - 2);
+            dc.DrawPoint(tab.m_rect.x + 1, tab.m_rect.y + tab.m_rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x, tab.m_rect.y + tab.m_rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 2,
+                tab.m_rect.y + tab.m_rect.height - 1);
+            dc.DrawPoint(tab.m_rect.x + tab.m_rect.width - 1,
+                tab.m_rect.y + tab.m_rect.height - 1);
         }
     }
 
-    if ( tab.page == nullptr )
+    if ( tab.m_page == nullptr )
         return;
 
     if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
     {
-        wxBitmap icon = tab.page->GetIcon();
+        wxBitmap icon = tab.m_page->GetIcon();
         if ( icon.IsOk() )
         {
-        int x = tab.rect.x + 4;
+        int x = tab.m_rect.x + 4;
         if ( (m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS) == 0 )
-            x = tab.rect.x + (tab.rect.width - icon.GetLogicalWidth()) / 2;
-        dc.DrawBitmap(icon, x, tab.rect.y + 1 + (tab.rect.height - 1 -
+            x = tab.m_rect.x + (tab.m_rect.width - icon.GetLogicalWidth()) / 2;
+        dc.DrawBitmap(icon, x, tab.m_rect.y + 1 + (tab.m_rect.height - 1 -
             icon.GetLogicalHeight()) / 2, true);
         }
     }
     if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS )
     {
-        wxString label = tab.page->GetLabel();
+        wxString label = tab.m_page->GetLabel();
         if ( !label.empty() )
         {
-            dc.SetFont(m_tab_label_font);
+            dc.SetFont(m_tabLabelFont);
 
-            if ( tab.active )
+            if ( tab.m_active )
             {
-                dc.SetTextForeground(m_tab_active_label_colour);
+                dc.SetTextForeground(m_tabActiveLabelColour);
             }
-            else if ( tab.hovered )
+            else if ( tab.m_hovered )
             {
-                dc.SetTextForeground(m_tab_hover_label_colour);
+                dc.SetTextForeground(m_tabHoverLabelColour);
             }
             else
             {
-                dc.SetTextForeground(m_tab_label_colour);
+                dc.SetTextForeground(m_tabLabelColour);
             }
 
             dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
-            int text_height;
-            int text_width;
-            dc.GetTextExtent(label, &text_width, &text_height);
-            int width = tab.rect.width - 5;
-            int x = tab.rect.x + 3;
+            int textHeight;
+            int textWidth;
+            dc.GetTextExtent(label, &textWidth, &textHeight);
+            int width = tab.m_rect.width - 5;
+            int x = tab.m_rect.x + 3;
             if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
             {
-                const wxBitmap& icon = tab.page->GetIcon();
+                const wxBitmap& icon = tab.m_page->GetIcon();
                 if ( icon.IsOk() )
                 {
                     const int iconWidth = icon.GetLogicalWidth();
@@ -190,16 +190,16 @@ void wxRibbonMSWFlatArtProvider::DrawTab(
                     width -= 3 + iconWidth;
                 }
             }
-            int y = tab.rect.y + (tab.rect.height - text_height) / 2;
+            int y = tab.m_rect.y + (tab.m_rect.height - textHeight) / 2;
 
-            if ( width <= text_width )
+            if ( width <= textWidth )
             {
-                wxDCClipper clip(dc, x, tab.rect.y, width, tab.rect.height);
+                wxDCClipper clip(dc, x, tab.m_rect.y, width, tab.m_rect.height);
                 dc.DrawText(label, x, y);
             }
             else
             {
-                dc.DrawText(label, x + (width - text_width) / 2 + 1, y);
+                dc.DrawText(label, x + (width - textWidth) / 2 + 1, y);
             }
         }
     }
@@ -208,31 +208,31 @@ void wxRibbonMSWFlatArtProvider::DrawTab(
 void wxRibbonMSWFlatArtProvider::ReallyDrawTabSeparator(wxWindow* wnd,
     const wxRect& rect, double visibility)
 {
-    if ( !m_cached_tab_separator.IsOk()
-        || m_cached_tab_separator.GetLogicalSize() != rect.GetSize() )
+    if ( !m_cachedTabSeparator.IsOk()
+        || m_cachedTabSeparator.GetLogicalSize() != rect.GetSize() )
     {
-        m_cached_tab_separator = wxBitmap(rect.GetSize());
+        m_cachedTabSeparator = wxBitmap(rect.GetSize());
     }
 
-    wxMemoryDC dc(m_cached_tab_separator);
+    wxMemoryDC dc(m_cachedTabSeparator);
     DrawTabCtrlBackground(dc, wnd, rect);
 
     wxCoord x = rect.x + rect.width / 2;
 
-    unsigned char r = (unsigned char)(m_tab_separator_colour.Red() * visibility
-        + m_tab_ctrl_background_brush.GetColour().Red() * (1.0 - visibility)
+    unsigned char r = (unsigned char)(m_tabSeparatorColour.Red() * visibility
+        + m_tabCtrlBackgroundBrush.GetColour().Red() * (1.0 - visibility)
         + 0.5);
-    unsigned char g = (unsigned char)(m_tab_separator_colour.Green() * visibility
-        + m_tab_ctrl_background_brush.GetColour().Green() * (1.0 - visibility)
+    unsigned char g = (unsigned char)(m_tabSeparatorColour.Green() * visibility
+        + m_tabCtrlBackgroundBrush.GetColour().Green() * (1.0 - visibility)
         + 0.5);
-    unsigned char b = (unsigned char)(m_tab_separator_colour.Blue() * visibility
-        + m_tab_ctrl_background_brush.GetColour().Blue() * (1.0 - visibility)
+    unsigned char b = (unsigned char)(m_tabSeparatorColour.Blue() * visibility
+        + m_tabCtrlBackgroundBrush.GetColour().Blue() * (1.0 - visibility)
         + 0.5);
 
     dc.SetPen(wxPen(wxColour(r, g, b)));
     dc.DrawLine(x, rect.y, x, rect.y + rect.height - 1);
 
-    m_cached_tab_separator_visibility = visibility;
+    m_cachedTabSeparatorVisibility = visibility;
 }
 
 void wxRibbonMSWFlatArtProvider::DrawPartialPageBackground(wxDC& dc,
@@ -252,13 +252,13 @@ void wxRibbonMSWFlatArtProvider::DrawPartialPageBackground(wxDC& dc,
         page->AdjustRectToIncludeScrollButtons(&background);
         background.height -= 2;
     }
-    wxRect paint_rect(r);
-    paint_rect.x += offset.x;
-    paint_rect.y += offset.y;
+    wxRect paintRect(r);
+    paintRect.x += offset.x;
+    paintRect.y += offset.y;
 
     // Clamp vertically to the background but allow full width, as expanded
     // panels can be wider than the page.
-    wxRect rect(paint_rect);
+    wxRect rect(paintRect);
     if ( rect.y < background.y )
     {
         rect.height -= (background.y - rect.y);
@@ -271,14 +271,14 @@ void wxRibbonMSWFlatArtProvider::DrawPartialPageBackground(wxDC& dc,
 
     if ( rect.width > 0 && rect.height > 0 )
     {
-        wxColour bg_colour;
+        wxColour bgColour;
         if ( hovered )
-            bg_colour = m_page_hover_background_colour;
+            bgColour = m_pageHoverBackgroundColour;
         else
-            bg_colour = m_page_background_colour;
+            bgColour = m_pageBackgroundColour;
 
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(wxBrush(bg_colour));
+        dc.SetBrush(wxBrush(bgColour));
         dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
     }
 }
@@ -289,7 +289,7 @@ void wxRibbonMSWFlatArtProvider::DrawPageBackground(
                         const wxRect& rect)
 {
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(m_tab_ctrl_background_brush);
+    dc.SetBrush(m_tabCtrlBackgroundBrush);
 
     {
         wxRect edge(rect);
@@ -314,25 +314,25 @@ void wxRibbonMSWFlatArtProvider::DrawPageBackground(
 
         if ( background.width > 0 && background.height > 0 )
         {
-            dc.SetBrush(wxBrush(m_page_background_colour));
+            dc.SetBrush(wxBrush(m_pageBackgroundColour));
             dc.DrawRectangle(background.x, background.y,
                 background.width, background.height);
         }
     }
 
     {
-        wxPoint border_points[8];
-        border_points[0] = wxPoint(2, 0);
-        border_points[1] = wxPoint(1, 1);
-        border_points[2] = wxPoint(1, rect.height - 4);
-        border_points[3] = wxPoint(3, rect.height - 2);
-        border_points[4] = wxPoint(rect.width - 4, rect.height - 2);
-        border_points[5] = wxPoint(rect.width - 2, rect.height - 4);
-        border_points[6] = wxPoint(rect.width - 2, 1);
-        border_points[7] = wxPoint(rect.width - 4, -1);
+        wxPoint borderPoints[8];
+        borderPoints[0] = wxPoint(2, 0);
+        borderPoints[1] = wxPoint(1, 1);
+        borderPoints[2] = wxPoint(1, rect.height - 4);
+        borderPoints[3] = wxPoint(3, rect.height - 2);
+        borderPoints[4] = wxPoint(rect.width - 4, rect.height - 2);
+        borderPoints[5] = wxPoint(rect.width - 2, rect.height - 4);
+        borderPoints[6] = wxPoint(rect.width - 2, 1);
+        borderPoints[7] = wxPoint(rect.width - 4, -1);
 
-        dc.SetPen(m_page_border_pen);
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points,
+        dc.SetPen(m_pageBorderPen);
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints,
             rect.x, rect.y);
     }
 }
@@ -348,7 +348,7 @@ void wxRibbonMSWFlatArtProvider::DrawScrollButton(
     if ( (style & wxRIBBON_SCROLL_BTN_FOR_MASK) == wxRIBBON_SCROLL_BTN_FOR_PAGE )
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_tab_ctrl_background_brush);
+        dc.SetBrush(m_tabCtrlBackgroundBrush);
         dc.DrawRectangle(rect);
         dc.SetClippingRegion(rect);
         switch ( style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
@@ -384,96 +384,96 @@ void wxRibbonMSWFlatArtProvider::DrawScrollButton(
         if ( background.width > 0 && background.height > 0 )
         {
             dc.SetPen(*wxTRANSPARENT_PEN);
-            dc.SetBrush(wxBrush(m_page_background_colour));
+            dc.SetBrush(wxBrush(m_pageBackgroundColour));
             dc.DrawRectangle(background.x, background.y,
                 background.width, background.height);
         }
     }
 
     {
-        wxPoint border_points[7];
+        wxPoint borderPoints[7];
         switch ( style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
         {
         case wxRIBBON_SCROLL_BTN_LEFT:
-            border_points[0] = wxPoint(2, 0);
-            border_points[1] = wxPoint(rect.width - 1, 0);
-            border_points[2] = wxPoint(rect.width - 1, rect.height - 1);
-            border_points[3] = wxPoint(2, rect.height - 1);
-            border_points[4] = wxPoint(0, rect.height - 3);
-            border_points[5] = wxPoint(0, 2);
+            borderPoints[0] = wxPoint(2, 0);
+            borderPoints[1] = wxPoint(rect.width - 1, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, rect.height - 1);
+            borderPoints[3] = wxPoint(2, rect.height - 1);
+            borderPoints[4] = wxPoint(0, rect.height - 3);
+            borderPoints[5] = wxPoint(0, 2);
             break;
         case wxRIBBON_SCROLL_BTN_RIGHT:
-            border_points[0] = wxPoint(0, 0);
-            border_points[1] = wxPoint(rect.width - 3, 0);
-            border_points[2] = wxPoint(rect.width - 1, 2);
-            border_points[3] = wxPoint(rect.width - 1, rect.height - 3);
-            border_points[4] = wxPoint(rect.width - 3, rect.height - 1);
-            border_points[5] = wxPoint(0, rect.height - 1);
+            borderPoints[0] = wxPoint(0, 0);
+            borderPoints[1] = wxPoint(rect.width - 3, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, 2);
+            borderPoints[3] = wxPoint(rect.width - 1, rect.height - 3);
+            borderPoints[4] = wxPoint(rect.width - 3, rect.height - 1);
+            borderPoints[5] = wxPoint(0, rect.height - 1);
             break;
         case wxRIBBON_SCROLL_BTN_UP:
-            border_points[0] = wxPoint(2, 0);
-            border_points[1] = wxPoint(rect.width - 3, 0);
-            border_points[2] = wxPoint(rect.width - 1, 2);
-            border_points[3] = wxPoint(rect.width - 1, rect.height - 1);
-            border_points[4] = wxPoint(0, rect.height - 1);
-            border_points[5] = wxPoint(0, 2);
+            borderPoints[0] = wxPoint(2, 0);
+            borderPoints[1] = wxPoint(rect.width - 3, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, 2);
+            borderPoints[3] = wxPoint(rect.width - 1, rect.height - 1);
+            borderPoints[4] = wxPoint(0, rect.height - 1);
+            borderPoints[5] = wxPoint(0, 2);
             break;
         case wxRIBBON_SCROLL_BTN_DOWN:
-            border_points[0] = wxPoint(0, 0);
-            border_points[1] = wxPoint(rect.width - 1, 0);
-            border_points[2] = wxPoint(rect.width - 1, rect.height - 3);
-            border_points[3] = wxPoint(rect.width - 3, rect.height - 1);
-            border_points[4] = wxPoint(2, rect.height - 1);
-            border_points[5] = wxPoint(0, rect.height - 3);
+            borderPoints[0] = wxPoint(0, 0);
+            borderPoints[1] = wxPoint(rect.width - 1, 0);
+            borderPoints[2] = wxPoint(rect.width - 1, rect.height - 3);
+            borderPoints[3] = wxPoint(rect.width - 3, rect.height - 1);
+            borderPoints[4] = wxPoint(2, rect.height - 1);
+            borderPoints[5] = wxPoint(0, rect.height - 3);
             break;
         }
-        border_points[6] = border_points[0];
+        borderPoints[6] = borderPoints[0];
 
-        dc.SetPen(m_page_border_pen);
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points,
+        dc.SetPen(m_pageBorderPen);
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints,
             rect.x, rect.y);
     }
 
     {
         // NB: Code for handling hovered/active state is temporary
-        wxPoint arrow_points[3];
+        wxPoint arrowPoints[3];
         switch ( style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
         {
         case wxRIBBON_SCROLL_BTN_LEFT:
-            arrow_points[0] = wxPoint(rect.width / 2 - 2, rect.height / 2);
+            arrowPoints[0] = wxPoint(rect.width / 2 - 2, rect.height / 2);
             if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] + wxPoint(3, -3);
-            arrow_points[2] = arrow_points[0] + wxPoint(3,  3);
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] + wxPoint(3, -3);
+            arrowPoints[2] = arrowPoints[0] + wxPoint(3,  3);
             break;
         case wxRIBBON_SCROLL_BTN_RIGHT:
-            arrow_points[0] = wxPoint(rect.width / 2 + 2, rect.height / 2);
+            arrowPoints[0] = wxPoint(rect.width / 2 + 2, rect.height / 2);
             if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] - wxPoint(3,  3);
-            arrow_points[2] = arrow_points[0] - wxPoint(3, -3);
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] - wxPoint(3,  3);
+            arrowPoints[2] = arrowPoints[0] - wxPoint(3, -3);
             break;
         case wxRIBBON_SCROLL_BTN_UP:
-            arrow_points[0] = wxPoint(rect.width / 2, rect.height / 2 - 2);
+            arrowPoints[0] = wxPoint(rect.width / 2, rect.height / 2 - 2);
             if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] + wxPoint( 3, 3);
-            arrow_points[2] = arrow_points[0] + wxPoint(-3, 3);
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] + wxPoint( 3, 3);
+            arrowPoints[2] = arrowPoints[0] + wxPoint(-3, 3);
             break;
         case wxRIBBON_SCROLL_BTN_DOWN:
-            arrow_points[0] = wxPoint(rect.width / 2, rect.height / 2 + 2);
+            arrowPoints[0] = wxPoint(rect.width / 2, rect.height / 2 + 2);
             if ( style & wxRIBBON_SCROLL_BTN_ACTIVE )
-                arrow_points[0].y += 1;
-            arrow_points[1] = arrow_points[0] - wxPoint( 3, 3);
-            arrow_points[2] = arrow_points[0] - wxPoint(-3, 3);
+                arrowPoints[0].y += 1;
+            arrowPoints[1] = arrowPoints[0] - wxPoint( 3, 3);
+            arrowPoints[2] = arrowPoints[0] - wxPoint(-3, 3);
             break;
         }
 
         dc.SetPen(*wxTRANSPARENT_PEN);
         wxBrush brush(style & wxRIBBON_SCROLL_BTN_HOVERED
-            ? m_tab_active_background_colour : m_tab_label_colour);
+            ? m_tabActiveBackgroundColour : m_tabLabelColour);
         dc.SetBrush(brush);
-        dc.DrawPolygon(sizeof(arrow_points)/sizeof(wxPoint), arrow_points,
+        dc.DrawPolygon(sizeof(arrowPoints)/sizeof(wxPoint), arrowPoints,
             rect.x, rect.y);
     }
 }
@@ -484,25 +484,25 @@ void wxRibbonMSWFlatArtProvider::DrawGalleryButton(wxDC& dc,
                                             wxBitmapBundle* bundles,
                                             wxWindow* wnd)
 {
-    wxBitmap btn_bitmap;
-    wxColour btn_colour;
+    wxBitmap btnBitmap;
+    wxColour btnColour;
     switch ( state )
     {
     case wxRIBBON_GALLERY_BUTTON_NORMAL:
-        btn_colour = m_gallery_button_background_colour;
-        btn_bitmap = bundles[0].GetBitmapFor(wnd);
+        btnColour = m_galleryButtonBackgroundColour;
+        btnBitmap = bundles[0].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_HOVERED:
-        btn_colour = m_gallery_button_hover_background_colour;
-        btn_bitmap = bundles[1].GetBitmapFor(wnd);
+        btnColour = m_galleryButtonHoverBackgroundColour;
+        btnBitmap = bundles[1].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_ACTIVE:
-        btn_colour = m_gallery_button_active_background_colour;
-        btn_bitmap = bundles[2].GetBitmapFor(wnd);
+        btnColour = m_galleryButtonActiveBackgroundColour;
+        btnBitmap = bundles[2].GetBitmapFor(wnd);
         break;
     case wxRIBBON_GALLERY_BUTTON_DISABLED:
-        btn_colour = m_gallery_button_disabled_background_colour;
-        btn_bitmap = bundles[3].GetBitmapFor(wnd);
+        btnColour = m_galleryButtonDisabledBackgroundColour;
+        btnBitmap = bundles[3].GetBitmapFor(wnd);
         break;
     }
 
@@ -520,10 +520,10 @@ void wxRibbonMSWFlatArtProvider::DrawGalleryButton(wxDC& dc,
     }
 
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(wxBrush(btn_colour));
+    dc.SetBrush(wxBrush(btnColour));
     dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
-    dc.DrawBitmap(btn_bitmap, rect.x + rect.width / 2 - 2,
+    dc.DrawBitmap(btnBitmap, rect.x + rect.width / 2 - 2,
         rect.y + (rect.height / 2) - 2, true);
 }
 
@@ -537,7 +537,7 @@ void wxRibbonMSWFlatArtProvider::DrawGalleryItemBackground(
         wnd->GetSelection() != item )
         return;
 
-    dc.SetPen(m_gallery_item_border_pen);
+    dc.SetPen(m_galleryItemBorderPen);
     dc.DrawLine(rect.x + 1, rect.y, rect.x + rect.width - 1, rect.y);
     dc.DrawLine(rect.x, rect.y + 1, rect.x, rect.y + rect.height - 1);
     dc.DrawLine(rect.x + 1, rect.y + rect.height - 1, rect.x + rect.width - 1,
@@ -545,12 +545,12 @@ void wxRibbonMSWFlatArtProvider::DrawGalleryItemBackground(
     dc.DrawLine(rect.x + rect.width - 1, rect.y + 1, rect.x + rect.width - 1,
         rect.y + rect.height - 1);
 
-    wxColour bg_colour;
+    wxColour bgColour;
 
     if ( wnd->GetActiveItem() == item || wnd->GetSelection() == item )
-        bg_colour = m_gallery_button_active_background_colour;
+        bgColour = m_galleryButtonActiveBackgroundColour;
     else
-        bg_colour = m_gallery_button_hover_background_colour;
+        bgColour = m_galleryButtonHoverBackgroundColour;
 
     wxRect inner(rect);
     inner.x += 1;
@@ -560,18 +560,18 @@ void wxRibbonMSWFlatArtProvider::DrawGalleryItemBackground(
     if ( inner.width > 0 && inner.height > 0 )
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(wxBrush(bg_colour));
+        dc.SetBrush(wxBrush(bgColour));
         dc.DrawRectangle(inner.x, inner.y, inner.width, inner.height);
     }
 }
 
 void wxRibbonMSWFlatArtProvider::DrawPanelBorder(wxDC& dc, const wxRect& rect,
-                                             wxPen& primary_colour,
-                                             wxPen& secondary_colour)
+                                             wxPen& primaryColour,
+                                             wxPen& secondaryColour)
 {
-    wxUnusedVar(secondary_colour);
+    wxUnusedVar(secondaryColour);
 
-    const wxPoint border_points[] = {
+    const wxPoint borderPoints[] = {
         {2, 0},
         {rect.width - 3, 0},
         {rect.width - 1, 2},
@@ -583,8 +583,8 @@ void wxRibbonMSWFlatArtProvider::DrawPanelBorder(wxDC& dc, const wxRect& rect,
         {2, 0},
     };
 
-    dc.SetPen(primary_colour);
-    dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points,
+    dc.SetPen(primaryColour);
+    dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints,
         rect.x, rect.y);
 }
 
@@ -596,57 +596,57 @@ void wxRibbonMSWFlatArtProvider::DrawMinimisedPanel(
 {
     DrawPartialPageBackground(dc, wnd, rect, false);
 
-    wxRect true_rect(rect);
-    RemovePanelPadding(&true_rect);
+    wxRect trueRect(rect);
+    RemovePanelPadding(&trueRect);
 
     if ( wnd->GetExpandedPanel() != nullptr )
     {
-        wxRect client_rect(true_rect);
-        client_rect.x++;
-        client_rect.width -= 2;
-        client_rect.y++;
-        client_rect.height = (true_rect.y + true_rect.height) - client_rect.y;
+        wxRect clientRect(trueRect);
+        clientRect.x++;
+        clientRect.width -= 2;
+        clientRect.y++;
+        clientRect.height = (trueRect.y + trueRect.height) - clientRect.y;
 
-        if ( client_rect.width > 0 && client_rect.height > 0 )
+        if ( clientRect.width > 0 && clientRect.height > 0 )
         {
             dc.SetPen(*wxTRANSPARENT_PEN);
-            dc.SetBrush(wxBrush(m_panel_active_background_colour));
-            dc.DrawRectangle(client_rect.x, client_rect.y,
-                client_rect.width, client_rect.height);
+            dc.SetBrush(wxBrush(m_panelActiveBackgroundColour));
+            dc.DrawRectangle(clientRect.x, clientRect.y,
+                clientRect.width, clientRect.height);
         }
     }
     else if ( wnd->IsHovered() )
     {
-        wxRect client_rect(true_rect);
-        client_rect.x++;
-        client_rect.width -= 2;
-        client_rect.y++;
-        client_rect.height -= 2;
-        if ( client_rect.width > 0 && client_rect.height > 0 )
-            DrawPartialPageBackground(dc, wnd, client_rect, true);
+        wxRect clientRect(trueRect);
+        clientRect.x++;
+        clientRect.width -= 2;
+        clientRect.y++;
+        clientRect.height -= 2;
+        if ( clientRect.width > 0 && clientRect.height > 0 )
+            DrawPartialPageBackground(dc, wnd, clientRect, true);
     }
 
     wxRect preview;
-    DrawMinimisedPanelCommon(dc, wnd, true_rect, &preview);
+    DrawMinimisedPanelCommon(dc, wnd, trueRect, &preview);
 
-    dc.SetBrush(m_panel_hover_label_background_brush);
+    dc.SetBrush(m_panelHoverLabelBackgroundBrush);
     dc.SetPen(*wxTRANSPARENT_PEN);
     dc.DrawRectangle(preview.x + 1, preview.y + preview.height - 8,
         preview.width - 2, 7);
 
     {
-        wxRect full_rect(preview);
-        full_rect.x += 1;
-        full_rect.y += 1;
-        full_rect.width -= 2;
-        full_rect.height -= 9;
+        wxRect fullRect(preview);
+        fullRect.x += 1;
+        fullRect.y += 1;
+        fullRect.width -= 2;
+        fullRect.height -= 9;
 
-        if ( full_rect.width > 0 && full_rect.height > 0 )
+        if ( fullRect.width > 0 && fullRect.height > 0 )
         {
             dc.SetPen(*wxTRANSPARENT_PEN);
-            dc.SetBrush(wxBrush(m_page_hover_background_colour));
-            dc.DrawRectangle(full_rect.x, full_rect.y,
-                full_rect.width, full_rect.height);
+            dc.SetBrush(wxBrush(m_pageHoverBackgroundColour));
+            dc.DrawRectangle(fullRect.x, fullRect.y,
+                fullRect.width, fullRect.height);
         }
     }
 
@@ -659,14 +659,14 @@ void wxRibbonMSWFlatArtProvider::DrawMinimisedPanel(
     }
 
     if ( !wnd->IsHovered() )
-        DrawPanelBorder(dc, preview, m_panel_border_pen,
-            m_panel_border_gradient_pen);
+        DrawPanelBorder(dc, preview, m_panelBorderPen,
+            m_panelBorderGradientPen);
     else
-        DrawPanelBorder(dc, preview, m_panel_hover_border_pen,
-            m_panel_hover_border_gradient_pen);
+        DrawPanelBorder(dc, preview, m_panelHoverBorderPen,
+            m_panelHoverBorderGradientPen);
 
-    DrawPanelBorder(dc, true_rect, m_panel_minimised_border_pen,
-        m_panel_minimised_border_gradient_pen);
+    DrawPanelBorder(dc, trueRect, m_panelMinimisedBorderPen,
+        m_panelMinimisedBorderGradientPen);
 }
 
 void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
@@ -676,8 +676,8 @@ void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
                         wxRibbonButtonKind kind,
                         long state,
                         const wxString& label,
-                        const wxBitmap& bitmap_large,
-                        const wxBitmap& bitmap_small)
+                        const wxBitmap& bitmapLarge,
+                        const wxBitmap& bitmapSmall)
 {
     if ( kind == wxRIBBON_BUTTON_TOGGLE )
     {
@@ -690,15 +690,15 @@ void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
         wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK) )
     {
         if ( state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK )
-            dc.SetPen(m_button_bar_active_border_pen);
+            dc.SetPen(m_buttonBarActiveBorderPen);
         else
-            dc.SetPen(m_button_bar_hover_border_pen);
+            dc.SetPen(m_buttonBarHoverBorderPen);
 
-        wxRect bg_rect(rect);
-        bg_rect.x++;
-        bg_rect.y++;
-        bg_rect.width -= 2;
-        bg_rect.height -= 2;
+        wxRect bgRect(rect);
+        bgRect.x++;
+        bgRect.y++;
+        bgRect.width -= 2;
+        bgRect.height -= 2;
 
         if ( kind == wxRIBBON_BUTTON_HYBRID )
         {
@@ -706,20 +706,20 @@ void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
             {
             case wxRIBBON_BUTTONBAR_BUTTON_LARGE:
                 {
-                    int iYBorder = rect.y + bitmap_large.GetLogicalHeight() + 4;
-                    wxRect partial_bg(rect);
+                    int iYBorder = rect.y + bitmapLarge.GetLogicalHeight() + 4;
+                    wxRect partialBg(rect);
                     if ( state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED )
                     {
-                        partial_bg.SetBottom(iYBorder - 1);
+                        partialBg.SetBottom(iYBorder - 1);
                     }
                     else
                     {
-                        partial_bg.height -= (iYBorder - partial_bg.y + 1);
-                        partial_bg.y = iYBorder + 1;
+                        partialBg.height -= (iYBorder - partialBg.y + 1);
+                        partialBg.y = iYBorder + 1;
                     }
                     dc.DrawLine(rect.x, iYBorder, rect.x + rect.width,
                         iYBorder);
-                    bg_rect.Intersect(partial_bg);
+                    bgRect.Intersect(partialBg);
                 }
                 break;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
@@ -728,39 +728,39 @@ void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
                     int iArrowWidth = 9;
                     if ( state & wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED )
                     {
-                        bg_rect.width -= iArrowWidth;
-                        dc.DrawLine(bg_rect.x + bg_rect.width,
-                            rect.y, bg_rect.x + bg_rect.width,
+                        bgRect.width -= iArrowWidth;
+                        dc.DrawLine(bgRect.x + bgRect.width,
+                            rect.y, bgRect.x + bgRect.width,
                             rect.y + rect.height);
                     }
                     else
                     {
                         --iArrowWidth;
-                        bg_rect.x += bg_rect.width - iArrowWidth;
-                        bg_rect.width = iArrowWidth;
-                        dc.DrawLine(bg_rect.x - 1, rect.y,
-                            bg_rect.x - 1, rect.y + rect.height);
+                        bgRect.x += bgRect.width - iArrowWidth;
+                        bgRect.width = iArrowWidth;
+                        dc.DrawLine(bgRect.x - 1, rect.y,
+                            bgRect.x - 1, rect.y + rect.height);
                     }
                 }
                 break;
             }
         }
 
-        wxColour bg_colour;
+        wxColour bgColour;
         if ( state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK )
-            bg_colour = m_button_bar_active_background_colour;
+            bgColour = m_buttonBarActiveBackgroundColour;
         else
-            bg_colour = m_button_bar_hover_background_colour;
+            bgColour = m_buttonBarHoverBackgroundColour;
 
-        if ( bg_rect.width > 0 && bg_rect.height > 0 )
+        if ( bgRect.width > 0 && bgRect.height > 0 )
         {
             dc.SetPen(*wxTRANSPARENT_PEN);
-            dc.SetBrush(wxBrush(bg_colour));
-            dc.DrawRectangle(bg_rect.x, bg_rect.y,
-                bg_rect.width, bg_rect.height);
+            dc.SetBrush(wxBrush(bgColour));
+            dc.DrawRectangle(bgRect.x, bgRect.y,
+                bgRect.width, bgRect.height);
         }
 
-        const wxPoint border_points[] = {
+        const wxPoint borderPoints[] = {
             {2, 0},
             {rect.width - 3, 0},
             {rect.width - 1, 2},
@@ -773,20 +773,20 @@ void wxRibbonMSWFlatArtProvider::DrawButtonBarButton(
         };
 
         if ( state & wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK )
-            dc.SetPen(m_button_bar_active_border_pen);
+            dc.SetPen(m_buttonBarActiveBorderPen);
         else
-            dc.SetPen(m_button_bar_hover_border_pen);
+            dc.SetPen(m_buttonBarHoverBorderPen);
 
-        dc.DrawLines(sizeof(border_points)/sizeof(wxPoint), border_points,
+        dc.DrawLines(sizeof(borderPoints)/sizeof(wxPoint), borderPoints,
             rect.x, rect.y);
     }
 
-    dc.SetFont(m_button_bar_label_font);
+    dc.SetFont(m_buttonBarLabelFont);
     dc.SetTextForeground(state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED
-                            ? m_button_bar_label_disabled_colour
-                            : m_button_bar_label_colour);
-    DrawButtonBarButtonForeground(dc, rect, kind, state, label, bitmap_large,
-        bitmap_small);
+                            ? m_buttonBarLabelDisabledColour
+                            : m_buttonBarLabelColour);
+    DrawButtonBarButtonForeground(dc, rect, kind, state, label, bitmapLarge,
+        bitmapSmall);
 }
 
 void wxRibbonMSWFlatArtProvider::DrawTabSeparator(
@@ -804,19 +804,19 @@ void wxRibbonMSWFlatArtProvider::DrawTabSeparator(
         visibility = 1.0;
     }
 
-    if ( !m_cached_tab_separator.IsOk() || m_cached_tab_separator.GetLogicalSize() != rect.GetSize() || visibility != m_cached_tab_separator_visibility )
+    if ( !m_cachedTabSeparator.IsOk() || m_cachedTabSeparator.GetLogicalSize() != rect.GetSize() || visibility != m_cachedTabSeparatorVisibility )
     {
         wxRect size(rect.GetSize());
         ReallyDrawTabSeparator(wnd, size, visibility);
     }
-    dc.DrawBitmap(m_cached_tab_separator, rect.x, rect.y, false);
+    dc.DrawBitmap(m_cachedTabSeparator, rect.x, rect.y, false);
 }
 
 void wxRibbonMSWFlatArtProvider::DrawPartialPageBackground(
                         wxDC& dc,
                         wxWindow* wnd,
                         const wxRect& rect,
-                        bool allow_hovered)
+                        bool allowHovered)
 {
     // Assume the window is a child of a ribbon page, and also check for a
     // hovered panel somewhere between the window and the page, as it causes
@@ -829,7 +829,7 @@ void wxRibbonMSWFlatArtProvider::DrawPartialPageBackground(
 
     if ( panel != nullptr )
     {
-        hovered = allow_hovered && panel->IsHovered();
+        hovered = allowHovered && panel->IsHovered();
         if ( panel->GetExpandedDummy() != nullptr )
         {
             offset = panel->GetExpandedDummy()->GetPosition();
@@ -843,7 +843,7 @@ void wxRibbonMSWFlatArtProvider::DrawPartialPageBackground(
             panel = wxDynamicCast(parent, wxRibbonPanel);
             if ( panel != nullptr )
             {
-                hovered = allow_hovered && panel->IsHovered();
+                hovered = allowHovered && panel->IsHovered();
                 if ( panel->GetExpandedDummy() != nullptr )
                 {
                     parent = panel->GetExpandedDummy();
@@ -876,51 +876,51 @@ void wxRibbonMSWFlatArtProvider::DrawPanelBackground(
 {
     DrawPartialPageBackground(dc, wnd, rect, false);
 
-    wxRect true_rect(rect);
-    RemovePanelPadding(&true_rect);
-    bool has_ext_button = wnd->HasExtButton();
+    wxRect trueRect(rect);
+    RemovePanelPadding(&trueRect);
+    bool hasExtButton = wnd->HasExtButton();
 
-    int label_height;
+    int labelHeight;
     {
-        dc.SetFont(m_panel_label_font);
+        dc.SetFont(m_panelLabelFont);
         dc.SetPen(*wxTRANSPARENT_PEN);
         if ( wnd->IsHovered() )
         {
-            dc.SetBrush(m_panel_hover_label_background_brush);
-            dc.SetTextForeground(m_panel_hover_label_colour);
+            dc.SetBrush(m_panelHoverLabelBackgroundBrush);
+            dc.SetTextForeground(m_panelHoverLabelColour);
         }
         else
         {
-            dc.SetBrush(m_panel_label_background_brush);
-            dc.SetTextForeground(m_panel_label_colour);
+            dc.SetBrush(m_panelLabelBackgroundBrush);
+            dc.SetTextForeground(m_panelLabelColour);
         }
 
-        wxRect label_rect(true_rect);
+        wxRect labelRect(trueRect);
         wxString label = wnd->GetLabel();
-        bool clip_label = false;
-        wxSize label_size(dc.GetTextExtent(label));
+        bool clipLabel = false;
+        wxSize labelSize(dc.GetTextExtent(label));
 
-        label_rect.SetX(label_rect.GetX() + 1);
-        label_rect.SetWidth(label_rect.GetWidth() - 2);
-        label_rect.SetHeight(label_size.GetHeight() + 2);
-        label_rect.SetY(true_rect.GetBottom() - label_rect.GetHeight());
-        label_height = label_rect.GetHeight();
+        labelRect.SetX(labelRect.GetX() + 1);
+        labelRect.SetWidth(labelRect.GetWidth() - 2);
+        labelRect.SetHeight(labelSize.GetHeight() + 2);
+        labelRect.SetY(trueRect.GetBottom() - labelRect.GetHeight());
+        labelHeight = labelRect.GetHeight();
 
-        wxRect label_bg_rect = label_rect;
+        wxRect labelBgRect = labelRect;
 
-        if ( has_ext_button )
-            label_rect.SetWidth(label_rect.GetWidth() - 13);
+        if ( hasExtButton )
+            labelRect.SetWidth(labelRect.GetWidth() - 13);
 
-        if ( label_size.GetWidth() > label_rect.GetWidth() )
+        if ( labelSize.GetWidth() > labelRect.GetWidth() )
         {
             // Test if there is enough length for 3 letters and ...
-            wxString new_label = label.Mid(0, 3) + "...";
-            label_size = dc.GetTextExtent(new_label);
-            if ( label_size.GetWidth() > label_rect.GetWidth() )
+            wxString newLabel = label.Mid(0, 3) + "...";
+            labelSize = dc.GetTextExtent(newLabel);
+            if ( labelSize.GetWidth() > labelRect.GetWidth() )
             {
                 // Not enough room for three characters and ...
                 // Display the entire label and just crop it
-                clip_label = true;
+                clipLabel = true;
             }
             else
             {
@@ -928,61 +928,61 @@ void wxRibbonMSWFlatArtProvider::DrawPanelBackground(
                 // Display as many characters as possible and append ...
                 for ( int len = static_cast<int>(label.Len()) - 1; len >= 3; --len )
                 {
-                    new_label = label.Mid(0, len) + "...";
-                    label_size = dc.GetTextExtent(new_label);
-                    if ( label_size.GetWidth() <= label_rect.GetWidth() )
+                    newLabel = label.Mid(0, len) + "...";
+                    labelSize = dc.GetTextExtent(newLabel);
+                    if ( labelSize.GetWidth() <= labelRect.GetWidth() )
                     {
-                        label = new_label;
+                        label = newLabel;
                         break;
                     }
                 }
             }
         }
 
-        dc.DrawRectangle(label_bg_rect);
-        if ( clip_label )
+        dc.DrawRectangle(labelBgRect);
+        if ( clipLabel )
         {
-            wxDCClipper clip(dc, label_rect);
-            dc.DrawText(label, label_rect.x, label_rect.y +
-                (label_rect.GetHeight() - label_size.GetHeight()) / 2);
+            wxDCClipper clip(dc, labelRect);
+            dc.DrawText(label, labelRect.x, labelRect.y +
+                (labelRect.GetHeight() - labelSize.GetHeight()) / 2);
         }
         else
         {
-            dc.DrawText(label, label_rect.x +
-                (label_rect.GetWidth() - label_size.GetWidth()) / 2,
-                label_rect.y +
-                (label_rect.GetHeight() - label_size.GetHeight()) / 2);
+            dc.DrawText(label, labelRect.x +
+                (labelRect.GetWidth() - labelSize.GetWidth()) / 2,
+                labelRect.y +
+                (labelRect.GetHeight() - labelSize.GetHeight()) / 2);
         }
 
-        if ( has_ext_button )
+        if ( hasExtButton )
         {
             if ( wnd->IsExtButtonHovered() )
             {
-                dc.SetPen(m_panel_hover_button_border_pen);
-                dc.SetBrush(m_panel_hover_button_background_brush);
-                dc.DrawRoundedRectangle(label_rect.GetRight(), label_rect.GetBottom() - 13, 13, 13, 1.0);
-                dc.DrawBitmap(m_panel_extension_bundle[1].GetBitmapFor(wnd), label_rect.GetRight() + 3, label_rect.GetBottom() - 10, true);
+                dc.SetPen(m_panelHoverButtonBorderPen);
+                dc.SetBrush(m_panelHoverButtonBackgroundBrush);
+                dc.DrawRoundedRectangle(labelRect.GetRight(), labelRect.GetBottom() - 13, 13, 13, 1.0);
+                dc.DrawBitmap(m_panelExtensionBundle[1].GetBitmapFor(wnd), labelRect.GetRight() + 3, labelRect.GetBottom() - 10, true);
             }
             else
-                dc.DrawBitmap(m_panel_extension_bundle[0].GetBitmapFor(wnd), label_rect.GetRight() + 3, label_rect.GetBottom() - 10, true);
+                dc.DrawBitmap(m_panelExtensionBundle[0].GetBitmapFor(wnd), labelRect.GetRight() + 3, labelRect.GetBottom() - 10, true);
         }
     }
 
     if ( wnd->IsHovered() )
     {
-        wxRect client_rect(true_rect);
-        client_rect.x++;
-        client_rect.width -= 2;
-        client_rect.y++;
-        client_rect.height -= 2 + label_height;
-        if ( client_rect.width > 0 && client_rect.height > 0 )
-            DrawPartialPageBackground(dc, wnd, client_rect, true);
+        wxRect clientRect(trueRect);
+        clientRect.x++;
+        clientRect.width -= 2;
+        clientRect.y++;
+        clientRect.height -= 2 + labelHeight;
+        if ( clientRect.width > 0 && clientRect.height > 0 )
+            DrawPartialPageBackground(dc, wnd, clientRect, true);
     }
 
     if ( !wnd->IsHovered() )
-        DrawPanelBorder(dc, true_rect, m_panel_border_pen, m_panel_border_gradient_pen);
+        DrawPanelBorder(dc, trueRect, m_panelBorderPen, m_panelBorderGradientPen);
     else
-        DrawPanelBorder(dc, true_rect, m_panel_hover_border_pen, m_panel_hover_border_gradient_pen);
+        DrawPanelBorder(dc, trueRect, m_panelHoverBorderPen, m_panelHoverBorderGradientPen);
 }
 
 void wxRibbonMSWFlatArtProvider::DrawGalleryBackground(
@@ -995,7 +995,7 @@ void wxRibbonMSWFlatArtProvider::DrawGalleryBackground(
     if ( wnd->IsHovered() )
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(m_gallery_hover_background_brush);
+        dc.SetBrush(m_galleryHoverBackgroundBrush);
         if ( m_flags & wxRIBBON_BAR_FLOW_VERTICAL )
         {
             dc.DrawRectangle(rect.x + 1, rect.y + 1, rect.width - 2,
@@ -1008,7 +1008,7 @@ void wxRibbonMSWFlatArtProvider::DrawGalleryBackground(
         }
     }
 
-    dc.SetPen(m_gallery_border_pen);
+    dc.SetPen(m_galleryBorderPen);
     // Outline
     dc.DrawLine(rect.x + 1, rect.y, rect.x + rect.width - 1, rect.y);
     dc.DrawLine(rect.x, rect.y + 1, rect.x, rect.y + rect.height - 1);
@@ -1050,21 +1050,21 @@ wxRibbonMSWFlatArtProvider::DrawToggleButton(wxDC& dc,
 
     if ( wnd->IsToggleButtonHovered() )
     {
-        dc.SetPen(m_ribbon_toggle_pen);
-        dc.SetBrush(m_ribbon_toggle_brush);
+        dc.SetPen(m_ribbonTogglePen);
+        dc.SetBrush(m_ribbonToggleBrush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
         bindex = 1;
     }
     switch ( mode )
     {
         case wxRIBBON_BAR_PINNED:
-            dc.DrawBitmap(m_ribbon_toggle_up_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawBitmap(m_ribbonToggleUpBundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
             break;
         case wxRIBBON_BAR_MINIMIZED:
-            dc.DrawBitmap(m_ribbon_toggle_down_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawBitmap(m_ribbonToggleDownBundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
             break;
         case wxRIBBON_BAR_EXPANDED:
-            dc.DrawBitmap(m_ribbon_toggle_pin_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
+            dc.DrawBitmap(m_ribbonTogglePinBundle[bindex].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
             break;
     }
 }
@@ -1080,14 +1080,14 @@ void wxRibbonMSWFlatArtProvider::DrawHelpButton(wxDC& dc,
 
     if ( wnd->IsHelpButtonHovered() )
     {
-        dc.SetPen(m_ribbon_toggle_pen);
-        dc.SetBrush(m_ribbon_toggle_brush);
+        dc.SetPen(m_ribbonTogglePen);
+        dc.SetBrush(m_ribbonToggleBrush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[1].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
+        dc.DrawBitmap(m_ribbonBarHelpButtonBundle[1].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
     }
     else
     {
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[0].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
+        dc.DrawBitmap(m_ribbonBarHelpButtonBundle[0].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
     }
 }
 
@@ -1105,27 +1105,27 @@ void wxRibbonMSWFlatArtProvider::DrawTool(
             state ^= wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
     }
 
-    wxRect bg_rect(rect);
-    bg_rect.Deflate(1);
+    wxRect bgRect(rect);
+    bgRect.Deflate(1);
     if ( (state & wxRIBBON_TOOLBAR_TOOL_LAST) == 0 )
-        bg_rect.width++;
-    bool is_split_hybrid = (kind == wxRIBBON_BUTTON_HYBRID && (state &
+        bgRect.width++;
+    bool isSplitHybrid = (kind == wxRIBBON_BUTTON_HYBRID && (state &
         (wxRIBBON_TOOLBAR_TOOL_HOVER_MASK | wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK)));
 
     // Background - single solid fill
-    wxColour bg_colour = m_tool_background_colour;
+    wxColour bgColour = m_toolBackgroundColour;
     if ( state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK )
-        bg_colour = m_tool_active_background_colour;
+        bgColour = m_toolActiveBackgroundColour;
     else if ( state & wxRIBBON_TOOLBAR_TOOL_HOVER_MASK )
-        bg_colour = m_tool_hover_background_colour;
+        bgColour = m_toolHoverBackgroundColour;
 
     dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.SetBrush(wxBrush(bg_colour));
-    dc.DrawRectangle(bg_rect.x, bg_rect.y, bg_rect.width, bg_rect.height);
+    dc.SetBrush(wxBrush(bgColour));
+    dc.DrawRectangle(bgRect.x, bgRect.y, bgRect.width, bgRect.height);
 
-    if ( is_split_hybrid )
+    if ( isSplitHybrid )
     {
-        wxRect nonrect(bg_rect);
+        wxRect nonrect(bgRect);
         if ( state & (wxRIBBON_TOOLBAR_TOOL_DROPDOWN_HOVERED |
             wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE) )
         {
@@ -1136,14 +1136,14 @@ void wxRibbonMSWFlatArtProvider::DrawTool(
             nonrect.x += nonrect.width - 8;
             nonrect.width = 8;
         }
-        wxBrush B(m_tool_hover_background_top_colour);
+        wxBrush B(m_toolHoverBackgroundTopColour);
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(B);
         dc.DrawRectangle(nonrect.x, nonrect.y, nonrect.width, nonrect.height);
     }
 
     // Border
-    dc.SetPen(m_toolbar_border_pen);
+    dc.SetPen(m_toolbarBorderPen);
     if ( state & wxRIBBON_TOOLBAR_TOOL_FIRST )
     {
         dc.DrawPoint(rect.x + 1, rect.y + 1);
@@ -1159,20 +1159,20 @@ void wxRibbonMSWFlatArtProvider::DrawTool(
     }
 
     // Foreground
-    int avail_width = bg_rect.GetWidth();
+    int availWidth = bgRect.GetWidth();
     if ( kind & wxRIBBON_BUTTON_DROPDOWN )
     {
-        avail_width -= 8;
-        if ( is_split_hybrid )
+        availWidth -= 8;
+        if ( isSplitHybrid )
         {
-            dc.DrawLine(rect.x + avail_width + 1, rect.y,
-                rect.x + avail_width + 1, rect.y + rect.height);
+            dc.DrawLine(rect.x + availWidth + 1, rect.y,
+                rect.x + availWidth + 1, rect.y + rect.height);
         }
-        dc.DrawBitmap(m_toolbar_drop_bundle.GetBitmapFor(wnd), bg_rect.x + avail_width + 2,
-            bg_rect.y + (bg_rect.height / 2) - 2, true);
+        dc.DrawBitmap(m_toolbarDropBundle.GetBitmapFor(wnd), bgRect.x + availWidth + 2,
+            bgRect.y + (bgRect.height / 2) - 2, true);
     }
-    dc.DrawBitmap(bitmap, bg_rect.x + (avail_width - bitmap.GetLogicalWidth()) / 2,
-        bg_rect.y + (bg_rect.height - bitmap.GetLogicalHeight()) / 2, true);
+    dc.DrawBitmap(bitmap, bgRect.x + (availWidth - bitmap.GetLogicalWidth()) / 2,
+        bgRect.y + (bgRect.height - bitmap.GetLogicalHeight()) / 2, true);
 }
 
 #endif // wxUSE_RIBBON

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/bar.cpp
 // Purpose:     Top-level component of the ribbon-bar-style interface
 // Author:      Peter Cawley
@@ -22,7 +22,7 @@
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 #include "wx/imaglist.h"
@@ -61,43 +61,43 @@ void wxRibbonBar::AddPage(wxRibbonPage *page)
 {
     wxRibbonPageTabInfo info;
 
-    info.page = page;
-    info.active = false;
-    info.hovered = false;
-    info.highlight = false;
-    info.shown = true;
+    info.m_page = page;
+    info.m_active = false;
+    info.m_hovered = false;
+    info.m_highlight = false;
+    info.m_shown = true;
     // info.rect not set (intentional)
 
     wxInfoDC dcTemp(this);
     wxString label;
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS )
         label = page->GetLabel();
     wxBitmap icon;
-    if(m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS)
+    if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
         icon = page->GetIcon();
     m_art->GetBarTabWidth(dcTemp, this, label, icon,
-                          &info.ideal_width,
-                          &info.small_begin_need_separator_width,
-                          &info.small_must_have_separator_width,
-                          &info.minimum_width);
+                          &info.m_idealWidth,
+                          &info.m_smallBeginNeedSeparatorWidth,
+                          &info.m_smallMustHaveSeparatorWidth,
+                          &info.m_minimumWidth);
 
-    if(m_pages.IsEmpty())
+    if ( m_pages.IsEmpty() )
     {
-        m_tabs_total_width_ideal = info.ideal_width;
-        m_tabs_total_width_minimum = info.minimum_width;
+        m_tabsTotalWidthIdeal = info.m_idealWidth;
+        m_tabsTotalWidthMinimum = info.m_minimumWidth;
     }
     else
     {
         int sep = m_art->GetMetric(wxRIBBON_ART_TAB_SEPARATION_SIZE);
-        m_tabs_total_width_ideal += sep + info.ideal_width;
-        m_tabs_total_width_minimum += sep + info.minimum_width;
+        m_tabsTotalWidthIdeal += sep + info.m_idealWidth;
+        m_tabsTotalWidthMinimum += sep + info.m_minimumWidth;
     }
     m_pages.Add(info);
 
     page->Hide(); // Most likely case is that this new page is not the active tab
     page->SetArtProvider(m_art);
 
-    if(m_pages.GetCount() == 1)
+    if ( m_pages.GetCount() == 1 )
     {
         SetActivePage((size_t)0);
     }
@@ -105,9 +105,9 @@ void wxRibbonBar::AddPage(wxRibbonPage *page)
 
 bool wxRibbonBar::DismissExpandedPanel()
 {
-    if(m_current_page == wxNOT_FOUND)
+    if ( m_currentPage == wxNOT_FOUND )
         return false;
-    return m_pages.Item(m_current_page).page->DismissExpandedPanel();
+    return m_pages.Item(m_currentPage).m_page->DismissExpandedPanel();
 }
 
 
@@ -129,7 +129,7 @@ void wxRibbonBar::ShowPanels(wxRibbonDisplayMode mode)
     Realise();
     GetParent()->Layout();
 
-    m_ribbon_state = mode;
+    m_ribbonState = mode;
 }
 
 
@@ -141,7 +141,7 @@ void wxRibbonBar::ShowPanels(bool show)
 void wxRibbonBar::SetWindowStyleFlag(long style)
 {
     m_flags = style;
-    if(m_art)
+    if ( m_art )
         m_art->SetFlags(style);
 }
 
@@ -156,45 +156,45 @@ bool wxRibbonBar::Realize()
 
     wxInfoDC dcTemp(this);
     int sep = m_art->GetMetric(wxRIBBON_ART_TAB_SEPARATION_SIZE);
-    size_t numtabs = m_pages.GetCount();
+    size_t numTabs = m_pages.GetCount();
     bool firstVisible = true;
     size_t i;
-    for(i = 0; i < numtabs; ++i)
+    for ( i = 0; i < numTabs; ++i )
     {
         wxRibbonPageTabInfo& info = m_pages.Item(i);
-        if (!info.shown)
+        if ( !info.m_shown )
             continue;
-        RepositionPage(info.page);
-        if(!info.page->Realize())
+        RepositionPage(info.m_page);
+        if ( !info.m_page->Realize() )
         {
             status = false;
         }
         wxString label;
-        if(m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS)
-            label = info.page->GetLabel();
+        if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS )
+            label = info.m_page->GetLabel();
         wxBitmap icon;
-        if(m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS)
-            icon = info.page->GetIcon();
+        if ( m_flags & wxRIBBON_BAR_SHOW_PAGE_ICONS )
+            icon = info.m_page->GetIcon();
         m_art->GetBarTabWidth(dcTemp, this, label, icon,
-                              &info.ideal_width,
-                              &info.small_begin_need_separator_width,
-                              &info.small_must_have_separator_width,
-                              &info.minimum_width);
+                              &info.m_idealWidth,
+                              &info.m_smallBeginNeedSeparatorWidth,
+                              &info.m_smallMustHaveSeparatorWidth,
+                              &info.m_minimumWidth);
 
         if ( firstVisible )
         {
             firstVisible = false;
 
-            m_tabs_total_width_ideal = info.ideal_width;
-            m_tabs_total_width_minimum = info.minimum_width;
+            m_tabsTotalWidthIdeal = info.m_idealWidth;
+            m_tabsTotalWidthMinimum = info.m_minimumWidth;
         }
         else
         {
-            m_tabs_total_width_ideal += sep + info.ideal_width;
-            m_tabs_total_width_minimum += sep + info.minimum_width;
+            m_tabsTotalWidthIdeal += sep + info.m_idealWidth;
+            m_tabsTotalWidthMinimum += sep + info.m_minimumWidth;
         }
     }
-    m_tab_height = m_art->GetTabCtrlHeight(dcTemp, this, m_pages);
+    m_tabHeight = m_art->GetTabCtrlHeight(dcTemp, this, m_pages);
 
     RecalculateMinSize();
     RecalculateTabSizes();
@@ -207,122 +207,123 @@ void wxRibbonBar::OnMouseMove(wxMouseEvent& evt)
 {
     int x = evt.GetX();
     int y = evt.GetY();
-    int hovered_page = wxNOT_FOUND;
-    bool refresh_tabs = false;
-    if(y < m_tab_height)
+    int hoveredPage = wxNOT_FOUND;
+    bool refreshTabs = false;
+    if ( y < m_tabHeight )
     {
         // It is quite likely that the mouse moved a small amount and is still over the same tab
-        if(m_current_hovered_page != wxNOT_FOUND && m_pages.Item((size_t)m_current_hovered_page).rect.Contains(x, y))
+        if ( m_currentHoveredPage != wxNOT_FOUND &&
+            m_pages.Item((size_t)m_currentHoveredPage).m_rect.Contains(x, y) )
         {
-            hovered_page = m_current_hovered_page;
+            hoveredPage = m_currentHoveredPage;
             // But be careful, if tabs can be scrolled, then parts of the tab rect may not be valid
-            if(m_tab_scroll_buttons_shown)
+            if ( m_tabScrollButtonsShown )
             {
-                if(x >= m_tab_scroll_right_button_rect.GetX() || x < m_tab_scroll_left_button_rect.GetRight())
+                if ( x >= m_tabScrollRightButtonRect.GetX() || x < m_tabScrollLeftButtonRect.GetRight() )
                 {
-                    hovered_page = wxNOT_FOUND;
+                    hoveredPage = wxNOT_FOUND;
                 }
             }
         }
         else
         {
-            HitTestTabs(evt.GetPosition(), &hovered_page);
+            HitTestTabs(evt.GetPosition(), &hoveredPage);
         }
     }
-    if(hovered_page != m_current_hovered_page)
+    if ( hoveredPage != m_currentHoveredPage )
     {
-        if(m_current_hovered_page != wxNOT_FOUND)
+        if ( m_currentHoveredPage != wxNOT_FOUND )
         {
-            m_pages.Item((int)m_current_hovered_page).hovered = false;
+            m_pages.Item((int)m_currentHoveredPage).m_hovered = false;
         }
-        m_current_hovered_page = hovered_page;
-        if(m_current_hovered_page != wxNOT_FOUND)
+        m_currentHoveredPage = hoveredPage;
+        if ( m_currentHoveredPage != wxNOT_FOUND )
         {
-            m_pages.Item((int)m_current_hovered_page).hovered = true;
+            m_pages.Item((int)m_currentHoveredPage).m_hovered = true;
         }
-        refresh_tabs = true;
+        refreshTabs = true;
     }
-    if(m_tab_scroll_buttons_shown)
+    if ( m_tabScrollButtonsShown )
     {
 #define SET_FLAG(variable, flag) \
-    { if(((variable) & (flag)) != (flag)) { variable |= (flag); refresh_tabs = true; }}
+    { if ( ((variable) & (flag)) != (flag) ) { variable |= (flag); refreshTabs = true; }}
 #define UNSET_FLAG(variable, flag) \
-    { if((variable) & (flag)) { variable &= ~(flag); refresh_tabs = true; }}
+    { if ( (variable) & (flag) ) { variable &= ~(flag); refreshTabs = true; }}
 
-        if(m_tab_scroll_left_button_rect.Contains(x, y))
-            SET_FLAG(m_tab_scroll_left_button_state, wxRIBBON_SCROLL_BTN_HOVERED)
+        if ( m_tabScrollLeftButtonRect.Contains(x, y) )
+            SET_FLAG(m_tabScrollLeftButtonState, wxRIBBON_SCROLL_BTN_HOVERED)
         else
-            UNSET_FLAG(m_tab_scroll_left_button_state, wxRIBBON_SCROLL_BTN_HOVERED)
+            UNSET_FLAG(m_tabScrollLeftButtonState, wxRIBBON_SCROLL_BTN_HOVERED)
 
-        if(m_tab_scroll_right_button_rect.Contains(x, y))
-            SET_FLAG(m_tab_scroll_right_button_state, wxRIBBON_SCROLL_BTN_HOVERED)
+        if ( m_tabScrollRightButtonRect.Contains(x, y) )
+            SET_FLAG(m_tabScrollRightButtonState, wxRIBBON_SCROLL_BTN_HOVERED)
         else
-            UNSET_FLAG(m_tab_scroll_right_button_state, wxRIBBON_SCROLL_BTN_HOVERED)
+            UNSET_FLAG(m_tabScrollRightButtonState, wxRIBBON_SCROLL_BTN_HOVERED)
 #undef SET_FLAG
 #undef UNSET_FLAG
     }
-    if(refresh_tabs)
+    if ( refreshTabs )
     {
         RefreshTabBar();
     }
     if ( m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON )
-        HitTestRibbonButton(m_toggle_button_rect, evt.GetPosition(), m_toggle_button_hovered);
+        HitTestRibbonButton(m_toggleButtonRect, evt.GetPosition(), m_toggleButtonHovered);
     if ( m_flags & wxRIBBON_BAR_SHOW_HELP_BUTTON )
-        HitTestRibbonButton(m_help_button_rect, evt.GetPosition(), m_help_button_hovered);
+        HitTestRibbonButton(m_helpButtonRect, evt.GetPosition(), m_helpButtonHovered);
 }
 
 void wxRibbonBar::OnMouseLeave(wxMouseEvent& WXUNUSED(evt))
 {
     // The ribbon bar is (usually) at the top of a window, and at least on MSW, the mouse
     // can leave the window quickly and leave a tab in the hovered state.
-    bool refresh_tabs = false;
-    if(m_current_hovered_page != wxNOT_FOUND)
+    bool refreshTabs = false;
+    if ( m_currentHoveredPage != wxNOT_FOUND )
     {
-        m_pages.Item((int)m_current_hovered_page).hovered = false;
-        m_current_hovered_page = wxNOT_FOUND;
-        refresh_tabs = true;
+        m_pages.Item((int)m_currentHoveredPage).m_hovered = false;
+        m_currentHoveredPage = wxNOT_FOUND;
+        refreshTabs = true;
     }
-    if(m_tab_scroll_left_button_state & wxRIBBON_SCROLL_BTN_HOVERED)
+    if ( m_tabScrollLeftButtonState & wxRIBBON_SCROLL_BTN_HOVERED )
     {
-        m_tab_scroll_left_button_state &= ~wxRIBBON_SCROLL_BTN_HOVERED;
-        refresh_tabs = true;
+        m_tabScrollLeftButtonState &= ~wxRIBBON_SCROLL_BTN_HOVERED;
+        refreshTabs = true;
     }
-    if(m_tab_scroll_right_button_state & wxRIBBON_SCROLL_BTN_HOVERED)
+    if ( m_tabScrollRightButtonState & wxRIBBON_SCROLL_BTN_HOVERED )
     {
-        m_tab_scroll_right_button_state &= ~wxRIBBON_SCROLL_BTN_HOVERED;
-        refresh_tabs = true;
+        m_tabScrollRightButtonState &= ~wxRIBBON_SCROLL_BTN_HOVERED;
+        refreshTabs = true;
     }
-    if(refresh_tabs)
+    if ( refreshTabs )
     {
         RefreshTabBar();
     }
-    if(m_toggle_button_hovered)
+    if ( m_toggleButtonHovered )
     {
-        m_bar_hovered = false;
-        m_toggle_button_hovered = false;
+        m_barHovered = false;
+        m_toggleButtonHovered = false;
         Refresh(false);
     }
-    if ( m_help_button_hovered )
+    if ( m_helpButtonHovered )
     {
-        m_help_button_hovered = false;
-        m_bar_hovered = false;
+        m_helpButtonHovered = false;
+        m_barHovered = false;
         Refresh(false);
     }
 }
 
 wxRibbonPage* wxRibbonBar::GetPage(int n)
 {
-    if(n < 0 || (size_t)n >= m_pages.GetCount())
+    if ( n < 0 || (size_t)n >= m_pages.GetCount() )
         return nullptr;
-    return m_pages.Item(n).page;
+    return m_pages.Item(n).m_page;
 }
 
 wxRibbonPage* wxRibbonBar::GetPageById(wxWindowID id)
 {
-    for (const auto& page : m_pages)
+    for ( const auto& page : m_pages )
     {
-        if (page.page->GetId() == id)
-            return page.page;
+        if ( page.m_page->GetId() == id )
+            return page.m_page;
     }
     return nullptr;
 }
@@ -334,59 +335,59 @@ size_t wxRibbonBar::GetPageCount() const
 
 bool wxRibbonBar::IsPageShown(size_t page) const
 {
-    if (page >= m_pages.GetCount())
+    if ( page >= m_pages.GetCount() )
         return false;
-    return m_pages.Item(page).shown;
+    return m_pages.Item(page).m_shown;
 }
 
 void wxRibbonBar::ShowPage(size_t page, bool show)
 {
-    if(page >= m_pages.GetCount())
+    if ( page >= m_pages.GetCount() )
         return;
-    m_pages.Item(page).shown = show;
+    m_pages.Item(page).m_shown = show;
 }
 
 bool wxRibbonBar::IsPageHighlighted(size_t page) const
 {
-    if (page >= m_pages.GetCount())
+    if ( page >= m_pages.GetCount() )
         return false;
-    return m_pages.Item(page).highlight;
+    return m_pages.Item(page).m_highlight;
 }
 
 void wxRibbonBar::AddPageHighlight(size_t page, bool highlight)
 {
-    if(page >= m_pages.GetCount())
+    if ( page >= m_pages.GetCount() )
         return;
-    m_pages.Item(page).highlight = highlight;
+    m_pages.Item(page).m_highlight = highlight;
 }
 
 void wxRibbonBar::DeletePage(size_t n)
 {
-    if(n < m_pages.GetCount())
+    if ( n < m_pages.GetCount() )
     {
-        wxRibbonPage *page = m_pages.Item(n).page;
+        wxRibbonPage *page = m_pages.Item(n).m_page;
 
         // Schedule page object for destruction and not destroying directly
         // as this function can be called in an event handler and page functions
         // can be called after removing.
         // Like in wxRibbonButtonBar::OnMouseUp
-        if(!wxTheApp->IsScheduledForDestruction(page))
+        if ( !wxTheApp->IsScheduledForDestruction(page) )
         {
             wxTheApp->ScheduleForDestruction(page);
         }
 
         m_pages.RemoveAt(n);
 
-        if(m_current_page == static_cast<int>(n))
+        if ( m_currentPage == static_cast<int>(n) )
         {
-            m_current_page = wxNOT_FOUND;
+            m_currentPage = wxNOT_FOUND;
 
-            if(m_pages.GetCount() > 0)
+            if ( m_pages.GetCount() > 0 )
                 SetActivePage(wxMin(n, m_pages.GetCount() - 1));
         }
-        else if(m_current_page > static_cast<int>(n))
+        else if ( m_currentPage > static_cast<int>(n) )
         {
-            m_current_page--;
+            m_currentPage--;
         }
     }
 }
@@ -394,46 +395,46 @@ void wxRibbonBar::DeletePage(size_t n)
 void wxRibbonBar::ClearPages()
 {
     size_t i;
-    for(i=0; i<m_pages.GetCount(); i++)
+    for ( i = 0; i <m_pages.GetCount(); i++ )
     {
-        wxRibbonPage *page = m_pages.Item(i).page;
+        wxRibbonPage *page = m_pages.Item(i).m_page;
         // Schedule page object for destruction and not destroying directly
         // as this function can be called in an event handler and page functions
         // can be called after removing.
         // Like in wxRibbonButtonBar::OnMouseUp
-        if(!wxTheApp->IsScheduledForDestruction(page))
+        if ( !wxTheApp->IsScheduledForDestruction(page) )
         {
             wxTheApp->ScheduleForDestruction(page);
         }
     }
     m_pages.Empty();
     Realize();
-    m_current_page = wxNOT_FOUND;
+    m_currentPage = wxNOT_FOUND;
     Refresh();
 }
 
 bool wxRibbonBar::SetActivePage(size_t page)
 {
-    if(m_current_page == (int)page)
+    if ( m_currentPage == (int)page )
     {
         return true;
     }
 
-    if(page >= m_pages.GetCount())
+    if ( page >= m_pages.GetCount() )
     {
         return false;
     }
 
-    if(m_current_page != wxNOT_FOUND)
+    if ( m_currentPage != wxNOT_FOUND )
     {
-        m_pages.Item((size_t)m_current_page).active = false;
-        m_pages.Item((size_t)m_current_page).page->Hide();
+        m_pages.Item((size_t)m_currentPage).m_active = false;
+        m_pages.Item((size_t)m_currentPage).m_page->Hide();
     }
-    m_current_page = (int)page;
-    m_pages.Item(page).active = true;
-    m_pages.Item(page).shown = true;
+    m_currentPage = (int)page;
+    m_pages.Item(page).m_active = true;
+    m_pages.Item(page).m_shown = true;
     {
-        wxRibbonPage* wnd = m_pages.Item(page).page;
+        wxRibbonPage* wnd = m_pages.Item(page).m_page;
         RepositionPage(wnd);
         wnd->Layout();
         wnd->Show();
@@ -445,11 +446,11 @@ bool wxRibbonBar::SetActivePage(size_t page)
 
 bool wxRibbonBar::SetActivePage(wxRibbonPage* page)
 {
-    size_t numpages = m_pages.GetCount();
+    size_t numPages = m_pages.GetCount();
     size_t i;
-    for(i = 0; i < numpages; ++i)
+    for ( i = 0; i < numPages; ++i )
     {
-        if(m_pages.Item(i).page == page)
+        if ( m_pages.Item(i).m_page == page )
         {
             return SetActivePage(i);
         }
@@ -459,10 +460,10 @@ bool wxRibbonBar::SetActivePage(wxRibbonPage* page)
 
 int wxRibbonBar::GetPageNumber(wxRibbonPage* page) const
 {
-    size_t numpages = m_pages.GetCount();
-    for(size_t i = 0; i < numpages; ++i)
+    size_t numPages = m_pages.GetCount();
+    for ( size_t i = 0; i < numPages; ++i )
     {
-        if(m_pages.Item(i).page == page)
+        if ( m_pages.Item(i).m_page == page )
         {
             return i;
         }
@@ -473,13 +474,13 @@ int wxRibbonBar::GetPageNumber(wxRibbonPage* page) const
 
 int wxRibbonBar::GetActivePage() const
 {
-    return m_current_page;
+    return m_currentPage;
 }
 
 void wxRibbonBar::SetTabCtrlMargins(int left, int right)
 {
-    m_tab_margin_left = left;
-    m_tab_margin_right = right;
+    m_tabMarginLeft = left;
+    m_tabMarginRight = right;
 
     RecalculateTabSizes();
 }
@@ -493,8 +494,8 @@ struct PageComparedBySmallWidthAsc
 
     bool operator<(const PageComparedBySmallWidthAsc& other) const
     {
-        return m_page->small_must_have_separator_width
-                < other.m_page->small_must_have_separator_width;
+        return m_page->m_smallMustHaveSeparatorWidth
+                < other.m_page->m_smallMustHaveSeparatorWidth;
     }
 
     wxRibbonPageTabInfo *m_page;
@@ -502,213 +503,213 @@ struct PageComparedBySmallWidthAsc
 
 void wxRibbonBar::RecalculateTabSizes()
 {
-    size_t numtabs = m_pages.GetCount();
+    size_t numTabs = m_pages.GetCount();
 
-    if(numtabs == 0)
+    if ( numTabs == 0 )
         return;
 
-    int width = GetSize().GetWidth() - m_tab_margin_left - m_tab_margin_right;
-    int tabsep = m_art->GetMetric(wxRIBBON_ART_TAB_SEPARATION_SIZE);
-    int x = m_tab_margin_left;
+    int width = GetSize().GetWidth() - m_tabMarginLeft - m_tabMarginRight;
+    int tabSep = m_art->GetMetric(wxRIBBON_ART_TAB_SEPARATION_SIZE);
+    int x = m_tabMarginLeft;
     const int y = 0;
 
-    if(width >= m_tabs_total_width_ideal)
+    if ( width >= m_tabsTotalWidthIdeal )
     {
         // Simple case: everything at ideal width
         size_t i;
-        for(i = 0; i < numtabs; ++i)
+        for ( i = 0; i < numTabs; ++i )
         {
             wxRibbonPageTabInfo& info = m_pages.Item(i);
-            if (!info.shown)
+            if ( !info.m_shown )
                 continue;
-            info.rect.x = x;
-            info.rect.y = y;
-            info.rect.width = info.ideal_width;
-            info.rect.height = m_tab_height;
-            x += info.rect.width + tabsep;
+            info.m_rect.x = x;
+            info.m_rect.y = y;
+            info.m_rect.width = info.m_idealWidth;
+            info.m_rect.height = m_tabHeight;
+            x += info.m_rect.width + tabSep;
         }
-        m_tab_scroll_buttons_shown = false;
-        m_tab_scroll_left_button_rect.SetWidth(0);
-        m_tab_scroll_right_button_rect.SetWidth(0);
+        m_tabScrollButtonsShown = false;
+        m_tabScrollLeftButtonRect.SetWidth(0);
+        m_tabScrollRightButtonRect.SetWidth(0);
     }
-    else if(width < m_tabs_total_width_minimum)
+    else if ( width < m_tabsTotalWidthMinimum )
     {
         // Simple case: everything minimum with scrollbar
         size_t i;
-        for(i = 0; i < numtabs; ++i)
+        for ( i = 0; i < numTabs; ++i )
         {
             wxRibbonPageTabInfo& info = m_pages.Item(i);
-            if (!info.shown)
+            if ( !info.m_shown )
                 continue;
-            info.rect.x = x;
-            info.rect.y = y;
-            info.rect.width = info.minimum_width;
-            info.rect.height = m_tab_height;
-            x += info.rect.width + tabsep;
+            info.m_rect.x = x;
+            info.m_rect.y = y;
+            info.m_rect.width = info.m_minimumWidth;
+            info.m_rect.height = m_tabHeight;
+            x += info.m_rect.width + tabSep;
         }
-        if(!m_tab_scroll_buttons_shown)
+        if ( !m_tabScrollButtonsShown )
         {
-            m_tab_scroll_left_button_state = wxRIBBON_SCROLL_BTN_NORMAL;
-            m_tab_scroll_right_button_state = wxRIBBON_SCROLL_BTN_NORMAL;
-            m_tab_scroll_buttons_shown = true;
+            m_tabScrollLeftButtonState = wxRIBBON_SCROLL_BTN_NORMAL;
+            m_tabScrollRightButtonState = wxRIBBON_SCROLL_BTN_NORMAL;
+            m_tabScrollButtonsShown = true;
         }
         {
-            wxInfoDC temp_dc(this);
-            int right_button_pos = GetClientSize().GetWidth() - m_tab_margin_right - m_tab_scroll_right_button_rect.GetWidth();
-            if ( right_button_pos < m_tab_margin_left )
-                right_button_pos = m_tab_margin_left;
+            wxInfoDC tempDc(this);
+            int rightButtonPos = GetClientSize().GetWidth() - m_tabMarginRight - m_tabScrollRightButtonRect.GetWidth();
+            if ( rightButtonPos < m_tabMarginLeft )
+                rightButtonPos = m_tabMarginLeft;
 
-            m_tab_scroll_left_button_rect.SetWidth(m_art->GetScrollButtonMinimumSize(temp_dc, this, wxRIBBON_SCROLL_BTN_LEFT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
-            m_tab_scroll_left_button_rect.SetHeight(m_tab_height);
-            m_tab_scroll_left_button_rect.SetX(m_tab_margin_left);
-            m_tab_scroll_left_button_rect.SetY(0);
-            m_tab_scroll_right_button_rect.SetWidth(m_art->GetScrollButtonMinimumSize(temp_dc, this, wxRIBBON_SCROLL_BTN_RIGHT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
-            m_tab_scroll_right_button_rect.SetHeight(m_tab_height);
-            m_tab_scroll_right_button_rect.SetX(right_button_pos);
-            m_tab_scroll_right_button_rect.SetY(0);
+            m_tabScrollLeftButtonRect.SetWidth(m_art->GetScrollButtonMinimumSize(tempDc, this, wxRIBBON_SCROLL_BTN_LEFT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
+            m_tabScrollLeftButtonRect.SetHeight(m_tabHeight);
+            m_tabScrollLeftButtonRect.SetX(m_tabMarginLeft);
+            m_tabScrollLeftButtonRect.SetY(0);
+            m_tabScrollRightButtonRect.SetWidth(m_art->GetScrollButtonMinimumSize(tempDc, this, wxRIBBON_SCROLL_BTN_RIGHT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
+            m_tabScrollRightButtonRect.SetHeight(m_tabHeight);
+            m_tabScrollRightButtonRect.SetX(rightButtonPos);
+            m_tabScrollRightButtonRect.SetY(0);
         }
-        if(m_tab_scroll_amount == 0)
+        if ( m_tabScrollAmount == 0 )
         {
-            m_tab_scroll_left_button_rect.SetWidth(0);
+            m_tabScrollLeftButtonRect.SetWidth(0);
         }
-        else if(m_tab_scroll_amount + width >= m_tabs_total_width_minimum)
+        else if ( m_tabScrollAmount + width >= m_tabsTotalWidthMinimum )
         {
-            m_tab_scroll_amount = m_tabs_total_width_minimum - width;
-            m_tab_scroll_right_button_rect.SetX(m_tab_scroll_right_button_rect.GetX() + m_tab_scroll_right_button_rect.GetWidth());
-            m_tab_scroll_right_button_rect.SetWidth(0);
+            m_tabScrollAmount = m_tabsTotalWidthMinimum - width;
+            m_tabScrollRightButtonRect.SetX(m_tabScrollRightButtonRect.GetX() + m_tabScrollRightButtonRect.GetWidth());
+            m_tabScrollRightButtonRect.SetWidth(0);
         }
-        for(i = 0; i < numtabs; ++i)
+        for ( i = 0; i < numTabs; ++i )
         {
             wxRibbonPageTabInfo& info = m_pages.Item(i);
-            if (!info.shown)
+            if ( !info.m_shown )
                 continue;
-            info.rect.x -= m_tab_scroll_amount;
+            info.m_rect.x -= m_tabScrollAmount;
         }
     }
     else
     {
-        m_tab_scroll_buttons_shown = false;
-        m_tab_scroll_left_button_rect.SetWidth(0);
-        m_tab_scroll_right_button_rect.SetWidth(0);
+        m_tabScrollButtonsShown = false;
+        m_tabScrollLeftButtonRect.SetWidth(0);
+        m_tabScrollRightButtonRect.SetWidth(0);
         // Complex case: everything sized such that: minimum <= width < ideal
         /*
            Strategy:
-             1) Uniformly reduce all tab widths from ideal to small_must_have_separator_width
+             1) Uniformly reduce all tab widths from ideal to smallMustHaveSeparatorWidth
              2) Reduce the largest tab by 1 pixel, repeating until all tabs are same width (or at minimum)
              3) Uniformly reduce all tabs down to their minimum width
         */
-        int smallest_tab_width = INT_MAX;
-        int total_small_width = tabsep * (numtabs - 1);
+        int smallestTabWidth = INT_MAX;
+        int totalSmallWidth = tabSep * (numTabs - 1);
         size_t i;
-        for(i = 0; i < numtabs; ++i)
+        for ( i = 0; i < numTabs; ++i )
         {
             wxRibbonPageTabInfo& info = m_pages.Item(i);
-            if (!info.shown)
+            if ( !info.m_shown )
                 continue;
-            if(info.small_must_have_separator_width < smallest_tab_width)
+            if ( info.m_smallMustHaveSeparatorWidth < smallestTabWidth )
             {
-                smallest_tab_width = info.small_must_have_separator_width;
+                smallestTabWidth = info.m_smallMustHaveSeparatorWidth;
             }
-            total_small_width += info.small_must_have_separator_width;
+            totalSmallWidth += info.m_smallMustHaveSeparatorWidth;
         }
-        if(width >= total_small_width)
+        if ( width >= totalSmallWidth )
         {
             // Do (1)
-            int total_delta = m_tabs_total_width_ideal - total_small_width;
-            total_small_width -= tabsep * (numtabs - 1);
-            width -= tabsep * (numtabs - 1);
-            for(i = 0; i < numtabs; ++i)
+            int totalDelta = m_tabsTotalWidthIdeal - totalSmallWidth;
+            totalSmallWidth -= tabSep * (numTabs - 1);
+            width -= tabSep * (numTabs - 1);
+            for ( i = 0; i < numTabs; ++i )
             {
                 wxRibbonPageTabInfo& info = m_pages.Item(i);
-                if (!info.shown)
+                if ( !info.m_shown )
                     continue;
-                int delta = info.ideal_width - info.small_must_have_separator_width;
-                info.rect.x = x;
-                info.rect.y = y;
-                info.rect.width = info.small_must_have_separator_width + delta * (width - total_small_width) / total_delta;
-                info.rect.height = m_tab_height;
+                int delta = info.m_idealWidth - info.m_smallMustHaveSeparatorWidth;
+                info.m_rect.x = x;
+                info.m_rect.y = y;
+                info.m_rect.width = info.m_smallMustHaveSeparatorWidth + delta * (width - totalSmallWidth) / totalDelta;
+                info.m_rect.height = m_tabHeight;
 
-                x += info.rect.width + tabsep;
-                total_delta -= delta;
-                total_small_width -= info.small_must_have_separator_width;
-                width -= info.rect.width;
+                x += info.m_rect.width + tabSep;
+                totalDelta -= delta;
+                totalSmallWidth -= info.m_smallMustHaveSeparatorWidth;
+                width -= info.m_rect.width;
             }
         }
         else
         {
-            total_small_width = tabsep * (numtabs - 1);
-            for(i = 0; i < numtabs; ++i)
+            totalSmallWidth = tabSep * (numTabs - 1);
+            for ( i = 0; i < numTabs; ++i )
             {
                 wxRibbonPageTabInfo& info = m_pages.Item(i);
-                if (!info.shown)
+                if ( !info.m_shown )
                     continue;
-                if(info.minimum_width < smallest_tab_width)
+                if ( info.m_minimumWidth < smallestTabWidth )
                 {
-                    total_small_width += smallest_tab_width;
+                    totalSmallWidth += smallestTabWidth;
                 }
                 else
                 {
-                    total_small_width += info.minimum_width;
+                    totalSmallWidth += info.m_minimumWidth;
                 }
             }
-            if(width >= total_small_width)
+            if ( width >= totalSmallWidth )
             {
                 // Do (2)
-                wxVector<PageComparedBySmallWidthAsc> sorted_pages;
-                sorted_pages.reserve(numtabs);
-                for ( i = 0; i < numtabs; ++i )
-                    sorted_pages.push_back(PageComparedBySmallWidthAsc(&m_pages.Item(i)));
+                wxVector<PageComparedBySmallWidthAsc> sortedPages;
+                sortedPages.reserve(numTabs);
+                for ( i = 0; i < numTabs; ++i )
+                    sortedPages.push_back(PageComparedBySmallWidthAsc(&m_pages.Item(i)));
 
-                wxVectorSort(sorted_pages);
-                width -= tabsep * (numtabs - 1);
-                for(i = 0; i < numtabs; ++i)
+                wxVectorSort(sortedPages);
+                width -= tabSep * (numTabs - 1);
+                for ( i = 0; i < numTabs; ++i )
                 {
-                    wxRibbonPageTabInfo* info = sorted_pages[i].m_page;
-                    if (!info->shown)
+                    wxRibbonPageTabInfo* info = sortedPages[i].m_page;
+                    if ( !info->m_shown )
                         continue;
-                    if(info->small_must_have_separator_width * (int)(numtabs - i) <= width)
+                    if ( info->m_smallMustHaveSeparatorWidth * (int)(numTabs - i) <= width )
                     {
-                        info->rect.width = info->small_must_have_separator_width;
+                        info->m_rect.width = info->m_smallMustHaveSeparatorWidth;
                     }
                     else
                     {
-                        info->rect.width = width / (numtabs - i);
+                        info->m_rect.width = width / (numTabs - i);
                     }
-                    width -= info->rect.width;
+                    width -= info->m_rect.width;
                 }
-                for(i = 0; i < numtabs; ++i)
+                for ( i = 0; i < numTabs; ++i )
                 {
                     wxRibbonPageTabInfo& info = m_pages.Item(i);
-                    if (!info.shown)
+                    if ( !info.m_shown )
                         continue;
-                    info.rect.x = x;
-                    info.rect.y = y;
-                    info.rect.height = m_tab_height;
-                    x += info.rect.width + tabsep;
+                    info.m_rect.x = x;
+                    info.m_rect.y = y;
+                    info.m_rect.height = m_tabHeight;
+                    x += info.m_rect.width + tabSep;
                 }
             }
             else
             {
                 // Do (3)
-                total_small_width = (smallest_tab_width + tabsep) * numtabs - tabsep;
-                int total_delta = total_small_width - m_tabs_total_width_minimum;
-                total_small_width = m_tabs_total_width_minimum - tabsep * (numtabs - 1);
-                width -= tabsep * (numtabs - 1);
-                for(i = 0; i < numtabs; ++i)
+                totalSmallWidth = (smallestTabWidth + tabSep) * numTabs - tabSep;
+                int totalDelta = totalSmallWidth - m_tabsTotalWidthMinimum;
+                totalSmallWidth = m_tabsTotalWidthMinimum - tabSep * (numTabs - 1);
+                width -= tabSep * (numTabs - 1);
+                for ( i = 0; i < numTabs; ++i )
                 {
                     wxRibbonPageTabInfo& info = m_pages.Item(i);
-                    if (!info.shown)
+                    if ( !info.m_shown )
                         continue;
-                    int delta = smallest_tab_width - info.minimum_width;
-                    info.rect.x = x;
-                    info.rect.y = y;
-                    info.rect.width = info.minimum_width + delta * (width - total_small_width) / total_delta;
-                    info.rect.height = m_tab_height;
+                    int delta = smallestTabWidth - info.m_minimumWidth;
+                    info.m_rect.x = x;
+                    info.m_rect.y = y;
+                    info.m_rect.width = info.m_minimumWidth + delta * (width - totalSmallWidth) / totalDelta;
+                    info.m_rect.height = m_tabHeight;
 
-                    x += info.rect.width + tabsep;
-                    total_delta -= delta;
-                    total_small_width -= info.minimum_width;
-                    width -= info.rect.width;
+                    x += info.m_rect.width + tabSep;
+                    totalDelta -= delta;
+                    totalSmallWidth -= info.m_minimumWidth;
+                    width -= info.m_rect.width;
                 }
             }
         }
@@ -718,19 +719,19 @@ void wxRibbonBar::RecalculateTabSizes()
 wxRibbonBar::wxRibbonBar()
 {
     m_flags = 0;
-    m_tabs_total_width_ideal = 0;
-    m_tabs_total_width_minimum = 0;
-    m_tab_margin_left = 0;
-    m_tab_margin_right = 0;
-    m_tab_height = 0;
-    m_tab_scroll_amount = 0;
-    m_current_page = wxNOT_FOUND;
-    m_current_hovered_page = wxNOT_FOUND;
-    m_tab_scroll_left_button_state = wxRIBBON_SCROLL_BTN_NORMAL;
-    m_tab_scroll_right_button_state = wxRIBBON_SCROLL_BTN_NORMAL;
-    m_tab_scroll_buttons_shown = false;
+    m_tabsTotalWidthIdeal = 0;
+    m_tabsTotalWidthMinimum = 0;
+    m_tabMarginLeft = 0;
+    m_tabMarginRight = 0;
+    m_tabHeight = 0;
+    m_tabScrollAmount = 0;
+    m_currentPage = wxNOT_FOUND;
+    m_currentHoveredPage = wxNOT_FOUND;
+    m_tabScrollLeftButtonState = wxRIBBON_SCROLL_BTN_NORMAL;
+    m_tabScrollRightButtonState = wxRIBBON_SCROLL_BTN_NORMAL;
+    m_tabScrollButtonsShown = false;
     m_arePanelsShown = true;
-    m_help_button_hovered = false;
+    m_helpButtonHovered = false;
 
 }
 
@@ -748,9 +749,9 @@ wxRibbonBar::~wxRibbonBar()
 {
     SetArtProvider(nullptr);
 
-    for ( size_t n = 0; n < m_image_lists.size(); ++n )
+    for ( size_t n = 0; n < m_imageLists.size(); ++n )
     {
-        delete m_image_lists[n];
+        delete m_imageLists[n];
     }
 }
 
@@ -760,7 +761,7 @@ bool wxRibbonBar::Create(wxWindow* parent,
                 const wxSize& size,
                 long style)
 {
-    if(!wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE))
+    if ( !wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE) )
         return false;
 
     CommonInit(style);
@@ -773,46 +774,46 @@ void wxRibbonBar::CommonInit(long style)
     SetName("wxRibbonBar");
 
     m_flags = style;
-    m_tabs_total_width_ideal = 0;
-    m_tabs_total_width_minimum = 0;
-    m_tab_margin_left = 50;
-    m_tab_margin_right = 20;
+    m_tabsTotalWidthIdeal = 0;
+    m_tabsTotalWidthMinimum = 0;
+    m_tabMarginLeft = 50;
+    m_tabMarginRight = 20;
     if ( m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON )
-        m_tab_margin_right += 20;
+        m_tabMarginRight += 20;
     if ( m_flags & wxRIBBON_BAR_SHOW_HELP_BUTTON )
-        m_tab_margin_right += 20;
-    m_tab_height = 20; // initial guess
-    m_tab_scroll_amount = 0;
-    m_current_page = wxNOT_FOUND;
-    m_current_hovered_page = wxNOT_FOUND;
-    m_tab_scroll_left_button_state = wxRIBBON_SCROLL_BTN_NORMAL;
-    m_tab_scroll_right_button_state = wxRIBBON_SCROLL_BTN_NORMAL;
-    m_tab_scroll_buttons_shown = false;
+        m_tabMarginRight += 20;
+    m_tabHeight = 20; // initial guess
+    m_tabScrollAmount = 0;
+    m_currentPage = wxNOT_FOUND;
+    m_currentHoveredPage = wxNOT_FOUND;
+    m_tabScrollLeftButtonState = wxRIBBON_SCROLL_BTN_NORMAL;
+    m_tabScrollRightButtonState = wxRIBBON_SCROLL_BTN_NORMAL;
+    m_tabScrollButtonsShown = false;
     m_arePanelsShown = true;
 
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
     {
         SetArtProvider(new wxRibbonDefaultArtProvider);
     }
     SetBackgroundStyle(wxBG_STYLE_PAINT);
 
-    m_toggle_button_hovered = false;
-    m_bar_hovered = false;
+    m_toggleButtonHovered = false;
+    m_barHovered = false;
 
-    m_ribbon_state = wxRIBBON_BAR_PINNED;
+    m_ribbonState = wxRIBBON_BAR_PINNED;
 }
 
 wxImageList* wxRibbonBar::GetButtonImageList(wxSize size, int initialCount)
 {
-    for ( size_t n = 0; n < m_image_lists.size(); ++n )
+    for ( size_t n = 0; n < m_imageLists.size(); ++n )
     {
-        if ( m_image_lists[n]->GetSize() == size )
-            return m_image_lists[n];
+        if ( m_imageLists[n]->GetSize() == size )
+            return m_imageLists[n];
     }
 
     wxImageList* const
         il = new wxImageList(size.GetWidth(), size.GetHeight(), /*mask*/false, initialCount);
-    m_image_lists.push_back(il);
+    m_imageLists.push_back(il);
 
     return il;
 }
@@ -822,16 +823,16 @@ void wxRibbonBar::SetArtProvider(wxRibbonArtProvider* art)
     wxRibbonArtProvider *old = m_art;
     m_art = art;
 
-    if(art)
+    if ( art )
     {
         art->SetFlags(m_flags);
     }
-    size_t numpages = m_pages.GetCount();
+    size_t numPages = m_pages.GetCount();
     size_t i;
-    for(i = 0; i < numpages; ++i)
+    for ( i = 0; i < numPages; ++i )
     {
-        wxRibbonPage *page = m_pages.Item(i).page;
-        if(page->GetArtProvider() != art)
+        wxRibbonPage *page = m_pages.Item(i).m_page;
+        if ( page->GetArtProvider() != art )
         {
             page->SetArtProvider(art);
         }
@@ -844,7 +845,7 @@ void wxRibbonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
     wxAutoBufferedPaintDC dc(this);
 
-    if(GetUpdateRegion().Contains(0, 0, GetClientSize().GetWidth(), m_tab_height) == wxOutRegion)
+    if ( GetUpdateRegion().Contains(0, 0, GetClientSize().GetWidth(), m_tabHeight) == wxOutRegion )
     {
         // Nothing to do in the tab area, and the page area is handled by the active page
         return;
@@ -852,92 +853,93 @@ void wxRibbonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
     DoEraseBackground(dc);
 
-    if ( m_flags & wxRIBBON_BAR_SHOW_HELP_BUTTON  )
-        m_help_button_rect = m_art->GetRibbonHelpButtonArea(GetSize());
-    if ( m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON  )
-        m_toggle_button_rect = m_art->GetBarToggleButtonArea(GetSize());
+    if ( m_flags & wxRIBBON_BAR_SHOW_HELP_BUTTON )
+        m_helpButtonRect = m_art->GetRibbonHelpButtonArea(GetSize());
+    if ( m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON )
+        m_toggleButtonRect = m_art->GetBarToggleButtonArea(GetSize());
 
-    size_t numtabs = m_pages.GetCount();
-    double sep_visibility = 0.0;
-    bool draw_sep = false;
-    wxRect tabs_rect(m_tab_margin_left, 0, GetClientSize().GetWidth() - m_tab_margin_left - m_tab_margin_right, m_tab_height);
-    if(m_tab_scroll_buttons_shown)
+    size_t numTabs = m_pages.GetCount();
+    double sepVisibility = 0.0;
+    bool drawSep = false;
+    wxRect tabsRect(m_tabMarginLeft, 0, GetClientSize().GetWidth() - m_tabMarginLeft - m_tabMarginRight, m_tabHeight);
+    if ( m_tabScrollButtonsShown )
     {
-        tabs_rect.x += m_tab_scroll_left_button_rect.GetWidth();
-        tabs_rect.width -= m_tab_scroll_left_button_rect.GetWidth() + m_tab_scroll_right_button_rect.GetWidth();
+        tabsRect.x += m_tabScrollLeftButtonRect.GetWidth();
+        tabsRect.width -= m_tabScrollLeftButtonRect.GetWidth() + m_tabScrollRightButtonRect.GetWidth();
     }
     size_t i;
-    for(i = 0; i < numtabs; ++i)
+    for ( i = 0; i < numTabs; ++i )
     {
         wxRibbonPageTabInfo& info = m_pages.Item(i);
-        if (!info.shown)
+        if ( !info.m_shown )
             continue;
 
         dc.DestroyClippingRegion();
-        if(m_tab_scroll_buttons_shown)
+        if ( m_tabScrollButtonsShown )
         {
-            if(!tabs_rect.Intersects(info.rect))
+            if ( !tabsRect.Intersects(info.m_rect) )
                 continue;
-            dc.SetClippingRegion(tabs_rect);
+            dc.SetClippingRegion(tabsRect);
         }
-        dc.SetClippingRegion(info.rect);
+        dc.SetClippingRegion(info.m_rect);
         m_art->DrawTab(dc, this, info);
 
-        if(info.rect.width < info.small_begin_need_separator_width)
+        if ( info.m_rect.width < info.m_smallBeginNeedSeparatorWidth )
         {
-            draw_sep = true;
-            if(info.rect.width < info.small_must_have_separator_width)
+            drawSep = true;
+            if ( info.m_rect.width < info.m_smallMustHaveSeparatorWidth )
             {
-                sep_visibility += 1.0;
+                sepVisibility += 1.0;
             }
             else
             {
-                sep_visibility += (double)(info.small_begin_need_separator_width - info.rect.width) / (double)(info.small_begin_need_separator_width - info.small_must_have_separator_width);
+                sepVisibility += (double)(info.m_smallBeginNeedSeparatorWidth - info.m_rect.width) /
+                                 (double)(info.m_smallBeginNeedSeparatorWidth - info.m_smallMustHaveSeparatorWidth);
             }
         }
     }
-    if(draw_sep)
+    if ( drawSep )
     {
-        wxRect rect = m_pages.Item(0).rect;
+        wxRect rect = m_pages.Item(0).m_rect;
         rect.width = m_art->GetMetric(wxRIBBON_ART_TAB_SEPARATION_SIZE);
-        sep_visibility /= (double)numtabs;
-        for(i = 0; i < numtabs - 1; ++i)
+        sepVisibility /= (double)numTabs;
+        for ( i = 0; i < numTabs - 1; ++i )
         {
             wxRibbonPageTabInfo& info = m_pages.Item(i);
-            if (!info.shown)
+            if ( !info.m_shown )
                 continue;
-            rect.x = info.rect.x + info.rect.width;
+            rect.x = info.m_rect.x + info.m_rect.width;
 
-            if(m_tab_scroll_buttons_shown && !tabs_rect.Intersects(rect))
+            if ( m_tabScrollButtonsShown && !tabsRect.Intersects(rect) )
             {
                 continue;
             }
 
             dc.DestroyClippingRegion();
             dc.SetClippingRegion(rect);
-            m_art->DrawTabSeparator(dc, this, rect, sep_visibility);
+            m_art->DrawTabSeparator(dc, this, rect, sepVisibility);
         }
     }
-    if(m_tab_scroll_buttons_shown)
+    if ( m_tabScrollButtonsShown )
     {
-        if(m_tab_scroll_left_button_rect.GetWidth() != 0)
+        if ( m_tabScrollLeftButtonRect.GetWidth() != 0 )
         {
             dc.DestroyClippingRegion();
-            dc.SetClippingRegion(m_tab_scroll_left_button_rect);
-            m_art->DrawScrollButton(dc, this, m_tab_scroll_left_button_rect, wxRIBBON_SCROLL_BTN_LEFT | m_tab_scroll_left_button_state | wxRIBBON_SCROLL_BTN_FOR_TABS);
+            dc.SetClippingRegion(m_tabScrollLeftButtonRect);
+            m_art->DrawScrollButton(dc, this, m_tabScrollLeftButtonRect, wxRIBBON_SCROLL_BTN_LEFT | m_tabScrollLeftButtonState | wxRIBBON_SCROLL_BTN_FOR_TABS);
         }
-        if(m_tab_scroll_right_button_rect.GetWidth() != 0)
+        if ( m_tabScrollRightButtonRect.GetWidth() != 0 )
         {
             dc.DestroyClippingRegion();
-            dc.SetClippingRegion(m_tab_scroll_right_button_rect);
-            m_art->DrawScrollButton(dc, this, m_tab_scroll_right_button_rect, wxRIBBON_SCROLL_BTN_RIGHT | m_tab_scroll_right_button_state | wxRIBBON_SCROLL_BTN_FOR_TABS);
+            dc.SetClippingRegion(m_tabScrollRightButtonRect);
+            m_art->DrawScrollButton(dc, this, m_tabScrollRightButtonRect, wxRIBBON_SCROLL_BTN_RIGHT | m_tabScrollRightButtonState | wxRIBBON_SCROLL_BTN_FOR_TABS);
         }
     }
 
-    if ( m_flags & wxRIBBON_BAR_SHOW_HELP_BUTTON  )
-        m_art->DrawHelpButton(dc, this, m_help_button_rect);
-    if ( m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON  )
-        m_art->DrawToggleButton(dc, this, m_toggle_button_rect, m_ribbon_state);
+    if ( m_flags & wxRIBBON_BAR_SHOW_HELP_BUTTON )
+        m_art->DrawHelpButton(dc, this, m_helpButtonRect);
+    if ( m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON )
+        m_art->DrawToggleButton(dc, this, m_toggleButtonRect, m_ribbonState);
 
 }
 
@@ -949,16 +951,16 @@ void wxRibbonBar::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
 void wxRibbonBar::DoEraseBackground(wxDC& dc)
 {
     wxRect tabs(GetSize());
-    tabs.height = m_tab_height;
+    tabs.height = m_tabHeight;
     m_art->DrawTabCtrlBackground(dc, this, tabs);
 }
 
 void wxRibbonBar::OnSize(wxSizeEvent& evt)
 {
     RecalculateTabSizes();
-    if(m_current_page != wxNOT_FOUND)
+    if ( m_currentPage != wxNOT_FOUND )
     {
-        RepositionPage(m_pages.Item(m_current_page).page);
+        RepositionPage(m_pages.Item(m_currentPage).m_page);
     }
     RefreshTabBar();
 
@@ -971,16 +973,16 @@ void wxRibbonBar::OnDPIChanged(wxDPIChangedEvent& event)
     RecalculateTabSizes();
 
     // Realize all pages to update their layouts
-    size_t page_count = m_pages.GetCount();
-    for(size_t i = 0; i < page_count; ++i)
+    size_t pageCount = m_pages.GetCount();
+    for ( size_t i = 0; i < pageCount; ++i )
     {
-        m_pages.Item(i).page->Realize();
+        m_pages.Item(i).m_page->Realize();
     }
 
     // Reposition current page
-    if(m_current_page != wxNOT_FOUND)
+    if ( m_currentPage != wxNOT_FOUND )
     {
-        RepositionPage(m_pages.Item(m_current_page).page);
+        RepositionPage(m_pages.Item(m_currentPage).m_page);
     }
 
     Refresh();
@@ -991,29 +993,29 @@ void wxRibbonBar::RepositionPage(wxRibbonPage *page)
 {
     int w, h;
     GetSize(&w, &h);
-    page->SetSizeWithScrollButtonAdjustment(0, m_tab_height, w, h - m_tab_height);
+    page->SetSizeWithScrollButtonAdjustment(0, m_tabHeight, w, h - m_tabHeight);
 }
 
 wxRibbonPageTabInfo* wxRibbonBar::HitTestTabs(wxPoint position, int* index)
 {
-    wxRect tabs_rect(m_tab_margin_left, 0, GetClientSize().GetWidth() - m_tab_margin_left - m_tab_margin_right, m_tab_height);
-    if(m_tab_scroll_buttons_shown)
+    wxRect tabsRect(m_tabMarginLeft, 0, GetClientSize().GetWidth() - m_tabMarginLeft - m_tabMarginRight, m_tabHeight);
+    if ( m_tabScrollButtonsShown )
     {
-        tabs_rect.SetX(tabs_rect.GetX() + m_tab_scroll_left_button_rect.GetWidth());
-        tabs_rect.SetWidth(tabs_rect.GetWidth() - m_tab_scroll_left_button_rect.GetWidth() - m_tab_scroll_right_button_rect.GetWidth());
+        tabsRect.SetX(tabsRect.GetX() + m_tabScrollLeftButtonRect.GetWidth());
+        tabsRect.SetWidth(tabsRect.GetWidth() - m_tabScrollLeftButtonRect.GetWidth() - m_tabScrollRightButtonRect.GetWidth());
     }
-    if(tabs_rect.Contains(position))
+    if ( tabsRect.Contains(position) )
     {
-        size_t numtabs = m_pages.GetCount();
+        size_t numTabs = m_pages.GetCount();
         size_t i;
-        for(i = 0; i < numtabs; ++i)
+        for ( i = 0; i < numTabs; ++i )
         {
             wxRibbonPageTabInfo& info = m_pages.Item(i);
-            if (!info.shown)
+            if ( !info.m_shown )
                 continue;
-            if(info.rect.Contains(position))
+            if ( info.m_rect.Contains(position) )
             {
-                if(index != nullptr)
+                if ( index != nullptr )
                 {
                     *index = (int)i;
                 }
@@ -1021,7 +1023,7 @@ wxRibbonPageTabInfo* wxRibbonBar::HitTestTabs(wxPoint position, int* index)
             }
         }
     }
-    if(index != nullptr)
+    if ( index != nullptr )
     {
         *index = -1;
     }
@@ -1034,65 +1036,65 @@ void wxRibbonBar::OnMouseLeftDown(wxMouseEvent& evt)
     SetFocus();
     if ( tab )
     {
-        if ( m_ribbon_state == wxRIBBON_BAR_MINIMIZED )
+        if ( m_ribbonState == wxRIBBON_BAR_MINIMIZED )
         {
             ShowPanels(wxRIBBON_BAR_EXPANDED);
         }
-        else if ( (tab == &m_pages.Item(m_current_page)) && (m_ribbon_state == wxRIBBON_BAR_EXPANDED) )
+        else if ( (tab == &m_pages.Item(m_currentPage)) && (m_ribbonState == wxRIBBON_BAR_EXPANDED) )
         {
             HidePanels();
         }
     }
     else
     {
-        if ( m_ribbon_state == wxRIBBON_BAR_EXPANDED )
+        if ( m_ribbonState == wxRIBBON_BAR_EXPANDED )
         {
             HidePanels();
         }
     }
-    if(tab && tab != &m_pages.Item(m_current_page))
+    if ( tab && tab != &m_pages.Item(m_currentPage) )
     {
-        wxRibbonBarEvent query(wxEVT_RIBBONBAR_PAGE_CHANGING, GetId(), tab->page);
+        wxRibbonBarEvent query(wxEVT_RIBBONBAR_PAGE_CHANGING, GetId(), tab->m_page);
         query.SetEventObject(this);
         ProcessWindowEvent(query);
-        if(query.IsAllowed())
+        if ( query.IsAllowed() )
         {
             SetActivePage(query.GetPage());
 
-            wxRibbonBarEvent notification(wxEVT_RIBBONBAR_PAGE_CHANGED, GetId(), m_pages.Item(m_current_page).page);
+            wxRibbonBarEvent notification(wxEVT_RIBBONBAR_PAGE_CHANGED, GetId(), m_pages.Item(m_currentPage).m_page);
             notification.SetEventObject(this);
             ProcessWindowEvent(notification);
         }
     }
-    else if(tab == nullptr)
+    else if ( tab == nullptr )
     {
-        if(m_tab_scroll_left_button_rect.Contains(evt.GetPosition()))
+        if ( m_tabScrollLeftButtonRect.Contains(evt.GetPosition()) )
         {
-            m_tab_scroll_left_button_state |= wxRIBBON_SCROLL_BTN_ACTIVE | wxRIBBON_SCROLL_BTN_HOVERED;
+            m_tabScrollLeftButtonState |= wxRIBBON_SCROLL_BTN_ACTIVE | wxRIBBON_SCROLL_BTN_HOVERED;
             RefreshTabBar();
         }
-        else if(m_tab_scroll_right_button_rect.Contains(evt.GetPosition()))
+        else if ( m_tabScrollRightButtonRect.Contains(evt.GetPosition()) )
         {
-            m_tab_scroll_right_button_state |= wxRIBBON_SCROLL_BTN_ACTIVE | wxRIBBON_SCROLL_BTN_HOVERED;
+            m_tabScrollRightButtonState |= wxRIBBON_SCROLL_BTN_ACTIVE | wxRIBBON_SCROLL_BTN_HOVERED;
             RefreshTabBar();
         }
     }
 
     wxPoint position = evt.GetPosition();
 
-    if(position.x >= 0 && position.y >= 0)
+    if ( position.x >= 0 && position.y >= 0 )
     {
         wxSize size = GetSize();
-        if(position.x < size.GetWidth() && position.y < size.GetHeight())
+        if ( position.x < size.GetWidth() && position.y < size.GetHeight() )
         {
-            if(m_toggle_button_rect.Contains(position))
+            if ( m_toggleButtonRect.Contains(position) )
             {
                 ShowPanels(ArePanelsShown() ? wxRIBBON_BAR_MINIMIZED : wxRIBBON_BAR_PINNED);
                 wxRibbonBarEvent event(wxEVT_RIBBONBAR_TOGGLED, GetId());
                 event.SetEventObject(this);
                 ProcessWindowEvent(event);
             }
-            if ( m_help_button_rect.Contains(position) )
+            if ( m_helpButtonRect.Contains(position) )
             {
                 wxRibbonBarEvent event(wxEVT_RIBBONBAR_HELP_CLICK, GetId());
                 event.SetEventObject(this);
@@ -1104,83 +1106,83 @@ void wxRibbonBar::OnMouseLeftDown(wxMouseEvent& evt)
 
 void wxRibbonBar::OnMouseLeftUp(wxMouseEvent& WXUNUSED(evt))
 {
-    if(!m_tab_scroll_buttons_shown)
+    if ( !m_tabScrollButtonsShown )
     {
         return;
     }
 
     int amount = 0;
-    if(m_tab_scroll_left_button_state & wxRIBBON_SCROLL_BTN_ACTIVE)
+    if ( m_tabScrollLeftButtonState & wxRIBBON_SCROLL_BTN_ACTIVE )
     {
         amount = -1;
     }
-    else if(m_tab_scroll_right_button_state & wxRIBBON_SCROLL_BTN_ACTIVE)
+    else if ( m_tabScrollRightButtonState & wxRIBBON_SCROLL_BTN_ACTIVE )
     {
         amount = 1;
     }
-    if(amount != 0)
+    if ( amount != 0 )
     {
-        m_tab_scroll_left_button_state &= ~wxRIBBON_SCROLL_BTN_ACTIVE;
-        m_tab_scroll_right_button_state &= ~wxRIBBON_SCROLL_BTN_ACTIVE;
+        m_tabScrollLeftButtonState &= ~wxRIBBON_SCROLL_BTN_ACTIVE;
+        m_tabScrollRightButtonState &= ~wxRIBBON_SCROLL_BTN_ACTIVE;
         ScrollTabBar(amount * 8);
     }
 }
 
 void wxRibbonBar::ScrollTabBar(int amount)
 {
-    bool show_left = true;
-    bool show_right = true;
-    if(m_tab_scroll_amount + amount <= 0)
+    bool showLeft = true;
+    bool showRight = true;
+    if ( m_tabScrollAmount + amount <= 0 )
     {
-        amount = -m_tab_scroll_amount;
-        show_left = false;
+        amount = -m_tabScrollAmount;
+        showLeft = false;
     }
-    else if(m_tab_scroll_amount + amount + (GetClientSize().GetWidth() - m_tab_margin_left - m_tab_margin_right) >= m_tabs_total_width_minimum)
+    else if ( m_tabScrollAmount + amount + (GetClientSize().GetWidth() - m_tabMarginLeft - m_tabMarginRight) >= m_tabsTotalWidthMinimum )
     {
-        amount = m_tabs_total_width_minimum - m_tab_scroll_amount - (GetClientSize().GetWidth() - m_tab_margin_left - m_tab_margin_right);
-        show_right = false;
+        amount = m_tabsTotalWidthMinimum - m_tabScrollAmount - (GetClientSize().GetWidth() - m_tabMarginLeft - m_tabMarginRight);
+        showRight = false;
     }
-    if(amount == 0)
+    if ( amount == 0 )
     {
         return;
     }
-    m_tab_scroll_amount += amount;
-    size_t numtabs = m_pages.GetCount();
+    m_tabScrollAmount += amount;
+    size_t numTabs = m_pages.GetCount();
     size_t i;
-    for(i = 0; i < numtabs; ++i)
+    for ( i = 0; i < numTabs; ++i )
     {
         wxRibbonPageTabInfo& info = m_pages.Item(i);
-        if (!info.shown)
+        if ( !info.m_shown )
             continue;
-        info.rect.SetX(info.rect.GetX() - amount);
+        info.m_rect.SetX(info.m_rect.GetX() - amount);
     }
-    if(show_right != (m_tab_scroll_right_button_rect.GetWidth() != 0) ||
-        show_left != (m_tab_scroll_left_button_rect.GetWidth() != 0))
+    if ( showRight != (m_tabScrollRightButtonRect.GetWidth() != 0) ||
+        showLeft != (m_tabScrollLeftButtonRect.GetWidth() != 0) )
     {
-        wxInfoDC temp_dc(this);
-        if(show_left)
+        wxInfoDC tempDc(this);
+        if ( showLeft )
         {
-            m_tab_scroll_left_button_rect.SetWidth(m_art->GetScrollButtonMinimumSize(temp_dc, this, wxRIBBON_SCROLL_BTN_LEFT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
+            m_tabScrollLeftButtonRect.SetWidth(m_art->GetScrollButtonMinimumSize(tempDc, this, wxRIBBON_SCROLL_BTN_LEFT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
         }
         else
         {
-            m_tab_scroll_left_button_rect.SetWidth(0);
+            m_tabScrollLeftButtonRect.SetWidth(0);
         }
 
-        if(show_right)
+        if ( showRight )
         {
-            if(m_tab_scroll_right_button_rect.GetWidth() == 0)
+            if ( m_tabScrollRightButtonRect.GetWidth() == 0 )
             {
-                m_tab_scroll_right_button_rect.SetWidth(m_art->GetScrollButtonMinimumSize(temp_dc, this, wxRIBBON_SCROLL_BTN_RIGHT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
-                m_tab_scroll_right_button_rect.SetX(m_tab_scroll_right_button_rect.GetX() - m_tab_scroll_right_button_rect.GetWidth());
+                m_tabScrollRightButtonRect.SetWidth(m_art->GetScrollButtonMinimumSize(tempDc, this, wxRIBBON_SCROLL_BTN_RIGHT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());
+                m_tabScrollRightButtonRect.SetX(m_tabScrollRightButtonRect.GetX() - m_tabScrollRightButtonRect.GetWidth());
             }
         }
         else
         {
-            if(m_tab_scroll_right_button_rect.GetWidth() != 0)
+            if ( m_tabScrollRightButtonRect.GetWidth() != 0 )
             {
-                m_tab_scroll_right_button_rect.SetX(m_tab_scroll_right_button_rect.GetX() + m_tab_scroll_right_button_rect.GetWidth());
-                m_tab_scroll_right_button_rect.SetWidth(0);
+                m_tabScrollRightButtonRect.SetX(m_tabScrollRightButtonRect.GetX() + m_tabScrollRightButtonRect.GetWidth());
+                m_tabScrollRightButtonRect.SetWidth(0);
             }
         }
     }
@@ -1190,8 +1192,8 @@ void wxRibbonBar::ScrollTabBar(int amount)
 
 void wxRibbonBar::RefreshTabBar()
 {
-    wxRect tab_rect(0, 0, GetClientSize().GetWidth(), m_tab_height);
-    Refresh(false, &tab_rect);
+    wxRect tabRect(0, 0, GetClientSize().GetWidth(), m_tabHeight);
+    Refresh(false, &tabRect);
 }
 
 void wxRibbonBar::OnMouseMiddleDown(wxMouseEvent& evt)
@@ -1218,9 +1220,9 @@ void wxRibbonBar::OnMouseDoubleClick(wxMouseEvent& evt)
 {
     wxRibbonPageTabInfo *tab = HitTestTabs(evt.GetPosition());
     SetFocus();
-    if ( tab && tab == &m_pages.Item(m_current_page) )
+    if ( tab && tab == &m_pages.Item(m_currentPage) )
     {
-        if ( m_ribbon_state == wxRIBBON_BAR_PINNED )
+        if ( m_ribbonState == wxRIBBON_BAR_PINNED )
         {
             HidePanels();
         }
@@ -1231,12 +1233,12 @@ void wxRibbonBar::OnMouseDoubleClick(wxMouseEvent& evt)
     }
 }
 
-void wxRibbonBar::DoMouseButtonCommon(wxMouseEvent& evt, wxEventType tab_event_type)
+void wxRibbonBar::DoMouseButtonCommon(wxMouseEvent& evt, wxEventType tabEventType)
 {
     wxRibbonPageTabInfo *tab = HitTestTabs(evt.GetPosition());
-    if(tab)
+    if ( tab )
     {
-        wxRibbonBarEvent notification(tab_event_type, GetId(), tab->page);
+        wxRibbonBarEvent notification(tabEventType, GetId(), tab->m_page);
         notification.SetEventObject(this);
         ProcessWindowEvent(notification);
     }
@@ -1244,77 +1246,77 @@ void wxRibbonBar::DoMouseButtonCommon(wxMouseEvent& evt, wxEventType tab_event_t
 
 void wxRibbonBar::RecalculateMinSize()
 {
-    wxSize min_size(wxDefaultCoord, wxDefaultCoord);
-    size_t numtabs = m_pages.GetCount();
-    if(numtabs != 0)
+    wxSize minSize(wxDefaultCoord, wxDefaultCoord);
+    size_t numTabs = m_pages.GetCount();
+    if ( numTabs != 0 )
     {
-        min_size = m_pages.Item(0).page->GetMinSize();
+        minSize = m_pages.Item(0).m_page->GetMinSize();
 
         size_t i;
-        for(i = 1; i < numtabs; ++i)
+        for ( i = 1; i < numTabs; ++i )
         {
             wxRibbonPageTabInfo& info = m_pages.Item(i);
-            if (!info.shown)
+            if ( !info.m_shown )
                 continue;
-            wxSize page_min = info.page->GetMinSize();
+            wxSize pageMin = info.m_page->GetMinSize();
 
-            min_size.x = wxMax(min_size.x, page_min.x);
-            min_size.y = wxMax(min_size.y, page_min.y);
+            minSize.x = wxMax(minSize.x, pageMin.x);
+            minSize.y = wxMax(minSize.y, pageMin.y);
         }
     }
-    if(min_size.y != wxDefaultCoord)
+    if ( minSize.y != wxDefaultCoord )
     {
         // TODO: Decide on best course of action when min height is unspecified
         // - should we specify it to the tab minimum, or leave it unspecified?
-        min_size.IncBy(0, m_tab_height);
+        minSize.IncBy(0, m_tabHeight);
     }
 
-    m_minWidth = min_size.GetWidth();
-    m_minHeight = m_arePanelsShown ? min_size.GetHeight() : m_tab_height;
+    m_minWidth = minSize.GetWidth();
+    m_minHeight = m_arePanelsShown ? minSize.GetHeight() : m_tabHeight;
 }
 
 wxSize wxRibbonBar::DoGetBestSize() const
 {
     wxSize best(0, 0);
-    if(m_current_page != wxNOT_FOUND)
+    if ( m_currentPage != wxNOT_FOUND )
     {
-        best = m_pages.Item(m_current_page).page->GetBestSize();
+        best = m_pages.Item(m_currentPage).m_page->GetBestSize();
     }
-    if(best.GetHeight() == wxDefaultCoord)
+    if ( best.GetHeight() == wxDefaultCoord )
     {
-        best.SetHeight(m_tab_height);
+        best.SetHeight(m_tabHeight);
     }
     else
     {
-        best.IncBy(0, m_tab_height);
+        best.IncBy(0, m_tabHeight);
     }
-    if(!m_arePanelsShown)
+    if ( !m_arePanelsShown )
     {
-        best.SetHeight(m_tab_height);
+        best.SetHeight(m_tabHeight);
     }
     return best;
 }
 
-void wxRibbonBar::HitTestRibbonButton(const wxRect& rect, const wxPoint& position, bool &hover_flag)
+void wxRibbonBar::HitTestRibbonButton(const wxRect& rect, const wxPoint& position, bool &hoverFlag)
 {
     bool hovered = false;
-    if(position.x >= 0 && position.y >= 0)
+    if ( position.x >= 0 && position.y >= 0 )
     {
         wxSize size = GetSize();
-        if(position.x < size.GetWidth() && position.y < size.GetHeight())
+        if ( position.x < size.GetWidth() && position.y < size.GetHeight() )
         {
             hovered = true;
         }
     }
-    if(hovered)
+    if ( hovered )
     {
-        bool toggle_button_hovered;
-        toggle_button_hovered = rect.Contains(position);
+        bool toggleButtonHovered;
+        toggleButtonHovered = rect.Contains(position);
 
-        if ( hovered != m_bar_hovered || toggle_button_hovered != hover_flag )
+        if ( hovered != m_barHovered || toggleButtonHovered != hoverFlag )
         {
-            m_bar_hovered = hovered;
-            hover_flag = toggle_button_hovered;
+            m_barHovered = hovered;
+            hoverFlag = toggleButtonHovered;
             Refresh(false);
         }
     }
@@ -1322,7 +1324,7 @@ void wxRibbonBar::HitTestRibbonButton(const wxRect& rect, const wxPoint& positio
 
 void wxRibbonBar::HideIfExpanded()
 {
-    if ( m_ribbon_state == wxRIBBON_BAR_EXPANDED)
+    if ( m_ribbonState == wxRIBBON_BAR_EXPANDED )
         HidePanels();
 }
 

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/buttonbar.cpp
 // Purpose:     Ribbon control similar to a tool bar
 // Author:      Peter Cawley
@@ -22,7 +22,7 @@
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 wxDEFINE_EVENT(wxEVT_RIBBONBUTTONBAR_CLICKED, wxRibbonButtonBarEvent);
@@ -47,10 +47,10 @@ wxEND_EVENT_TABLE()
 class wxRibbonButtonBarButtonSizeInfo
 {
 public:
-    bool is_supported;
+    bool isSupported;
     wxSize size;
-    wxRect normal_region;
-    wxRect dropdown_region;
+    wxRect normalRegion;
+    wxRect dropdownRegion;
 };
 
 class wxRibbonButtonBarButtonInstance
@@ -100,38 +100,38 @@ public:
 
     wxRibbonButtonBarButtonState GetLargestSize()
     {
-        if(sizes[wxRIBBON_BUTTONBAR_BUTTON_LARGE].is_supported
-           && max_size_class >= wxRIBBON_BUTTONBAR_BUTTON_LARGE)
+        if ( sizes[wxRIBBON_BUTTONBAR_BUTTON_LARGE].isSupported
+           && maxSizeClass >= wxRIBBON_BUTTONBAR_BUTTON_LARGE )
         {
             return wxRIBBON_BUTTONBAR_BUTTON_LARGE;
         }
-        if(sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].is_supported
-           && max_size_class >= wxRIBBON_BUTTONBAR_BUTTON_MEDIUM)
+        if ( sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].isSupported
+           && maxSizeClass >= wxRIBBON_BUTTONBAR_BUTTON_MEDIUM )
         {
             return wxRIBBON_BUTTONBAR_BUTTON_MEDIUM;
         }
-        wxASSERT(sizes[wxRIBBON_BUTTONBAR_BUTTON_SMALL].is_supported);
+        wxASSERT(sizes[wxRIBBON_BUTTONBAR_BUTTON_SMALL].isSupported);
         return wxRIBBON_BUTTONBAR_BUTTON_SMALL;
     }
 
     bool GetSmallerSize(
         wxRibbonButtonBarButtonState* size, int n = 1)
     {
-        for(; n > 0; --n)
+        for ( ; n > 0; --n )
         {
-            switch(*size)
+            switch ( *size )
             {
             case wxRIBBON_BUTTONBAR_BUTTON_LARGE:
-                if(sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].is_supported
-                   && min_size_class <= wxRIBBON_BUTTONBAR_BUTTON_MEDIUM)
+                if ( sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].isSupported
+                   && minSizeClass <= wxRIBBON_BUTTONBAR_BUTTON_MEDIUM )
                 {
                     *size = wxRIBBON_BUTTONBAR_BUTTON_MEDIUM;
                     break;
                 }
                 wxFALLTHROUGH;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
-                if(sizes[wxRIBBON_BUTTONBAR_BUTTON_SMALL].is_supported
-                   && min_size_class <= wxRIBBON_BUTTONBAR_BUTTON_SMALL)
+                if ( sizes[wxRIBBON_BUTTONBAR_BUTTON_SMALL].isSupported
+                   && minSizeClass <= wxRIBBON_BUTTONBAR_BUTTON_SMALL )
                 {
                     *size = wxRIBBON_BUTTONBAR_BUTTON_SMALL;
                     break;
@@ -146,8 +146,8 @@ public:
     }
 
     wxString label;
-    wxString help_string;
-    wxCoord text_min_width[3];
+    wxString helpString;
+    wxCoord textMinWidth[3];
 
     // Indices into parent wxRibbonButtonBar's wxWithImages collections
     int imageIndexLarge;
@@ -156,9 +156,9 @@ public:
     int imageIndexSmallDisabled;
 
     wxRibbonButtonBarButtonSizeInfo sizes[3];
-    wxRibbonButtonBarButtonState min_size_class;
-    wxRibbonButtonBarButtonState max_size_class;
-    wxClientDataContainer client_data;
+    wxRibbonButtonBarButtonState minSizeClass;
+    wxRibbonButtonBarButtonState maxSizeClass;
+    wxClientDataContainer clientData;
     int id;
     wxRibbonButtonKind kind;
     long state;
@@ -167,24 +167,24 @@ public:
 class wxRibbonButtonBarLayout
 {
 public:
-    wxSize overall_size;
+    wxSize overallSize;
     std::vector<wxRibbonButtonBarButtonInstance> buttons;
 
     void CalculateOverallSize()
     {
-        overall_size = wxSize(0, 0);
+        overallSize = wxSize(0, 0);
         for ( auto& instance : buttons )
         {
             wxSize size = instance.base->sizes[instance.size].size;
             int right = instance.position.x + size.GetWidth();
             int bottom = instance.position.y + size.GetHeight();
-            if(right > overall_size.GetWidth())
+            if ( right > overallSize.GetWidth() )
             {
-                overall_size.SetWidth(right);
+                overallSize.SetWidth(right);
             }
-            if(bottom > overall_size.GetHeight())
+            if ( bottom > overallSize.GetHeight() )
             {
-                overall_size.SetHeight(bottom);
+                overallSize.SetHeight(bottom);
             }
         }
     }
@@ -192,13 +192,13 @@ public:
     wxRibbonButtonBarButtonInstance* FindSimilarInstance(
         wxRibbonButtonBarButtonInstance* inst)
     {
-        if(inst == nullptr)
+        if ( inst == nullptr )
         {
             return nullptr;
         }
         for ( auto& instance : buttons )
         {
-            if(instance.base == inst->base)
+            if ( instance.base == inst->base )
             {
                 return &instance;
             }
@@ -209,8 +209,8 @@ public:
 
 wxRibbonButtonBar::wxRibbonButtonBar()
 {
-    m_layouts_valid = false;
-    CommonInit (0);
+    m_layoutsValid = false;
+    CommonInit(0);
 }
 
 wxRibbonButtonBar::wxRibbonButtonBar(wxWindow* parent,
@@ -220,7 +220,7 @@ wxRibbonButtonBar::wxRibbonButtonBar(wxWindow* parent,
                   long style)
     : wxRibbonControl(parent, id, pos, size, wxBORDER_NONE)
 {
-    m_layouts_valid = false;
+    m_layoutsValid = false;
 
     CommonInit(style);
 }
@@ -229,7 +229,7 @@ wxRibbonButtonBar::~wxRibbonButtonBar()
 {
     size_t count = m_buttons.GetCount();
     size_t i;
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
         delete button;
@@ -237,7 +237,7 @@ wxRibbonButtonBar::~wxRibbonButtonBar()
     m_buttons.Clear();
 
     count = m_layouts.GetCount();
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonButtonBarLayout* layout = m_layouts.Item(i);
         delete layout;
@@ -251,7 +251,7 @@ bool wxRibbonButtonBar::Create(wxWindow* parent,
                 const wxSize& size,
                 long style)
 {
-    if(!wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE))
+    if ( !wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE) )
     {
         return false;
     }
@@ -261,91 +261,91 @@ bool wxRibbonButtonBar::Create(wxWindow* parent,
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::AddButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind)
 {
-    return AddButton(button_id, label, bitmap, wxBitmapBundle(), wxBitmapBundle(),
-        wxBitmapBundle(), kind, help_string);
+    return AddButton(buttonId, label, bitmap, wxBitmapBundle(), wxBitmapBundle(),
+        wxBitmapBundle(), kind, helpString);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::AddDropdownButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    return AddButton(button_id, label, bitmap, help_string,
+    return AddButton(buttonId, label, bitmap, helpString,
         wxRIBBON_BUTTON_DROPDOWN);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::AddToggleButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    return AddButton(button_id, label, bitmap, help_string,
+    return AddButton(buttonId, label, bitmap, helpString,
         wxRIBBON_BUTTON_TOGGLE);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::AddHybridButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    return AddButton(button_id, label, bitmap, help_string,
+    return AddButton(buttonId, label, bitmap, helpString,
         wxRIBBON_BUTTON_HYBRID);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::AddButton(
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_small,
-                const wxBitmapBundle& bitmap_disabled,
-                const wxBitmapBundle& bitmap_small_disabled,
+                const wxBitmapBundle& bitmapSmall,
+                const wxBitmapBundle& bitmapDisabled,
+                const wxBitmapBundle& bitmapSmallDisabled,
                 wxRibbonButtonKind kind,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    return InsertButton(GetButtonCount(), button_id, label, bitmap,
-        bitmap_small, bitmap_disabled,bitmap_small_disabled, kind, help_string);
+    return InsertButton(GetButtonCount(), buttonId, label, bitmap,
+        bitmapSmall, bitmapDisabled, bitmapSmallDisabled, kind, helpString);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_small,
-                const wxBitmapBundle& bitmap_disabled,
-                const wxBitmapBundle& bitmap_small_disabled,
+                const wxBitmapBundle& bitmapSmall,
+                const wxBitmapBundle& bitmapDisabled,
+                const wxBitmapBundle& bitmapSmallDisabled,
                 wxRibbonButtonKind kind,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    wxASSERT(bitmap.IsOk() || bitmap_small.IsOk());
+    wxASSERT(bitmap.IsOk() || bitmapSmall.IsOk());
 
-    if(m_buttons.IsEmpty())
+    if ( m_buttons.IsEmpty() )
     {
-        if(bitmap.IsOk())
+        if ( bitmap.IsOk() )
         {
-            m_bitmap_size_large = bitmap.GetDefaultSize();
-            if(!bitmap_small.IsOk())
+            m_bitmapSizeLarge = bitmap.GetDefaultSize();
+            if ( !bitmapSmall.IsOk() )
             {
-                m_bitmap_size_small = m_bitmap_size_large;
-                m_bitmap_size_small *= 0.5;
+                m_bitmapSizeSmall = m_bitmapSizeLarge;
+                m_bitmapSizeSmall *= 0.5;
             }
         }
-        if(bitmap_small.IsOk())
+        if ( bitmapSmall.IsOk() )
         {
-            m_bitmap_size_small = bitmap_small.GetDefaultSize();
-            if(!bitmap.IsOk())
+            m_bitmapSizeSmall = bitmapSmall.GetDefaultSize();
+            if ( !bitmap.IsOk() )
             {
-                m_bitmap_size_large = m_bitmap_size_small;
-                m_bitmap_size_large *= 2.0;
+                m_bitmapSizeLarge = m_bitmapSizeSmall;
+                m_bitmapSizeLarge *= 2.0;
             }
         }
     }
@@ -356,55 +356,55 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
     int idxLargeDisabled = -1;
     int idxSmallDisabled = -1;
 
-    if(bitmap.IsOk())
+    if ( bitmap.IsOk() )
     {
         idxLarge = m_bundlesLarge.size();
         m_bundlesLarge.push_back(bitmap);
 
         idxLargeDisabled = m_bundlesLargeDisabled.size();
-        if(bitmap_disabled.IsOk())
+        if ( bitmapDisabled.IsOk() )
         {
-            m_bundlesLargeDisabled.push_back(bitmap_disabled);
+            m_bundlesLargeDisabled.push_back(bitmapDisabled);
         }
         else
         {
             // Generate disabled bitmap from normal one
-            wxBitmap bmp = bitmap.GetBitmap(m_bitmap_size_large);
+            wxBitmap bmp = bitmap.GetBitmap(m_bitmapSizeLarge);
             m_bundlesLargeDisabled.push_back(wxBitmapBundle::FromBitmap(MakeDisabledBitmap(bmp)));
         }
     }
 
-    if(bitmap_small.IsOk())
+    if ( bitmapSmall.IsOk() )
     {
         idxSmall = m_bundlesSmall.size();
-        m_bundlesSmall.push_back(bitmap_small);
+        m_bundlesSmall.push_back(bitmapSmall);
 
         idxSmallDisabled = m_bundlesSmallDisabled.size();
-        if(bitmap_small_disabled.IsOk())
+        if ( bitmapSmallDisabled.IsOk() )
         {
-            m_bundlesSmallDisabled.push_back(bitmap_small_disabled);
+            m_bundlesSmallDisabled.push_back(bitmapSmallDisabled);
         }
         else
         {
             // Generate disabled bitmap from normal one
-            wxBitmap bmp = bitmap_small.GetBitmap(m_bitmap_size_small);
+            wxBitmap bmp = bitmapSmall.GetBitmap(m_bitmapSizeSmall);
             m_bundlesSmallDisabled.push_back(wxBitmapBundle::FromBitmap(MakeDisabledBitmap(bmp)));
         }
     }
-    else if(bitmap.IsOk())
+    else if ( bitmap.IsOk() )
     {
         // No dedicated small bitmap was provided, so derive one from the large
         // bundle. The derived bitmap must have the small default size; otherwise
         // wxBitmapBundle::GetBitmap() would keep returning bitmaps whose logical
         // size is the large default size and the "small" buttons would be drawn
         // too big.
-        const wxSize sizeSmallPhys = ToPhys(FromDIP(m_bitmap_size_small));
+        const wxSize sizeSmallPhys = ToPhys(FromDIP(m_bitmapSizeSmall));
         wxBitmap smallBmp = bitmap.GetBitmap(sizeSmallPhys);
         // Tag the derived bitmap with the small logical size (its scale factor
         // is simply physical/logical) so that the resulting bundle's default
         // size is correct and small buttons are not drawn at the large size.
         smallBmp.SetScaleFactor(static_cast<double>(sizeSmallPhys.y) /
-                                m_bitmap_size_small.y);
+                                m_bitmapSizeSmall.y);
 
         idxSmall = m_bundlesSmall.size();
         m_bundlesSmall.push_back(wxBitmapBundle::FromBitmap(smallBmp));
@@ -415,25 +415,25 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
     }
 
     wxRibbonButtonBarButtonBase* base = new wxRibbonButtonBarButtonBase;
-    base->id = button_id;
+    base->id = buttonId;
     base->label = label;
     base->SetBundleIndices(idxLarge, idxSmall, idxLargeDisabled, idxSmallDisabled);
     base->kind = kind;
-    base->help_string = help_string;
+    base->helpString = helpString;
     base->state = 0;
-    base->text_min_width[0] = 0;
-    base->text_min_width[1] = 0;
-    base->text_min_width[2] = 0;
-    base->min_size_class = wxRIBBON_BUTTONBAR_BUTTON_SMALL;
-    base->max_size_class = wxRIBBON_BUTTONBAR_BUTTON_LARGE;
+    base->textMinWidth[0] = 0;
+    base->textMinWidth[1] = 0;
+    base->textMinWidth[2] = 0;
+    base->minSizeClass = wxRIBBON_BUTTONBAR_BUTTON_SMALL;
+    base->maxSizeClass = wxRIBBON_BUTTONBAR_BUTTON_LARGE;
 
-    wxInfoDC temp_dc(this);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
+    wxInfoDC tempDc(this);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, tempDc);
 
     m_buttons.Insert(base, pos);
-    m_layouts_valid = false;
+    m_layoutsValid = false;
     return base;
 }
 
@@ -444,7 +444,7 @@ wxRibbonButtonBar::SetItemClientObject(wxRibbonButtonBarButtonBase* item,
 {
     wxCHECK_RET( item, "Can't associate client object with an invalid item" );
 
-    item->client_data.SetClientObject(data);
+    item->clientData.SetClientObject(data);
 }
 
 wxClientData*
@@ -452,7 +452,7 @@ wxRibbonButtonBar::GetItemClientObject(const wxRibbonButtonBarButtonBase* item) 
 {
     wxCHECK_MSG( item, nullptr, "Can't get client object for an invalid item" );
 
-    return item->client_data.GetClientObject();
+    return item->clientData.GetClientObject();
 }
 
 void
@@ -461,7 +461,7 @@ wxRibbonButtonBar::SetItemClientData(wxRibbonButtonBarButtonBase* item,
 {
     wxCHECK_RET( item, "Can't associate client data with an invalid item" );
 
-    item->client_data.SetClientData(data);
+    item->clientData.SetClientData(data);
 }
 
 void*
@@ -469,52 +469,52 @@ wxRibbonButtonBar::GetItemClientData(const wxRibbonButtonBarButtonBase* item) co
 {
     wxCHECK_MSG( item, nullptr, "Can't get client data for an invalid item" );
 
-    return item->client_data.GetClientData();
+    return item->clientData.GetClientData();
 }
 
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind)
 {
-    return InsertButton(pos, button_id, label, bitmap, wxBitmapBundle(),
-        wxBitmapBundle(), wxBitmapBundle(), kind, help_string);
+    return InsertButton(pos, buttonId, label, bitmap, wxBitmapBundle(),
+        wxBitmapBundle(), wxBitmapBundle(), kind, helpString);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertDropdownButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    return InsertButton(pos, button_id, label, bitmap, help_string,
+    return InsertButton(pos, buttonId, label, bitmap, helpString,
         wxRIBBON_BUTTON_DROPDOWN);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertToggleButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    return InsertButton(pos, button_id, label, bitmap, help_string,
+    return InsertButton(pos, buttonId, label, bitmap, helpString,
         wxRIBBON_BUTTON_TOGGLE);
 }
 
 wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertHybridButton(
                 size_t pos,
-                int button_id,
+                int buttonId,
                 const wxString& label,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string)
+                const wxString& helpString)
 {
-    return InsertButton(pos, button_id, label, bitmap, help_string,
+    return InsertButton(pos, buttonId, label, bitmap, helpString,
         wxRIBBON_BUTTON_HYBRID);
 }
 
@@ -522,18 +522,18 @@ void wxRibbonButtonBar::FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,
         wxRibbonButtonBarButtonState size, wxReadOnlyDC& dc)
 {
     wxRibbonButtonBarButtonSizeInfo& info = button->sizes[size];
-    if(m_art)
+    if ( m_art )
     {
-        const wxSize bmpSizeLarge = FromDIP(m_bitmap_size_large);
-        const wxSize bmpSizeSmall = FromDIP(m_bitmap_size_small);
+        const wxSize bmpSizeLarge = FromDIP(m_bitmapSizeLarge);
+        const wxSize bmpSizeSmall = FromDIP(m_bitmapSizeSmall);
 
-        info.is_supported = m_art->GetButtonBarButtonSize(dc, this,
-            button->kind, size, button->label, button->text_min_width[size],
+        info.isSupported = m_art->GetButtonBarButtonSize(dc, this,
+            button->kind, size, button->label, button->textMinWidth[size],
             bmpSizeLarge, bmpSizeSmall, &info.size,
-            &info.normal_region, &info.dropdown_region);
+            &info.normalRegion, &info.dropdownRegion);
     }
     else
-        info.is_supported = false;
+        info.isSupported = false;
 }
 
 size_t wxRibbonButtonBar::GetButtonCount() const
@@ -543,20 +543,20 @@ size_t wxRibbonButtonBar::GetButtonCount() const
 
 bool wxRibbonButtonBar::Realize()
 {
-    if(!m_layouts_valid)
+    if ( !m_layoutsValid )
     {
         MakeLayouts();
-        m_layouts_valid = true;
+        m_layoutsValid = true;
     }
     return true;
 }
 
 void wxRibbonButtonBar::ClearButtons()
 {
-    m_layouts_valid = false;
+    m_layoutsValid = false;
     size_t count = m_buttons.GetCount();
     size_t i;
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
         delete button;
@@ -565,21 +565,21 @@ void wxRibbonButtonBar::ClearButtons()
     Realize();
 }
 
-bool wxRibbonButtonBar::DeleteButton(int button_id)
+bool wxRibbonButtonBar::DeleteButton(int buttonId)
 {
     size_t count = m_buttons.GetCount();
     size_t i;
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
-        if(button->id == button_id)
+        if ( button->id == buttonId )
         {
-            m_layouts_valid = false;
+            m_layoutsValid = false;
             m_buttons.RemoveAt(i);
-            if (m_hovered_button && m_hovered_button->base == button)
-                m_hovered_button = nullptr;
-            if (m_active_button  && m_active_button->base  == button)
-                m_active_button = nullptr;
+            if ( m_hoveredButton && m_hoveredButton->base == button )
+                m_hoveredButton = nullptr;
+            if ( m_activeButton  && m_activeButton->base  == button )
+                m_activeButton = nullptr;
             delete button;
             Realize();
             Refresh();
@@ -589,18 +589,18 @@ bool wxRibbonButtonBar::DeleteButton(int button_id)
     return false;
 }
 
-void wxRibbonButtonBar::EnableButton(int button_id, bool enable)
+void wxRibbonButtonBar::EnableButton(int buttonId, bool enable)
 {
     size_t count = m_buttons.GetCount();
     size_t i;
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
-        if(button->id == button_id)
+        if ( button->id == buttonId )
         {
-            if(enable)
+            if ( enable )
             {
-                if(button->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED)
+                if ( button->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED )
                 {
                     button->state &= ~wxRIBBON_BUTTONBAR_BUTTON_DISABLED;
                     Refresh();
@@ -608,7 +608,7 @@ void wxRibbonButtonBar::EnableButton(int button_id, bool enable)
             }
             else
             {
-                if((button->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0)
+                if ( (button->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0 )
                 {
                     button->state |= wxRIBBON_BUTTONBAR_BUTTON_DISABLED;
                     Refresh();
@@ -619,18 +619,18 @@ void wxRibbonButtonBar::EnableButton(int button_id, bool enable)
     }
 }
 
-void wxRibbonButtonBar::ToggleButton(int button_id, bool checked)
+void wxRibbonButtonBar::ToggleButton(int buttonId, bool checked)
 {
     size_t count = m_buttons.GetCount();
     size_t i;
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
-        if(button->id == button_id)
+        if ( button->id == buttonId )
         {
-            if(checked)
+            if ( checked )
             {
-                if((button->state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED) == 0)
+                if ( (button->state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED) == 0 )
                 {
                     button->state |= wxRIBBON_BUTTONBAR_BUTTON_TOGGLED;
                     Refresh();
@@ -638,7 +638,7 @@ void wxRibbonButtonBar::ToggleButton(int button_id, bool checked)
             }
             else
             {
-                if(button->state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED)
+                if ( button->state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED )
                 {
                     button->state &= ~wxRIBBON_BUTTONBAR_BUTTON_TOGGLED;
                     Refresh();
@@ -650,44 +650,44 @@ void wxRibbonButtonBar::ToggleButton(int button_id, bool checked)
 }
 
 void wxRibbonButtonBar::SetButtonIcon(
-                int button_id,
+                int buttonId,
                 const wxBitmapBundle& bitmap,
-                const wxBitmapBundle& bitmap_small,
-                const wxBitmapBundle& bitmap_disabled,
-                const wxBitmapBundle& bitmap_small_disabled)
+                const wxBitmapBundle& bitmapSmall,
+                const wxBitmapBundle& bitmapDisabled,
+                const wxBitmapBundle& bitmapSmallDisabled)
 {
-    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
-    if(base == nullptr)
+    wxRibbonButtonBarButtonBase* base = GetItemById(buttonId);
+    if ( base == nullptr )
         return;
 
     // Update the bundles in our vectors
-    if(bitmap.IsOk() && base->imageIndexLarge >= 0)
+    if ( bitmap.IsOk() && base->imageIndexLarge >= 0 )
     {
         m_bundlesLarge[base->imageIndexLarge] = bitmap;
 
-        if(bitmap_disabled.IsOk())
+        if ( bitmapDisabled.IsOk() )
         {
-            m_bundlesLargeDisabled[base->imageIndexLargeDisabled] = bitmap_disabled;
+            m_bundlesLargeDisabled[base->imageIndexLargeDisabled] = bitmapDisabled;
         }
         else
         {
-            wxBitmap bmp = bitmap.GetBitmap(m_bitmap_size_large);
+            wxBitmap bmp = bitmap.GetBitmap(m_bitmapSizeLarge);
             m_bundlesLargeDisabled[base->imageIndexLargeDisabled] =
                 wxBitmapBundle::FromBitmap(MakeDisabledBitmap(bmp));
         }
     }
 
-    if(bitmap_small.IsOk() && base->imageIndexSmall >= 0)
+    if ( bitmapSmall.IsOk() && base->imageIndexSmall >= 0 )
     {
-        m_bundlesSmall[base->imageIndexSmall] = bitmap_small;
+        m_bundlesSmall[base->imageIndexSmall] = bitmapSmall;
 
-        if(bitmap_small_disabled.IsOk())
+        if ( bitmapSmallDisabled.IsOk() )
         {
-            m_bundlesSmallDisabled[base->imageIndexSmallDisabled] = bitmap_small_disabled;
+            m_bundlesSmallDisabled[base->imageIndexSmallDisabled] = bitmapSmallDisabled;
         }
         else
         {
-            wxBitmap bmp = bitmap_small.GetBitmap(m_bitmap_size_small);
+            wxBitmap bmp = bitmapSmall.GetBitmap(m_bitmapSizeSmall);
             m_bundlesSmallDisabled[base->imageIndexSmallDisabled] =
                 wxBitmapBundle::FromBitmap(MakeDisabledBitmap(bmp));
         }
@@ -696,90 +696,90 @@ void wxRibbonButtonBar::SetButtonIcon(
     Refresh();
 }
 
-void wxRibbonButtonBar::SetButtonText(int button_id, const wxString& label)
+void wxRibbonButtonBar::SetButtonText(int buttonId, const wxString& label)
 {
-    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
-    if(base == nullptr)
+    wxRibbonButtonBarButtonBase* base = GetItemById(buttonId);
+    if ( base == nullptr )
         return;
     base->label = label;
 
-    wxInfoDC temp_dc(this);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
-    m_layouts_valid = false;
+    wxInfoDC tempDc(this);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, tempDc);
+    m_layoutsValid = false;
     Refresh();
 }
 
-void wxRibbonButtonBar::SetButtonTextMinWidth(int button_id,
-                int min_width_medium, int min_width_large)
+void wxRibbonButtonBar::SetButtonTextMinWidth(int buttonId,
+                int minWidthMedium, int minWidthLarge)
 {
-    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
-    if(base == nullptr)
+    wxRibbonButtonBarButtonBase* base = GetItemById(buttonId);
+    if ( base == nullptr )
         return;
-    base->text_min_width[0] = 0;
-    base->text_min_width[1] = min_width_medium;
-    base->text_min_width[2] = min_width_large;
-    wxInfoDC temp_dc(this);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
-    m_layouts_valid = false;
+    base->textMinWidth[0] = 0;
+    base->textMinWidth[1] = minWidthMedium;
+    base->textMinWidth[2] = minWidthLarge;
+    wxInfoDC tempDc(this);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, tempDc);
+    m_layoutsValid = false;
 }
 
 void wxRibbonButtonBar::SetButtonTextMinWidth(
-                int button_id, const wxString& label)
+                int buttonId, const wxString& label)
 {
-    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
-    if(base == nullptr)
+    wxRibbonButtonBarButtonBase* base = GetItemById(buttonId);
+    if ( base == nullptr )
         return;
-    wxInfoDC temp_dc(this);
-    base->text_min_width[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM] =
+    wxInfoDC tempDc(this);
+    base->textMinWidth[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM] =
         m_art->GetButtonBarButtonTextWidth(
-        temp_dc, label, base->kind, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM);
-    base->text_min_width[wxRIBBON_BUTTONBAR_BUTTON_LARGE] =
+        tempDc, label, base->kind, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM);
+    base->textMinWidth[wxRIBBON_BUTTONBAR_BUTTON_LARGE] =
         m_art->GetButtonBarButtonTextWidth(
-        temp_dc, label, base->kind, wxRIBBON_BUTTONBAR_BUTTON_LARGE);
+        tempDc, label, base->kind, wxRIBBON_BUTTONBAR_BUTTON_LARGE);
 
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
-    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
-    m_layouts_valid = false;
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, tempDc);
+    FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, tempDc);
+    m_layoutsValid = false;
 }
 
-void wxRibbonButtonBar::SetButtonMinSizeClass(int button_id,
-                wxRibbonButtonBarButtonState min_size_class)
+void wxRibbonButtonBar::SetButtonMinSizeClass(int buttonId,
+                wxRibbonButtonBarButtonState minSizeClass)
 {
-    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
-    if(base == nullptr)
+    wxRibbonButtonBarButtonBase* base = GetItemById(buttonId);
+    if ( base == nullptr )
         return;
-    if(base->max_size_class < min_size_class)
+    if ( base->maxSizeClass < minSizeClass )
     {
         wxFAIL_MSG("Button minimum size is larger than maximum size");
         return;
     }
-    base->min_size_class = min_size_class;
-    m_layouts_valid = false;
+    base->minSizeClass = minSizeClass;
+    m_layoutsValid = false;
 }
 
-void wxRibbonButtonBar::SetButtonMaxSizeClass(int button_id,
-                wxRibbonButtonBarButtonState max_size_class)
+void wxRibbonButtonBar::SetButtonMaxSizeClass(int buttonId,
+                wxRibbonButtonBarButtonState maxSizeClass)
 {
-    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
-    if(base == nullptr)
+    wxRibbonButtonBarButtonBase* base = GetItemById(buttonId);
+    if ( base == nullptr )
         return;
-    if(base->min_size_class > max_size_class)
+    if ( base->minSizeClass > maxSizeClass )
     {
         wxFAIL_MSG("Button maximum size is smaller than minimum size");
         return;
     }
-    base->max_size_class = max_size_class;
-    m_layouts_valid = false;
+    base->maxSizeClass = maxSizeClass;
+    m_layoutsValid = false;
 }
 
 void wxRibbonButtonBar::SetArtProvider(wxRibbonArtProvider* art)
 {
-    if(art == m_art)
+    if ( art == m_art )
     {
         return;
     }
@@ -790,22 +790,22 @@ void wxRibbonButtonBar::SetArtProvider(wxRibbonArtProvider* art)
     // null during our destruction and this actually results in problems during
     // program shutdown due to trying to get DPI of the already destroyed TLW
     // parent.
-    if (!art)
+    if ( !art )
         return;
 
-    wxInfoDC temp_dc(this);
-    size_t btn_count = m_buttons.Count();
-    size_t btn_i;
-    for(btn_i = 0; btn_i < btn_count; ++btn_i)
+    wxInfoDC tempDc(this);
+    size_t btnCount = m_buttons.Count();
+    size_t btnI;
+    for ( btnI = 0; btnI < btnCount; ++btnI )
     {
-        wxRibbonButtonBarButtonBase* base = m_buttons.Item(btn_i);
+        wxRibbonButtonBarButtonBase* base = m_buttons.Item(btnI);
 
-        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
-        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
-        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
+        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, tempDc);
+        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, tempDc);
+        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, tempDc);
     }
 
-    m_layouts_valid = false;
+    m_layoutsValid = false;
     Realize();
 }
 
@@ -817,16 +817,16 @@ bool wxRibbonButtonBar::IsSizingContinuous() const
 wxSize wxRibbonButtonBar::DoGetNextSmallerSize(wxOrientation direction,
                                              wxSize result) const
 {
-    size_t nlayouts = m_layouts.GetCount();
+    size_t nLayouts = m_layouts.GetCount();
     size_t i;
-    for(i = 0; i < nlayouts; ++i)
+    for ( i = 0; i < nLayouts; ++i )
     {
         wxRibbonButtonBarLayout* layout = m_layouts.Item(i);
-        wxSize size = layout->overall_size;
-        switch(direction)
+        wxSize size = layout->overallSize;
+        switch ( direction )
         {
         case wxHORIZONTAL:
-            if(size.x < result.x && size.y <= result.y)
+            if ( size.x < result.x && size.y <= result.y )
             {
                 result.x = size.x;
                 break;
@@ -834,7 +834,7 @@ wxSize wxRibbonButtonBar::DoGetNextSmallerSize(wxOrientation direction,
             else
                 continue;
         case wxVERTICAL:
-            if(size.x <= result.x && size.y < result.y)
+            if ( size.x <= result.x && size.y < result.y )
             {
                 result.y = size.y;
                 break;
@@ -842,7 +842,7 @@ wxSize wxRibbonButtonBar::DoGetNextSmallerSize(wxOrientation direction,
             else
                 continue;
         case wxBOTH:
-            if(size.x < result.x && size.y < result.y)
+            if ( size.x < result.x && size.y < result.y )
             {
                 result = size;
                 break;
@@ -858,17 +858,17 @@ wxSize wxRibbonButtonBar::DoGetNextSmallerSize(wxOrientation direction,
 wxSize wxRibbonButtonBar::DoGetNextLargerSize(wxOrientation direction,
                                             wxSize result) const
 {
-    size_t nlayouts = m_layouts.GetCount();
-    size_t i = nlayouts;
-    while(i > 0)
+    size_t nLayouts = m_layouts.GetCount();
+    size_t i = nLayouts;
+    while ( i > 0 )
     {
         --i;
         wxRibbonButtonBarLayout* layout = m_layouts.Item(i);
-        wxSize size = layout->overall_size;
-        switch(direction)
+        wxSize size = layout->overallSize;
+        switch ( direction )
         {
         case wxHORIZONTAL:
-            if(size.x > result.x && size.y <= result.y)
+            if ( size.x > result.x && size.y <= result.y )
             {
                 result.x = size.x;
                 break;
@@ -876,7 +876,7 @@ wxSize wxRibbonButtonBar::DoGetNextLargerSize(wxOrientation direction,
             else
                 continue;
         case wxVERTICAL:
-            if(size.x <= result.x && size.y > result.y)
+            if ( size.x <= result.x && size.y > result.y )
             {
                 result.y = size.y;
                 break;
@@ -884,7 +884,7 @@ wxSize wxRibbonButtonBar::DoGetNextLargerSize(wxOrientation direction,
             else
                 continue;
         case wxBOTH:
-            if(size.x > result.x && size.y > result.y)
+            if ( size.x > result.x && size.y > result.y )
             {
                 result = size;
                 break;
@@ -905,11 +905,11 @@ void wxRibbonButtonBar::UpdateWindowUI(long flags)
     if ( !IsShown() )
         return;
 
-    size_t btn_count = m_buttons.size();
+    size_t btnCount = m_buttons.size();
     bool rerealize = false;
-    for ( size_t btn_i = 0; btn_i < btn_count; ++btn_i )
+    for ( size_t btnI = 0; btnI < btnCount; ++btnI )
     {
-        wxRibbonButtonBarButtonBase& btn = *m_buttons.Item(btn_i);
+        wxRibbonButtonBarButtonBase& btn = *m_buttons.Item(btnI);
         int id = btn.id;
 
         wxUpdateUIEvent event(id);
@@ -943,26 +943,26 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
     wxAutoBufferedPaintDC dc(this);
     m_art->DrawButtonBarBackground(dc, this, GetSize());
 
-    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
+    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_currentLayout);
 
     // Calculate DPI-scaled bitmap sizes (must match layout calculation)
     const double scale = GetDPIScaleFactor();
-    const wxSize scaledLarge = m_bitmap_size_large * scale;
-    const wxSize scaledSmall = m_bitmap_size_small * scale;
+    const wxSize scaledLarge = m_bitmapSizeLarge * scale;
+    const wxSize scaledSmall = m_bitmapSizeSmall * scale;
 
     for ( auto& button : layout->buttons )
     {
         wxRibbonButtonBarButtonBase* base = button.base;
-        wxRect rect(button.position + m_layout_offset, base->sizes[button.size].size);
+        wxRect rect(button.position + m_layoutOffset, base->sizes[button.size].size);
 
-        wxBitmap bitmap, bitmap_small;
+        wxBitmap bitmap, bitmapSmall;
 
         bool disabled = (base->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) != 0;
 
-        if(base->imageIndexLarge >= 0)
+        if ( base->imageIndexLarge >= 0 )
         {
             int idx = disabled ? base->imageIndexLargeDisabled : base->imageIndexLarge;
-            if(idx >= 0 && idx < (int)m_bundlesLarge.size())
+            if ( idx >= 0 && idx < (int)m_bundlesLarge.size() )
             {
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesLargeDisabled[idx] : m_bundlesLarge[idx];
@@ -970,29 +970,29 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
             }
         }
 
-        if(base->imageIndexSmall >= 0)
+        if ( base->imageIndexSmall >= 0 )
         {
             int idx = disabled ? base->imageIndexSmallDisabled : base->imageIndexSmall;
-            if(idx >= 0 && idx < (int)m_bundlesSmall.size())
+            if ( idx >= 0 && idx < (int)m_bundlesSmall.size() )
             {
                 const wxBitmapBundle& bundle = disabled ?
                     m_bundlesSmallDisabled[idx] : m_bundlesSmall[idx];
-                bitmap_small = bundle.GetBitmap(scaledSmall);
+                bitmapSmall = bundle.GetBitmap(scaledSmall);
             }
         }
 
         m_art->DrawButtonBarButton(dc, this, rect, base->kind,
-            base->state | button.size, base->label, bitmap, bitmap_small);
+            base->state | button.size, base->label, bitmap, bitmapSmall);
      }
 }
 
 wxBitmap wxRibbonButtonBar::GetButtonBitmap(int imageIndex, bool large) const
 {
-    if(imageIndex < 0)
+    if ( imageIndex < 0 )
         return wxNullBitmap;
 
     const wxVector<wxBitmapBundle>& bundles = large ? m_bundlesLarge : m_bundlesSmall;
-    if(imageIndex >= (int)bundles.size())
+    if ( imageIndex >= (int)bundles.size() )
         return wxNullBitmap;
 
     return bundles[imageIndex].GetBitmapFor(this);
@@ -1000,22 +1000,22 @@ wxBitmap wxRibbonButtonBar::GetButtonBitmap(int imageIndex, bool large) const
 
 void wxRibbonButtonBar::OnSize(wxSizeEvent& evt)
 {
-    wxSize new_size = evt.GetSize();
-    size_t layout_count = m_layouts.GetCount();
-    size_t layout_i;
-    m_current_layout = layout_count - 1;
-    for(layout_i = 0; layout_i < layout_count; ++layout_i)
+    wxSize newSize = evt.GetSize();
+    size_t layoutCount = m_layouts.GetCount();
+    size_t layoutI;
+    m_currentLayout = layoutCount - 1;
+    for ( layoutI = 0; layoutI < layoutCount; ++layoutI )
     {
-        wxSize layout_size = m_layouts.Item(layout_i)->overall_size;
-        if(layout_size.x <= new_size.x && layout_size.y <= new_size.y)
+        wxSize layoutSize = m_layouts.Item(layoutI)->overallSize;
+        if ( layoutSize.x <= newSize.x && layoutSize.y <= newSize.y )
         {
-            m_layout_offset.x = (new_size.x - layout_size.x) / 2;
-            m_layout_offset.y = (new_size.y - layout_size.y) / 2;
-            m_current_layout = layout_i;
+            m_layoutOffset.x = (newSize.x - layoutSize.x) / 2;
+            m_layoutOffset.y = (newSize.y - layoutSize.y) / 2;
+            m_currentLayout = layoutI;
             break;
         }
     }
-    m_hovered_button = m_layouts.Item(m_current_layout)->FindSimilarInstance(m_hovered_button);
+    m_hoveredButton = m_layouts.Item(m_currentLayout)->FindSimilarInstance(m_hoveredButton);
     Refresh();
 }
 
@@ -1026,110 +1026,110 @@ void wxRibbonButtonBar::CommonInit(long WXUNUSED(style))
     // Create() later.
     m_ribbonBar = GetAncestorRibbonBar();
 
-    m_bitmap_size_large = wxSize(32, 32);
-    m_bitmap_size_small = wxSize(16, 16);
+    m_bitmapSizeLarge = wxSize(32, 32);
+    m_bitmapSizeSmall = wxSize(16, 16);
 
-    wxRibbonButtonBarLayout* placeholder_layout = new wxRibbonButtonBarLayout;
-    placeholder_layout->overall_size = wxSize(20, 20);
-    m_layouts.Add(placeholder_layout);
-    m_current_layout = 0;
-    m_layout_offset = wxPoint(0, 0);
-    m_hovered_button = nullptr;
-    m_active_button = nullptr;
-    m_lock_active_state = false;
-    m_show_tooltips_for_disabled = false;
+    wxRibbonButtonBarLayout* placeholderLayout = new wxRibbonButtonBarLayout;
+    placeholderLayout->overallSize = wxSize(20, 20);
+    m_layouts.Add(placeholderLayout);
+    m_currentLayout = 0;
+    m_layoutOffset = wxPoint(0, 0);
+    m_hoveredButton = nullptr;
+    m_activeButton = nullptr;
+    m_lockActiveState = false;
+    m_showTooltipsForDisabled = false;
 
     SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 void wxRibbonButtonBar::SetShowToolTipsForDisabled(bool show)
 {
-    m_show_tooltips_for_disabled = show;
+    m_showTooltipsForDisabled = show;
 }
 
 bool wxRibbonButtonBar::GetShowToolTipsForDisabled() const
 {
-    return m_show_tooltips_for_disabled;
+    return m_showTooltipsForDisabled;
 }
 
 wxSize wxRibbonButtonBar::GetMinSize() const
 {
-    return m_layouts.Last()->overall_size;
+    return m_layouts.Last()->overallSize;
 }
 
 wxSize wxRibbonButtonBar::DoGetBestSize() const
 {
-    return m_layouts.Item(0)->overall_size;
+    return m_layouts.Item(0)->overallSize;
 }
 
 void wxRibbonButtonBar::MakeLayouts()
 {
-    if(m_layouts_valid || m_art == nullptr)
+    if ( m_layoutsValid || m_art == nullptr )
     {
         return;
     }
     {
         // Clear existing layouts
-        if(m_hovered_button)
+        if ( m_hoveredButton )
         {
-            m_hovered_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
-            m_hovered_button = nullptr;
+            m_hoveredButton->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
+            m_hoveredButton = nullptr;
         }
-        if(m_active_button)
+        if ( m_activeButton )
         {
-            m_active_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
-            m_active_button = nullptr;
+            m_activeButton->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
+            m_activeButton = nullptr;
         }
         size_t count = m_layouts.GetCount();
         size_t i;
-        for(i = 0; i < count; ++i)
+        for ( i = 0; i < count; ++i )
         {
             wxRibbonButtonBarLayout* layout = m_layouts.Item(i);
             delete layout;
         }
         m_layouts.Clear();
     }
-    size_t btn_count = m_buttons.Count();
-    size_t btn_i;
+    size_t btnCount = m_buttons.Count();
+    size_t btnI;
 
     // Determine available height:
     // 1 large button or, if not found, 3 medium or small buttons
-    int available_height = 0;
-    bool large_button_found = false;
-    for(btn_i = 0; btn_i < btn_count; ++btn_i)
+    int availableHeight = 0;
+    bool largeButtonFound = false;
+    for ( btnI = 0; btnI < btnCount; ++btnI )
     {
-        wxRibbonButtonBarButtonBase* button = m_buttons.Item(btn_i);
-        wxRibbonButtonBarButtonState size_class = button->GetLargestSize();
-        available_height = wxMax(available_height,
-                                 button->sizes[size_class].size.GetHeight());
-        if(size_class == wxRIBBON_BUTTONBAR_BUTTON_LARGE)
-            large_button_found = true;
+        wxRibbonButtonBarButtonBase* button = m_buttons.Item(btnI);
+        wxRibbonButtonBarButtonState sizeClass = button->GetLargestSize();
+        availableHeight = wxMax(availableHeight,
+                                 button->sizes[sizeClass].size.GetHeight());
+        if ( sizeClass == wxRIBBON_BUTTONBAR_BUTTON_LARGE )
+            largeButtonFound = true;
     }
-    if(!large_button_found)
-        available_height *= 3;
+    if ( !largeButtonFound )
+        availableHeight *= 3;
 
-    int stacked_width = 0;
+    int stackedWidth = 0;
     {
         // Best layout : all buttons large, stacking horizontally,
         //               small buttons small, stacked vertically
         wxRibbonButtonBarLayout* layout = new wxRibbonButtonBarLayout;
         wxPoint cursor(0, 0);
-        for(btn_i = 0; btn_i < btn_count; ++btn_i)
+        for ( btnI = 0; btnI < btnCount; ++btnI )
         {
-            wxRibbonButtonBarButtonBase* button = m_buttons.Item(btn_i);
+            wxRibbonButtonBarButtonBase* button = m_buttons.Item(btnI);
             wxRibbonButtonBarButtonInstance instance = button->NewInstance();
             instance.position = cursor;
             instance.size = button->GetLargestSize();
             wxSize& size = button->sizes[instance.size].size;
 
-            if(instance.size < wxRIBBON_BUTTONBAR_BUTTON_LARGE)
+            if ( instance.size < wxRIBBON_BUTTONBAR_BUTTON_LARGE )
             {
-                stacked_width = wxMax(stacked_width, size.GetWidth());
-                if(cursor.y + size.GetHeight() >= available_height)
+                stackedWidth = wxMax(stackedWidth, size.GetWidth());
+                if ( cursor.y + size.GetHeight() >= availableHeight )
                 {
                     cursor.y = 0;
-                    cursor.x += stacked_width;
-                    stacked_width = 0;
+                    cursor.x += stackedWidth;
+                    stackedWidth = 0;
                 }
                 else
                 {
@@ -1138,11 +1138,11 @@ void wxRibbonButtonBar::MakeLayouts()
             }
             else
             {
-                if(cursor.y != 0)
+                if ( cursor.y != 0 )
                 {
                     cursor.y = 0;
-                    cursor.x += stacked_width;
-                    stacked_width = 0;
+                    cursor.x += stackedWidth;
+                    stackedWidth = 0;
                     instance.position = cursor;
                 }
                 cursor.x += size.GetWidth();
@@ -1152,21 +1152,21 @@ void wxRibbonButtonBar::MakeLayouts()
         layout->CalculateOverallSize();
         m_layouts.Add(layout);
     }
-    if(btn_count >= 2)
+    if ( btnCount >= 2 )
     {
         // Collapse the rightmost buttons and stack them vertically
         // if they are not already small. If rightmost buttons can't
-        // be collapsed because "min_size_class" is set, try it again
+        // be collapsed because "minSizeClass" is set, try it again
         // starting from second rightmost button and so on.
-        size_t iLast = btn_count;
-        while(iLast-- > 0)
+        size_t iLast = btnCount;
+        while ( iLast-- > 0 )
         {
             TryCollapseLayout(m_layouts.Last(), iLast, &iLast,
                               wxRIBBON_BUTTONBAR_BUTTON_MEDIUM);
         }
 
-        iLast = btn_count;
-        while(iLast-- > 0)
+        iLast = btnCount;
+        while ( iLast-- > 0 )
         {
             TryCollapseLayout(m_layouts.Last(), iLast, &iLast,
                               wxRIBBON_BUTTONBAR_BUTTON_SMALL);
@@ -1175,107 +1175,107 @@ void wxRibbonButtonBar::MakeLayouts()
 }
 
 void wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
-                                          size_t first_btn, size_t* last_button,
-                                          wxRibbonButtonBarButtonState target_size)
+                                          size_t firstBtn, size_t* lastButton,
+                                          wxRibbonButtonBarButtonState targetSize)
 {
-    size_t btn_count = m_buttons.Count();
-    size_t btn_i;
-    int used_height = 0;
-    int used_width = 0;
-    int original_column_width = 0;
-    int available_width = 0;
-    int available_height = original->overall_size.GetHeight();
+    size_t btnCount = m_buttons.Count();
+    size_t btnI;
+    int usedHeight = 0;
+    int usedWidth = 0;
+    int originalColumnWidth = 0;
+    int availableWidth = 0;
+    int availableHeight = original->overallSize.GetHeight();
 
     // Search for button range from right which should be
     // collapsed into a column of small buttons.
-    for(btn_i = first_btn + 1; btn_i > 0; /* decrement is inside loop */)
+    for ( btnI = firstBtn + 1; btnI > 0; /* decrement is inside loop */ )
     {
-        --btn_i;
-        wxRibbonButtonBarButtonBase* button = m_buttons.Item(btn_i);
-        wxRibbonButtonBarButtonState large_size_class = button->GetLargestSize();
-        wxSize large_size = button->sizes[large_size_class].size;
-        int t_available_width = available_width;
+        --btnI;
+        wxRibbonButtonBarButtonBase* button = m_buttons.Item(btnI);
+        wxRibbonButtonBarButtonState largeSizeClass = button->GetLargestSize();
+        wxSize largeSize = button->sizes[largeSizeClass].size;
+        int tAvailableWidth = availableWidth;
 
-        original_column_width = wxMax(original_column_width,
-                                      large_size.GetWidth());
+        originalColumnWidth = wxMax(originalColumnWidth,
+                                      largeSize.GetWidth());
 
         // Top button in column: add column width to available width
-        if(original->buttons.at(btn_i).position.y == 0)
+        if ( original->buttons.at(btnI).position.y == 0 )
         {
-            t_available_width += original_column_width;
-            original_column_width = 0;
+            tAvailableWidth += originalColumnWidth;
+            originalColumnWidth = 0;
         }
 
-        wxRibbonButtonBarButtonState small_size_class = large_size_class;
-        if(large_size_class > target_size)
+        wxRibbonButtonBarButtonState smallSizeClass = largeSizeClass;
+        if ( largeSizeClass > targetSize )
         {
-            if(!button->GetSmallerSize(&small_size_class,
-                                       small_size_class - target_size))
+            if ( !button->GetSmallerSize(&smallSizeClass,
+                                       smallSizeClass - targetSize) )
             {
                 // Large button that cannot shrink: stop search
-                ++btn_i;
+                ++btnI;
                 break;
             }
         }
-        wxSize small_size = button->sizes[small_size_class].size;
-        int t_used_height = used_height + small_size.GetHeight();
-        int t_used_width = wxMax(used_width, small_size.GetWidth());
+        wxSize smallSize = button->sizes[smallSizeClass].size;
+        int tUsedHeight = usedHeight + smallSize.GetHeight();
+        int tUsedWidth = wxMax(usedWidth, smallSize.GetWidth());
 
         // Height is full: stop search
-        if(t_used_height > available_height)
+        if ( tUsedHeight > availableHeight )
         {
-            ++btn_i;
+            ++btnI;
             break;
         }
         else
         {
-            used_height = t_used_height;
-            used_width = t_used_width;
-            available_width = t_available_width;
+            usedHeight = tUsedHeight;
+            usedWidth = tUsedWidth;
+            availableWidth = tAvailableWidth;
         }
     }
 
     // Layout got wider than before or no suitable button found: abort
-    if(btn_i >= first_btn || used_width >= available_width)
+    if ( btnI >= firstBtn || usedWidth >= availableWidth )
     {
         return;
     }
-    if(last_button != nullptr)
+    if ( lastButton != nullptr )
     {
-        *last_button = btn_i;
+        *lastButton = btnI;
     }
 
     wxRibbonButtonBarLayout* layout = new wxRibbonButtonBarLayout;
     WX_APPEND_ARRAY(layout->buttons, original->buttons);
-    wxPoint cursor(layout->buttons.at(btn_i).position);
+    wxPoint cursor(layout->buttons.at(btnI).position);
 
     cursor.y = 0;
-    for(; btn_i <= first_btn; ++btn_i)
+    for ( ; btnI <= firstBtn; ++btnI )
     {
-        wxRibbonButtonBarButtonInstance& instance = layout->buttons.at(btn_i);
-        if(instance.size > target_size)
+        wxRibbonButtonBarButtonInstance& instance = layout->buttons.at(btnI);
+        if ( instance.size > targetSize )
         {
             instance.base->GetSmallerSize(&instance.size,
-                                          instance.size - target_size);
+                                          instance.size - targetSize);
         }
         instance.position = cursor;
         cursor.y += instance.base->sizes[instance.size].size.GetHeight();
     }
 
-    int x_adjust = available_width - used_width;
+    int xAdjust = availableWidth - usedWidth;
 
     // Adjust x coords of buttons right of shrinked column
-    for(; btn_i < btn_count; ++btn_i)
+    for ( ; btnI < btnCount; ++btnI )
     {
-        wxRibbonButtonBarButtonInstance& instance = layout->buttons.at(btn_i);
-        instance.position.x -= x_adjust;
+        wxRibbonButtonBarButtonInstance& instance = layout->buttons.at(btnI);
+        instance.position.x -= xAdjust;
     }
 
     layout->CalculateOverallSize();
 
     // Sanity check
-    if(layout->overall_size.GetWidth() >= original->overall_size.GetWidth() ||
-        layout->overall_size.GetHeight() > original->overall_size.GetHeight())
+    if ( layout->overallSize.GetWidth() >= original->overallSize.GetWidth() ||
+        layout->overallSize.GetHeight() > original->overallSize.GetHeight() )
     {
         delete layout;
         wxFAIL_MSG("Layout collapse resulted in increased size");
@@ -1285,11 +1285,11 @@ void wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
     // If height isn't preserved (i.e. it is reduced), then the minimum
     // size for the button bar will decrease, preventing the original
     // layout from being used (in some cases).
-    // If neither "min_size_class" nor "max_size_class" is set, this is
+    // If neither "minSizeClass" nor "maxSizeClass" is set, this is
     // only required when the first button is involved in a collapse but
     // if small, medium and large buttons as well as min/max size classes
     // are involved this is always a good idea.
-    layout->overall_size.SetHeight(original->overall_size.GetHeight());
+    layout->overallSize.SetHeight(original->overallSize.GetHeight());
 
     m_layouts.Add(layout);
 }
@@ -1297,38 +1297,38 @@ void wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
 void wxRibbonButtonBar::OnMouseMove(wxMouseEvent& evt)
 {
     wxPoint cursor(evt.GetPosition());
-    wxRibbonButtonBarButtonInstance* new_hovered = nullptr;
+    wxRibbonButtonBarButtonInstance* newHovered = nullptr;
     wxRibbonButtonBarButtonInstance* tooltipButton = nullptr;
-    long new_hovered_state = 0;
+    long newHoveredState = 0;
 
-    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
+    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_currentLayout);
     for ( auto& instance : layout->buttons )
     {
         wxRibbonButtonBarButtonSizeInfo& size = instance.base->sizes[instance.size];
-        wxRect btn_rect;
-        btn_rect.SetTopLeft(m_layout_offset + instance.position);
-        btn_rect.SetSize(size.size);
-        if(btn_rect.Contains(cursor))
+        wxRect btnRect;
+        btnRect.SetTopLeft(m_layoutOffset + instance.position);
+        btnRect.SetSize(size.size);
+        if ( btnRect.Contains(cursor) )
         {
-            if((instance.base->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0)
+            if ( (instance.base->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0 )
             {
                 tooltipButton = &instance;
-                new_hovered = &instance;
-                new_hovered_state = instance.base->state;
-                new_hovered_state &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
+                newHovered = &instance;
+                newHoveredState = instance.base->state;
+                newHoveredState &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
                 wxPoint offset(cursor);
-                offset -= btn_rect.GetTopLeft();
-                if(size.normal_region.Contains(offset))
+                offset -= btnRect.GetTopLeft();
+                if ( size.normalRegion.Contains(offset) )
                 {
-                    new_hovered_state |= wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED;
+                    newHoveredState |= wxRIBBON_BUTTONBAR_BUTTON_NORMAL_HOVERED;
                 }
-                if(size.dropdown_region.Contains(offset))
+                if ( size.dropdownRegion.Contains(offset) )
                 {
-                    new_hovered_state |= wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_HOVERED;
+                    newHoveredState |= wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_HOVERED;
                 }
                 break;
             }
-            else if (m_show_tooltips_for_disabled)
+            else if ( m_showTooltipsForDisabled )
             {
                 tooltipButton = &instance;
             }
@@ -1336,60 +1336,60 @@ void wxRibbonButtonBar::OnMouseMove(wxMouseEvent& evt)
     }
 
 #if wxUSE_TOOLTIPS
-    if(tooltipButton == nullptr && GetToolTip())
+    if ( tooltipButton == nullptr && GetToolTip() )
     {
         UnsetToolTip();
     }
-    if(tooltipButton)
+    if ( tooltipButton )
     {
-        if (tooltipButton != m_hovered_button &&
-                !(tooltipButton->size & wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_ACTIVE))
-            SetToolTip(tooltipButton->base->help_string);
+        if ( tooltipButton != m_hoveredButton &&
+                !(tooltipButton->size & wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_ACTIVE) )
+            SetToolTip(tooltipButton->base->helpString);
     }
 #else
     wxUnusedVar(tooltipButton);
 #endif
 
-    if(new_hovered != m_hovered_button || (m_hovered_button != nullptr &&
-        new_hovered_state != m_hovered_button->base->state))
+    if ( newHovered != m_hoveredButton || (m_hoveredButton != nullptr &&
+        newHoveredState != m_hoveredButton->base->state) )
     {
-        if(m_hovered_button != nullptr)
+        if ( m_hoveredButton != nullptr )
         {
-            m_hovered_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
+            m_hoveredButton->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
         }
-        m_hovered_button = new_hovered;
-        if(m_hovered_button != nullptr)
+        m_hoveredButton = newHovered;
+        if ( m_hoveredButton != nullptr )
         {
-            m_hovered_button->base->state = new_hovered_state;
+            m_hoveredButton->base->state = newHoveredState;
         }
         Refresh(false);
     }
 
-    if(m_active_button && !m_lock_active_state)
+    if ( m_activeButton && !m_lockActiveState )
     {
-        long new_active_state = m_active_button->base->state;
-        new_active_state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
+        long newActiveState = m_activeButton->base->state;
+        newActiveState &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
         wxRibbonButtonBarButtonSizeInfo& size =
-            m_active_button->base->sizes[m_active_button->size];
-        wxRect btn_rect;
-        btn_rect.SetTopLeft(m_layout_offset + m_active_button->position);
-        btn_rect.SetSize(size.size);
-        if(btn_rect.Contains(cursor))
+            m_activeButton->base->sizes[m_activeButton->size];
+        wxRect btnRect;
+        btnRect.SetTopLeft(m_layoutOffset + m_activeButton->position);
+        btnRect.SetSize(size.size);
+        if ( btnRect.Contains(cursor) )
         {
             wxPoint offset(cursor);
-            offset -= btn_rect.GetTopLeft();
-            if(size.normal_region.Contains(offset))
+            offset -= btnRect.GetTopLeft();
+            if ( size.normalRegion.Contains(offset) )
             {
-                new_active_state |= wxRIBBON_BUTTONBAR_BUTTON_NORMAL_ACTIVE;
+                newActiveState |= wxRIBBON_BUTTONBAR_BUTTON_NORMAL_ACTIVE;
             }
-            if(size.dropdown_region.Contains(offset))
+            if ( size.dropdownRegion.Contains(offset) )
             {
-                new_active_state |= wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_ACTIVE;
+                newActiveState |= wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_ACTIVE;
             }
         }
-        if(new_active_state != m_active_button->base->state)
+        if ( newActiveState != m_activeButton->base->state )
         {
-            m_active_button->base->state = new_active_state;
+            m_activeButton->base->state = newActiveState;
             Refresh(false);
         }
     }
@@ -1398,27 +1398,27 @@ void wxRibbonButtonBar::OnMouseMove(wxMouseEvent& evt)
 void wxRibbonButtonBar::OnMouseDown(wxMouseEvent& evt)
 {
     wxPoint cursor(evt.GetPosition());
-    m_active_button = nullptr;
+    m_activeButton = nullptr;
 
-    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
+    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_currentLayout);
     for ( auto& instance : layout->buttons )
     {
         wxRibbonButtonBarButtonSizeInfo& size = instance.base->sizes[instance.size];
-        wxRect btn_rect;
-        btn_rect.SetTopLeft(m_layout_offset + instance.position);
-        btn_rect.SetSize(size.size);
-        if(btn_rect.Contains(cursor))
+        wxRect btnRect;
+        btnRect.SetTopLeft(m_layoutOffset + instance.position);
+        btnRect.SetSize(size.size);
+        if ( btnRect.Contains(cursor) )
         {
-            if((instance.base->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0)
+            if ( (instance.base->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0 )
             {
-                m_active_button = &instance;
-                cursor -= btn_rect.GetTopLeft();
+                m_activeButton = &instance;
+                cursor -= btnRect.GetTopLeft();
                 long state = 0;
-                if(size.normal_region.Contains(cursor))
+                if ( size.normalRegion.Contains(cursor) )
                 {
                     state = wxRIBBON_BUTTONBAR_BUTTON_NORMAL_ACTIVE;
                 }
-                else if(size.dropdown_region.Contains(cursor))
+                else if ( size.dropdownRegion.Contains(cursor) )
                 {
                     state = wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_ACTIVE;
                     UnsetToolTip();
@@ -1435,47 +1435,47 @@ void wxRibbonButtonBar::OnMouseUp(wxMouseEvent& evt)
 {
     wxPoint cursor(evt.GetPosition());
 
-    if(m_active_button)
+    if ( m_activeButton )
     {
         wxRibbonButtonBarButtonSizeInfo& size =
-            m_active_button->base->sizes[m_active_button->size];
-        wxRect btn_rect;
-        btn_rect.SetTopLeft(m_layout_offset + m_active_button->position);
-        btn_rect.SetSize(size.size);
-        if(btn_rect.Contains(cursor))
+            m_activeButton->base->sizes[m_activeButton->size];
+        wxRect btnRect;
+        btnRect.SetTopLeft(m_layoutOffset + m_activeButton->position);
+        btnRect.SetSize(size.size);
+        if ( btnRect.Contains(cursor) )
         {
-            int id = m_active_button->base->id;
-            cursor -= btn_rect.GetTopLeft();
-            wxEventType event_type;
+            int id = m_activeButton->base->id;
+            cursor -= btnRect.GetTopLeft();
+            wxEventType eventType;
             do
             {
-                if(size.normal_region.Contains(cursor))
-                    event_type = wxEVT_RIBBONBUTTONBAR_CLICKED;
-                else if(size.dropdown_region.Contains(cursor))
-                    event_type = wxEVT_RIBBONBUTTONBAR_DROPDOWN_CLICKED;
+                if ( size.normalRegion.Contains(cursor) )
+                    eventType = wxEVT_RIBBONBUTTONBAR_CLICKED;
+                else if ( size.dropdownRegion.Contains(cursor) )
+                    eventType = wxEVT_RIBBONBUTTONBAR_DROPDOWN_CLICKED;
                 else
                     break;
-                wxRibbonButtonBarEvent notification(event_type, id);
-                if(m_active_button->base->kind == wxRIBBON_BUTTON_TOGGLE)
+                wxRibbonButtonBarEvent notification(eventType, id);
+                if ( m_activeButton->base->kind == wxRIBBON_BUTTON_TOGGLE )
                 {
-                    m_active_button->base->state ^=
+                    m_activeButton->base->state ^=
                         wxRIBBON_BUTTONBAR_BUTTON_TOGGLED;
-                    notification.SetInt(m_active_button->base->state &
+                    notification.SetInt(m_activeButton->base->state &
                         wxRIBBON_BUTTONBAR_BUTTON_TOGGLED);
                 }
                 notification.SetEventObject(this);
                 notification.SetBar(this);
-                notification.SetButton(m_active_button->base);
-                m_lock_active_state = true;
+                notification.SetButton(m_activeButton->base);
+                m_lockActiveState = true;
                 ProcessWindowEvent(notification);
-                m_lock_active_state = false;
+                m_lockActiveState = false;
 
                 wxStaticCast(m_parent, wxRibbonPanel)->HideIfExpanded();
-            } while(false);
-            if(m_active_button) // may have been NULLed by event handler
+            } while ( false );
+            if ( m_activeButton ) // may have been NULLed by event handler
             {
-                m_active_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
-                m_active_button = nullptr;
+                m_activeButton->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
+                m_activeButton = nullptr;
             }
             Refresh(false);
         }
@@ -1484,40 +1484,40 @@ void wxRibbonButtonBar::OnMouseUp(wxMouseEvent& evt)
 
 void wxRibbonButtonBar::OnMouseEnter(wxMouseEvent& evt)
 {
-    if(m_active_button && !evt.LeftIsDown())
+    if ( m_activeButton && !evt.LeftIsDown() )
     {
-        m_active_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
-        m_active_button = nullptr;
+        m_activeButton->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
+        m_activeButton = nullptr;
     }
 }
 
 void wxRibbonButtonBar::OnMouseLeave(wxMouseEvent& WXUNUSED(evt))
 {
     bool repaint = false;
-    if(m_hovered_button != nullptr)
+    if ( m_hoveredButton != nullptr )
     {
-        m_hovered_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
-        m_hovered_button = nullptr;
+        m_hoveredButton->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_HOVER_MASK;
+        m_hoveredButton = nullptr;
         repaint = true;
     }
-    if(m_active_button != nullptr && !m_lock_active_state)
+    if ( m_activeButton != nullptr && !m_lockActiveState )
     {
-        m_active_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
+        m_activeButton->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
         repaint = true;
     }
-    if(repaint)
+    if ( repaint )
         Refresh(false);
 }
 
 wxRibbonButtonBarButtonBase *wxRibbonButtonBar::GetActiveItem() const
 {
-    return m_active_button == nullptr ? nullptr : m_active_button->base;
+    return m_activeButton == nullptr ? nullptr : m_activeButton->base;
 }
 
 
 wxRibbonButtonBarButtonBase *wxRibbonButtonBar::GetHoveredItem() const
 {
-    return m_hovered_button == nullptr ? nullptr : m_hovered_button->base;
+    return m_hoveredButton == nullptr ? nullptr : m_hoveredButton->base;
 }
 
 
@@ -1527,13 +1527,13 @@ wxRibbonButtonBarButtonBase *wxRibbonButtonBar::GetItem(size_t n) const
     return m_buttons.Item(n);
 }
 
-wxRibbonButtonBarButtonBase *wxRibbonButtonBar::GetItemById(int button_id) const
+wxRibbonButtonBarButtonBase *wxRibbonButtonBar::GetItemById(int buttonId) const
 {
     size_t count = m_buttons.GetCount();
     for ( size_t i = 0; i < count; ++i )
     {
         wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
-        if ( button->id == button_id )
+        if ( button->id == buttonId )
             return button;
     }
 
@@ -1547,21 +1547,21 @@ int wxRibbonButtonBar::GetItemId(wxRibbonButtonBarButtonBase *item) const
     return item->id;
 }
 
-wxRect wxRibbonButtonBar::GetItemRect(int button_id)const
+wxRect wxRibbonButtonBar::GetItemRect(int buttonId) const
 {
-    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
+    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_currentLayout);
     for ( auto& instance : layout->buttons )
     {
         wxRibbonButtonBarButtonBase* button = instance.base;
 
-        if (button->id == button_id)
+        if ( button->id == buttonId )
         {
             wxRibbonButtonBarButtonSizeInfo& size = button->sizes[instance.size];
-            wxRect btn_rect;
-            btn_rect.SetTopLeft(m_layout_offset + instance.position);
-            btn_rect.SetSize(size.size);
+            wxRect btnRect;
+            btnRect.SetTopLeft(m_layoutOffset + instance.position);
+            btnRect.SetSize(size.size);
 
-            return btn_rect;
+            return btnRect;
         }
     }
     return wxRect();
@@ -1570,15 +1570,15 @@ wxRect wxRibbonButtonBar::GetItemRect(int button_id)const
 bool wxRibbonButtonBarEvent::PopupMenu(wxMenu* menu)
 {
     wxPoint pos = wxDefaultPosition;
-    if(m_bar->m_active_button)
+    if ( m_bar->m_activeButton )
     {
         wxRibbonButtonBarButtonSizeInfo& size =
-            m_bar->m_active_button->base->sizes[m_bar->m_active_button->size];
-        wxRect btn_rect;
-        btn_rect.SetTopLeft(m_bar->m_layout_offset +
-            m_bar->m_active_button->position);
-        btn_rect.SetSize(size.size);
-        pos = btn_rect.GetBottomLeft();
+            m_bar->m_activeButton->base->sizes[m_bar->m_activeButton->size];
+        wxRect btnRect;
+        btnRect.SetTopLeft(m_bar->m_layoutOffset +
+            m_bar->m_activeButton->position);
+        btnRect.SetSize(size.size);
+        pos = btnRect.GetBottomLeft();
         pos.y++;
     }
     return m_bar->PopupMenu(menu, pos);
@@ -1587,17 +1587,17 @@ bool wxRibbonButtonBarEvent::PopupMenu(wxMenu* menu)
 void wxRibbonButtonBar::OnDPIChanged(wxDPIChangedEvent& event)
 {
     // Recalculate all button sizes with new DPI scale, then rebuild layouts
-    wxInfoDC temp_dc(this);
-    size_t btn_count = m_buttons.GetCount();
-    for(size_t btn_i = 0; btn_i < btn_count; ++btn_i)
+    wxInfoDC tempDc(this);
+    size_t btnCount = m_buttons.GetCount();
+    for ( size_t btnI = 0; btnI < btnCount; ++btnI )
     {
-        wxRibbonButtonBarButtonBase* base = m_buttons.Item(btn_i);
-        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
-        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
-        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
+        wxRibbonButtonBarButtonBase* base = m_buttons.Item(btnI);
+        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, tempDc);
+        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, tempDc);
+        FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, tempDc);
     }
 
-    m_layouts_valid = false;
+    m_layoutsValid = false;
     Realize();
     Refresh();
     event.Skip();

--- a/src/ribbon/control.cpp
+++ b/src/ribbon/control.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 wxIMPLEMENT_CLASS(wxRibbonControl, wxControl);
@@ -33,10 +33,10 @@ bool wxRibbonControl::Create(wxWindow *parent, wxWindowID id,
     if ( !wxControl::Create(parent, id, pos, size, style, validator, name) )
         return false;
 
-    wxRibbonControl *ribbon_parent = wxDynamicCast(parent, wxRibbonControl);
-    if(ribbon_parent)
+    wxRibbonControl *ribbonParent = wxDynamicCast(parent, wxRibbonControl);
+    if ( ribbonParent )
     {
-        m_art = ribbon_parent->GetArtProvider();
+        m_art = ribbonParent->GetArtProvider();
     }
 
     return true;
@@ -52,11 +52,11 @@ wxSize wxRibbonControl::DoGetNextSmallerSize(wxOrientation direction,
 {
     // Dummy implementation for code which doesn't check for IsSizingContinuous() == true
     wxSize minimum(GetMinSize());
-    if((direction & wxHORIZONTAL) && size.x > minimum.x)
+    if ( (direction & wxHORIZONTAL) && size.x > minimum.x )
     {
         size.x--;
     }
-    if((direction & wxVERTICAL) && size.y > minimum.y)
+    if ( (direction & wxVERTICAL) && size.y > minimum.y )
     {
         size.y--;
     }
@@ -67,11 +67,11 @@ wxSize wxRibbonControl::DoGetNextLargerSize(wxOrientation direction,
                                           wxSize size) const
 {
     // Dummy implementation for code which doesn't check for IsSizingContinuous() == true
-    if(direction & wxHORIZONTAL)
+    if ( direction & wxHORIZONTAL )
     {
         size.x++;
     }
-    if(direction & wxVERTICAL)
+    if ( direction & wxVERTICAL )
     {
         size.y++;
     }
@@ -79,15 +79,15 @@ wxSize wxRibbonControl::DoGetNextLargerSize(wxOrientation direction,
 }
 
 wxSize wxRibbonControl::GetNextSmallerSize(wxOrientation direction,
-                                           wxSize relative_to) const
+                                           wxSize relativeTo) const
 {
-    return DoGetNextSmallerSize(direction, relative_to);
+    return DoGetNextSmallerSize(direction, relativeTo);
 }
 
 wxSize wxRibbonControl::GetNextLargerSize(wxOrientation direction,
-                                          wxSize relative_to) const
+                                          wxSize relativeTo) const
 {
-    return DoGetNextLargerSize(direction, relative_to);
+    return DoGetNextLargerSize(direction, relativeTo);
 }
 
 wxSize wxRibbonControl::GetNextSmallerSize(wxOrientation direction) const
@@ -105,7 +105,7 @@ bool wxRibbonControl::Realize()
     return true;
 }
 
-wxRibbonBar* wxRibbonControl::GetAncestorRibbonBar()const
+wxRibbonBar* wxRibbonControl::GetAncestorRibbonBar() const
 {
     for ( wxWindow* win = GetParent(); win; win = win->GetParent() )
     {

--- a/src/ribbon/gallery.cpp
+++ b/src/ribbon/gallery.cpp
@@ -22,7 +22,7 @@
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 wxDEFINE_EVENT(wxEVT_RIBBONGALLERY_HOVER_CHANGED, wxRibbonGalleryEvent);
@@ -37,29 +37,29 @@ class wxRibbonGalleryItem
 public:
     wxRibbonGalleryItem() = default;
 
-    void SetId(int id) {m_id = id;}
-    void SetBitmap(const wxBitmapBundle& bitmap) {m_bitmap = bitmap;}
-    const wxBitmapBundle& GetBitmapBundle() const {return m_bitmap;}
-    wxBitmap GetBitmap(wxWindow* wnd) const {return m_bitmap.GetBitmapFor(wnd);}
-    void SetIsVisible(bool visible) {m_is_visible = visible;}
+    void SetId(int id) { m_id = id; }
+    void SetBitmap(const wxBitmapBundle& bitmap) { m_bitmap = bitmap; }
+    const wxBitmapBundle& GetBitmapBundle() const { return m_bitmap; }
+    wxBitmap GetBitmap(wxWindow* wnd) const { return m_bitmap.GetBitmapFor(wnd); }
+    void SetIsVisible(bool visible) { m_isVisible = visible; }
     void SetPosition(int x, int y, const wxSize& size)
     {
         m_position = wxRect(wxPoint(x, y), size);
     }
-    bool IsVisible() const {return m_is_visible;}
-    const wxRect& GetPosition() const {return m_position;}
+    bool IsVisible() const { return m_isVisible; }
+    const wxRect& GetPosition() const { return m_position; }
 
-    void SetClientObject(wxClientData *data) {m_client_data.SetClientObject(data);}
-    wxClientData *GetClientObject() const {return m_client_data.GetClientObject();}
-    void SetClientData(void *data) {m_client_data.SetClientData(data);}
-    void *GetClientData() const {return m_client_data.GetClientData();}
+    void SetClientObject(wxClientData *data) { m_clientData.SetClientObject(data); }
+    wxClientData *GetClientObject() const { return m_clientData.GetClientObject(); }
+    void SetClientData(void *data) { m_clientData.SetClientData(data); }
+    void *GetClientData() const { return m_clientData.GetClientData(); }
 
 protected:
     wxBitmapBundle m_bitmap;
-    wxClientDataContainer m_client_data;
+    wxClientDataContainer m_clientData;
     wxRect m_position;
     int m_id = 0;
-    bool m_is_visible = false;
+    bool m_isVisible = false;
 };
 
 wxBEGIN_EVENT_TABLE(wxRibbonGallery, wxRibbonControl)
@@ -100,7 +100,7 @@ bool wxRibbonGallery::Create(wxWindow* parent,
                 const wxSize& size,
                 long style)
 {
-    if(!wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE))
+    if ( !wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE) )
     {
         return false;
     }
@@ -111,22 +111,22 @@ bool wxRibbonGallery::Create(wxWindow* parent,
 
 void wxRibbonGallery::CommonInit(long WXUNUSED(style))
 {
-    m_selected_item = nullptr;
-    m_hovered_item = nullptr;
-    m_active_item = nullptr;
-    m_scroll_up_button_rect = wxRect(0, 0, 0, 0);
-    m_scroll_down_button_rect = wxRect(0, 0, 0, 0);
-    m_extension_button_rect = wxRect(0, 0, 0, 0);
-    m_mouse_active_rect = nullptr;
-    m_bitmap_size = wxSize(64, 32);
-    m_bitmap_padded_size = m_bitmap_size;
-    m_item_separation_x = 0;
-    m_item_separation_y = 0;
-    m_scroll_amount = 0;
-    m_scroll_limit = 0;
-    m_up_button_state = wxRIBBON_GALLERY_BUTTON_DISABLED;
-    m_down_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
-    m_extension_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
+    m_selectedItem = nullptr;
+    m_hoveredItem = nullptr;
+    m_activeItem = nullptr;
+    m_scrollUpButtonRect = wxRect(0, 0, 0, 0);
+    m_scrollDownButtonRect = wxRect(0, 0, 0, 0);
+    m_extensionButtonRect = wxRect(0, 0, 0, 0);
+    m_mouseActiveRect = nullptr;
+    m_bitmapSize = wxSize(64, 32);
+    m_bitmapPaddedSize = m_bitmapSize;
+    m_itemSeparationX = 0;
+    m_itemSeparationY = 0;
+    m_scrollAmount = 0;
+    m_scrollLimit = 0;
+    m_upButtonState = wxRIBBON_GALLERY_BUTTON_DISABLED;
+    m_downButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
+    m_extensionButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
     m_hovered = false;
 
     SetBackgroundStyle(wxBG_STYLE_PAINT);
@@ -135,10 +135,10 @@ void wxRibbonGallery::CommonInit(long WXUNUSED(style))
 void wxRibbonGallery::OnMouseEnter(wxMouseEvent& evt)
 {
     m_hovered = true;
-    if(m_mouse_active_rect != nullptr && !evt.LeftIsDown())
+    if ( m_mouseActiveRect != nullptr && !evt.LeftIsDown() )
     {
-        m_mouse_active_rect = nullptr;
-        m_active_item = nullptr;
+        m_mouseActiveRect = nullptr;
+        m_activeItem = nullptr;
     }
     Refresh(false);
 }
@@ -148,80 +148,80 @@ void wxRibbonGallery::OnMouseMove(wxMouseEvent& evt)
     bool refresh = false;
     wxPoint pos = evt.GetPosition();
 
-    if(TestButtonHover(m_scroll_up_button_rect, pos, &m_up_button_state))
+    if ( TestButtonHover(m_scrollUpButtonRect, pos, &m_upButtonState) )
         refresh = true;
-    if(TestButtonHover(m_scroll_down_button_rect, pos, &m_down_button_state))
+    if ( TestButtonHover(m_scrollDownButtonRect, pos, &m_downButtonState) )
         refresh = true;
-    if(TestButtonHover(m_extension_button_rect, pos, &m_extension_button_state))
+    if ( TestButtonHover(m_extensionButtonRect, pos, &m_extensionButtonState) )
         refresh = true;
 
-    wxRibbonGalleryItem *hovered_item = nullptr;
-    wxRibbonGalleryItem *active_item = nullptr;
-    if(m_client_rect.Contains(pos))
+    wxRibbonGalleryItem *hoveredItem = nullptr;
+    wxRibbonGalleryItem *activeItem = nullptr;
+    if ( m_clientRect.Contains(pos) )
     {
-        if(m_art && m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
-            pos.x += m_scroll_amount;
+        if ( m_art && m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
+            pos.x += m_scrollAmount;
         else
-            pos.y += m_scroll_amount;
+            pos.y += m_scrollAmount;
 
-        size_t item_count = m_items.Count();
-        size_t item_i;
-        for(item_i = 0; item_i < item_count; ++item_i)
+        size_t itemCount = m_items.Count();
+        size_t i;
+        for ( i = 0; i < itemCount; ++i )
         {
-            wxRibbonGalleryItem *item = m_items.Item(item_i);
-            if(!item->IsVisible())
+            wxRibbonGalleryItem *item = m_items.Item(i);
+            if ( !item->IsVisible() )
                 continue;
 
-            if(item->GetPosition().Contains(pos))
+            if ( item->GetPosition().Contains(pos) )
             {
-                if(m_mouse_active_rect == &item->GetPosition())
-                    active_item = item;
-                hovered_item = item;
+                if ( m_mouseActiveRect == &item->GetPosition() )
+                    activeItem = item;
+                hoveredItem = item;
                 break;
             }
         }
     }
-    if(active_item != m_active_item)
+    if ( activeItem != m_activeItem )
     {
-        m_active_item = active_item;
+        m_activeItem = activeItem;
         refresh = true;
     }
-    if(hovered_item != m_hovered_item)
+    if ( hoveredItem != m_hoveredItem )
     {
-        m_hovered_item = hovered_item;
+        m_hoveredItem = hoveredItem;
         wxRibbonGalleryEvent notification(
             wxEVT_RIBBONGALLERY_HOVER_CHANGED, GetId());
         notification.SetEventObject(this);
         notification.SetGallery(this);
-        notification.SetGalleryItem(hovered_item);
+        notification.SetGalleryItem(hoveredItem);
         ProcessWindowEvent(notification);
         refresh = true;
     }
 
-    if(refresh)
+    if ( refresh )
         Refresh(false);
 }
 
 bool wxRibbonGallery::TestButtonHover(const wxRect& rect, wxPoint pos,
         wxRibbonGalleryButtonState* state)
 {
-    if(*state == wxRIBBON_GALLERY_BUTTON_DISABLED)
+    if ( *state == wxRIBBON_GALLERY_BUTTON_DISABLED )
         return false;
 
-    wxRibbonGalleryButtonState new_state;
-    if(rect.Contains(pos))
+    wxRibbonGalleryButtonState newState;
+    if ( rect.Contains(pos) )
     {
-        if(m_mouse_active_rect == &rect)
-            new_state = wxRIBBON_GALLERY_BUTTON_ACTIVE;
+        if ( m_mouseActiveRect == &rect )
+            newState = wxRIBBON_GALLERY_BUTTON_ACTIVE;
         else
-            new_state = wxRIBBON_GALLERY_BUTTON_HOVERED;
+            newState = wxRIBBON_GALLERY_BUTTON_HOVERED;
     }
     else
-        new_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
+        newState = wxRIBBON_GALLERY_BUTTON_NORMAL;
 
-    if(new_state != *state)
+    if ( newState != *state )
     {
-        *state = new_state;
+        *state = newState;
         return true;
     }
     else
@@ -233,16 +233,16 @@ bool wxRibbonGallery::TestButtonHover(const wxRect& rect, wxPoint pos,
 void wxRibbonGallery::OnMouseLeave(wxMouseEvent& WXUNUSED(evt))
 {
     m_hovered = false;
-    m_active_item = nullptr;
-    if(m_up_button_state != wxRIBBON_GALLERY_BUTTON_DISABLED)
-        m_up_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
-    if(m_down_button_state != wxRIBBON_GALLERY_BUTTON_DISABLED)
-        m_down_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
-    if(m_extension_button_state != wxRIBBON_GALLERY_BUTTON_DISABLED)
-        m_extension_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
-    if(m_hovered_item != nullptr)
+    m_activeItem = nullptr;
+    if ( m_upButtonState != wxRIBBON_GALLERY_BUTTON_DISABLED )
+        m_upButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
+    if ( m_downButtonState != wxRIBBON_GALLERY_BUTTON_DISABLED )
+        m_downButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
+    if ( m_extensionButtonState != wxRIBBON_GALLERY_BUTTON_DISABLED )
+        m_extensionButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
+    if ( m_hoveredItem != nullptr )
     {
-        m_hovered_item = nullptr;
+        m_hoveredItem = nullptr;
         wxRibbonGalleryEvent notification(
             wxEVT_RIBBONGALLERY_HOVER_CHANGED, GetId());
         notification.SetEventObject(this);
@@ -255,100 +255,100 @@ void wxRibbonGallery::OnMouseLeave(wxMouseEvent& WXUNUSED(evt))
 void wxRibbonGallery::OnMouseDown(wxMouseEvent& evt)
 {
     wxPoint pos = evt.GetPosition();
-    m_mouse_active_rect = nullptr;
-    if(m_client_rect.Contains(pos))
+    m_mouseActiveRect = nullptr;
+    if ( m_clientRect.Contains(pos) )
     {
-        if(m_art && m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
-            pos.x += m_scroll_amount;
+        if ( m_art && m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
+            pos.x += m_scrollAmount;
         else
-            pos.y += m_scroll_amount;
-        size_t item_count = m_items.Count();
-        size_t item_i;
-        for(item_i = 0; item_i < item_count; ++item_i)
+            pos.y += m_scrollAmount;
+        size_t itemCount = m_items.Count();
+        size_t i;
+        for ( i = 0; i < itemCount; ++i )
         {
-            wxRibbonGalleryItem *item = m_items.Item(item_i);
-            if(!item->IsVisible())
+            wxRibbonGalleryItem *item = m_items.Item(i);
+            if ( !item->IsVisible() )
                 continue;
 
             const wxRect& rect = item->GetPosition();
-            if(rect.Contains(pos))
+            if ( rect.Contains(pos) )
             {
-                m_active_item = item;
-                m_mouse_active_rect = &rect;
+                m_activeItem = item;
+                m_mouseActiveRect = &rect;
                 break;
             }
         }
     }
-    else if(m_scroll_up_button_rect.Contains(pos))
+    else if ( m_scrollUpButtonRect.Contains(pos) )
     {
-        if(m_up_button_state != wxRIBBON_GALLERY_BUTTON_DISABLED)
+        if ( m_upButtonState != wxRIBBON_GALLERY_BUTTON_DISABLED )
         {
-            m_mouse_active_rect = &m_scroll_up_button_rect;
-            m_up_button_state = wxRIBBON_GALLERY_BUTTON_ACTIVE;
+            m_mouseActiveRect = &m_scrollUpButtonRect;
+            m_upButtonState = wxRIBBON_GALLERY_BUTTON_ACTIVE;
         }
     }
-    else if(m_scroll_down_button_rect.Contains(pos))
+    else if ( m_scrollDownButtonRect.Contains(pos) )
     {
-        if(m_down_button_state != wxRIBBON_GALLERY_BUTTON_DISABLED)
+        if ( m_downButtonState != wxRIBBON_GALLERY_BUTTON_DISABLED )
         {
-            m_mouse_active_rect = &m_scroll_down_button_rect;
-            m_down_button_state = wxRIBBON_GALLERY_BUTTON_ACTIVE;
+            m_mouseActiveRect = &m_scrollDownButtonRect;
+            m_downButtonState = wxRIBBON_GALLERY_BUTTON_ACTIVE;
         }
     }
-    else if(m_extension_button_rect.Contains(pos))
+    else if ( m_extensionButtonRect.Contains(pos) )
     {
-        if(m_extension_button_state != wxRIBBON_GALLERY_BUTTON_DISABLED)
+        if ( m_extensionButtonState != wxRIBBON_GALLERY_BUTTON_DISABLED )
         {
-            m_mouse_active_rect = &m_extension_button_rect;
-            m_extension_button_state = wxRIBBON_GALLERY_BUTTON_ACTIVE;
+            m_mouseActiveRect = &m_extensionButtonRect;
+            m_extensionButtonState = wxRIBBON_GALLERY_BUTTON_ACTIVE;
         }
     }
-    if(m_mouse_active_rect != nullptr)
+    if ( m_mouseActiveRect != nullptr )
         Refresh(false);
 }
 
 void wxRibbonGallery::OnMouseUp(wxMouseEvent& evt)
 {
-    if(m_mouse_active_rect != nullptr)
+    if ( m_mouseActiveRect != nullptr )
     {
         wxPoint pos = evt.GetPosition();
-        if(m_active_item)
+        if ( m_activeItem )
         {
-            if(m_art && m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
-                pos.x += m_scroll_amount;
+            if ( m_art && m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
+                pos.x += m_scrollAmount;
             else
-                pos.y += m_scroll_amount;
+                pos.y += m_scrollAmount;
         }
-        if(m_mouse_active_rect->Contains(pos))
+        if ( m_mouseActiveRect->Contains(pos) )
         {
-            if(m_mouse_active_rect == &m_scroll_up_button_rect)
+            if ( m_mouseActiveRect == &m_scrollUpButtonRect )
             {
-                m_up_button_state = wxRIBBON_GALLERY_BUTTON_HOVERED;
+                m_upButtonState = wxRIBBON_GALLERY_BUTTON_HOVERED;
                 ScrollLines(-1);
             }
-            else if(m_mouse_active_rect == &m_scroll_down_button_rect)
+            else if ( m_mouseActiveRect == &m_scrollDownButtonRect )
             {
-                m_down_button_state = wxRIBBON_GALLERY_BUTTON_HOVERED;
+                m_downButtonState = wxRIBBON_GALLERY_BUTTON_HOVERED;
                 ScrollLines(1);
             }
-            else if(m_mouse_active_rect == &m_extension_button_rect)
+            else if ( m_mouseActiveRect == &m_extensionButtonRect )
             {
-                m_extension_button_state = wxRIBBON_GALLERY_BUTTON_HOVERED;
+                m_extensionButtonState = wxRIBBON_GALLERY_BUTTON_HOVERED;
                 wxCommandEvent notification(wxEVT_BUTTON,
                     GetId());
                 notification.SetEventObject(this);
                 ProcessWindowEvent(notification);
             }
-            else if(m_active_item != nullptr)
+            else if ( m_activeItem != nullptr )
             {
-                if(m_selected_item != m_active_item)
+                if ( m_selectedItem != m_activeItem )
                 {
-                    m_selected_item = m_active_item;
+                    m_selectedItem = m_activeItem;
                     wxRibbonGalleryEvent notification(
                         wxEVT_RIBBONGALLERY_SELECTED, GetId());
                     notification.SetEventObject(this);
                     notification.SetGallery(this);
-                    notification.SetGalleryItem(m_selected_item);
+                    notification.SetGalleryItem(m_selectedItem);
                     ProcessWindowEvent(notification);
                 }
 
@@ -356,12 +356,12 @@ void wxRibbonGallery::OnMouseUp(wxMouseEvent& evt)
                     wxEVT_RIBBONGALLERY_CLICKED, GetId());
                 notification.SetEventObject(this);
                 notification.SetGallery(this);
-                notification.SetGalleryItem(m_selected_item);
+                notification.SetGalleryItem(m_selectedItem);
                 ProcessWindowEvent(notification);
             }
         }
-        m_mouse_active_rect = nullptr;
-        m_active_item = nullptr;
+        m_mouseActiveRect = nullptr;
+        m_activeItem = nullptr;
         Refresh(false);
     }
 }
@@ -398,7 +398,7 @@ void* wxRibbonGallery::GetItemClientData(const wxRibbonGalleryItem* itm) const
 
 bool wxRibbonGallery::ScrollLines(int lines)
 {
-    if(m_scroll_limit == 0 || m_art == nullptr)
+    if ( m_scrollLimit == 0 || m_art == nullptr )
         return false;
 
     return ScrollPixels(lines * GetScrollLineSize());
@@ -406,52 +406,52 @@ bool wxRibbonGallery::ScrollLines(int lines)
 
 int wxRibbonGallery::GetScrollLineSize() const
 {
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
         return 32;
 
-    int line_size = m_bitmap_padded_size.GetHeight();
-    if(m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
-        line_size = m_bitmap_padded_size.GetWidth();
+    int lineSize = m_bitmapPaddedSize.GetHeight();
+    if ( m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
+        lineSize = m_bitmapPaddedSize.GetWidth();
 
-    return line_size;
+    return lineSize;
 }
 
 bool wxRibbonGallery::ScrollPixels(int pixels)
 {
-    if(m_scroll_limit == 0 || m_art == nullptr)
+    if ( m_scrollLimit == 0 || m_art == nullptr )
         return false;
 
-    if(pixels < 0)
+    if ( pixels < 0 )
     {
-        if(m_scroll_amount > 0)
+        if ( m_scrollAmount > 0 )
         {
-            m_scroll_amount += pixels;
-            if(m_scroll_amount <= 0)
+            m_scrollAmount += pixels;
+            if ( m_scrollAmount <= 0 )
             {
-                m_scroll_amount = 0;
-                m_up_button_state = wxRIBBON_GALLERY_BUTTON_DISABLED;
+                m_scrollAmount = 0;
+                m_upButtonState = wxRIBBON_GALLERY_BUTTON_DISABLED;
             }
-            else if(m_up_button_state == wxRIBBON_GALLERY_BUTTON_DISABLED)
-                m_up_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
-            if(m_down_button_state == wxRIBBON_GALLERY_BUTTON_DISABLED)
-                m_down_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
+            else if ( m_upButtonState == wxRIBBON_GALLERY_BUTTON_DISABLED )
+                m_upButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
+            if ( m_downButtonState == wxRIBBON_GALLERY_BUTTON_DISABLED )
+                m_downButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
             return true;
         }
     }
-    else if(pixels > 0)
+    else if ( pixels > 0 )
     {
-        if(m_scroll_amount < m_scroll_limit)
+        if ( m_scrollAmount < m_scrollLimit )
         {
-            m_scroll_amount += pixels;
-            if(m_scroll_amount >= m_scroll_limit)
+            m_scrollAmount += pixels;
+            if ( m_scrollAmount >= m_scrollLimit )
             {
-                m_scroll_amount = m_scroll_limit;
-                m_down_button_state = wxRIBBON_GALLERY_BUTTON_DISABLED;
+                m_scrollAmount = m_scrollLimit;
+                m_downButtonState = wxRIBBON_GALLERY_BUTTON_DISABLED;
             }
-            else if(m_down_button_state == wxRIBBON_GALLERY_BUTTON_DISABLED)
-                m_down_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
-            if(m_up_button_state == wxRIBBON_GALLERY_BUTTON_DISABLED)
-                m_up_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
+            else if ( m_downButtonState == wxRIBBON_GALLERY_BUTTON_DISABLED )
+                m_downButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
+            if ( m_upButtonState == wxRIBBON_GALLERY_BUTTON_DISABLED )
+                m_upButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
             return true;
         }
     }
@@ -460,22 +460,22 @@ bool wxRibbonGallery::ScrollPixels(int pixels)
 
 void wxRibbonGallery::EnsureVisible(const wxRibbonGalleryItem* item)
 {
-    if(item == nullptr || !item->IsVisible() || IsEmpty() || m_art == nullptr )
+    if ( item == nullptr || !item->IsVisible() || IsEmpty() || m_art == nullptr )
         return;
 
-    if(m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
+    if ( m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
     {
         int x = item->GetPosition().GetLeft();
-        int base_x = m_items.Item(0)->GetPosition().GetLeft();
-        int delta = x - base_x - m_scroll_amount;
-        ScrollLines(delta / m_bitmap_padded_size.GetWidth());
+        int baseX = m_items.Item(0)->GetPosition().GetLeft();
+        int delta = x - baseX - m_scrollAmount;
+        ScrollLines(delta / m_bitmapPaddedSize.GetWidth());
     }
     else
     {
         int y = item->GetPosition().GetTop();
-        int base_y = m_items.Item(0)->GetPosition().GetTop();
-        int delta = y - base_y - m_scroll_amount;
-        ScrollLines(delta / m_bitmap_padded_size.GetHeight());
+        int baseY = m_items.Item(0)->GetPosition().GetTop();
+        int delta = y - baseY - m_scrollAmount;
+        ScrollLines(delta / m_bitmapPaddedSize.GetHeight());
     }
 }
 
@@ -492,7 +492,7 @@ void wxRibbonGallery::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
 void wxRibbonGallery::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
     wxAutoBufferedPaintDC dc(this);
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
         return;
 
     m_art->DrawGalleryBackground(dc, this, GetSize());
@@ -500,29 +500,29 @@ void wxRibbonGallery::OnPaint(wxPaintEvent& WXUNUSED(evt))
     int padding_top = m_art->GetMetric(wxRIBBON_ART_GALLERY_BITMAP_PADDING_TOP_SIZE);
     int padding_left = m_art->GetMetric(wxRIBBON_ART_GALLERY_BITMAP_PADDING_LEFT_SIZE);
 
-    dc.SetClippingRegion(m_client_rect);
+    dc.SetClippingRegion(m_clientRect);
 
-    bool offset_vertical = true;
-    if(m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
-        offset_vertical = false;
-    size_t item_count = m_items.Count();
-    size_t item_i;
-    for(item_i = 0; item_i < item_count; ++item_i)
+    bool offsetVertical = true;
+    if ( m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
+        offsetVertical = false;
+    size_t itemCount = m_items.Count();
+    size_t i;
+    for ( i = 0; i < itemCount; ++i )
     {
-        wxRibbonGalleryItem *item = m_items.Item(item_i);
-        if(!item->IsVisible())
+        wxRibbonGalleryItem *item = m_items.Item(i);
+        if ( !item->IsVisible() )
             continue;
 
         const wxRect& pos = item->GetPosition();
         wxRect offset_pos(pos);
-        if(offset_vertical)
-            offset_pos.SetTop(offset_pos.GetTop() - m_scroll_amount);
+        if ( offsetVertical )
+            offset_pos.SetTop(offset_pos.GetTop() - m_scrollAmount);
         else
-            offset_pos.SetLeft(offset_pos.GetLeft() - m_scroll_amount);
+            offset_pos.SetLeft(offset_pos.GetLeft() - m_scrollAmount);
         m_art->DrawGalleryItemBackground(dc, this, offset_pos, item);
         // Resolve bitmap bundle for current DPI
         wxBitmap bmp = item->GetBitmap(this);
-        if (bmp.IsOk())
+        if ( bmp.IsOk() )
             dc.DrawBitmap(bmp, offset_pos.GetLeft() + padding_left,
                 offset_pos.GetTop() + padding_top);
     }
@@ -542,14 +542,14 @@ void wxRibbonGallery::OnDPIChanged(wxDPIChangedEvent& event)
 wxRibbonGalleryItem* wxRibbonGallery::Append(const wxBitmapBundle& bitmap, int id)
 {
     wxASSERT(bitmap.IsOk());
-    if(m_items.IsEmpty())
+    if ( m_items.IsEmpty() )
     {
-        m_bitmap_size = bitmap.GetDefaultSize();
+        m_bitmapSize = bitmap.GetDefaultSize();
         CalculateMinSize();
     }
     else
     {
-        wxASSERT(bitmap.GetDefaultSize() == m_bitmap_size);
+        wxASSERT(bitmap.GetDefaultSize() == m_bitmapSize);
     }
 
     wxRibbonGalleryItem *item = new wxRibbonGalleryItem;
@@ -577,18 +577,17 @@ wxRibbonGalleryItem* wxRibbonGallery::Append(const wxBitmapBundle& bitmap, int i
 
 void wxRibbonGallery::Clear()
 {
-    size_t item_count = m_items.Count();
-    size_t item_i;
-    for(item_i = 0; item_i < item_count; ++item_i)
+    size_t itemCount = m_items.Count();
+    for ( size_t  i = 0; i < itemCount; ++i )
     {
-        wxRibbonGalleryItem *item = m_items.Item(item_i);
+        wxRibbonGalleryItem *item = m_items.Item(i);
         delete item;
     }
     m_items.Clear();
 
-    m_selected_item = nullptr;
-    m_hovered_item = nullptr;
-    m_active_item = nullptr;
+    m_selectedItem = nullptr;
+    m_hoveredItem = nullptr;
+    m_activeItem = nullptr;
 }
 
 bool wxRibbonGallery::IsSizingContinuous() const
@@ -598,26 +597,26 @@ bool wxRibbonGallery::IsSizingContinuous() const
 
 void wxRibbonGallery::CalculateMinSize()
 {
-    if(m_art == nullptr || !m_bitmap_size.IsFullySpecified())
+    if ( m_art == nullptr || !m_bitmapSize.IsFullySpecified() )
     {
         SetMinSize(wxSize(20, 20));
     }
     else
     {
-        m_bitmap_padded_size = m_bitmap_size;
-        m_bitmap_padded_size.IncBy(
+        m_bitmapPaddedSize = m_bitmapSize;
+        m_bitmapPaddedSize.IncBy(
             m_art->GetMetric(wxRIBBON_ART_GALLERY_BITMAP_PADDING_LEFT_SIZE) +
             m_art->GetMetric(wxRIBBON_ART_GALLERY_BITMAP_PADDING_RIGHT_SIZE),
             m_art->GetMetric(wxRIBBON_ART_GALLERY_BITMAP_PADDING_TOP_SIZE) +
             m_art->GetMetric(wxRIBBON_ART_GALLERY_BITMAP_PADDING_BOTTOM_SIZE));
 
         wxMemoryDC dc;
-        SetMinSize(m_art->GetGallerySize(dc, this, m_bitmap_padded_size));
+        SetMinSize(m_art->GetGallerySize(dc, this, m_bitmapPaddedSize));
 
         // The best size is displaying several items
-        m_best_size = m_bitmap_padded_size;
-        m_best_size.x *= 3;
-        m_best_size = m_art->GetGallerySize(dc, this, m_best_size);
+        m_bestSize = m_bitmapPaddedSize;
+        m_bestSize.x *= 3;
+        m_bestSize = m_art->GetGallerySize(dc, this, m_bestSize);
     }
 }
 
@@ -629,97 +628,97 @@ bool wxRibbonGallery::Realize()
 
 bool wxRibbonGallery::Layout()
 {
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
         return false;
 
     wxMemoryDC dc;
     wxPoint origin;
-    wxSize client_size = m_art->GetGalleryClientSize(dc, this, GetSize(),
-        &origin, &m_scroll_up_button_rect, &m_scroll_down_button_rect,
-        &m_extension_button_rect);
-    m_client_rect = wxRect(origin, client_size);
+    wxSize clientSize = m_art->GetGalleryClientSize(dc, this, GetSize(),
+        &origin, &m_scrollUpButtonRect, &m_scrollDownButtonRect,
+        &m_extensionButtonRect);
+    m_clientRect = wxRect(origin, clientSize);
 
     int x_cursor = 0;
     int y_cursor = 0;
 
-    size_t item_count = m_items.Count();
-    size_t item_i;
-    long art_flags = m_art->GetFlags();
-    for(item_i = 0; item_i < item_count; ++item_i)
+    size_t itemCount = m_items.Count();
+    size_t i;
+    long artFlags = m_art->GetFlags();
+    for ( i = 0; i < itemCount; ++i )
     {
-        wxRibbonGalleryItem *item = m_items.Item(item_i);
+        wxRibbonGalleryItem *item = m_items.Item(i);
         item->SetIsVisible(true);
-        if(art_flags & wxRIBBON_BAR_FLOW_VERTICAL)
+        if ( artFlags & wxRIBBON_BAR_FLOW_VERTICAL )
         {
-            if(y_cursor + m_bitmap_padded_size.y > client_size.GetHeight())
+            if ( y_cursor + m_bitmapPaddedSize.y > clientSize.GetHeight() )
             {
-                if(y_cursor == 0)
+                if ( y_cursor == 0 )
                     break;
                 y_cursor = 0;
-                x_cursor += m_bitmap_padded_size.x;
+                x_cursor += m_bitmapPaddedSize.x;
             }
             item->SetPosition(origin.x + x_cursor, origin.y + y_cursor,
-                m_bitmap_padded_size);
-            y_cursor += m_bitmap_padded_size.y;
+                m_bitmapPaddedSize);
+            y_cursor += m_bitmapPaddedSize.y;
         }
         else
         {
-            if(x_cursor + m_bitmap_padded_size.x > client_size.GetWidth())
+            if ( x_cursor + m_bitmapPaddedSize.x > clientSize.GetWidth() )
             {
-                if(x_cursor == 0)
+                if ( x_cursor == 0 )
                     break;
                 x_cursor = 0;
-                y_cursor += m_bitmap_padded_size.y;
+                y_cursor += m_bitmapPaddedSize.y;
             }
             item->SetPosition(origin.x + x_cursor, origin.y + y_cursor,
-                m_bitmap_padded_size);
-            x_cursor += m_bitmap_padded_size.x;
+                m_bitmapPaddedSize);
+            x_cursor += m_bitmapPaddedSize.x;
         }
     }
-    for(; item_i < item_count; ++item_i)
+    for ( ; i < itemCount; ++i )
     {
-        wxRibbonGalleryItem *item = m_items.Item(item_i);
+        wxRibbonGalleryItem *item = m_items.Item(i);
         item->SetIsVisible(false);
     }
-    if(art_flags & wxRIBBON_BAR_FLOW_VERTICAL)
-        m_scroll_limit = x_cursor;
+    if ( artFlags & wxRIBBON_BAR_FLOW_VERTICAL )
+        m_scrollLimit = x_cursor;
     else
-        m_scroll_limit = y_cursor;
-    if(m_scroll_amount >= m_scroll_limit)
+        m_scrollLimit = y_cursor;
+    if ( m_scrollAmount >= m_scrollLimit )
     {
-        m_scroll_amount = m_scroll_limit;
-        m_down_button_state = wxRIBBON_GALLERY_BUTTON_DISABLED;
+        m_scrollAmount = m_scrollLimit;
+        m_downButtonState = wxRIBBON_GALLERY_BUTTON_DISABLED;
     }
-    else if(m_down_button_state == wxRIBBON_GALLERY_BUTTON_DISABLED)
-        m_down_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
+    else if ( m_downButtonState == wxRIBBON_GALLERY_BUTTON_DISABLED )
+        m_downButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
 
-    if(m_scroll_amount <= 0)
+    if ( m_scrollAmount <= 0 )
     {
-        m_scroll_amount = 0;
-        m_up_button_state = wxRIBBON_GALLERY_BUTTON_DISABLED;
+        m_scrollAmount = 0;
+        m_upButtonState = wxRIBBON_GALLERY_BUTTON_DISABLED;
     }
-    else if(m_up_button_state == wxRIBBON_GALLERY_BUTTON_DISABLED)
-        m_up_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
+    else if ( m_upButtonState == wxRIBBON_GALLERY_BUTTON_DISABLED )
+        m_upButtonState = wxRIBBON_GALLERY_BUTTON_NORMAL;
 
     return true;
 }
 
 wxSize wxRibbonGallery::DoGetBestSize() const
 {
-    return m_best_size;
+    return m_bestSize;
 }
 
 wxSize wxRibbonGallery::DoGetNextSmallerSize(wxOrientation direction,
-                                        wxSize relative_to) const
+                                        wxSize relativeTo) const
 {
-    if(m_art == nullptr)
-        return relative_to;
+    if ( m_art == nullptr )
+        return relativeTo;
 
     wxMemoryDC dc;
 
-    wxSize client = m_art->GetGalleryClientSize(dc, this, relative_to, nullptr,
+    wxSize client = m_art->GetGalleryClientSize(dc, this, relativeTo, nullptr,
         nullptr, nullptr, nullptr);
-    switch(direction)
+    switch ( direction )
     {
     case wxHORIZONTAL:
         client.DecBy(1, 0);
@@ -731,28 +730,28 @@ wxSize wxRibbonGallery::DoGetNextSmallerSize(wxOrientation direction,
         client.DecBy(1, 1);
         break;
     }
-    if(client.GetWidth() < 0 || client.GetHeight() < 0)
-        return relative_to;
+    if ( client.GetWidth() < 0 || client.GetHeight() < 0 )
+        return relativeTo;
 
-    client.x = (client.x / m_bitmap_padded_size.x) * m_bitmap_padded_size.x;
-    client.y = (client.y / m_bitmap_padded_size.y) * m_bitmap_padded_size.y;
+    client.x = (client.x / m_bitmapPaddedSize.x) * m_bitmapPaddedSize.x;
+    client.y = (client.y / m_bitmapPaddedSize.y) * m_bitmapPaddedSize.y;
 
     wxSize size = m_art->GetGallerySize(dc, this, client);
     wxSize minimum = GetMinSize();
 
-    if(size.GetWidth() < minimum.GetWidth() ||
-        size.GetHeight() < minimum.GetHeight())
+    if ( size.GetWidth() < minimum.GetWidth() ||
+         size.GetHeight() < minimum.GetHeight() )
     {
-        return relative_to;
+        return relativeTo;
     }
 
-    switch(direction)
+    switch ( direction )
     {
     case wxHORIZONTAL:
-        size.SetHeight(relative_to.GetHeight());
+        size.SetHeight(relativeTo.GetHeight());
         break;
     case wxVERTICAL:
-        size.SetWidth(relative_to.GetWidth());
+        size.SetWidth(relativeTo.GetWidth());
         break;
     default:
         break;
@@ -762,54 +761,54 @@ wxSize wxRibbonGallery::DoGetNextSmallerSize(wxOrientation direction,
 }
 
 wxSize wxRibbonGallery::DoGetNextLargerSize(wxOrientation direction,
-                                       wxSize relative_to) const
+                                       wxSize relativeTo) const
 {
-    if(m_art == nullptr)
-        return relative_to;
+    if ( m_art == nullptr )
+        return relativeTo;
 
     wxMemoryDC dc;
 
-    wxSize client = m_art->GetGalleryClientSize(dc, this, relative_to, nullptr,
+    wxSize client = m_art->GetGalleryClientSize(dc, this, relativeTo, nullptr,
         nullptr, nullptr, nullptr);
 
     // No need to grow if the given size can already display every item
-    int nitems = (client.GetWidth() / m_bitmap_padded_size.x) *
-        (client.GetHeight() / m_bitmap_padded_size.y);
-    if(nitems >= (int)m_items.GetCount())
-        return relative_to;
+    int nItems = (client.GetWidth() / m_bitmapPaddedSize.x) *
+        (client.GetHeight() / m_bitmapPaddedSize.y);
+    if ( nItems >= (int)m_items.GetCount() )
+        return relativeTo;
 
-    switch(direction)
+    switch ( direction )
     {
     case wxHORIZONTAL:
-        client.IncBy(m_bitmap_padded_size.x, 0);
+        client.IncBy(m_bitmapPaddedSize.x, 0);
         break;
     case wxVERTICAL:
-        client.IncBy(0, m_bitmap_padded_size.y);
+        client.IncBy(0, m_bitmapPaddedSize.y);
         break;
     case wxBOTH:
-        client.IncBy(m_bitmap_padded_size);
+        client.IncBy(m_bitmapPaddedSize);
         break;
     }
 
-    client.x = (client.x / m_bitmap_padded_size.x) * m_bitmap_padded_size.x;
-    client.y = (client.y / m_bitmap_padded_size.y) * m_bitmap_padded_size.y;
+    client.x = (client.x / m_bitmapPaddedSize.x) * m_bitmapPaddedSize.x;
+    client.y = (client.y / m_bitmapPaddedSize.y) * m_bitmapPaddedSize.y;
 
     wxSize size = m_art->GetGallerySize(dc, this, client);
     wxSize minimum = GetMinSize();
 
-    if(size.GetWidth() < minimum.GetWidth() ||
-        size.GetHeight() < minimum.GetHeight())
+    if ( size.GetWidth() < minimum.GetWidth() ||
+         size.GetHeight() < minimum.GetHeight() )
     {
-        return relative_to;
+        return relativeTo;
     }
 
-    switch(direction)
+    switch ( direction )
     {
     case wxHORIZONTAL:
-        size.SetHeight(relative_to.GetHeight());
+        size.SetHeight(relativeTo.GetHeight());
         break;
     case wxVERTICAL:
-        size.SetWidth(relative_to.GetWidth());
+        size.SetWidth(relativeTo.GetWidth());
         break;
     default:
         break;
@@ -830,48 +829,48 @@ unsigned int wxRibbonGallery::GetCount() const
 
 wxRibbonGalleryItem* wxRibbonGallery::GetItem(unsigned int n)
 {
-    if(n >= GetCount())
+    if ( n >= GetCount() )
         return nullptr;
     return m_items.Item(n);
 }
 
 void wxRibbonGallery::SetSelection(wxRibbonGalleryItem* item)
 {
-    if(item != m_selected_item)
+    if ( item != m_selectedItem )
     {
-        m_selected_item = item;
+        m_selectedItem = item;
         Refresh(false);
     }
 }
 
 wxRibbonGalleryItem* wxRibbonGallery::GetSelection() const
 {
-    return m_selected_item;
+    return m_selectedItem;
 }
 
 wxRibbonGalleryItem* wxRibbonGallery::GetHoveredItem() const
 {
-    return m_hovered_item;
+    return m_hoveredItem;
 }
 
 wxRibbonGalleryItem* wxRibbonGallery::GetActiveItem() const
 {
-    return m_active_item;
+    return m_activeItem;
 }
 
 wxRibbonGalleryButtonState wxRibbonGallery::GetUpButtonState() const
 {
-    return m_up_button_state;
+    return m_upButtonState;
 }
 
 wxRibbonGalleryButtonState wxRibbonGallery::GetDownButtonState() const
 {
-    return m_down_button_state;
+    return m_downButtonState;
 }
 
 wxRibbonGalleryButtonState wxRibbonGallery::GetExtensionButtonState() const
 {
-    return m_extension_button_state;
+    return m_extensionButtonState;
 }
 
 #endif // wxUSE_RIBBON

--- a/src/ribbon/page.cpp
+++ b/src/ribbon/page.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/page.cpp
 // Purpose:     Container for ribbon-bar-style interface panels
 // Author:      Peter Cawley
@@ -20,7 +20,7 @@
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 static int GetSizeInOrientation(wxSize size, wxOrientation orientation);
@@ -95,7 +95,7 @@ void wxRibbonPageScrollButton::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
 void wxRibbonPageScrollButton::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
     wxAutoBufferedPaintDC dc(this);
-    if(m_art)
+    if ( m_art )
     {
         m_art->DrawScrollButton(dc, this, GetSize(), m_flags);
     }
@@ -122,11 +122,11 @@ void wxRibbonPageScrollButton::OnMouseDown(wxMouseEvent& WXUNUSED(evt))
 
 void wxRibbonPageScrollButton::OnMouseUp(wxMouseEvent& WXUNUSED(evt))
 {
-    if(m_flags & wxRIBBON_SCROLL_BTN_ACTIVE)
+    if ( m_flags & wxRIBBON_SCROLL_BTN_ACTIVE )
     {
         m_flags &= ~wxRIBBON_SCROLL_BTN_ACTIVE;
         Refresh(false);
-        switch(m_flags & wxRIBBON_SCROLL_BTN_DIRECTION_MASK)
+        switch ( m_flags & wxRIBBON_SCROLL_BTN_DIRECTION_MASK )
         {
         case wxRIBBON_SCROLL_BTN_DOWN:
         case wxRIBBON_SCROLL_BTN_RIGHT:
@@ -153,10 +153,10 @@ wxEND_EVENT_TABLE()
 
 wxRibbonPage::wxRibbonPage()
 {
-    m_scroll_left_btn = nullptr;
-    m_scroll_right_btn = nullptr;
-    m_scroll_amount = 0;
-    m_scroll_buttons_visible = false;
+    m_scrollLeftBtn = nullptr;
+    m_scrollRightBtn = nullptr;
+    m_scrollAmount = 0;
+    m_scrollButtonsVisible = false;
 }
 
 wxRibbonPage::wxRibbonPage(wxRibbonBar* parent,
@@ -171,9 +171,9 @@ wxRibbonPage::wxRibbonPage(wxRibbonBar* parent,
 
 wxRibbonPage::~wxRibbonPage()
 {
-    delete[] m_size_calc_array;
-    delete m_scroll_left_btn;
-    delete m_scroll_right_btn;
+    delete[] m_sizeCalcArray;
+    delete m_scrollLeftBtn;
+    delete m_scrollRightBtn;
 }
 
 bool wxRibbonPage::Create(wxRibbonBar* parent,
@@ -182,7 +182,7 @@ bool wxRibbonPage::Create(wxRibbonBar* parent,
                 const wxBitmapBundle& icon,
                 long WXUNUSED(style))
 {
-    if(!wxRibbonControl::Create(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE))
+    if ( !wxRibbonControl::Create(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE) )
         return false;
 
     CommonInit(label, icon);
@@ -196,16 +196,16 @@ void wxRibbonPage::CommonInit(const wxString& label, const wxBitmapBundle& icon)
 
     SetLabel(label);
     m_icon = icon;
-    m_scroll_left_btn = nullptr;
-    m_scroll_right_btn = nullptr;
-    m_size_calc_array = nullptr;
-    m_size_calc_array_size = 0;
-    m_scroll_amount = 0;
-    m_scroll_buttons_visible = false;
+    m_scrollLeftBtn = nullptr;
+    m_scrollRightBtn = nullptr;
+    m_sizeCalcArray = nullptr;
+    m_sizeCalcArraySize = 0;
+    m_scrollAmount = 0;
+    m_scrollButtonsVisible = false;
 
     SetBackgroundStyle(wxBG_STYLE_PAINT);
 
-    if (auto* const bar = wxCheckedStaticCast<wxRibbonBar>(GetParent()))
+    if ( auto* const bar = wxCheckedStaticCast<wxRibbonBar>(GetParent()) )
         bar->AddPage(this);
 }
 
@@ -217,54 +217,54 @@ void wxRibbonPage::SetArtProvider(wxRibbonArtProvider* art)
           node = node->GetNext() )
     {
         wxWindow* child = node->GetData();
-        wxRibbonControl* ribbon_child = wxDynamicCast(child, wxRibbonControl);
-        if(ribbon_child)
+        wxRibbonControl* ribbonChild = wxDynamicCast(child, wxRibbonControl);
+        if ( ribbonChild )
         {
-            ribbon_child->SetArtProvider(art);
+            ribbonChild->SetArtProvider(art);
         }
     }
 
     // The scroll buttons are children of the parent ribbon control, not the
     // page, so they're not taken into account by the loop above, but they
     // still use the same art provider, so we need to update them too.
-    if ( m_scroll_left_btn )
-        m_scroll_left_btn->SetArtProvider(art);
-    if ( m_scroll_right_btn )
-        m_scroll_right_btn->SetArtProvider(art);
+    if ( m_scrollLeftBtn )
+        m_scrollLeftBtn->SetArtProvider(art);
+    if ( m_scrollRightBtn )
+        m_scrollRightBtn->SetArtProvider(art);
 }
 
 void wxRibbonPage::AdjustRectToIncludeScrollButtons(wxRect* rect) const
 {
-    if(m_scroll_buttons_visible)
+    if ( m_scrollButtonsVisible )
     {
-        if(GetMajorAxis() == wxVERTICAL)
+        if ( GetMajorAxis() == wxVERTICAL )
         {
-            if(m_scroll_left_btn)
+            if ( m_scrollLeftBtn )
             {
                 rect->SetY(rect->GetY() -
-                    m_scroll_left_btn->GetSize().GetHeight());
+                    m_scrollLeftBtn->GetSize().GetHeight());
                 rect->SetHeight(rect->GetHeight() +
-                    m_scroll_left_btn->GetSize().GetHeight());
+                    m_scrollLeftBtn->GetSize().GetHeight());
             }
-            if(m_scroll_right_btn)
+            if ( m_scrollRightBtn )
             {
                 rect->SetHeight(rect->GetHeight() +
-                    m_scroll_right_btn->GetSize().GetHeight());
+                    m_scrollRightBtn->GetSize().GetHeight());
             }
         }
         else
         {
-            if(m_scroll_left_btn)
+            if ( m_scrollLeftBtn )
             {
                 rect->SetX(rect->GetX() -
-                    m_scroll_left_btn->GetSize().GetWidth());
+                    m_scrollLeftBtn->GetSize().GetWidth());
                 rect->SetWidth(rect->GetWidth() +
-                    m_scroll_left_btn->GetSize().GetWidth());
+                    m_scrollLeftBtn->GetSize().GetWidth());
             }
-            if(m_scroll_right_btn)
+            if ( m_scrollRightBtn )
             {
                 rect->SetWidth(rect->GetWidth() +
-                    m_scroll_right_btn->GetSize().GetWidth());
+                    m_scrollRightBtn->GetSize().GetWidth());
             }
         }
     }
@@ -287,7 +287,7 @@ void wxRibbonPage::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
 wxOrientation wxRibbonPage::GetMajorAxis() const
 {
-    if(m_art && (m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL))
+    if ( m_art && (m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL) )
     {
         return wxVERTICAL;
     }
@@ -304,24 +304,24 @@ bool wxRibbonPage::ScrollLines(int lines)
 
 bool wxRibbonPage::ScrollPixels(int pixels)
 {
-    if(pixels < 0)
+    if ( pixels < 0 )
     {
-        if(m_scroll_amount == 0)
+        if ( m_scrollAmount == 0 )
             return false;
-        if(m_scroll_amount < -pixels)
-            pixels = -m_scroll_amount;
+        if ( m_scrollAmount < -pixels )
+            pixels = -m_scrollAmount;
     }
-    else if(pixels > 0)
+    else if ( pixels > 0 )
     {
-        if(m_scroll_amount == m_scroll_amount_limit)
+        if ( m_scrollAmount == m_scrollAmountLimit )
             return false;
-        if(m_scroll_amount + pixels > m_scroll_amount_limit)
-            pixels = m_scroll_amount_limit - m_scroll_amount;
+        if ( m_scrollAmount + pixels > m_scrollAmountLimit )
+            pixels = m_scrollAmountLimit - m_scrollAmount;
     }
     else
         return false;
 
-    m_scroll_amount += pixels;
+    m_scrollAmount += pixels;
 
     for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
               node;
@@ -330,14 +330,14 @@ bool wxRibbonPage::ScrollPixels(int pixels)
         wxWindow* child = node->GetData();
         int x, y;
         child->GetPosition(&x, &y);
-        if(GetMajorAxis() == wxHORIZONTAL)
+        if ( GetMajorAxis() == wxHORIZONTAL )
             x -= pixels;
         else
             y -= pixels;
         child->SetPosition(wxPoint(x, y));
     }
 
-    if (ShowScrollButtons())
+    if ( ShowScrollButtons() )
         DoActualLayout();
     Refresh();
     return true;
@@ -356,15 +356,15 @@ bool wxRibbonPage::ScrollSections(int sections)
     // much if the available width is smaller than the items.
 
     // Scroll at minimum the same amount as ScrollLines(1):
-    int minscroll = sections * 8;
+    int minScroll = sections * 8;
     // How many pixels to scroll:
     int pixels = 0;
 
     // Determine the scroll position, that is, the page border where items
     // are appearing.
-    int scrollpos = 0;
+    int scrollPos = 0;
 
-    wxOrientation major_axis = GetMajorAxis();
+    wxOrientation majorAxis = GetMajorAxis();
     int gap = 0;
 
     int width = 0;
@@ -373,45 +373,45 @@ bool wxRibbonPage::ScrollSections(int sections)
     int y = 0;
     GetSize(&width, &height);
     GetPosition(&x, &y);
-    if(major_axis == wxHORIZONTAL)
+    if ( majorAxis == wxHORIZONTAL )
     {
         gap = m_art->GetMetric(wxRIBBON_ART_PANEL_X_SEPARATION_SIZE);
-        if (scrollForward)
+        if ( scrollForward )
         {
-            scrollpos = width - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE);
+            scrollPos = width - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE);
         }
         else
         {
-            scrollpos = m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE);
+            scrollPos = m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE);
         }
     }
     else
     {
         gap = m_art->GetMetric(wxRIBBON_ART_PANEL_Y_SEPARATION_SIZE);
-        if (scrollForward)
+        if ( scrollForward )
         {
-            scrollpos = width - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE);
+            scrollPos = width - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE);
         }
         else
         {
-            scrollpos = m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_TOP_SIZE);
+            scrollPos = m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_TOP_SIZE);
         }
     }
 
     // Find the child that is partially shown or just beyond the scroll position
-    for(wxWindowList::compatibility_iterator
+    for ( wxWindowList::compatibility_iterator
             node = scrollForward ? GetChildren().GetFirst()
                                  : GetChildren().GetLast();
         node;
         node = scrollForward ? node->GetNext()
-                             : node->GetPrevious())
+                             : node->GetPrevious() )
     {
         wxWindow* child = node->GetData();
         child->GetSize(&width, &height);
         child->GetPosition(&x, &y);
         int pos0 = 0;
         int pos1 = 0;
-        if (major_axis == wxHORIZONTAL)
+        if ( majorAxis == wxHORIZONTAL )
         {
             pos0 = x;
             pos1 = x + width + gap;
@@ -421,27 +421,27 @@ bool wxRibbonPage::ScrollSections(int sections)
             pos0 = y;
             pos1 = y + height + gap;
         }
-        if (scrollpos >= pos0 && scrollpos <= pos1)
+        if ( scrollPos >= pos0 && scrollPos <= pos1 )
         {
             // This section is partially visible, scroll to make it fully visible.
-            if (scrollForward)
+            if ( scrollForward )
             {
-                pixels += pos1 - scrollpos;
+                pixels += pos1 - scrollPos;
             }
             else
             {
-                pixels += pos0 - scrollpos;
+                pixels += pos0 - scrollPos;
             }
-            if (abs(pixels) >= abs(minscroll))
+            if ( abs(pixels) >= abs(minScroll) )
                 break;
         }
-        if (scrollpos <= pos0 && scrollForward)
+        if ( scrollPos <= pos0 && scrollForward )
         {
             // This section is next, scroll the entire section width
             pixels += (pos1 - pos0);
             break;
         }
-        if (scrollpos >= pos1 && !scrollForward)
+        if ( scrollPos >= pos1 && !scrollForward )
         {
             // This section is next, scroll the entire section width
             pixels += (pos0 - pos1);
@@ -449,11 +449,11 @@ bool wxRibbonPage::ScrollSections(int sections)
         }
     }
     // Do a final safety sanity check, should not be necessary, but will not hurt either.
-    if (pixels == 0)
+    if ( pixels == 0 )
     {
-        pixels = minscroll;
+        pixels = minScroll;
     }
-    if (pixels * minscroll < 0)
+    if ( pixels * minScroll < 0 )
     {
         pixels = -pixels;
     }
@@ -463,43 +463,43 @@ bool wxRibbonPage::ScrollSections(int sections)
 
 void wxRibbonPage::SetSizeWithScrollButtonAdjustment(int x, int y, int width, int height)
 {
-    if(m_scroll_buttons_visible)
+    if ( m_scrollButtonsVisible )
     {
-        if(GetMajorAxis() == wxHORIZONTAL)
+        if ( GetMajorAxis() == wxHORIZONTAL )
         {
-            if(m_scroll_left_btn)
+            if ( m_scrollLeftBtn )
             {
-                int w = m_scroll_left_btn->GetSize().GetWidth();
-                m_scroll_left_btn->SetPosition(wxPoint(x, y));
+                int w = m_scrollLeftBtn->GetSize().GetWidth();
+                m_scrollLeftBtn->SetPosition(wxPoint(x, y));
                 x += w;
                 width -= w;
             }
-            if(m_scroll_right_btn)
+            if ( m_scrollRightBtn )
             {
-                int w = m_scroll_right_btn->GetSize().GetWidth();
+                int w = m_scrollRightBtn->GetSize().GetWidth();
                 width -= w;
-                m_scroll_right_btn->SetPosition(wxPoint(x + width, y));
+                m_scrollRightBtn->SetPosition(wxPoint(x + width, y));
             }
         }
         else
         {
-            if(m_scroll_left_btn)
+            if ( m_scrollLeftBtn )
             {
-                int h = m_scroll_left_btn->GetSize().GetHeight();
-                m_scroll_left_btn->SetPosition(wxPoint(x, y));
+                int h = m_scrollLeftBtn->GetSize().GetHeight();
+                m_scrollLeftBtn->SetPosition(wxPoint(x, y));
                 y += h;
                 height -= h;
             }
-            if(m_scroll_right_btn)
+            if ( m_scrollRightBtn )
             {
-                int h = m_scroll_right_btn->GetSize().GetHeight();
+                int h = m_scrollRightBtn->GetSize().GetHeight();
                 height -= h;
-                m_scroll_right_btn->SetPosition(wxPoint(x, y + height));
+                m_scrollRightBtn->SetPosition(wxPoint(x, y + height));
             }
         }
     }
-    if (width < 0) width = 0;
-    if (height < 0) height = 0;
+    if ( width < 0 ) width = 0;
+    if ( height < 0 ) height = 0;
     SetSize(x, y, width, height);
 }
 
@@ -510,26 +510,26 @@ void wxRibbonPage::DoSetSize(int x, int y, int width, int height, int sizeFlags)
     // and report the 1st size to the 2nd size event. Hence the most recent size is
     // remembered internally and used in Layout() where appropriate.
 
-    if(GetMajorAxis() == wxHORIZONTAL)
+    if ( GetMajorAxis() == wxHORIZONTAL )
     {
-        m_size_in_major_axis_for_children = width;
-        if(m_scroll_buttons_visible)
+        m_sizeInMajorAxisForChildren = width;
+        if ( m_scrollButtonsVisible )
         {
-            if(m_scroll_left_btn)
-                m_size_in_major_axis_for_children += m_scroll_left_btn->GetSize().GetWidth();
-            if(m_scroll_right_btn)
-                m_size_in_major_axis_for_children += m_scroll_right_btn->GetSize().GetWidth();
+            if ( m_scrollLeftBtn )
+                m_sizeInMajorAxisForChildren += m_scrollLeftBtn->GetSize().GetWidth();
+            if ( m_scrollRightBtn )
+                m_sizeInMajorAxisForChildren += m_scrollRightBtn->GetSize().GetWidth();
         }
     }
     else
     {
-        m_size_in_major_axis_for_children = height;
-        if(m_scroll_buttons_visible)
+        m_sizeInMajorAxisForChildren = height;
+        if ( m_scrollButtonsVisible )
         {
-            if(m_scroll_left_btn)
-                m_size_in_major_axis_for_children += m_scroll_left_btn->GetSize().GetHeight();
-            if(m_scroll_right_btn)
-                m_size_in_major_axis_for_children += m_scroll_right_btn->GetSize().GetHeight();
+            if ( m_scrollLeftBtn )
+                m_sizeInMajorAxisForChildren += m_scrollLeftBtn->GetSize().GetHeight();
+            if ( m_scrollRightBtn )
+                m_sizeInMajorAxisForChildren += m_scrollRightBtn->GetSize().GetHeight();
         }
     }
 
@@ -538,18 +538,18 @@ void wxRibbonPage::DoSetSize(int x, int y, int width, int height, int sizeFlags)
 
 void wxRibbonPage::OnSize(wxSizeEvent& evt)
 {
-    wxSize new_size = evt.GetSize();
+    wxSize newSize = evt.GetSize();
 
-    if (m_art)
+    if ( m_art )
     {
-        wxMemoryDC temp_dc;
-        wxRect invalid_rect = m_art->GetPageBackgroundRedrawArea(temp_dc, this, m_old_size, new_size);
-        Refresh(true, &invalid_rect);
+        wxMemoryDC tempDc;
+        wxRect invalidRect = m_art->GetPageBackgroundRedrawArea(tempDc, this, m_oldSize, newSize);
+        Refresh(true, &invalidRect);
     }
 
-    m_old_size = new_size;
+    m_oldSize = newSize;
 
-    if(new_size.GetX() > 0 && new_size.GetY() > 0)
+    if ( newSize.GetX() > 0 && newSize.GetY() > 0 )
     {
         Layout();
     }
@@ -557,7 +557,7 @@ void wxRibbonPage::OnSize(wxSizeEvent& evt)
     {
         // Simplify other calculations by pretending new size is zero in both
         // X and Y
-        new_size.Set(0, 0);
+        newSize.Set(0, 0);
         // When size == 0, no point in doing any layout
     }
 
@@ -573,27 +573,27 @@ void wxRibbonPage::OnDPIChanged(wxDPIChangedEvent& event)
 void wxRibbonPage::RemoveChild(wxWindowBase *child)
 {
     // Remove all references to the child from the collapse stack
-    size_t count = m_collapse_stack.GetCount();
+    size_t count = m_collapseStack.GetCount();
     size_t src, dst;
-    for(src = 0, dst = 0; src < count; ++src, ++dst)
+    for ( src = 0, dst = 0; src < count; ++src, ++dst )
     {
-        wxRibbonControl *item = m_collapse_stack.Item(src);
-        if(item == child)
+        wxRibbonControl *item = m_collapseStack.Item(src);
+        if ( item == child )
         {
             ++src;
-            if(src == count)
+            if ( src == count )
             {
                 break;
             }
         }
-        if(src != dst)
+        if ( src != dst )
         {
-            m_collapse_stack.Item(dst) = item;
+            m_collapseStack.Item(dst) = item;
         }
     }
-    if(src > dst)
+    if ( src > dst )
     {
-        m_collapse_stack.RemoveAt(dst, src - dst);
+        m_collapseStack.RemoveAt(dst, src - dst);
     }
 
     // ... and then proceed as normal
@@ -604,17 +604,17 @@ bool wxRibbonPage::Realize()
 {
     bool status = true;
 
-    m_collapse_stack.Clear();
-    for (wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
+    m_collapseStack.Clear();
+    for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
                   node;
-                  node = node->GetNext())
+                  node = node->GetNext() )
     {
         wxRibbonControl* child = wxDynamicCast(node->GetData(), wxRibbonControl);
-        if(child == nullptr)
+        if ( child == nullptr )
         {
             continue;
         }
-        if(!child->Realize())
+        if ( !child->Realize() )
         {
             status = false;
         }
@@ -624,7 +624,7 @@ bool wxRibbonPage::Realize()
     return DoActualLayout() && status;
 }
 
-void wxRibbonPage::PopulateSizeCalcArray(wxSize (wxWindow::*get_size)(void) const)
+void wxRibbonPage::PopulateSizeCalcArray(wxSize (wxWindow::*getSize)(void) const)
 {
     wxSize parentSize = GetSize();
     parentSize.x -= m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE);
@@ -632,30 +632,30 @@ void wxRibbonPage::PopulateSizeCalcArray(wxSize (wxWindow::*get_size)(void) cons
     parentSize.y -= m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_TOP_SIZE);
     parentSize.y -= m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE);
 
-    if(m_size_calc_array_size != GetChildren().GetCount())
+    if ( m_sizeCalcArraySize != GetChildren().GetCount() )
     {
-        delete[] m_size_calc_array;
-        m_size_calc_array_size = GetChildren().GetCount();
-        m_size_calc_array = new wxSize[m_size_calc_array_size];
+        delete[] m_sizeCalcArray;
+        m_sizeCalcArraySize = GetChildren().GetCount();
+        m_sizeCalcArray = new wxSize[m_sizeCalcArraySize];
     }
 
-    wxSize* node_size = m_size_calc_array;
+    wxSize* nodeSize = m_sizeCalcArray;
     for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
           node;
-          node = node->GetNext(), ++node_size )
+          node = node->GetNext(), ++nodeSize )
     {
         wxWindow* child = node->GetData();
         wxRibbonPanel* panel = wxDynamicCast(child, wxRibbonPanel);
-        if (panel && panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE)
-            *node_size = panel->GetBestSizeForParentSize(parentSize);
+        if ( panel && panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE )
+            *nodeSize = panel->GetBestSizeForParentSize(parentSize);
         else
-            *node_size = (child->*get_size)();
+            *nodeSize = (child->*getSize)();
     }
 }
 
 bool wxRibbonPage::Layout()
 {
-    if(GetChildren().GetCount() == 0)
+    if ( GetChildren().GetCount() == 0 )
     {
         return true;
     }
@@ -669,95 +669,95 @@ bool wxRibbonPage::Layout()
 bool wxRibbonPage::DoActualLayout()
 {
     wxPoint origin(m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE), m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_TOP_SIZE));
-    wxOrientation major_axis = GetMajorAxis();
+    wxOrientation majorAxis = GetMajorAxis();
     int gap;
-    int minor_axis_size;
-    int available_space;
-    if(major_axis == wxHORIZONTAL)
+    int minorAxisSize;
+    int availableSpace;
+    if ( majorAxis == wxHORIZONTAL )
     {
         gap = m_art->GetMetric(wxRIBBON_ART_PANEL_X_SEPARATION_SIZE);
-        minor_axis_size = GetSize().GetHeight() - origin.y - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE);
-        available_space = m_size_in_major_axis_for_children - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE) - origin.x;
+        minorAxisSize = GetSize().GetHeight() - origin.y - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE);
+        availableSpace = m_sizeInMajorAxisForChildren - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE) - origin.x;
     }
     else
     {
         gap = m_art->GetMetric(wxRIBBON_ART_PANEL_Y_SEPARATION_SIZE);
-        minor_axis_size = GetSize().GetWidth() - origin.x - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE);
-        available_space = m_size_in_major_axis_for_children - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE) - origin.y;
+        minorAxisSize = GetSize().GetWidth() - origin.x - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE);
+        availableSpace = m_sizeInMajorAxisForChildren - m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE) - origin.y;
     }
-    if (minor_axis_size < 0) minor_axis_size = 0;
-    size_t size_index;
-    for(size_index = 0; size_index < m_size_calc_array_size; ++size_index)
+    if ( minorAxisSize < 0 ) minorAxisSize = 0;
+    size_t sizeIndex;
+    for ( sizeIndex = 0; sizeIndex < m_sizeCalcArraySize; ++sizeIndex )
     {
-        if(major_axis == wxHORIZONTAL)
+        if ( majorAxis == wxHORIZONTAL )
         {
-            available_space -= m_size_calc_array[size_index].GetWidth();
-            m_size_calc_array[size_index].SetHeight(minor_axis_size);
+            availableSpace -= m_sizeCalcArray[sizeIndex].GetWidth();
+            m_sizeCalcArray[sizeIndex].SetHeight(minorAxisSize);
         }
         else
         {
-            available_space -= m_size_calc_array[size_index].GetHeight();
-            m_size_calc_array[size_index].SetWidth(minor_axis_size);
+            availableSpace -= m_sizeCalcArray[sizeIndex].GetHeight();
+            m_sizeCalcArray[sizeIndex].SetWidth(minorAxisSize);
         }
-        if(size_index != 0)
-            available_space -= gap;
+        if ( sizeIndex != 0 )
+            availableSpace -= gap;
     }
-    bool todo_hide_scroll_buttons = false;
-    bool todo_show_scroll_buttons = false;
-    if(available_space >= 0)
+    bool todoHideScrollButtons = false;
+    bool todoShowScrollButtons = false;
+    if ( availableSpace >= 0 )
     {
-        if(m_scroll_buttons_visible)
-            todo_hide_scroll_buttons = true;
-        if(available_space > 0)
-            ExpandPanels(major_axis, available_space);
+        if ( m_scrollButtonsVisible )
+            todoHideScrollButtons = true;
+        if ( availableSpace > 0 )
+            ExpandPanels(majorAxis, availableSpace);
     }
     else
     {
-        if(m_scroll_buttons_visible)
+        if ( m_scrollButtonsVisible )
         {
             // Scroll buttons already visible - not going to be able to downsize any more
-            m_scroll_amount_limit = -available_space;
-            if(m_scroll_amount > m_scroll_amount_limit)
+            m_scrollAmountLimit = -availableSpace;
+            if ( m_scrollAmount > m_scrollAmountLimit )
             {
-                m_scroll_amount = m_scroll_amount_limit;
-                todo_show_scroll_buttons = true;
+                m_scrollAmount = m_scrollAmountLimit;
+                todoShowScrollButtons = true;
             }
         }
         else
         {
-            if(!CollapsePanels(major_axis, -available_space))
+            if ( !CollapsePanels(majorAxis, -availableSpace) )
             {
-                m_scroll_amount = 0;
-                m_scroll_amount_limit = -available_space;
-                todo_show_scroll_buttons = true;
+                m_scrollAmount = 0;
+                m_scrollAmountLimit = -availableSpace;
+                todoShowScrollButtons = true;
             }
         }
     }
-    if(m_scroll_buttons_visible)
+    if ( m_scrollButtonsVisible )
     {
-        if(major_axis == wxHORIZONTAL)
+        if ( majorAxis == wxHORIZONTAL )
         {
-            origin.x -= m_scroll_amount;
-            if(m_scroll_left_btn)
-                origin.x -= m_scroll_left_btn->GetSize().GetWidth();
+            origin.x -= m_scrollAmount;
+            if ( m_scrollLeftBtn )
+                origin.x -= m_scrollLeftBtn->GetSize().GetWidth();
         }
         else
         {
-            origin.y -= m_scroll_amount;
-            if(m_scroll_left_btn)
-                origin.y -= m_scroll_left_btn->GetSize().GetHeight();
+            origin.y -= m_scrollAmount;
+            if ( m_scrollLeftBtn )
+                origin.y -= m_scrollLeftBtn->GetSize().GetHeight();
         }
     }
-    size_index = 0;
-    for(wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
+    sizeIndex = 0;
+    for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
         node;
-        node = node->GetNext(), ++size_index )
+        node = node->GetNext(), ++sizeIndex )
     {
         wxWindow* child = node->GetData();
-        int w = m_size_calc_array[size_index].GetWidth();
-        int h = m_size_calc_array[size_index].GetHeight();
+        int w = m_sizeCalcArray[sizeIndex].GetWidth();
+        int h = m_sizeCalcArray[sizeIndex].GetHeight();
         child->SetSize(origin.x, origin.y, w, h);
-        if(major_axis == wxHORIZONTAL)
+        if ( majorAxis == wxHORIZONTAL )
         {
             origin.x += w + (child->IsShown() ? gap : 0);
         }
@@ -767,11 +767,11 @@ bool wxRibbonPage::DoActualLayout()
         }
     }
 
-    if(todo_show_scroll_buttons)
+    if ( todoShowScrollButtons )
         ShowScrollButtons();
-    else if(todo_hide_scroll_buttons)
+    else if ( todoHideScrollButtons )
         HideScrollButtons();
-    else if(m_scroll_buttons_visible)
+    else if ( m_scrollButtonsVisible )
         ShowScrollButtons();
 
     Refresh();
@@ -780,120 +780,120 @@ bool wxRibbonPage::DoActualLayout()
 
 bool wxRibbonPage::Show(bool show)
 {
-    if(m_scroll_left_btn)
-        m_scroll_left_btn->Show(show);
-    if(m_scroll_right_btn)
-        m_scroll_right_btn->Show(show);
+    if ( m_scrollLeftBtn )
+        m_scrollLeftBtn->Show(show);
+    if ( m_scrollRightBtn )
+        m_scrollRightBtn->Show(show);
     return wxRibbonControl::Show(show);
 }
 
 void wxRibbonPage::HideScrollButtons()
 {
-    m_scroll_amount = 0;
-    m_scroll_amount_limit = 0;
+    m_scrollAmount = 0;
+    m_scrollAmountLimit = 0;
     ShowScrollButtons();
 }
 
 bool wxRibbonPage::ShowScrollButtons()
 {
-    bool show_left = true;
-    bool show_right = true;
+    bool showLeft = true;
+    bool showRight = true;
     bool reposition = false;
-    if(m_scroll_amount == 0)
+    if ( m_scrollAmount == 0 )
     {
-        show_left = false;
+        showLeft = false;
     }
-    if(m_scroll_amount >= m_scroll_amount_limit)
+    if ( m_scrollAmount >= m_scrollAmountLimit )
     {
-        show_right = false;
-        m_scroll_amount = m_scroll_amount_limit;
+        showRight = false;
+        m_scrollAmount = m_scrollAmountLimit;
     }
-    m_scroll_buttons_visible = show_left || show_right;
+    m_scrollButtonsVisible = showLeft || showRight;
 
-    if(show_left)
+    if ( showLeft )
     {
-        wxMemoryDC temp_dc;
+        wxMemoryDC tempDc;
         wxSize size;
         long direction;
-        if(GetMajorAxis() == wxHORIZONTAL)
+        if ( GetMajorAxis() == wxHORIZONTAL )
         {
               direction = wxRIBBON_SCROLL_BTN_LEFT;
-              size = m_art->GetScrollButtonMinimumSize(temp_dc, GetParent(), direction);
+              size = m_art->GetScrollButtonMinimumSize(tempDc, GetParent(), direction);
               size.SetHeight(GetSize().GetHeight());
         }
         else
         {
               direction = wxRIBBON_SCROLL_BTN_UP;
-              size = m_art->GetScrollButtonMinimumSize(temp_dc, GetParent(), direction);
+              size = m_art->GetScrollButtonMinimumSize(tempDc, GetParent(), direction);
               size.SetWidth(GetSize().GetWidth());
         }
-        if (m_scroll_left_btn)
+        if ( m_scrollLeftBtn )
         {
-              m_scroll_left_btn->SetSize(size);
+              m_scrollLeftBtn->SetSize(size);
         }
         else
         {
-              m_scroll_left_btn = new wxRibbonPageScrollButton(this, wxID_ANY, GetPosition(), size, direction);
+              m_scrollLeftBtn = new wxRibbonPageScrollButton(this, wxID_ANY, GetPosition(), size, direction);
               reposition = true;
         }
-        if(!IsShown())
+        if ( !IsShown() )
         {
-              m_scroll_left_btn->Hide();
+              m_scrollLeftBtn->Hide();
         }
     }
     else
     {
-        if(m_scroll_left_btn != nullptr)
+        if ( m_scrollLeftBtn != nullptr )
         {
-            m_scroll_left_btn->Destroy();
-            m_scroll_left_btn = nullptr;
+            m_scrollLeftBtn->Destroy();
+            m_scrollLeftBtn = nullptr;
             reposition = true;
         }
     }
 
-    if(show_right)
+    if ( showRight )
     {
-        wxMemoryDC temp_dc;
+        wxMemoryDC tempDc;
         wxSize size;
         long direction;
-        if(GetMajorAxis() == wxHORIZONTAL)
+        if ( GetMajorAxis() == wxHORIZONTAL )
         {
               direction = wxRIBBON_SCROLL_BTN_RIGHT;
-              size = m_art->GetScrollButtonMinimumSize(temp_dc, GetParent(), direction);
+              size = m_art->GetScrollButtonMinimumSize(tempDc, GetParent(), direction);
               size.SetHeight(GetSize().GetHeight());
         }
         else
         {
               direction = wxRIBBON_SCROLL_BTN_DOWN;
-              size = m_art->GetScrollButtonMinimumSize(temp_dc, GetParent(), direction);
+              size = m_art->GetScrollButtonMinimumSize(tempDc, GetParent(), direction);
               size.SetWidth(GetSize().GetWidth());
         }
-        wxPoint initial_pos = GetPosition() + GetSize() - size;
-        if (m_scroll_right_btn)
+        wxPoint initialPos = GetPosition() + GetSize() - size;
+        if ( m_scrollRightBtn )
         {
-              m_scroll_right_btn->SetSize(size);
+              m_scrollRightBtn->SetSize(size);
         }
         else
         {
-              m_scroll_right_btn = new wxRibbonPageScrollButton(this, wxID_ANY, initial_pos, size, direction);
+              m_scrollRightBtn = new wxRibbonPageScrollButton(this, wxID_ANY, initialPos, size, direction);
               reposition = true;
         }
-        if(!IsShown())
+        if ( !IsShown() )
         {
-              m_scroll_right_btn->Hide();
+              m_scrollRightBtn->Hide();
         }
     }
     else
     {
-        if(m_scroll_right_btn != nullptr)
+        if ( m_scrollRightBtn != nullptr )
         {
-            m_scroll_right_btn->Destroy();
-            m_scroll_right_btn = nullptr;
+            m_scrollRightBtn->Destroy();
+            m_scrollRightBtn = nullptr;
             reposition = true;
         }
     }
 
-    if(reposition)
+    if ( reposition )
     {
         wxASSERT_MSG(wxDynamicCast(GetParent(), wxRibbonBar), "pointer of wrong type?");
         static_cast<wxRibbonBar*>(GetParent())->RepositionPage(this);
@@ -904,7 +904,7 @@ bool wxRibbonPage::ShowScrollButtons()
 
 static int GetSizeInOrientation(wxSize size, wxOrientation orientation)
 {
-    switch(orientation)
+    switch ( orientation )
     {
     case wxHORIZONTAL: return size.GetWidth();
     case wxVERTICAL: return size.GetHeight();
@@ -915,85 +915,85 @@ static int GetSizeInOrientation(wxSize size, wxOrientation orientation)
 
 bool wxRibbonPage::ExpandPanels(wxOrientation direction, int maximum_amount)
 {
-    bool expanded_something = false;
-    while(maximum_amount > 0)
+    bool expandedSomething = false;
+    while ( maximum_amount > 0 )
     {
-        int smallest_size = INT_MAX;
-        wxRibbonPanel* smallest_panel = nullptr;
-        wxSize* smallest_panel_size = nullptr;
-        wxSize* panel_size = m_size_calc_array;
+        int smallestSize = INT_MAX;
+        wxRibbonPanel* smallestPanel = nullptr;
+        wxSize* smallestPanelSize = nullptr;
+        wxSize* panelSize = m_sizeCalcArray;
         for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
                   node;
-                  node = node->GetNext(), ++panel_size )
+                  node = node->GetNext(), ++panelSize )
         {
             wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-            if(panel == nullptr || !panel->IsShown())
+            if ( panel == nullptr || !panel->IsShown() )
             {
                 continue;
             }
-            if (panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE)
+            if ( panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE )
             {
                 // Don't change if it's flexible since we already calculated the
                 // correct size for the panel.
             }
-            else if(panel->IsSizingContinuous())
+            else if ( panel->IsSizingContinuous() )
             {
-                int size = GetSizeInOrientation(*panel_size, direction);
-                if(size < smallest_size)
+                int size = GetSizeInOrientation(*panelSize, direction);
+                if ( size < smallestSize )
                 {
-                    smallest_size = size;
-                    smallest_panel = panel;
-                    smallest_panel_size = panel_size;
+                    smallestSize = size;
+                    smallestPanel = panel;
+                    smallestPanelSize = panelSize;
                 }
             }
             else
             {
-                int size = GetSizeInOrientation(*panel_size, direction);
-                if(size < smallest_size)
+                int size = GetSizeInOrientation(*panelSize, direction);
+                if ( size < smallestSize )
                 {
-                    wxSize larger = panel->GetNextLargerSize(direction, *panel_size);
-                    if(larger != (*panel_size) && GetSizeInOrientation(larger, direction) > size)
+                    wxSize larger = panel->GetNextLargerSize(direction, *panelSize);
+                    if ( larger != (*panelSize) && GetSizeInOrientation(larger, direction) > size )
                     {
-                        smallest_size = size;
-                        smallest_panel = panel;
-                        smallest_panel_size = panel_size;
+                        smallestSize = size;
+                        smallestPanel = panel;
+                        smallestPanelSize = panelSize;
                     }
                 }
             }
         }
-        if(smallest_panel != nullptr)
+        if ( smallestPanel != nullptr )
         {
-            if(smallest_panel->IsSizingContinuous())
+            if ( smallestPanel->IsSizingContinuous() )
             {
                 int amount = maximum_amount;
-                if(amount > 32)
+                if ( amount > 32 )
                 {
                     // For "large" growth, grow this panel a bit, and then re-allocate
                     // the remainder (which may come to this panel again anyway)
                     amount = 32;
                 }
-                if(direction & wxHORIZONTAL)
+                if ( direction & wxHORIZONTAL )
                 {
-                    smallest_panel_size->x += amount;
+                    smallestPanelSize->x += amount;
                 }
-                if(direction & wxVERTICAL)
+                if ( direction & wxVERTICAL )
                 {
-                    smallest_panel_size->y += amount;
+                    smallestPanelSize->y += amount;
                 }
                 maximum_amount -= amount;
-                m_collapse_stack.Add(smallest_panel);
-                expanded_something = true;
+                m_collapseStack.Add(smallestPanel);
+                expandedSomething = true;
             }
             else
             {
-                wxSize larger = smallest_panel->GetNextLargerSize(direction, *smallest_panel_size);
-                wxSize delta = larger - (*smallest_panel_size);
-                if(GetSizeInOrientation(delta, direction) <= maximum_amount)
+                wxSize larger = smallestPanel->GetNextLargerSize(direction, *smallestPanelSize);
+                wxSize delta = larger - (*smallestPanelSize);
+                if ( GetSizeInOrientation(delta, direction) <= maximum_amount )
                 {
-                    *smallest_panel_size = larger;
+                    *smallestPanelSize = larger;
                     maximum_amount -= GetSizeInOrientation(delta, direction);
-                    m_collapse_stack.Add(smallest_panel);
-                    expanded_something = true;
+                    m_collapseStack.Add(smallestPanel);
+                    expandedSomething = true;
                 }
                 else
                 {
@@ -1006,100 +1006,100 @@ bool wxRibbonPage::ExpandPanels(wxOrientation direction, int maximum_amount)
             break;
         }
     }
-    return expanded_something;
+    return expandedSomething;
 }
 
 bool wxRibbonPage::CollapsePanels(wxOrientation direction, int minimum_amount)
 {
-    while(minimum_amount > 0)
+    while ( minimum_amount > 0 )
     {
-        wxRibbonPanel* largest_panel = nullptr;
-        wxSize* largest_panel_size = nullptr;
-        wxSize* panel_size = m_size_calc_array;
-        if(!m_collapse_stack.IsEmpty())
+        wxRibbonPanel* largestPanel = nullptr;
+        wxSize* largestPanelSize = nullptr;
+        wxSize* panelSize = m_sizeCalcArray;
+        if ( !m_collapseStack.IsEmpty() )
         {
             // For a more consistent panel layout, try to collapse panels which
             // were recently expanded.
-            largest_panel = wxDynamicCast(m_collapse_stack.Last(), wxRibbonPanel);
-            m_collapse_stack.RemoveAt(m_collapse_stack.GetCount() - 1);
-            for(wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
+            largestPanel = wxDynamicCast(m_collapseStack.Last(), wxRibbonPanel);
+            m_collapseStack.RemoveAt(m_collapseStack.GetCount() - 1);
+            for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
                       node;
-                      node = node->GetNext(), ++panel_size )
+                      node = node->GetNext(), ++panelSize )
             {
                 wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-                if(panel == largest_panel && panel->IsShown())
+                if ( panel == largestPanel && panel->IsShown() )
                 {
-                    largest_panel_size = panel_size;
+                    largestPanelSize = panelSize;
                     break;
                 }
             }
         }
         else
         {
-            int largest_size = 0;
-            for(wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
+            int largestSize = 0;
+            for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
                       node;
-                      node = node->GetNext(), ++panel_size )
+                      node = node->GetNext(), ++panelSize )
             {
                 wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-                if(panel == nullptr || !panel->IsShown())
+                if ( panel == nullptr || !panel->IsShown() )
                 {
                     continue;
                 }
-                if(panel->IsSizingContinuous())
+                if ( panel->IsSizingContinuous() )
                 {
-                    int size = GetSizeInOrientation(*panel_size, direction);
-                    if(size > largest_size)
+                    int size = GetSizeInOrientation(*panelSize, direction);
+                    if ( size > largestSize )
                     {
-                        largest_size = size;
-                        largest_panel = panel;
-                        largest_panel_size = panel_size;
+                        largestSize = size;
+                        largestPanel = panel;
+                        largestPanelSize = panelSize;
                     }
                 }
                 else
                 {
-                    int size = GetSizeInOrientation(*panel_size, direction);
-                    if(size > largest_size)
+                    int size = GetSizeInOrientation(*panelSize, direction);
+                    if ( size > largestSize )
                     {
-                        wxSize smaller = panel->GetNextSmallerSize(direction, *panel_size);
-                        if(smaller != (*panel_size) &&
-                            GetSizeInOrientation(smaller, direction) < size)
+                        wxSize smaller = panel->GetNextSmallerSize(direction, *panelSize);
+                        if ( smaller != (*panelSize) &&
+                            GetSizeInOrientation(smaller, direction) < size )
                         {
-                            largest_size = size;
-                            largest_panel = panel;
-                            largest_panel_size = panel_size;
+                            largestSize = size;
+                            largestPanel = panel;
+                            largestPanelSize = panelSize;
                         }
                     }
                 }
             }
         }
-        if(largest_panel != nullptr && largest_panel_size != nullptr)
+        if ( largestPanel != nullptr && largestPanelSize != nullptr )
         {
-            if(largest_panel->IsSizingContinuous())
+            if ( largestPanel->IsSizingContinuous() )
             {
                 int amount = minimum_amount;
-                if(amount > 32)
+                if ( amount > 32 )
                 {
                     // For "large" contraction, reduce this panel a bit, and
                     // then re-allocate the remainder of the quota (which may
                     // come to this panel again anyway)
                     amount = 32;
                 }
-                if(direction & wxHORIZONTAL)
+                if ( direction & wxHORIZONTAL )
                 {
-                    largest_panel_size->x -= amount;
+                    largestPanelSize->x -= amount;
                 }
-                if(direction & wxVERTICAL)
+                if ( direction & wxVERTICAL )
                 {
-                    largest_panel_size->y -= amount;
+                    largestPanelSize->y -= amount;
                 }
                 minimum_amount -= amount;
             }
             else
             {
-                wxSize smaller = largest_panel->GetNextSmallerSize(direction, *largest_panel_size);
-                wxSize delta = (*largest_panel_size) - smaller;
-                *largest_panel_size = smaller;
+                wxSize smaller = largestPanel->GetNextSmallerSize(direction, *largestPanelSize);
+                wxSize delta = (*largestPanelSize) - smaller;
+                *largestPanelSize = smaller;
                 minimum_amount -= GetSizeInOrientation(delta, direction);
             }
         }
@@ -1168,11 +1168,11 @@ bool wxRibbonPage::DismissExpandedPanel()
               node = node->GetNext() )
     {
         wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-        if(panel == nullptr || !panel->IsShown())
+        if ( panel == nullptr || !panel->IsShown() )
         {
             continue;
         }
-        if(panel->GetExpandedPanel() != nullptr)
+        if ( panel->GetExpandedPanel() != nullptr )
         {
             return panel->HideExpanded();
         }
@@ -1189,23 +1189,23 @@ wxSize wxRibbonPage::GetMinSize() const
           node = node->GetNext() )
     {
         wxWindow* child = node->GetData();
-        wxSize child_min(child->GetMinSize());
+        wxSize childMin(child->GetMinSize());
 
-        min.x = wxMax(min.x, child_min.x);
-        min.y = wxMax(min.y, child_min.y);
+        min.x = wxMax(min.x, childMin.x);
+        min.y = wxMax(min.y, childMin.y);
     }
 
-    if(GetMajorAxis() == wxHORIZONTAL)
+    if ( GetMajorAxis() == wxHORIZONTAL )
     {
         min.x = wxDefaultCoord;
-        if(min.y != wxDefaultCoord)
+        if ( min.y != wxDefaultCoord )
         {
             min.y += m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_TOP_SIZE) + m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE);
         }
     }
     else
     {
-        if(min.x != wxDefaultCoord)
+        if ( min.x != wxDefaultCoord )
         {
             min.x += m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE) + m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE);
         }
@@ -1220,7 +1220,7 @@ wxSize wxRibbonPage::DoGetBestSize() const
     wxSize best(0, 0);
     size_t count = 0;
 
-    if(GetMajorAxis() == wxHORIZONTAL)
+    if ( GetMajorAxis() == wxHORIZONTAL )
     {
         best.y = wxDefaultCoord;
 
@@ -1229,18 +1229,18 @@ wxSize wxRibbonPage::DoGetBestSize() const
           node = node->GetNext() )
         {
             wxWindow* child = node->GetData();
-            wxSize child_best(child->GetBestSize());
+            wxSize childBest(child->GetBestSize());
 
-            if(child_best.x != wxDefaultCoord)
+            if ( childBest.x != wxDefaultCoord )
             {
-                best.IncBy(child_best.x, 0);
+                best.IncBy(childBest.x, 0);
             }
-            best.y = wxMax(best.y, child_best.y);
+            best.y = wxMax(best.y, childBest.y);
 
             ++count;
         }
 
-        if(count > 1)
+        if ( count > 1 )
         {
             best.IncBy((count - 1) * m_art->GetMetric(wxRIBBON_ART_PANEL_X_SEPARATION_SIZE), 0);
         }
@@ -1254,28 +1254,28 @@ wxSize wxRibbonPage::DoGetBestSize() const
           node = node->GetNext() )
         {
             wxWindow* child = node->GetData();
-            wxSize child_best(child->GetBestSize());
+            wxSize childBest(child->GetBestSize());
 
-            best.x = wxMax(best.x, child_best.x);
-            if(child_best.y != wxDefaultCoord)
+            best.x = wxMax(best.x, childBest.x);
+            if ( childBest.y != wxDefaultCoord )
             {
-                best.IncBy(0, child_best.y);
+                best.IncBy(0, childBest.y);
             }
 
             ++count;
         }
 
-        if(count > 1)
+        if ( count > 1 )
         {
             best.IncBy(0, (count - 1) * m_art->GetMetric(wxRIBBON_ART_PANEL_Y_SEPARATION_SIZE));
         }
     }
 
-    if(best.x != wxDefaultCoord)
+    if ( best.x != wxDefaultCoord )
     {
         best.x += m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_LEFT_SIZE) + m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_RIGHT_SIZE);
     }
-    if(best.y != wxDefaultCoord)
+    if ( best.y != wxDefaultCoord )
     {
         best.y += m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_TOP_SIZE) + m_art->GetMetric(wxRIBBON_ART_PAGE_BORDER_BOTTOM_SIZE);
     }
@@ -1284,7 +1284,7 @@ wxSize wxRibbonPage::DoGetBestSize() const
 
 void wxRibbonPage::HideIfExpanded()
 {
-    if (auto* const bar = wxCheckedStaticCast<wxRibbonBar>(GetParent()))
+    if ( auto* const bar = wxCheckedStaticCast<wxRibbonBar>(GetParent()) )
         bar->HideIfExpanded();
 }
 

--- a/src/ribbon/panel.cpp
+++ b/src/ribbon/panel.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/panel.cpp
 // Purpose:     Ribbon-style container for a group of related tools / controls
 // Author:      Peter Cawley
@@ -20,11 +20,11 @@
 #include "wx/sizer.h"
 
 #ifndef WX_PRECOMP
-#include "wx/frame.h"
+    #include "wx/frame.h"
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 wxDEFINE_EVENT(wxEVT_RIBBONPANEL_EXTBUTTON_ACTIVATED, wxRibbonPanelEvent);
@@ -45,28 +45,28 @@ wxBEGIN_EVENT_TABLE(wxRibbonPanel, wxRibbonControl)
     EVT_DPI_CHANGED(wxRibbonPanel::OnDPIChanged)
 wxEND_EVENT_TABLE()
 
-wxRibbonPanel::wxRibbonPanel() : m_expanded_dummy(nullptr), m_expanded_panel(nullptr)
+wxRibbonPanel::wxRibbonPanel() : m_expandedDummy(nullptr), m_expandedPanel(nullptr)
 {
 }
 
 wxRibbonPanel::wxRibbonPanel(wxWindow* parent,
                   wxWindowID id,
                   const wxString& label,
-                  const wxBitmapBundle& minimised_icon,
+                  const wxBitmapBundle& minimisedIcon,
                   const wxPoint& pos,
                   const wxSize& size,
                   long style)
     : wxRibbonControl(parent, id, pos, size, wxBORDER_NONE)
 {
-    CommonInit(label, minimised_icon, style);
+    CommonInit(label, minimisedIcon, style);
 }
 
 wxRibbonPanel::~wxRibbonPanel()
 {
-    if(m_expanded_panel)
+    if ( m_expandedPanel )
     {
-        m_expanded_panel->m_expanded_dummy = nullptr;
-        m_expanded_panel->GetParent()->Destroy();
+        m_expandedPanel->m_expandedDummy = nullptr;
+        m_expandedPanel->GetParent()->Destroy();
     }
 }
 
@@ -78,7 +78,7 @@ bool wxRibbonPanel::Create(wxWindow* parent,
                 const wxSize& size,
                 long style)
 {
-    if(!wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE))
+    if ( !wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE) )
     {
         return false;
     }
@@ -96,14 +96,14 @@ void wxRibbonPanel::SetArtProvider(wxRibbonArtProvider* art)
           node = node->GetNext() )
     {
         wxWindow* child = node->GetData();
-        wxRibbonControl* ribbon_child = wxDynamicCast(child, wxRibbonControl);
-        if(ribbon_child)
+        wxRibbonControl* ribbonChild = wxDynamicCast(child, wxRibbonControl);
+        if ( ribbonChild )
         {
-            ribbon_child->SetArtProvider(art);
+            ribbonChild->SetArtProvider(art);
         }
     }
-    if(m_expanded_panel)
-        m_expanded_panel->SetArtProvider(art);
+    if ( m_expandedPanel )
+        m_expandedPanel->SetArtProvider(art);
 }
 
 void wxRibbonPanel::CommonInit(const wxString& label, const wxBitmapBundle& icon, long style)
@@ -111,21 +111,21 @@ void wxRibbonPanel::CommonInit(const wxString& label, const wxBitmapBundle& icon
     SetName(label);
     SetLabel(label);
 
-    m_minimised_size = wxDefaultSize; // Unknown / none
-    m_smallest_unminimised_size = wxDefaultSize;// Unknown / none for IsFullySpecified()
-    m_preferred_expand_direction = wxSOUTH;
-    m_expanded_dummy = nullptr;
-    m_expanded_panel = nullptr;
+    m_minimisedSize = wxDefaultSize; // Unknown / none
+    m_smallestUnminimisedSize = wxDefaultSize;// Unknown / none for IsFullySpecified()
+    m_preferredExpandDirection = wxSOUTH;
+    m_expandedDummy = nullptr;
+    m_expandedPanel = nullptr;
     m_flags = style;
-    m_minimised_icon = icon;
+    m_minimisedIcon = icon;
     m_minimised = false;
     m_hovered = false;
-    m_ext_button_hovered = false;
+    m_extButtonHovered = false;
 
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
     {
         wxRibbonControl* parent = wxDynamicCast(GetParent(), wxRibbonControl);
-        if(parent != nullptr)
+        if ( parent != nullptr )
         {
             m_art = parent->GetArtProvider();
         }
@@ -148,7 +148,7 @@ bool wxRibbonPanel::IsHovered() const
 
 bool wxRibbonPanel::IsExtButtonHovered() const
 {
-    return m_ext_button_hovered;
+    return m_extButtonHovered;
 }
 
 void wxRibbonPanel::OnMouseEnter(wxMouseEvent& evt)
@@ -160,7 +160,7 @@ void wxRibbonPanel::OnMouseEnterChild(wxMouseEvent& evt)
 {
     wxPoint pos = evt.GetPosition();
     wxWindow *child = wxDynamicCast(evt.GetEventObject(), wxWindow);
-    if(child)
+    if ( child )
     {
         pos += child->GetPosition();
         TestPositionForHover(pos);
@@ -177,7 +177,7 @@ void wxRibbonPanel::OnMouseLeaveChild(wxMouseEvent& evt)
 {
     wxPoint pos = evt.GetPosition();
     wxWindow *child = wxDynamicCast(evt.GetEventObject(), wxWindow);
-    if(child)
+    if ( child )
     {
         pos += child->GetPosition();
         TestPositionForHover(pos);
@@ -192,26 +192,26 @@ void wxRibbonPanel::OnMotion(wxMouseEvent& evt)
 
 void wxRibbonPanel::TestPositionForHover(const wxPoint& pos)
 {
-    bool hovered = false, ext_button_hovered = false;
-    if(pos.x >= 0 && pos.y >= 0)
+    bool hovered = false, extButtonHovered = false;
+    if ( pos.x >= 0 && pos.y >= 0 )
     {
         wxSize size = GetSize();
-        if(pos.x < size.GetWidth() && pos.y < size.GetHeight())
+        if ( pos.x < size.GetWidth() && pos.y < size.GetHeight() )
         {
             hovered = true;
         }
     }
-    if(hovered)
+    if ( hovered )
     {
-        if(HasExtButton())
-            ext_button_hovered = m_ext_button_rect.Contains(pos);
+        if ( HasExtButton() )
+            extButtonHovered = m_extButtonRect.Contains(pos);
         else
-            ext_button_hovered = false;
+            extButtonHovered = false;
     }
-    if(hovered != m_hovered || ext_button_hovered != m_ext_button_hovered)
+    if ( hovered != m_hovered || extButtonHovered != m_extButtonHovered )
     {
         m_hovered = hovered;
-        m_ext_button_hovered = ext_button_hovered;
+        m_extButtonHovered = extButtonHovered;
         Refresh(false);
     }
 }
@@ -236,10 +236,10 @@ void wxRibbonPanel::RemoveChild(wxWindowBase *child)
     wxRibbonControl::RemoveChild(child);
 }
 
-bool wxRibbonPanel::HasExtButton()const
+bool wxRibbonPanel::HasExtButton() const
 {
     wxRibbonBar* bar = GetAncestorRibbonBar();
-    if(bar==nullptr)
+    if ( bar == nullptr )
         return false;
     return (m_flags & wxRIBBON_PANEL_EXT_BUTTON) &&
         (bar->GetWindowStyleFlag() & wxRIBBON_BAR_SHOW_PANEL_EXT_BUTTONS);
@@ -247,7 +247,7 @@ bool wxRibbonPanel::HasExtButton()const
 
 void wxRibbonPanel::OnSize(wxSizeEvent& evt)
 {
-    if(GetAutoLayout())
+    if ( GetAutoLayout() )
         Layout();
 
     evt.Skip();
@@ -270,15 +270,15 @@ void wxRibbonPanel::DoSetSize(int x, int y, int width, int height, int sizeFlags
 
     bool minimised = (m_flags & wxRIBBON_PANEL_NO_AUTO_MINIMISE) == 0 &&
         IsMinimised(wxSize(width, height)); // check if would be at this size
-    if(minimised != m_minimised)
+    if ( minimised != m_minimised )
     {
         m_minimised = minimised;
         // Note that for sizers, this routine disallows the use of mixed shown
         // and hidden controls
         // TODO ? use some list of user set invisible children to restore status.
-        for (wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
+        for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
                   node;
-                  node = node->GetNext())
+                  node = node->GetNext() )
         {
             node->GetData()->Show(!minimised);
         }
@@ -289,27 +289,27 @@ void wxRibbonPanel::DoSetSize(int x, int y, int width, int height, int sizeFlags
     wxRibbonControl::DoSetSize(x, y, width, height, sizeFlags);
 }
 
-// Checks if panel would be minimised at (client size) at_size
-bool wxRibbonPanel::IsMinimised(wxSize at_size) const
+// Checks if panel would be minimised at (client size) atSize
+bool wxRibbonPanel::IsMinimised(wxSize atSize) const
 {
-    if(GetSizer())
+    if ( GetSizer() )
     {
         // we have no information on size change direction
         // so check both
         wxSize size = GetMinNotMinimisedSize();
-        if(size.x > at_size.x || size.y > at_size.y)
+        if ( size.x > atSize.x || size.y > atSize.y )
             return true;
 
         return false;
     }
 
-    if(!m_minimised_size.IsFullySpecified())
+    if ( !m_minimisedSize.IsFullySpecified() )
         return false;
 
-    return (at_size.GetX() < m_minimised_size.GetX() &&
-        at_size.GetY() < m_minimised_size.GetY()) ||
-        at_size.GetX() < m_smallest_unminimised_size.GetX() ||
-        at_size.GetY() < m_smallest_unminimised_size.GetY();
+    return (atSize.GetX() < m_minimisedSize.GetX() &&
+        atSize.GetY() < m_minimisedSize.GetY()) ||
+        atSize.GetX() < m_smallestUnminimisedSize.GetX() ||
+        atSize.GetY() < m_smallestUnminimisedSize.GetY();
 }
 
 void wxRibbonPanel::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
@@ -321,11 +321,11 @@ void wxRibbonPanel::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
     wxAutoBufferedPaintDC dc(this);
 
-    if(m_art != nullptr)
+    if ( m_art != nullptr )
     {
-        if(IsMinimised())
+        if ( IsMinimised() )
         {
-            m_art->DrawMinimisedPanel(dc, this, GetSize(), m_minimised_icon_resized);
+            m_art->DrawMinimisedPanel(dc, this, GetSize(), m_minimisedIconResized);
         }
         else
         {
@@ -349,20 +349,20 @@ bool wxRibbonPanel::IsSizingContinuous() const
 // Finds the best width and height given the parent's width and height
 wxSize wxRibbonPanel::GetBestSizeForParentSize(const wxSize& parentSize) const
 {
-    if (!IsShown())
+    if ( !IsShown() )
     {
         return wxSize(0, 0);
     }
-    if (GetChildren().GetCount() == 1)
+    if ( GetChildren().GetCount() == 1 )
     {
         wxWindow* win = GetChildren().GetFirst()->GetData();
         wxRibbonControl* control = wxDynamicCast(win, wxRibbonControl);
-        if (control)
+        if ( control )
         {
-            wxInfoDC temp_dc(const_cast<wxRibbonPanel*>(this));
-            wxSize clientParentSize = m_art->GetPanelClientSize(temp_dc, this, parentSize, nullptr);
+            wxInfoDC tempDc(const_cast<wxRibbonPanel*>(this));
+            wxSize clientParentSize = m_art->GetPanelClientSize(tempDc, this, parentSize, nullptr);
             wxSize childSize = control->GetBestSizeForParentSize(clientParentSize);
-            wxSize overallSize = m_art->GetPanelSize(temp_dc, this, childSize, nullptr);
+            wxSize overallSize = m_art->GetPanelSize(tempDc, this, childSize, nullptr);
             return overallSize;
         }
     }
@@ -370,64 +370,64 @@ wxSize wxRibbonPanel::GetBestSizeForParentSize(const wxSize& parentSize) const
 }
 
 wxSize wxRibbonPanel::DoGetNextSmallerSize(wxOrientation direction,
-                                         wxSize relative_to) const
+                                         wxSize relativeTo) const
 {
-    if(m_expanded_panel != nullptr)
+    if ( m_expandedPanel != nullptr )
     {
         // Next size depends upon children, who are currently in the
         // expanded panel
-        return m_expanded_panel->DoGetNextSmallerSize(direction, relative_to);
+        return m_expandedPanel->DoGetNextSmallerSize(direction, relativeTo);
     }
 
-    if(m_art != nullptr)
+    if ( m_art != nullptr )
     {
         wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
-        wxSize child_relative = m_art->GetPanelClientSize(dc, this, relative_to, nullptr);
+        wxSize childRelative = m_art->GetPanelClientSize(dc, this, relativeTo, nullptr);
         wxSize smaller(-1, -1);
         bool minimise = false;
 
-        if(GetSizer())
+        if ( GetSizer() )
         {
             // Get smallest non minimised size
             smaller = GetMinSize();
-            // and adjust to child_relative for parent page
-            if(m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
+            // and adjust to childRelative for parent page
+            if ( m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
             {
-                 minimise = (child_relative.y <= smaller.y);
-                 if(smaller.x < child_relative.x)
-                    smaller.x = child_relative.x;
+                 minimise = (childRelative.y <= smaller.y);
+                 if ( smaller.x < childRelative.x )
+                    smaller.x = childRelative.x;
             }
             else
             {
-                minimise = (child_relative.x <= smaller.x);
-                if(smaller.y < child_relative.y)
-                    smaller.y = child_relative.y;
+                minimise = (childRelative.x <= smaller.x);
+                if ( smaller.y < childRelative.y )
+                    smaller.y = childRelative.y;
             }
         }
-        else if(GetChildren().GetCount() == 1)
+        else if ( GetChildren().GetCount() == 1 )
         {
             // Simple (and common) case of single ribbon child or Sizer
             wxWindow* child = GetChildren().Item(0)->GetData();
-            wxRibbonControl* ribbon_child = wxDynamicCast(child, wxRibbonControl);
-            if(ribbon_child != nullptr)
+            wxRibbonControl* ribbonChild = wxDynamicCast(child, wxRibbonControl);
+            if ( ribbonChild != nullptr )
             {
-                smaller = ribbon_child->GetNextSmallerSize(direction, child_relative);
-                minimise = (smaller == child_relative);
+                smaller = ribbonChild->GetNextSmallerSize(direction, childRelative);
+                minimise = (smaller == childRelative);
             }
         }
 
-        if(minimise)
+        if ( minimise )
         {
-            if(CanAutoMinimise())
+            if ( CanAutoMinimise() )
             {
-                wxSize minimised = m_minimised_size;
-                switch(direction)
+                wxSize minimised = m_minimisedSize;
+                switch ( direction )
                 {
                 case wxHORIZONTAL:
-                    minimised.SetHeight(relative_to.GetHeight());
+                    minimised.SetHeight(relativeTo.GetHeight());
                     break;
                 case wxVERTICAL:
-                    minimised.SetWidth(relative_to.GetWidth());
+                    minimised.SetWidth(relativeTo.GetWidth());
                     break;
                 default:
                     break;
@@ -436,30 +436,30 @@ wxSize wxRibbonPanel::DoGetNextSmallerSize(wxOrientation direction,
             }
             else
             {
-                return relative_to;
+                return relativeTo;
             }
         }
-        else if(smaller.IsFullySpecified()) // Use fallback if !(sizer/child = 1)
+        else if ( smaller.IsFullySpecified() ) // Use fallback if !(sizer/child = 1 )
         {
             return m_art->GetPanelSize(dc, this, smaller, nullptr);
         }
     }
 
     // Fallback: Decrease by 20% (or minimum size, whichever larger)
-    wxSize current(relative_to);
+    wxSize current(relativeTo);
     wxSize minimum(GetMinSize());
-    if(direction & wxHORIZONTAL)
+    if ( direction & wxHORIZONTAL )
     {
         current.x = (current.x * 4) / 5;
-        if(current.x < minimum.x)
+        if ( current.x < minimum.x )
         {
             current.x = minimum.x;
         }
     }
-    if(direction & wxVERTICAL)
+    if ( direction & wxVERTICAL )
     {
         current.y = (current.y * 4) / 5;
-        if(current.y < minimum.y)
+        if ( current.y < minimum.y )
         {
             current.y = minimum.y;
         }
@@ -468,76 +468,76 @@ wxSize wxRibbonPanel::DoGetNextSmallerSize(wxOrientation direction,
 }
 
 wxSize wxRibbonPanel::DoGetNextLargerSize(wxOrientation direction,
-                                        wxSize relative_to) const
+                                        wxSize relativeTo) const
 {
-    if(m_expanded_panel != nullptr)
+    if ( m_expandedPanel != nullptr )
     {
         // Next size depends upon children, who are currently in the
         // expanded panel
-        return m_expanded_panel->DoGetNextLargerSize(direction, relative_to);
+        return m_expandedPanel->DoGetNextLargerSize(direction, relativeTo);
     }
 
-    if(IsMinimised(relative_to))
+    if ( IsMinimised(relativeTo) )
     {
-        wxSize current = relative_to;
-        wxSize min_size = GetMinNotMinimisedSize();
-        switch(direction)
+        wxSize current = relativeTo;
+        wxSize minSize = GetMinNotMinimisedSize();
+        switch ( direction )
         {
         case wxHORIZONTAL:
-            if(min_size.x > current.x && min_size.y == current.y)
-                return min_size;
+            if ( minSize.x > current.x && minSize.y == current.y )
+                return minSize;
             break;
         case wxVERTICAL:
-            if(min_size.x == current.x && min_size.y > current.y)
-                return min_size;
+            if ( minSize.x == current.x && minSize.y > current.y )
+                return minSize;
             break;
         case wxBOTH:
-            if(min_size.x > current.x && min_size.y > current.y)
-                return min_size;
+            if ( minSize.x > current.x && minSize.y > current.y )
+                return minSize;
             break;
         default:
             break;
         }
     }
 
-    if(m_art != nullptr)
+    if ( m_art != nullptr )
     {
         wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
-        wxSize child_relative = m_art->GetPanelClientSize(dc, this, relative_to, nullptr);
+        wxSize childRelative = m_art->GetPanelClientSize(dc, this, relativeTo, nullptr);
         wxSize larger(-1, -1);
 
-        if(GetSizer())
+        if ( GetSizer() )
         {
             // We could just let the sizer expand in flow direction but see comment
             // in IsSizingContinuous()
             larger = GetPanelSizerBestSize();
             // and adjust for page in non flow direction
-            if(m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
+            if ( m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
             {
-                 if(larger.x != child_relative.x)
-                    larger.x = child_relative.x;
+                 if ( larger.x != childRelative.x )
+                    larger.x = childRelative.x;
             }
-            else if(larger.y != child_relative.y)
+            else if ( larger.y != childRelative.y )
             {
-                larger.y = child_relative.y;
+                larger.y = childRelative.y;
             }
         }
-        else if(GetChildren().GetCount() == 1)
+        else if ( GetChildren().GetCount() == 1 )
         {
             // Simple (and common) case of single ribbon child
             wxWindow* child = GetChildren().Item(0)->GetData();
-            wxRibbonControl* ribbon_child = wxDynamicCast(child, wxRibbonControl);
-            if(ribbon_child != nullptr)
+            wxRibbonControl* ribbonChild = wxDynamicCast(child, wxRibbonControl);
+            if ( ribbonChild != nullptr )
             {
-                larger = ribbon_child->GetNextLargerSize(direction, child_relative);
+                larger = ribbonChild->GetNextLargerSize(direction, childRelative);
             }
         }
 
-        if(larger.IsFullySpecified()) // Use fallback if !(sizer/child = 1)
+        if ( larger.IsFullySpecified() ) // Use fallback if !(sizer/child = 1 )
         {
-            if(larger == child_relative)
+            if ( larger == childRelative )
             {
-                return relative_to;
+                return relativeTo;
             }
             else
             {
@@ -552,12 +552,12 @@ wxSize wxRibbonPanel::DoGetNextLargerSize(wxOrientation direction,
     // avoiding them is non-trivial unless an increase is by 100% rather than
     // a fractional amount. This would then be non-ideal as the resizes happen
     // at very large intervals.
-    wxSize current(relative_to);
-    if(direction & wxHORIZONTAL)
+    wxSize current(relativeTo);
+    if ( direction & wxHORIZONTAL )
     {
         current.x = (current.x * 5 + 3) / 4;
     }
-    if(direction & wxVERTICAL)
+    if ( direction & wxVERTICAL )
     {
         current.y = (current.y * 5 + 3) / 4;
     }
@@ -567,25 +567,25 @@ wxSize wxRibbonPanel::DoGetNextLargerSize(wxOrientation direction,
 bool wxRibbonPanel::CanAutoMinimise() const
 {
     return (m_flags & wxRIBBON_PANEL_NO_AUTO_MINIMISE) == 0
-        && m_minimised_size.IsFullySpecified();
+        && m_minimisedSize.IsFullySpecified();
 }
 
 wxSize wxRibbonPanel::GetMinSize() const
 {
-    if (!IsShown())
+    if ( !IsShown() )
     {
         return wxSize(0, 0);
     }
-    if(m_expanded_panel != nullptr)
+    if ( m_expandedPanel != nullptr )
     {
         // Minimum size depends upon children, who are currently in the
         // expanded panel
-        return m_expanded_panel->GetMinSize();
+        return m_expandedPanel->GetMinSize();
     }
 
-    if(CanAutoMinimise())
+    if ( CanAutoMinimise() )
     {
-        return m_minimised_size;
+        return m_minimisedSize;
     }
     else
     {
@@ -595,17 +595,17 @@ wxSize wxRibbonPanel::GetMinSize() const
 
 wxSize wxRibbonPanel::GetMinNotMinimisedSize() const
 {
-    if (!IsShown())
+    if ( !IsShown() )
     {
         return wxSize(0, 0);
     }
     // Ask sizer if present
-    if(GetSizer())
+    if ( GetSizer() )
     {
         wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         return m_art->GetPanelSize(dc, this, GetPanelSizerMinSize(), nullptr);
     }
-    else if(GetChildren().GetCount() == 1)
+    else if ( GetChildren().GetCount() == 1 )
     {
         // Common case of single child taking up the entire panel
         wxWindow* child = GetChildren().Item(0)->GetData();
@@ -618,22 +618,22 @@ wxSize wxRibbonPanel::GetMinNotMinimisedSize() const
 
 wxSize wxRibbonPanel::GetPanelSizerMinSize() const
 {
-    // Called from Realize() to set m_smallest_unminimised_size and from other
+    // Called from Realize() to set m_smallestUnminimisedSize and from other
     // functions to get the minimum size.
     // The panel will be invisible when minimised and sizer calcs will be 0
-    // Uses m_smallest_unminimised_size in preference to GetSizer()->CalcMin()
+    // Uses m_smallestUnminimisedSize in preference to GetSizer()->CalcMin()
     // to eliminate flicker.
 
     // Check if is visible and not previously calculated
-    if(IsShown() && !m_smallest_unminimised_size.IsFullySpecified())
+    if ( IsShown() && !m_smallestUnminimisedSize.IsFullySpecified() )
     {
          return GetSizer()->CalcMin();
     }
-    // else use previously calculated m_smallest_unminimised_size
+    // else use previously calculated m_smallestUnminimisedSize
     wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
     return m_art->GetPanelClientSize(dc,
                                     this,
-                                    m_smallest_unminimised_size,
+                                    m_smallestUnminimisedSize,
                                     nullptr);
 }
 
@@ -649,12 +649,12 @@ wxSize wxRibbonPanel::GetPanelSizerBestSize() const
 wxSize wxRibbonPanel::DoGetBestSize() const
 {
     // Ask sizer if present
-    if( GetSizer())
+    if ( GetSizer() )
     {
         wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         return m_art->GetPanelSize(dc, this, GetPanelSizerBestSize(), nullptr);
     }
-    else if(GetChildren().GetCount() == 1)
+    else if ( GetChildren().GetCount() == 1 )
     {
         // Common case of no sizer and single child taking up the entire panel
         wxWindow* child = GetChildren().Item(0)->GetData();
@@ -669,74 +669,74 @@ bool wxRibbonPanel::Realize()
 {
     bool status = true;
 
-    for (wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
+    for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
                   node;
-                  node = node->GetNext())
+                  node = node->GetNext() )
     {
         wxRibbonControl* child = wxDynamicCast(node->GetData(), wxRibbonControl);
-        if(child == nullptr)
+        if ( child == nullptr )
         {
             continue;
         }
-        if(!child->Realize())
+        if ( !child->Realize() )
         {
             status = false;
         }
     }
 
-    wxSize minimum_children_size(0, 0);
+    wxSize minimumChildrenSize(0, 0);
 
     // Reset it before calling GetPanelSizerMinSize() below as it shouldn't use
     // the old value, if we had any.
-    m_smallest_unminimised_size = wxDefaultSize;
+    m_smallestUnminimisedSize = wxDefaultSize;
 
     // Ask sizer if there is one present
-    if(GetSizer())
+    if ( GetSizer() )
     {
-        minimum_children_size = GetPanelSizerMinSize();
+        minimumChildrenSize = GetPanelSizerMinSize();
     }
-    else if(GetChildren().GetCount() == 1)
+    else if ( GetChildren().GetCount() == 1 )
     {
-        minimum_children_size = GetChildren().GetFirst()->GetData()->GetMinSize();
+        minimumChildrenSize = GetChildren().GetFirst()->GetData()->GetMinSize();
     }
 
-    if(m_art != nullptr)
+    if ( m_art != nullptr )
     {
-        wxInfoDC temp_dc(this);
+        wxInfoDC tempDc(this);
 
-        m_smallest_unminimised_size =
-            m_art->GetPanelSize(temp_dc, this, minimum_children_size, nullptr);
+        m_smallestUnminimisedSize =
+            m_art->GetPanelSize(tempDc, this, minimumChildrenSize, nullptr);
 
-        wxSize panel_min_size = GetMinNotMinimisedSize();
-        m_minimised_size = m_art->GetMinimisedPanelMinimumSize(temp_dc, this,
-            nullptr, &m_preferred_expand_direction);
-        if(m_minimised_icon.IsOk())
+        wxSize panelMinSize = GetMinNotMinimisedSize();
+        m_minimisedSize = m_art->GetMinimisedPanelMinimumSize(tempDc, this,
+            nullptr, &m_preferredExpandDirection);
+        if ( m_minimisedIcon.IsOk() )
         {
-            m_minimised_icon_resized = m_minimised_icon.GetBitmap(
-                m_minimised_icon.GetPreferredBitmapSizeFor(this));
+            m_minimisedIconResized = m_minimisedIcon.GetBitmap(
+                m_minimisedIcon.GetPreferredBitmapSizeFor(this));
         }
-        if(m_minimised_size.x > panel_min_size.x &&
-            m_minimised_size.y > panel_min_size.y)
+        if ( m_minimisedSize.x > panelMinSize.x &&
+            m_minimisedSize.y > panelMinSize.y )
         {
             // No point in having a minimised size which is larger than the
             // minimum size which the children can go to.
-            m_minimised_size = wxSize(-1, -1);
+            m_minimisedSize = wxSize(-1, -1);
         }
         else
         {
-            if(m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL)
+            if ( m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL )
             {
-                m_minimised_size.x = panel_min_size.x;
+                m_minimisedSize.x = panelMinSize.x;
             }
             else
             {
-                m_minimised_size.y = panel_min_size.y;
+                m_minimisedSize.y = panelMinSize.y;
             }
         }
     }
     else
     {
-        m_minimised_size = wxSize(-1, -1);
+        m_minimisedSize = wxSize(-1, -1);
     }
 
     return Layout() && status;
@@ -744,7 +744,7 @@ bool wxRibbonPanel::Realize()
 
 bool wxRibbonPanel::Layout()
 {
-    if(IsMinimised())
+    if ( IsMinimised() )
     {
         // Children are all invisible when minimised
         return true;
@@ -756,28 +756,28 @@ bool wxRibbonPanel::Layout()
     wxSize size = m_art->GetPanelClientSize(dc, this, GetSize(), &position);
 
     // If there is a sizer, use it
-    if(GetSizer())
+    if ( GetSizer() )
     {
         GetSizer()->SetDimension(position, size); // SetSize and Layout()
     }
-    else if(GetChildren().GetCount() == 1)
+    else if ( GetChildren().GetCount() == 1 )
     {
         // Common case of no sizer and single child taking up the entire panel
         wxWindow* child = GetChildren().Item(0)->GetData();
         child->SetSize(position.x, position.y, size.GetWidth(), size.GetHeight());
     }
 
-    if(HasExtButton())
-        m_ext_button_rect = m_art->GetPanelExtButtonArea(dc, this, GetSize());
+    if ( HasExtButton() )
+        m_extButtonRect = m_art->GetPanelExtButtonArea(dc, this, GetSize());
 
     return true;
 }
 
 void wxRibbonPanel::OnMouseClick(wxMouseEvent& WXUNUSED(evt))
 {
-    if(IsMinimised())
+    if ( IsMinimised() )
     {
-        if(m_expanded_panel != nullptr)
+        if ( m_expandedPanel != nullptr )
         {
             HideExpanded();
         }
@@ -786,7 +786,7 @@ void wxRibbonPanel::OnMouseClick(wxMouseEvent& WXUNUSED(evt))
             ShowExpanded();
         }
     }
-    else if(IsExtButtonHovered())
+    else if ( IsExtButtonHovered() )
     {
         wxRibbonPanelEvent notification(wxEVT_RIBBONPANEL_EXTBUTTON_ACTIVATED, GetId());
         notification.SetEventObject(this);
@@ -797,21 +797,21 @@ void wxRibbonPanel::OnMouseClick(wxMouseEvent& WXUNUSED(evt))
 
 wxRibbonPanel* wxRibbonPanel::GetExpandedDummy()
 {
-    return m_expanded_dummy;
+    return m_expandedDummy;
 }
 
 wxRibbonPanel* wxRibbonPanel::GetExpandedPanel()
 {
-    return m_expanded_panel;
+    return m_expandedPanel;
 }
 
 bool wxRibbonPanel::ShowExpanded()
 {
-    if(!IsMinimised())
+    if ( !IsMinimised() )
     {
         return false;
     }
-    if(m_expanded_dummy != nullptr || m_expanded_panel != nullptr)
+    if ( m_expandedDummy != nullptr || m_expandedPanel != nullptr )
     {
         return false;
     }
@@ -819,23 +819,23 @@ bool wxRibbonPanel::ShowExpanded()
     wxSize size = GetBestSize();
 
     // Special case for flexible panel layout, where GetBestSize doesn't work
-    if (GetFlags() & wxRIBBON_PANEL_FLEXIBLE)
+    if ( GetFlags() & wxRIBBON_PANEL_FLEXIBLE )
     {
         size = GetBestSizeForParentSize(wxSize(400, 1000));
     }
 
     wxPoint pos = GetExpandedPosition(wxRect(GetScreenPosition(), GetSize()),
-        size, m_preferred_expand_direction).GetTopLeft();
+        size, m_preferredExpandDirection).GetTopLeft();
 
     // Need a top-level frame to contain the expanded panel
     wxFrame *container = new wxFrame(nullptr, wxID_ANY, GetLabel(),
         pos, size, wxFRAME_NO_TASKBAR | wxBORDER_NONE);
 
-    m_expanded_panel = new wxRibbonPanel(container, wxID_ANY,
-        GetLabel(), m_minimised_icon, wxPoint(0, 0), size, (m_flags /* & ~wxRIBBON_PANEL_FLEXIBLE */));
+    m_expandedPanel = new wxRibbonPanel(container, wxID_ANY,
+        GetLabel(), m_minimisedIcon, wxPoint(0, 0), size, (m_flags /* & ~wxRIBBON_PANEL_FLEXIBLE */));
 
-    m_expanded_panel->SetArtProvider(m_art);
-    m_expanded_panel->m_expanded_dummy = this;
+    m_expandedPanel->SetArtProvider(m_art);
+    m_expandedPanel->m_expandedDummy = this;
 
     // Move all children to the new panel.
     // Conceptually it might be simpler to reparent this entire panel to the
@@ -845,26 +845,26 @@ bool wxRibbonPanel::ShowExpanded()
     // and thus assume a new position.
     // NB: Children iterators not used as behaviour is not well defined
     // when iterating over a container which is being emptied
-    while(!GetChildren().IsEmpty())
+    while ( !GetChildren().IsEmpty() )
     {
         wxWindow *child = GetChildren().GetFirst()->GetData();
-        child->Reparent(m_expanded_panel);
+        child->Reparent(m_expandedPanel);
         child->Show();
     }
 
     // Move sizer to new panel
-    if(GetSizer())
+    if ( GetSizer() )
     {
         wxSizer* sizer = GetSizer();
         SetSizer(nullptr, false);
-        m_expanded_panel->SetSizer(sizer);
+        m_expandedPanel->SetSizer(sizer);
     }
 
-    m_expanded_panel->Realize();
+    m_expandedPanel->Realize();
     Refresh();
     container->SetMinClientSize(size);
     container->Show();
-    m_expanded_panel->SetFocus();
+    m_expandedPanel->SetFocus();
 
     return true;
 }
@@ -883,10 +883,10 @@ bool wxRibbonPanel::ShouldSendEventToDummy(wxEvent& evt)
 
 bool wxRibbonPanel::TryAfter(wxEvent& evt)
 {
-    if(m_expanded_dummy && ShouldSendEventToDummy(evt))
+    if ( m_expandedDummy && ShouldSendEventToDummy(evt) )
     {
         wxPropagateOnce propagateOnce(evt);
-        return m_expanded_dummy->GetEventHandler()->ProcessEvent(evt);
+        return m_expandedDummy->GetEventHandler()->ProcessEvent(evt);
     }
     else
     {
@@ -896,10 +896,10 @@ bool wxRibbonPanel::TryAfter(wxEvent& evt)
 
 static bool IsAncestorOf(wxWindow *ancestor, wxWindow *window)
 {
-    while(window != nullptr)
+    while ( window != nullptr )
     {
         wxWindow *parent = window->GetParent();
-        if(parent == ancestor)
+        if ( parent == ancestor )
             return true;
         else
             window = parent;
@@ -909,16 +909,16 @@ static bool IsAncestorOf(wxWindow *ancestor, wxWindow *window)
 
 void wxRibbonPanel::OnKillFocus(wxFocusEvent& evt)
 {
-    if(m_expanded_dummy)
+    if ( m_expandedDummy )
     {
         wxWindow *receiver = evt.GetWindow();
-        if(IsAncestorOf(this, receiver))
+        if ( IsAncestorOf(this, receiver) )
         {
-            m_child_with_focus = receiver;
+            m_childWithFocus = receiver;
             receiver->Bind(wxEVT_KILL_FOCUS,
                 &wxRibbonPanel::OnChildKillFocus, this);
         }
-        else if(receiver == nullptr || receiver != m_expanded_dummy)
+        else if ( receiver == nullptr || receiver != m_expandedDummy )
         {
             HideExpanded();
         }
@@ -927,22 +927,22 @@ void wxRibbonPanel::OnKillFocus(wxFocusEvent& evt)
 
 void wxRibbonPanel::OnChildKillFocus(wxFocusEvent& evt)
 {
-    if(m_child_with_focus == nullptr)
+    if ( m_childWithFocus == nullptr )
         return; // Should never happen, but a check can't hurt
 
-    m_child_with_focus->Unbind(wxEVT_KILL_FOCUS,
+    m_childWithFocus->Unbind(wxEVT_KILL_FOCUS,
       &wxRibbonPanel::OnChildKillFocus, this);
-    m_child_with_focus = nullptr;
+    m_childWithFocus = nullptr;
 
     wxWindow *receiver = evt.GetWindow();
-    if(receiver == this || IsAncestorOf(this, receiver))
+    if ( receiver == this || IsAncestorOf(this, receiver) )
     {
-        m_child_with_focus = receiver;
+        m_childWithFocus = receiver;
         receiver->Bind(wxEVT_KILL_FOCUS,
             &wxRibbonPanel::OnChildKillFocus, this);
         evt.Skip();
     }
-    else if(receiver == nullptr || receiver != m_expanded_dummy)
+    else if ( receiver == nullptr || receiver != m_expandedDummy )
     {
         HideExpanded();
         // Do not skip event, as the panel has been de-expanded, causing the
@@ -957,11 +957,11 @@ void wxRibbonPanel::OnChildKillFocus(wxFocusEvent& evt)
 
 bool wxRibbonPanel::HideExpanded()
 {
-    if(m_expanded_dummy == nullptr)
+    if ( m_expandedDummy == nullptr )
     {
-        if(m_expanded_panel)
+        if ( m_expandedPanel )
         {
-            return m_expanded_panel->HideExpanded();
+            return m_expandedPanel->HideExpanded();
         }
         else
         {
@@ -972,24 +972,24 @@ bool wxRibbonPanel::HideExpanded()
     // Move children back to original panel
     // NB: Children iterators not used as behaviour is not well defined
     // when iterating over a container which is being emptied
-    while(!GetChildren().IsEmpty())
+    while ( !GetChildren().IsEmpty() )
     {
         wxWindow *child = GetChildren().GetFirst()->GetData();
-        child->Reparent(m_expanded_dummy);
+        child->Reparent(m_expandedDummy);
         child->Hide();
     }
 
     // Move sizer back
-    if(GetSizer())
+    if ( GetSizer() )
     {
         wxSizer* sizer = GetSizer();
         SetSizer(nullptr, false);
-        m_expanded_dummy->SetSizer(sizer);
+        m_expandedDummy->SetSizer(sizer);
     }
 
-    m_expanded_dummy->m_expanded_panel = nullptr;
-    m_expanded_dummy->Realize();
-    m_expanded_dummy->Refresh();
+    m_expandedDummy->m_expandedPanel = nullptr;
+    m_expandedDummy->Realize();
+    m_expandedDummy->Refresh();
     wxWindow *parent = GetParent();
     Destroy();
     parent->Destroy();
@@ -998,7 +998,7 @@ bool wxRibbonPanel::HideExpanded()
 }
 
 wxRect wxRibbonPanel::GetExpandedPosition(wxRect panel,
-                                          wxSize expanded_size,
+                                          wxSize expandedSize,
                                           wxDirection direction)
 {
     // Strategy:
@@ -1011,98 +1011,97 @@ wxRect wxRibbonPanel::GetExpandedPosition(wxRect panel,
     // 2.2) Move in the secondary axis
 
     wxPoint pos;
-    bool primary_x = false;
-    int secondary_x = 0;
-    int secondary_y = 0;
-    switch(direction)
+    bool primaryX = false;
+    int secondaryX = 0;
+    int secondaryY = 0;
+    switch ( direction )
     {
     case wxNORTH:
-        pos.x = panel.GetX() + (panel.GetWidth() - expanded_size.GetWidth()) / 2;
-        pos.y = panel.GetY() - expanded_size.GetHeight();
-        primary_x = true;
-        secondary_y = 1;
+        pos.x = panel.GetX() + (panel.GetWidth() - expandedSize.GetWidth()) / 2;
+        pos.y = panel.GetY() - expandedSize.GetHeight();
+        primaryX = true;
+        secondaryY = 1;
         break;
     case wxEAST:
         pos.x = panel.GetRight();
-        pos.y = panel.GetY() + (panel.GetHeight() - expanded_size.GetHeight()) / 2;
-        secondary_x = -1;
+        pos.y = panel.GetY() + (panel.GetHeight() - expandedSize.GetHeight()) / 2;
+        secondaryX = -1;
         break;
     case wxSOUTH:
-        pos.x = panel.GetX() + (panel.GetWidth() - expanded_size.GetWidth()) / 2;
+        pos.x = panel.GetX() + (panel.GetWidth() - expandedSize.GetWidth()) / 2;
         pos.y = panel.GetBottom();
-        primary_x = true;
-        secondary_y = -1;
+        primaryX = true;
+        secondaryY = -1;
         break;
     case wxWEST:
     default:
-        pos.x = panel.GetX() - expanded_size.GetWidth();
-        pos.y = panel.GetY() + (panel.GetHeight() - expanded_size.GetHeight()) / 2;
-        secondary_x = 1;
+        pos.x = panel.GetX() - expandedSize.GetWidth();
+        pos.y = panel.GetY() + (panel.GetHeight() - expandedSize.GetHeight()) / 2;
+        secondaryX = 1;
         break;
     }
-    wxRect expanded(pos, expanded_size);
+    wxRect expanded(pos, expandedSize);
 
     wxRect best(expanded);
-    int best_distance = INT_MAX;
+    int bestDistance = INT_MAX;
 
-    const unsigned display_n = wxDisplay::GetCount();
-    unsigned display_i;
-    for(display_i = 0; display_i < display_n; ++display_i)
+    const unsigned displayN = wxDisplay::GetCount();
+    for ( unsigned i = 0; i < displayN; ++i )
     {
-        wxRect display = wxDisplay(display_i).GetGeometry();
+        wxRect display = wxDisplay(i).GetGeometry();
 
-        if(display.Contains(expanded))
+        if ( display.Contains(expanded) )
         {
             return expanded;
         }
-        else if(display.Intersects(expanded))
+        else if ( display.Intersects(expanded) )
         {
-            wxRect new_rect(expanded);
+            wxRect newRect(expanded);
             int distance = 0;
 
-            if(primary_x)
+            if ( primaryX )
             {
-                if(expanded.GetRight() > display.GetRight())
+                if ( expanded.GetRight() > display.GetRight() )
                 {
                     distance = expanded.GetRight() - display.GetRight();
-                    new_rect.x -= distance;
+                    newRect.x -= distance;
                 }
-                else if(expanded.GetLeft() < display.GetLeft())
+                else if ( expanded.GetLeft() < display.GetLeft() )
                 {
                     distance = display.GetLeft() - expanded.GetLeft();
-                    new_rect.x += distance;
+                    newRect.x += distance;
                 }
             }
             else
             {
-                if(expanded.GetBottom() > display.GetBottom())
+                if ( expanded.GetBottom() > display.GetBottom() )
                 {
                     distance = expanded.GetBottom() - display.GetBottom();
-                    new_rect.y -= distance;
+                    newRect.y -= distance;
                 }
-                else if(expanded.GetTop() < display.GetTop())
+                else if ( expanded.GetTop() < display.GetTop() )
                 {
                     distance = display.GetTop() - expanded.GetTop();
-                    new_rect.y += distance;
+                    newRect.y += distance;
                 }
             }
-            if(!display.Contains(new_rect))
+            if ( !display.Contains(newRect) )
             {
                 // Tried moving in primary axis, but failed.
                 // Hence try moving in the secondary axis.
-                int dx = secondary_x * (panel.GetWidth() + expanded_size.GetWidth());
-                int dy = secondary_y * (panel.GetHeight() + expanded_size.GetHeight());
-                new_rect.x += dx;
-                new_rect.y += dy;
+                int dx = secondaryX * (panel.GetWidth() + expandedSize.GetWidth());
+                int dy = secondaryY * (panel.GetHeight() + expandedSize.GetHeight());
+                newRect.x += dx;
+                newRect.y += dy;
 
                 // Squaring makes secondary moves more expensive (and also
                 // prevents a negative cost)
                 distance += dx * dx + dy * dy;
             }
-            if(display.Contains(new_rect) && distance < best_distance)
+            if ( display.Contains(newRect) && distance < bestDistance )
             {
-                best = new_rect;
-                best_distance = distance;
+                best = newRect;
+                bestDistance = distance;
             }
         }
     }
@@ -1113,7 +1112,7 @@ wxRect wxRibbonPanel::GetExpandedPosition(wxRect panel,
 void wxRibbonPanel::HideIfExpanded()
 {
     wxRibbonPage* const containingPage = wxDynamicCast(m_parent, wxRibbonPage);
-    if (containingPage)
+    if ( containingPage )
         containingPage->HideIfExpanded();
 }
 

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // Name:        src/ribbon/toolbar.cpp
 // Purpose:     Ribbon-style tool bar
 // Author:      Peter Cawley
@@ -21,7 +21,7 @@
 #endif
 
 #ifdef __WXMSW__
-#include "wx/msw/private.h"
+    #include "wx/msw/private.h"
 #endif
 
 #include <memory>
@@ -29,13 +29,13 @@
 class wxRibbonToolBarToolBase
 {
 public:
-    wxString help_string;
+    wxString helpString;
     wxBitmapBundle bitmap;
-    wxBitmapBundle bitmap_disabled;
+    wxBitmapBundle bitmapDisabled;
     wxRect dropdown;
     wxPoint position;
     wxSize size;
-    wxObject* client_data = nullptr;
+    wxObject* clientData = nullptr;
     int id;
     wxRibbonButtonKind kind;
     long state;
@@ -47,7 +47,7 @@ class wxRibbonToolBarToolGroup
 {
 public:
     // To identify the group as a wxRibbonToolBarToolBase*
-    wxRibbonToolBarToolBase dummy_tool;
+    wxRibbonToolBarToolBase dummyTool;
 
     wxArrayRibbonToolBarToolBase tools;
     wxPoint position;
@@ -93,7 +93,7 @@ bool wxRibbonToolBar::Create(wxWindow* parent,
                 const wxSize& size,
                 long style)
 {
-    if(!wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE))
+    if ( !wxRibbonControl::Create(parent, id, pos, size, wxBORDER_NONE) )
     {
         return false;
     }
@@ -105,10 +105,10 @@ bool wxRibbonToolBar::Create(wxWindow* parent,
 void wxRibbonToolBar::CommonInit(long WXUNUSED(style))
 {
     AppendGroup();
-    m_hover_tool = nullptr;
-    m_active_tool = nullptr;
-    m_nrows_min = 1;
-    m_nrows_max = 1;
+    m_hoverTool = nullptr;
+    m_activeTool = nullptr;
+    m_nrowsMin = 1;
+    m_nrowsMax = 1;
     m_sizes = new wxSize[1];
     SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
@@ -117,11 +117,11 @@ wxRibbonToolBar::~wxRibbonToolBar()
 {
     size_t count = m_groups.GetCount();
     size_t i, t;
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(i);
-        size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        size_t toolCount = group->tools.GetCount();
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
             delete tool;
@@ -133,150 +133,150 @@ wxRibbonToolBar::~wxRibbonToolBar()
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::AddTool(
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind)
 {
-    return AddTool(tool_id, bitmap, wxBitmapBundle(), help_string, kind, nullptr);
+    return AddTool(toolId, bitmap, wxBitmapBundle(), helpString, kind, nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::AddDropdownTool(
-            int tool_id,
+            int toolId,
             const wxBitmapBundle& bitmap,
-            const wxString& help_string)
+            const wxString& helpString)
 {
-    return AddTool(tool_id, bitmap, wxBitmapBundle(), help_string,
+    return AddTool(toolId, bitmap, wxBitmapBundle(), helpString,
         wxRIBBON_BUTTON_DROPDOWN, nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::AddHybridTool(
-            int tool_id,
+            int toolId,
             const wxBitmapBundle& bitmap,
-            const wxString& help_string)
+            const wxString& helpString)
 {
-    return AddTool(tool_id, bitmap, wxBitmapBundle(), help_string,
+    return AddTool(toolId, bitmap, wxBitmapBundle(), helpString,
         wxRIBBON_BUTTON_HYBRID, nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::AddToggleTool(
-        int tool_id,
+        int toolId,
         const wxBitmapBundle& bitmap,
-        const wxString& help_string)
+        const wxString& helpString)
 {
-    return AddTool(tool_id, bitmap, wxBitmapBundle(), help_string,
+    return AddTool(toolId, bitmap, wxBitmapBundle(), helpString,
         wxRIBBON_BUTTON_TOGGLE, nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::AddTool(
-            int tool_id,
+            int toolId,
             const wxBitmapBundle& bitmap,
-            const wxBitmapBundle& bitmap_disabled,
-            const wxString& help_string,
+            const wxBitmapBundle& bitmapDisabled,
+            const wxString& helpString,
             wxRibbonButtonKind kind,
-            wxObject* client_data)
+            wxObject* clientData)
 {
-    return InsertTool(GetToolCount(), tool_id, bitmap, bitmap_disabled,
-        help_string, kind, client_data);
+    return InsertTool(GetToolCount(), toolId, bitmap, bitmapDisabled,
+        helpString, kind, clientData);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::AddSeparator()
 {
-    if(m_groups.Last()->tools.IsEmpty())
+    if ( m_groups.Last()->tools.IsEmpty() )
         return nullptr;
 
     AppendGroup();
-    return &m_groups.Last()->dummy_tool;
+    return &m_groups.Last()->dummyTool;
 }
 
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::InsertTool(
                 size_t pos,
-                int tool_id,
+                int toolId,
                 const wxBitmapBundle& bitmap,
-                const wxString& help_string,
+                const wxString& helpString,
                 wxRibbonButtonKind kind)
 {
-    return InsertTool(pos, tool_id, bitmap, wxBitmapBundle(), help_string, kind,
+    return InsertTool(pos, toolId, bitmap, wxBitmapBundle(), helpString, kind,
         nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::InsertDropdownTool(
             size_t pos,
-            int tool_id,
+            int toolId,
             const wxBitmapBundle& bitmap,
-            const wxString& help_string)
+            const wxString& helpString)
 {
-    return InsertTool(pos, tool_id, bitmap, wxBitmapBundle(), help_string,
+    return InsertTool(pos, toolId, bitmap, wxBitmapBundle(), helpString,
         wxRIBBON_BUTTON_DROPDOWN, nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::InsertHybridTool(
             size_t pos,
-            int tool_id,
+            int toolId,
             const wxBitmapBundle& bitmap,
-            const wxString& help_string)
+            const wxString& helpString)
 {
-    return InsertTool(pos, tool_id, bitmap, wxBitmapBundle(), help_string,
+    return InsertTool(pos, toolId, bitmap, wxBitmapBundle(), helpString,
         wxRIBBON_BUTTON_HYBRID, nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::InsertToggleTool(
         size_t pos,
-        int tool_id,
+        int toolId,
         const wxBitmapBundle& bitmap,
-        const wxString& help_string)
+        const wxString& helpString)
 {
-    return InsertTool(pos, tool_id, bitmap, wxBitmapBundle(), help_string,
+    return InsertTool(pos, toolId, bitmap, wxBitmapBundle(), helpString,
         wxRIBBON_BUTTON_TOGGLE, nullptr);
 }
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::InsertTool(
             size_t pos,
-            int tool_id,
+            int toolId,
             const wxBitmapBundle& bitmap,
-            const wxBitmapBundle& bitmap_disabled,
-            const wxString& help_string,
+            const wxBitmapBundle& bitmapDisabled,
+            const wxString& helpString,
             wxRibbonButtonKind kind,
-            wxObject* client_data)
+            wxObject* clientData)
 {
     wxASSERT(bitmap.IsOk());
 
     // Create the wxRibbonToolBarToolBase with parameters
     std::unique_ptr<wxRibbonToolBarToolBase> tool(new wxRibbonToolBarToolBase);
-    tool->id = tool_id;
+    tool->id = toolId;
     tool->bitmap = bitmap;
-    if(bitmap_disabled.IsOk())
+    if ( bitmapDisabled.IsOk() )
     {
-        wxASSERT(bitmap.GetDefaultSize() == bitmap_disabled.GetDefaultSize());
-        tool->bitmap_disabled = bitmap_disabled;
+        wxASSERT(bitmap.GetDefaultSize() == bitmapDisabled.GetDefaultSize());
+        tool->bitmapDisabled = bitmapDisabled;
     }
     else
     {
         // Generate disabled bitmap from normal bitmap
         wxBitmap bmp = bitmap.GetBitmap(bitmap.GetDefaultSize());
-        tool->bitmap_disabled = wxBitmapBundle::FromBitmap(MakeDisabledBitmap(bmp));
+        tool->bitmapDisabled = wxBitmapBundle::FromBitmap(MakeDisabledBitmap(bmp));
     }
-    tool->help_string = help_string;
+    tool->helpString = helpString;
     tool->kind = kind;
-    tool->client_data = client_data;
+    tool->clientData = clientData;
     tool->state = 0;
 
     // Find the position where insert tool
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        if(pos <= tool_count)
+        size_t toolCount = group->tools.GetCount();
+        if ( pos <= toolCount )
         {
             // Give the ownership of the tool to group->tools
             wxRibbonToolBarToolBase* const p = tool.release();
             group->tools.Insert(p, pos);
             return p;
         }
-        pos -= tool_count + 1;
+        pos -= toolCount + 1;
     }
     wxFAIL_MSG("Tool position out of toolbar bounds.");
     return nullptr;
@@ -284,34 +284,34 @@ wxRibbonToolBarToolBase* wxRibbonToolBar::InsertTool(
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::InsertSeparator(size_t pos)
 {
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
-        if(pos==0) // Prepend group
-            return &InsertGroup(g)->dummy_tool;
-        if(pos==group_count) // Append group
-            return &InsertGroup(g+1)->dummy_tool;
+        if ( pos== 0 ) // Prepend group
+            return &InsertGroup(g)->dummyTool;
+        if ( pos == groupCount ) // Append group
+            return &InsertGroup(g+1)->dummyTool;
 
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        if(pos < tool_count)
+        size_t toolCount = group->tools.GetCount();
+        if ( pos < toolCount )
         {
-            wxRibbonToolBarToolGroup* new_group = InsertGroup(g+1);
+            wxRibbonToolBarToolGroup* newGroup = InsertGroup(g+1);
 
-            for(size_t t = pos; t < tool_count; t++)
-                new_group->tools.Add(group->tools[t]);
-            group->tools.RemoveAt(pos, tool_count-pos);
+            for ( size_t t = pos; t < toolCount; t++ )
+                newGroup->tools.Add(group->tools[t]);
+            group->tools.RemoveAt(pos, toolCount-pos);
 
-            return &group->dummy_tool;
+            return &group->dummyTool;
         }
-        pos -= tool_count + 1;
+        pos -= toolCount + 1;
     }
     // Add an empty group at the end of the bar.
-    if(m_groups.Last()->tools.IsEmpty())
+    if ( m_groups.Last()->tools.IsEmpty() )
         return nullptr;
     AppendGroup();
-    return &m_groups.Last()->dummy_tool;
+    return &m_groups.Last()->dummyTool;
 }
 
 wxRibbonToolBarToolGroup* wxRibbonToolBar::InsertGroup(size_t pos)
@@ -325,11 +325,11 @@ void wxRibbonToolBar::ClearTools()
 {
     size_t count = m_groups.GetCount();
     size_t i, t;
-    for(i = 0; i < count; ++i)
+    for ( i = 0; i < count; ++i )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(i);
-        size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        size_t toolCount = group->tools.GetCount();
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
             delete tool;
@@ -339,18 +339,18 @@ void wxRibbonToolBar::ClearTools()
     m_groups.Clear();
 }
 
-bool wxRibbonToolBar::DeleteTool(int tool_id)
+bool wxRibbonToolBar::DeleteTool(int toolId)
 {
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        size_t toolCount = group->tools.GetCount();
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-            if(tool->id == tool_id)
+            if ( tool->id == toolId )
             {
                 group->tools.RemoveAt(t);
                 delete tool;
@@ -363,13 +363,13 @@ bool wxRibbonToolBar::DeleteTool(int tool_id)
 
 bool wxRibbonToolBar::DeleteToolByPos(size_t pos)
 {
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        if(pos<tool_count)
+        size_t toolCount = group->tools.GetCount();
+        if ( pos < toolCount )
         {
             // Remove tool
             wxRibbonToolBarToolBase* tool = group->tools.Item(pos);
@@ -377,36 +377,36 @@ bool wxRibbonToolBar::DeleteToolByPos(size_t pos)
             delete tool;
             return true;
         }
-        else if(pos==tool_count)
+        else if ( pos == toolCount )
         {
             // Remove separator
-            if(g < group_count - 1)
+            if ( g < groupCount - 1 )
             {
-                wxRibbonToolBarToolGroup* next_group = m_groups.Item(g+1);
-                for(t = 0; t < next_group->tools.GetCount(); ++t)
-                    group->tools.Add(next_group->tools[t]);
+                wxRibbonToolBarToolGroup* nextGroup = m_groups.Item(g+1);
+                for ( t = 0; t < nextGroup->tools.GetCount(); ++t )
+                    group->tools.Add(nextGroup->tools[t]);
                 m_groups.RemoveAt(g+1);
-                delete next_group;
+                delete nextGroup;
             }
             return true;
         }
-        pos -= tool_count+1;
+        pos -= toolCount + 1;
     }
     return false;
 }
 
-wxRibbonToolBarToolBase* wxRibbonToolBar::FindById(int tool_id)const
+wxRibbonToolBarToolBase* wxRibbonToolBar::FindById(int toolId) const
 {
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        size_t toolCount = group->tools.GetCount();
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-            if(tool->id == tool_id)
+            if ( tool->id == toolId )
             {
                 return tool;
             }
@@ -415,39 +415,39 @@ wxRibbonToolBarToolBase* wxRibbonToolBar::FindById(int tool_id)const
     return nullptr;
 }
 
-wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(size_t pos)const
+wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(size_t pos) const
 {
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        if(pos<tool_count)
+        size_t toolCount = group->tools.GetCount();
+        if ( pos < toolCount )
         {
             return group->tools[pos];
         }
-        else if(pos==tool_count)
+        else if ( pos == toolCount )
         {
             return nullptr;
         }
-        pos -= tool_count+1;
+        pos -= toolCount + 1;
     }
     return nullptr;
 }
 
-wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(wxCoord x, wxCoord y)const
+wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(wxCoord x, wxCoord y) const
 {
-    size_t group_count = m_groups.GetCount();
-    for ( size_t g = 0; g < group_count; ++g )
+    size_t groupCount = m_groups.GetCount();
+    for ( size_t g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        for ( size_t t = 0; t < tool_count; ++t )
+        size_t toolCount = group->tools.GetCount();
+        for ( size_t t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
             wxRect rect(group->position + tool->position, tool->size);
-            if(rect.Contains(x, y))
+            if ( rect.Contains(x, y) )
             {
                 return tool;
             }
@@ -459,19 +459,19 @@ wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(wxCoord x, wxCoord y)cons
 size_t wxRibbonToolBar::GetToolCount() const
 {
     size_t count = 0;
-    for(size_t g = 0; g < m_groups.GetCount(); ++g)
+    for ( size_t g = 0; g < m_groups.GetCount(); ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
         count += group->tools.GetCount();
     }
     // There is a splitter in front of every group except for the first
     // If only one group, no separator.
-    if(m_groups.GetCount()>1)
+    if ( m_groups.GetCount() > 1 )
         count += m_groups.GetCount() - 1;
     return count;
 }
 
-int wxRibbonToolBar::GetToolId(const wxRibbonToolBarToolBase* tool)const
+int wxRibbonToolBar::GetToolId(const wxRibbonToolBarToolBase* tool) const
 {
     wxCHECK_MSG(tool != nullptr , wxNOT_FOUND, "The tool pointer must not be null");
     return tool->id;
@@ -479,50 +479,50 @@ int wxRibbonToolBar::GetToolId(const wxRibbonToolBarToolBase* tool)const
 
 wxRibbonToolBarToolBase* wxRibbonToolBar::GetActiveTool() const
 {
-    return m_active_tool == nullptr ? nullptr : m_active_tool;
+    return m_activeTool == nullptr ? nullptr : m_activeTool;
 }
 
-wxObject* wxRibbonToolBar::GetToolClientData(int tool_id)const
+wxObject* wxRibbonToolBar::GetToolClientData(int toolId) const
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_MSG(tool != nullptr , nullptr, "Invalid tool id");
-    return tool->client_data;
+    return tool->clientData;
 }
 
-bool wxRibbonToolBar::GetToolEnabled(int tool_id)const
+bool wxRibbonToolBar::GetToolEnabled(int toolId) const
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_MSG(tool != nullptr , false, "Invalid tool id");
     return (tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED) == 0;
 }
 
-wxString wxRibbonToolBar::GetToolHelpString(int tool_id)const
+wxString wxRibbonToolBar::GetToolHelpString(int toolId) const
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_MSG(tool != nullptr , wxEmptyString, "Invalid tool id");
-    return tool->help_string;
+    return tool->helpString;
 }
 
-wxRibbonButtonKind wxRibbonToolBar::GetToolKind(int tool_id)const
+wxRibbonButtonKind wxRibbonToolBar::GetToolKind(int toolId) const
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_MSG(tool != nullptr , wxRIBBON_BUTTON_NORMAL, "Invalid tool id");
     return tool->kind;
 }
 
-int wxRibbonToolBar::GetToolPos(int tool_id)const
+int wxRibbonToolBar::GetToolPos(int toolId) const
 {
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
     int pos = 0;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        size_t toolCount = group->tools.GetCount();
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-            if(tool->id == tool_id)
+            if ( tool->id == toolId )
             {
                 return pos;
             }
@@ -533,19 +533,19 @@ int wxRibbonToolBar::GetToolPos(int tool_id)const
     return wxNOT_FOUND;
 }
 
-wxRect wxRibbonToolBar::GetToolRect(int tool_id)const
+wxRect wxRibbonToolBar::GetToolRect(int toolId) const
 {
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
 
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        size_t toolCount = group->tools.GetCount();
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-            if (tool->id == tool_id)
+            if ( tool->id == toolId )
             {
                 return wxRect(group->position + tool->position, tool->size);
             }
@@ -554,9 +554,9 @@ wxRect wxRibbonToolBar::GetToolRect(int tool_id)const
     return wxRect();
 }
 
-bool wxRibbonToolBar::GetToolState(int tool_id)const
+bool wxRibbonToolBar::GetToolState(int toolId) const
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_MSG(tool != nullptr , false, "Invalid tool id");
     return (tool->state & wxRIBBON_TOOLBAR_TOOL_TOGGLED) != 0;
 }
@@ -578,41 +578,41 @@ bool wxRibbonToolBar::IsSizingContinuous() const
     return false;
 }
 
-void wxRibbonToolBar::SetToolClientData(int tool_id, wxObject* clientData)
+void wxRibbonToolBar::SetToolClientData(int toolId, wxObject* clientData)
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_RET(tool != nullptr , "Invalid tool id");
-    tool->client_data = clientData;
+    tool->clientData = clientData;
 }
 
-void wxRibbonToolBar::SetToolDisabledBitmap(int tool_id, const wxBitmapBundle &bitmap)
+void wxRibbonToolBar::SetToolDisabledBitmap(int toolId, const wxBitmapBundle &bitmap)
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_RET(tool != nullptr , "Invalid tool id");
-    tool->bitmap_disabled = bitmap;
+    tool->bitmapDisabled = bitmap;
 }
 
-void wxRibbonToolBar::SetToolHelpString(int tool_id, const wxString& helpString)
+void wxRibbonToolBar::SetToolHelpString(int toolId, const wxString& helpString)
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_RET(tool != nullptr , "Invalid tool id");
-    tool->help_string = helpString;
+    tool->helpString = helpString;
 }
 
-void wxRibbonToolBar::SetToolNormalBitmap(int tool_id, const wxBitmapBundle &bitmap)
+void wxRibbonToolBar::SetToolNormalBitmap(int toolId, const wxBitmapBundle &bitmap)
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_RET(tool != nullptr , "Invalid tool id");
     tool->bitmap = bitmap;
 }
 
-void wxRibbonToolBar::EnableTool(int tool_id, bool enable)
+void wxRibbonToolBar::EnableTool(int toolId, bool enable)
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_RET(tool != nullptr , "Invalid tool id");
-    if(enable)
+    if ( enable )
     {
-        if(tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED)
+        if ( tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED )
         {
             tool->state &= ~wxRIBBON_TOOLBAR_TOOL_DISABLED;
             Refresh();
@@ -620,7 +620,7 @@ void wxRibbonToolBar::EnableTool(int tool_id, bool enable)
     }
     else
     {
-        if((tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED)==0)
+        if ( (tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED) == 0 )
         {
             tool->state |= wxRIBBON_TOOLBAR_TOOL_DISABLED;
             Refresh();
@@ -628,13 +628,13 @@ void wxRibbonToolBar::EnableTool(int tool_id, bool enable)
     }
 }
 
-void wxRibbonToolBar::ToggleTool(int tool_id, bool checked)
+void wxRibbonToolBar::ToggleTool(int toolId, bool checked)
 {
-    wxRibbonToolBarToolBase* tool = FindById(tool_id);
+    wxRibbonToolBarToolBase* tool = FindById(toolId);
     wxCHECK_RET(tool != nullptr , "Invalid tool id");
-    if(checked)
+    if ( checked )
     {
-        if((tool->state & wxRIBBON_TOOLBAR_TOOL_TOGGLED) == 0)
+        if ( (tool->state & wxRIBBON_TOOLBAR_TOOL_TOGGLED) == 0 )
         {
             tool->state |= wxRIBBON_TOOLBAR_TOOL_TOGGLED;
             Refresh();
@@ -642,7 +642,7 @@ void wxRibbonToolBar::ToggleTool(int tool_id, bool checked)
     }
     else
     {
-        if(tool->state & wxRIBBON_TOOLBAR_TOOL_TOGGLED)
+        if ( tool->state & wxRIBBON_TOOLBAR_TOOL_TOGGLED )
         {
             tool->state &= ~wxRIBBON_TOOLBAR_TOOL_TOGGLED;
             Refresh();
@@ -652,7 +652,7 @@ void wxRibbonToolBar::ToggleTool(int tool_id, bool checked)
 
 static int GetSizeInOrientation(wxSize size, wxOrientation orientation)
 {
-    switch(orientation)
+    switch ( orientation )
     {
     case wxHORIZONTAL: return size.GetWidth();
     case wxVERTICAL: return size.GetHeight();
@@ -662,42 +662,42 @@ static int GetSizeInOrientation(wxSize size, wxOrientation orientation)
 }
 
 wxSize wxRibbonToolBar::DoGetNextSmallerSize(wxOrientation direction,
-                                      wxSize relative_to) const
+                                      wxSize relativeTo) const
 {
-    wxSize result(relative_to);
+    wxSize result(relativeTo);
     int area = 0;
     int nrows;
-    for(nrows = m_nrows_min; nrows <= m_nrows_max; ++nrows)
+    for ( nrows = m_nrowsMin; nrows <= m_nrowsMax; ++nrows )
     {
-        wxSize size(m_sizes[nrows - m_nrows_min]);
+        wxSize size(m_sizes[nrows - m_nrowsMin]);
         wxSize original(size);
-        switch(direction)
+        switch ( direction )
         {
         case wxHORIZONTAL:
-            if(size.GetWidth() < relative_to.GetWidth()
-                && size.GetHeight() <= relative_to.GetHeight())
+            if ( size.GetWidth() < relativeTo.GetWidth()
+                && size.GetHeight() <= relativeTo.GetHeight() )
             {
-                size.SetHeight(relative_to.GetHeight());
+                size.SetHeight(relativeTo.GetHeight());
                 break;
             }
             continue;
         case wxVERTICAL:
-            if(size.GetWidth() <= relative_to.GetWidth()
-                && size.GetHeight() < relative_to.GetHeight())
+            if ( size.GetWidth() <= relativeTo.GetWidth()
+                && size.GetHeight() < relativeTo.GetHeight() )
             {
-                size.SetWidth(relative_to.GetWidth());
+                size.SetWidth(relativeTo.GetWidth());
                 break;
             }
             continue;
         case wxBOTH:
-            if(size.GetWidth() < relative_to.GetWidth()
-                && size.GetHeight() < relative_to.GetHeight())
+            if ( size.GetWidth() < relativeTo.GetWidth()
+                && size.GetHeight() < relativeTo.GetHeight() )
             {
                 break;
             }
             continue;
         }
-        if(GetSizeInOrientation(original, direction) > area)
+        if ( GetSizeInOrientation(original, direction) > area )
         {
             result = size;
             area = GetSizeInOrientation(original, direction);
@@ -707,43 +707,43 @@ wxSize wxRibbonToolBar::DoGetNextSmallerSize(wxOrientation direction,
 }
 
 wxSize wxRibbonToolBar::DoGetNextLargerSize(wxOrientation direction,
-                                 wxSize relative_to) const
+                                 wxSize relativeTo) const
 {
     // Pick the smallest of our sizes which are larger than the given size
-    wxSize result(relative_to);
+    wxSize result(relativeTo);
     int area = INT_MAX;
     int nrows;
-    for(nrows = m_nrows_min; nrows <= m_nrows_max; ++nrows)
+    for ( nrows = m_nrowsMin; nrows <= m_nrowsMax; ++nrows )
     {
-        wxSize size(m_sizes[nrows - m_nrows_min]);
+        wxSize size(m_sizes[nrows - m_nrowsMin]);
         wxSize original(size);
-        switch(direction)
+        switch ( direction )
         {
         case wxHORIZONTAL:
-            if(size.GetWidth() > relative_to.GetWidth()
-                && size.GetHeight() <= relative_to.GetHeight())
+            if ( size.GetWidth() > relativeTo.GetWidth()
+                && size.GetHeight() <= relativeTo.GetHeight() )
             {
-                size.SetHeight(relative_to.GetHeight());
+                size.SetHeight(relativeTo.GetHeight());
                 break;
             }
             continue;
         case wxVERTICAL:
-            if(size.GetWidth() <= relative_to.GetWidth()
-                && size.GetHeight() > relative_to.GetHeight())
+            if ( size.GetWidth() <= relativeTo.GetWidth()
+                && size.GetHeight() > relativeTo.GetHeight() )
             {
-                size.SetWidth(relative_to.GetWidth());
+                size.SetWidth(relativeTo.GetWidth());
                 break;
             }
             continue;
         case wxBOTH:
-            if(size.GetWidth() > relative_to.GetWidth()
-                && size.GetHeight() > relative_to.GetHeight())
+            if ( size.GetWidth() > relativeTo.GetWidth()
+                && size.GetHeight() > relativeTo.GetHeight() )
             {
                 break;
             }
             continue;
         }
-        if(GetSizeInOrientation(original, direction) < area)
+        if ( GetSizeInOrientation(original, direction) < area )
         {
             result = size;
             area = GetSizeInOrientation(original, direction);
@@ -755,49 +755,49 @@ wxSize wxRibbonToolBar::DoGetNextLargerSize(wxOrientation direction,
 
 void wxRibbonToolBar::SetRows(int nMin, int nMax)
 {
-    if(nMax == -1)
+    if ( nMax == -1 )
         nMax = nMin;
 
     wxASSERT(1 <= nMin);
     wxASSERT(nMin <= nMax);
 
-    m_nrows_min = nMin;
-    m_nrows_max = nMax;
+    m_nrowsMin = nMin;
+    m_nrowsMax = nMax;
 
     delete[] m_sizes;
-    m_sizes = new wxSize[m_nrows_max - m_nrows_min + 1];
+    m_sizes = new wxSize[m_nrowsMax - m_nrowsMin + 1];
 
     Realize();
 }
 
 bool wxRibbonToolBar::Realize()
 {
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
         return false;
 
     // Calculate the size of each group and the position/size of each tool
-    wxMemoryDC temp_dc;
-    size_t group_count = m_groups.GetCount();
+    wxMemoryDC tempDc;
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolBase* prev = nullptr;
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
+        size_t toolCount = group->tools.GetCount();
         int tallest = 0;
-        for(t = 0; t < tool_count; ++t)
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-            tool->size = m_art->GetToolSize(temp_dc, this,
+            tool->size = m_art->GetToolSize(tempDc, this,
                 tool->bitmap.GetPreferredLogicalSizeFor(this), tool->kind, t == 0,
-                t == (tool_count - 1), &tool->dropdown);
-            if(t == 0)
+                t == (toolCount - 1), &tool->dropdown);
+            if ( t == 0 )
                 tool->state |= wxRIBBON_TOOLBAR_TOOL_FIRST;
-            if(t == tool_count - 1)
+            if ( t == toolCount - 1 )
                 tool->state |= wxRIBBON_TOOLBAR_TOOL_LAST;
-            if(tool->size.GetHeight() > tallest)
+            if ( tool->size.GetHeight() > tallest )
                 tallest = tool->size.GetHeight();
-            if(prev)
+            if ( prev )
             {
                 tool->position = prev->position;
                 tool->position.x += prev->size.x;
@@ -808,12 +808,12 @@ bool wxRibbonToolBar::Realize()
             }
             prev = tool;
         }
-        if(tool_count == 0)
+        if ( toolCount == 0 )
             group->size = wxSize(0, 0);
         else
         {
             group->size = wxSize(prev->position.x + prev->size.x, tallest);
-            for(t = 0; t < tool_count; ++t)
+            for ( t = 0; t < toolCount; ++t )
                 group->tools.Item(t)->size.SetHeight(tallest);
         }
     }
@@ -821,9 +821,9 @@ bool wxRibbonToolBar::Realize()
     // Calculate the minimum size for each possible number of rows
     int nrows, r;
     int sep = m_art->GetMetric(wxRIBBON_ART_TOOL_GROUP_SEPARATION_SIZE);
-    int smallest_area = INT_MAX;
-    wxSize* row_sizes = new wxSize[m_nrows_max];
-    wxOrientation major_axis = m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL ?
+    int smallestArea = INT_MAX;
+    wxSize* rowSizes = new wxSize[m_nrowsMax];
+    wxOrientation majorAxis = m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL ?
         wxVERTICAL : wxHORIZONTAL;
 
     SetMinSize(wxSize(0, 0));
@@ -832,152 +832,152 @@ bool wxRibbonToolBar::Realize()
     // See if we're sizing flexibly (i.e. wrapping), and set min size differently
     bool sizingFlexibly = false;
     wxRibbonPanel* panel = wxDynamicCast(GetParent(), wxRibbonPanel);
-    if (panel && (panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE))
+    if ( panel && (panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE) )
         sizingFlexibly = true;
 
     // Without this, there will be redundant horizontal space because SetMinSize will
     // use the smallest possible height (and therefore largest width).
-    if (sizingFlexibly)
-        major_axis = wxHORIZONTAL;
+    if ( sizingFlexibly )
+        majorAxis = wxHORIZONTAL;
 
-    for(nrows = m_nrows_min; nrows <= m_nrows_max; ++nrows)
+    for ( nrows = m_nrowsMin; nrows <= m_nrowsMax; ++nrows )
     {
-        for(r = 0; r < nrows; ++r)
-            row_sizes[r] = wxSize(0, 0);
-        for(g = 0; g < group_count; ++g)
+        for ( r = 0; r < nrows; ++r )
+            rowSizes[r] = wxSize(0, 0);
+        for ( g = 0; g < groupCount; ++g )
         {
             wxRibbonToolBarToolGroup* group = m_groups.Item(g);
             int shortest_row = 0;
-            for(r = 1; r < nrows; ++r)
+            for ( r = 1; r < nrows; ++r )
             {
-                if(row_sizes[r].GetWidth() < row_sizes[shortest_row].GetWidth())
+                if ( rowSizes[r].GetWidth() < rowSizes[shortest_row].GetWidth() )
                     shortest_row = r;
             }
-            row_sizes[shortest_row].x += group->size.x + sep;
-            if(group->size.y > row_sizes[shortest_row].y)
-                row_sizes[shortest_row].y = group->size.y;
+            rowSizes[shortest_row].x += group->size.x + sep;
+            if ( group->size.y > rowSizes[shortest_row].y )
+                rowSizes[shortest_row].y = group->size.y;
         }
         wxSize size(0, 0);
-        for(r = 0; r < nrows; ++r)
+        for ( r = 0; r < nrows; ++r )
         {
-            if(row_sizes[r].GetWidth() != 0)
-                row_sizes[r].DecBy(sep, 0);
-            if(row_sizes[r].GetWidth() > size.GetWidth())
-                size.SetWidth(row_sizes[r].GetWidth());
-            size.IncBy(0, row_sizes[r].y);
+            if ( rowSizes[r].GetWidth() != 0 )
+                rowSizes[r].DecBy(sep, 0);
+            if ( rowSizes[r].GetWidth() > size.GetWidth() )
+                size.SetWidth(rowSizes[r].GetWidth());
+            size.IncBy(0, rowSizes[r].y);
         }
-        m_sizes[nrows - m_nrows_min] = size;
+        m_sizes[nrows - m_nrowsMin] = size;
 
-        if(GetSizeInOrientation(size, major_axis) < smallest_area)
+        if ( GetSizeInOrientation(size, majorAxis) < smallestArea )
         {
-            smallest_area = GetSizeInOrientation(size, major_axis);
+            smallestArea = GetSizeInOrientation(size, majorAxis);
             SetMinSize(size);
         }
 
-        if (sizingFlexibly)
+        if ( sizingFlexibly )
         {
-            if (size.x < minSize.x)
+            if ( size.x < minSize.x )
                 minSize.x = size.x;
-            if (size.y < minSize.y)
+            if ( size.y < minSize.y )
                 minSize.y = size.y;
         }
     }
 
-    if (sizingFlexibly)
+    if ( sizingFlexibly )
     {
         // Give it the min size in either direction regardless of row,
         // so that we're able to vary the size of the panel according to
         // the space the toolbar takes up.
         SetMinSize(minSize);
     }
-    delete[] row_sizes;
+    delete[] rowSizes;
 
     // Position the groups
-    wxSizeEvent dummy_event(GetSize());
-    OnSize(dummy_event);
+    wxSizeEvent dummyEvent(GetSize());
+    OnSize(dummyEvent);
 
     return true;
 }
 
 void wxRibbonToolBar::OnSize(wxSizeEvent& evt)
 {
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
         return;
 
     // Choose row count with largest possible area
     wxSize size = evt.GetSize();
-    int row_count = m_nrows_max;
-    wxOrientation major_axis = m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL ?
+    int rowCount = m_nrowsMax;
+    wxOrientation majorAxis = m_art->GetFlags() & wxRIBBON_BAR_FLOW_VERTICAL ?
         wxVERTICAL : wxHORIZONTAL;
 
     // See if we're sizing flexibly, and set min size differently
     bool sizingFlexibly = false;
     wxRibbonPanel* panel = wxDynamicCast(GetParent(), wxRibbonPanel);
-    if (panel && (panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE))
+    if ( panel && (panel->GetFlags() & wxRIBBON_PANEL_FLEXIBLE) )
         sizingFlexibly = true;
 
     // Without this, there will be redundant horizontal space because SetMinSize will
     // use the smallest possible height (and therefore largest width).
-    if (sizingFlexibly)
-        major_axis = wxHORIZONTAL;
+    if ( sizingFlexibly )
+        majorAxis = wxHORIZONTAL;
 
-    if(m_nrows_max != m_nrows_min)
+    if ( m_nrowsMax != m_nrowsMin )
     {
         int area = 0;
-        for(int i = 0; i <= m_nrows_max - m_nrows_min; ++i)
+        for ( int i = 0; i <= m_nrowsMax - m_nrowsMin; ++i )
         {
-            if(m_sizes[i].x <= size.x && m_sizes[i].y <= size.y &&
-                GetSizeInOrientation(m_sizes[i], major_axis) > area)
+            if ( m_sizes[i].x <= size.x && m_sizes[i].y <= size.y &&
+                GetSizeInOrientation(m_sizes[i], majorAxis) > area )
             {
-                area = GetSizeInOrientation(m_sizes[i], major_axis);
-                row_count = m_nrows_min + i;
+                area = GetSizeInOrientation(m_sizes[i], majorAxis);
+                rowCount = m_nrowsMin + i;
             }
         }
     }
 
     // Assign groups to rows and calculate row widths
-    wxSize* row_sizes = new wxSize[row_count];
+    wxSize* rowSizes = new wxSize[rowCount];
     int sep = m_art->GetMetric(wxRIBBON_ART_TOOL_GROUP_SEPARATION_SIZE);
 
     int r;
     size_t g;
-    size_t group_count = m_groups.GetCount();
-    for(g = 0; g < group_count; ++g)
+    size_t groupCount = m_groups.GetCount();
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
         int shortest_row = 0;
-        for(r = 1; r < row_count; ++r)
+        for ( r = 1; r < rowCount; ++r )
         {
-            if(row_sizes[r].GetWidth() < row_sizes[shortest_row].GetWidth())
+            if ( rowSizes[r].GetWidth() < rowSizes[shortest_row].GetWidth() )
                 shortest_row = r;
         }
-        group->position = wxPoint(row_sizes[shortest_row].x, shortest_row);
-        row_sizes[shortest_row].x += group->size.x + sep;
-        if(group->size.y > row_sizes[shortest_row].y)
-            row_sizes[shortest_row].y = group->size.y;
+        group->position = wxPoint(rowSizes[shortest_row].x, shortest_row);
+        rowSizes[shortest_row].x += group->size.x + sep;
+        if ( group->size.y > rowSizes[shortest_row].y )
+            rowSizes[shortest_row].y = group->size.y;
     }
 
     // Calculate row positions
-    int total_height = 0;
-    for(r = 0; r < row_count; ++r)
-        total_height += row_sizes[r].GetHeight();
-    int rowsep = (size.GetHeight() - total_height) / (row_count + 1);
-    int* rowypos = new int[row_count];
+    int totalHeight = 0;
+    for ( r = 0; r < rowCount; ++r )
+        totalHeight += rowSizes[r].GetHeight();
+    int rowsep = (size.GetHeight() - totalHeight) / (rowCount + 1);
+    int* rowypos = new int[rowCount];
     rowypos[0] = rowsep;
-    for(r = 1; r < row_count; ++r)
+    for ( r = 1; r < rowCount; ++r )
     {
-        rowypos[r] = rowypos[r - 1] + row_sizes[r - 1].GetHeight() + rowsep;
+        rowypos[r] = rowypos[r - 1] + rowSizes[r - 1].GetHeight() + rowsep;
     }
 
     // Set group y positions
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
         group->position.y = rowypos[group->position.y];
     }
 
     delete[] rowypos;
-    delete[] row_sizes;
+    delete[] rowSizes;
 }
 
 void wxRibbonToolBar::OnDPIChanged(wxDPIChangedEvent& event)
@@ -989,7 +989,7 @@ void wxRibbonToolBar::OnDPIChanged(wxDPIChangedEvent& event)
 // Finds the best width and height given the parents' width and height
 wxSize wxRibbonToolBar::GetBestSizeForParentSize(const wxSize& parentSize) const
 {
-    if (!m_sizes)
+    if ( !m_sizes )
         return GetMinSize();
 
     // Choose row count with largest possible area
@@ -998,18 +998,18 @@ wxSize wxRibbonToolBar::GetBestSizeForParentSize(const wxSize& parentSize) const
     // A toolbar should maximize its width whether vertical or horizontal, so
     // force the major axis to be horizontal. Without this, there will be
     // redundant horizontal space.
-    wxOrientation major_axis = wxHORIZONTAL;
+    wxOrientation majorAxis = wxHORIZONTAL;
     wxSize bestSize = m_sizes[0];
 
-    if(m_nrows_max != m_nrows_min)
+    if ( m_nrowsMax != m_nrowsMin )
     {
         int area = 0;
-        for(int i = 0; i <= m_nrows_max - m_nrows_min; ++i)
+        for ( int i = 0; i <= m_nrowsMax - m_nrowsMin; ++i )
         {
-            if(m_sizes[i].x <= size.x && m_sizes[i].y <= size.y &&
-                GetSizeInOrientation(m_sizes[i], major_axis) > area)
+            if ( m_sizes[i].x <= size.x && m_sizes[i].y <= size.y &&
+                GetSizeInOrientation(m_sizes[i], majorAxis) > area )
             {
-                area = GetSizeInOrientation(m_sizes[i], major_axis);
+                area = GetSizeInOrientation(m_sizes[i], majorAxis);
                 bestSize = m_sizes[i];
             }
         }
@@ -1030,29 +1030,29 @@ void wxRibbonToolBar::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
 void wxRibbonToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
     wxAutoBufferedPaintDC dc(this);
-    if(m_art == nullptr)
+    if ( m_art == nullptr )
         return;
 
     m_art->DrawToolBarBackground(dc, this, GetSize());
 
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        if(tool_count != 0)
+        size_t toolCount = group->tools.GetCount();
+        if ( toolCount != 0 )
         {
             m_art->DrawToolGroupBackground(dc, this,
                 wxRect(group->position, group->size));
-            for(t = 0; t < tool_count; ++t)
+            for ( t = 0; t < toolCount; ++t )
             {
                 wxRibbonToolBarToolBase* tool = group->tools.Item(t);
                 wxRect rect(group->position + tool->position, tool->size);
                 // Resolve bitmap bundle to actual bitmap for current DPI
                 wxBitmap bmp;
-                if(tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED)
-                    bmp = tool->bitmap_disabled.GetBitmapFor(this);
+                if ( tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED )
+                    bmp = tool->bitmapDisabled.GetBitmapFor(this);
                 else
                     bmp = tool->bitmap.GetBitmapFor(this);
                 m_art->DrawTool(dc, this, rect, bmp, tool->kind, tool->state);
@@ -1064,26 +1064,26 @@ void wxRibbonToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
 {
     wxPoint pos(evt.GetPosition());
-    wxRibbonToolBarToolBase *new_hover = nullptr;
+    wxRibbonToolBarToolBase *newHover = nullptr;
 
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        if(group->position.x <= pos.x && pos.x < group->position.x + group->size.x
-            && group->position.y <= pos.y && pos.y < group->position.y + group->size.y)
+        if ( group->position.x <= pos.x && pos.x < group->position.x + group->size.x
+            && group->position.y <= pos.y && pos.y < group->position.y + group->size.y )
         {
-            size_t tool_count = group->tools.GetCount();
+            size_t toolCount = group->tools.GetCount();
             pos -= group->position;
-            for(t = 0; t < tool_count; ++t)
+            for ( t = 0; t < toolCount; ++t )
             {
                 wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-                if(tool->position.x <= pos.x && pos.x < tool->position.x + tool->size.x
-                    && tool->position.y <= pos.y && pos.y < tool->position.y + tool->size.y)
+                if ( tool->position.x <= pos.x && pos.x < tool->position.x + tool->size.x
+                    && tool->position.y <= pos.y && pos.y < tool->position.y + tool->size.y )
                 {
                     pos -= tool->position;
-                    new_hover = tool;
+                    newHover = tool;
                     break;
                 }
             }
@@ -1092,60 +1092,60 @@ void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
     }
 
 #if wxUSE_TOOLTIPS
-    if(new_hover)
+    if ( newHover )
     {
-        if (new_hover != m_hover_tool &&
-                !(new_hover->state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE))
-            SetToolTip(new_hover->help_string);
+        if ( newHover != m_hoverTool &&
+                !(newHover->state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE) )
+            SetToolTip(newHover->helpString);
     }
-    else if(GetToolTip())
+    else if ( GetToolTip() )
     {
         UnsetToolTip();
     }
 #endif
 
-    if(new_hover != m_hover_tool)
+    if ( newHover != m_hoverTool )
     {
-        if(m_hover_tool)
+        if ( m_hoverTool )
         {
-            m_hover_tool->state &= ~(wxRIBBON_TOOLBAR_TOOL_HOVER_MASK
+            m_hoverTool->state &= ~(wxRIBBON_TOOLBAR_TOOL_HOVER_MASK
                 | wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK);
         }
-        m_hover_tool = new_hover;
+        m_hoverTool = newHover;
 
-        if(new_hover && new_hover->state & wxRIBBON_TOOLBAR_TOOL_DISABLED)
-            new_hover = nullptr; // A disabled tool can not be highlighted
+        if ( newHover && newHover->state & wxRIBBON_TOOLBAR_TOOL_DISABLED )
+            newHover = nullptr; // A disabled tool can not be highlighted
 
-        if(new_hover)
+        if ( newHover )
         {
             long what = wxRIBBON_TOOLBAR_TOOL_NORMAL_HOVERED;
-            if(new_hover->dropdown.Contains(pos))
+            if ( newHover->dropdown.Contains(pos) )
                 what = wxRIBBON_TOOLBAR_TOOL_DROPDOWN_HOVERED;
 
-            new_hover->state |= what;
+            newHover->state |= what;
 
-            if(new_hover == m_active_tool)
+            if ( newHover == m_activeTool )
             {
-                new_hover->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
-                new_hover->state |= (what << 2);
+                newHover->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
+                newHover->state |= (what << 2);
             }
         }
         Refresh(false);
     }
-    else if(m_hover_tool && m_hover_tool->kind == wxRIBBON_BUTTON_HYBRID)
+    else if ( m_hoverTool && m_hoverTool->kind == wxRIBBON_BUTTON_HYBRID )
     {
-        long newstate = m_hover_tool->state &~wxRIBBON_TOOLBAR_TOOL_HOVER_MASK;
+        long newState = m_hoverTool->state &~wxRIBBON_TOOLBAR_TOOL_HOVER_MASK;
         long what = wxRIBBON_TOOLBAR_TOOL_NORMAL_HOVERED;
-        if(m_hover_tool->dropdown.Contains(pos))
+        if ( m_hoverTool->dropdown.Contains(pos) )
             what = wxRIBBON_TOOLBAR_TOOL_DROPDOWN_HOVERED;
-        newstate |= what;
-        if(newstate != m_hover_tool->state)
+        newState |= what;
+        if ( newState != m_hoverTool->state )
         {
-            m_hover_tool->state = newstate;
-            if(m_hover_tool == m_active_tool)
+            m_hoverTool->state = newState;
+            if ( m_hoverTool == m_activeTool )
             {
-                m_hover_tool->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
-                m_hover_tool->state |= (what << 2);
+                m_hoverTool->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
+                m_hoverTool->state |= (what << 2);
             }
             Refresh(false);
         }
@@ -1155,11 +1155,11 @@ void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
 void wxRibbonToolBar::OnMouseDown(wxMouseEvent& evt)
 {
     OnMouseMove(evt);
-    if(m_hover_tool)
+    if ( m_hoverTool )
     {
-        m_active_tool = m_hover_tool;
-        m_active_tool->state |=
-            (m_active_tool->state & wxRIBBON_TOOLBAR_TOOL_HOVER_MASK) << 2;
+        m_activeTool = m_hoverTool;
+        m_activeTool->state |=
+            (m_activeTool->state & wxRIBBON_TOOLBAR_TOOL_HOVER_MASK) << 2;
         UnsetToolTip();
         Refresh(false);
     }
@@ -1167,45 +1167,45 @@ void wxRibbonToolBar::OnMouseDown(wxMouseEvent& evt)
 
 void wxRibbonToolBar::OnMouseLeave(wxMouseEvent& WXUNUSED(evt))
 {
-    if(m_hover_tool)
+    if ( m_hoverTool )
     {
-        m_hover_tool->state &= ~wxRIBBON_TOOLBAR_TOOL_HOVER_MASK;
-        m_hover_tool = nullptr;
+        m_hoverTool->state &= ~wxRIBBON_TOOLBAR_TOOL_HOVER_MASK;
+        m_hoverTool = nullptr;
         Refresh(false);
     }
 }
 
 void wxRibbonToolBar::OnMouseUp(wxMouseEvent& WXUNUSED(evt))
 {
-    if(m_active_tool)
+    if ( m_activeTool )
     {
-        if(m_active_tool->state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK)
+        if ( m_activeTool->state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK )
         {
-            wxEventType evt_type = wxEVT_RIBBONTOOLBAR_CLICKED;
-            if(m_active_tool->state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE)
-                evt_type = wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED;
-            wxRibbonToolBarEvent notification(evt_type, m_active_tool->id);
-            if(m_active_tool->kind == wxRIBBON_BUTTON_TOGGLE)
+            wxEventType evtType = wxEVT_RIBBONTOOLBAR_CLICKED;
+            if ( m_activeTool->state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE )
+                evtType = wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED;
+            wxRibbonToolBarEvent notification(evtType, m_activeTool->id);
+            if ( m_activeTool->kind == wxRIBBON_BUTTON_TOGGLE )
             {
-                m_active_tool->state ^=
+                m_activeTool->state ^=
                     wxRIBBON_TOOLBAR_TOOL_TOGGLED;
-                notification.SetInt(m_active_tool->state &
+                notification.SetInt(m_activeTool->state &
                     wxRIBBON_TOOLBAR_TOOL_TOGGLED);
             }
             notification.SetEventObject(this);
             notification.SetBar(this);
             ProcessEvent(notification);
 
-            if (auto* const panel = wxCheckedStaticCast<wxRibbonPanel>(GetParent()))
+            if ( auto* const panel = wxCheckedStaticCast<wxRibbonPanel>(GetParent()) )
                 panel->HideIfExpanded();
         }
 
-        // Notice that m_active_tool could have been reset by the event handler
+        // Notice that m_activeTool could have been reset by the event handler
         // above so we need to test it again.
-        if (m_active_tool)
+        if ( m_activeTool )
         {
-            m_active_tool->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
-            m_active_tool = nullptr;
+            m_activeTool->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
+            m_activeTool = nullptr;
             Refresh(false);
         }
     }
@@ -1213,10 +1213,10 @@ void wxRibbonToolBar::OnMouseUp(wxMouseEvent& WXUNUSED(evt))
 
 void wxRibbonToolBar::OnMouseEnter(wxMouseEvent& evt)
 {
-    if(m_active_tool && !evt.LeftIsDown())
+    if ( m_activeTool && !evt.LeftIsDown() )
     {
-        m_active_tool->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
-        m_active_tool = nullptr;
+        m_activeTool->state &= ~wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK;
+        m_activeTool = nullptr;
     }
 }
 
@@ -1228,13 +1228,13 @@ void wxRibbonToolBar::UpdateWindowUI(long flags)
     if ( !IsShown() )
         return;
 
-    size_t group_count = m_groups.GetCount();
+    size_t groupCount = m_groups.GetCount();
     size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( g = 0; g < groupCount; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
-        size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        size_t toolCount = group->tools.GetCount();
+        for ( t = 0; t < toolCount; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
             int id = tool->id;
@@ -1256,24 +1256,24 @@ void wxRibbonToolBar::UpdateWindowUI(long flags)
 bool wxRibbonToolBarEvent::PopupMenu(wxMenu* menu)
 {
     wxPoint pos = wxDefaultPosition;
-    if(m_bar->m_active_tool)
+    if ( m_bar->m_activeTool )
     {
         // Find the group which contains the tool
-        size_t group_count = m_bar->m_groups.GetCount();
+        size_t groupCount = m_bar->m_groups.GetCount();
         size_t g, t;
-        for(g = 0; g < group_count; ++g)
+        for ( g = 0; g < groupCount; ++g )
         {
             wxRibbonToolBarToolGroup* group = m_bar->m_groups.Item(g);
-            size_t tool_count = group->tools.GetCount();
-            for(t = 0; t < tool_count; ++t)
+            size_t toolCount = group->tools.GetCount();
+            for ( t = 0; t < toolCount; ++t )
             {
                 wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-                if(tool == m_bar->m_active_tool)
+                if ( tool == m_bar->m_activeTool )
                 {
                     pos = group->position;
                     pos += tool->position;
                     pos.y += tool->size.GetHeight();
-                    g = group_count;
+                    g = groupCount;
                     break;
                 }
             }


### PR DESCRIPTION
Name variables correctly (camel case, members prefixed with `m_`).
Fix spacing and other formatting.