### PR TITLE
Add dark mode support to wxMSW task dialog-based dialogs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5067,7 +5067,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS =  \
 	monodll_darkmode.o \
 	monodll_msw_appprogress.o \
 	monodll_taskbarbutton.o \
-	monodll_msw_power.o
+	monodll_msw_power.o \
+	monodll_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS)
@@ -5811,7 +5812,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_1 =  \
 	monodll_darkmode.o \
 	monodll_msw_appprogress.o \
 	monodll_taskbarbutton.o \
-	monodll_msw_power.o
+	monodll_msw_power.o \
+	monodll_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_1 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_1)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_1 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS)
@@ -6855,7 +6857,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_2 =  \
 	monolib_darkmode.o \
 	monolib_msw_appprogress.o \
 	monolib_taskbarbutton.o \
-	monolib_msw_power.o
+	monolib_msw_power.o \
+	monolib_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_2 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_2)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_2 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_17)
@@ -7599,7 +7602,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_3 =  \
 	monolib_darkmode.o \
 	monolib_msw_appprogress.o \
 	monolib_taskbarbutton.o \
-	monolib_msw_power.o
+	monolib_msw_power.o \
+	monolib_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_3 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_3)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_3 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_17)
@@ -8789,7 +8793,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_4 =  \
 	coredll_darkmode.o \
 	coredll_msw_appprogress.o \
 	coredll_taskbarbutton.o \
-	coredll_msw_power.o
+	coredll_msw_power.o \
+	coredll_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_4 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_4)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_4 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_1)
@@ -9533,7 +9538,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_5 =  \
 	coredll_darkmode.o \
 	coredll_msw_appprogress.o \
 	coredll_taskbarbutton.o \
-	coredll_msw_power.o
+	coredll_msw_power.o \
+	coredll_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_5 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_5)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_5 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_1)
@@ -10302,7 +10308,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_6 =  \
 	corelib_darkmode.o \
 	corelib_msw_appprogress.o \
 	corelib_taskbarbutton.o \
-	corelib_msw_power.o
+	corelib_msw_power.o \
+	corelib_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_6 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_6)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_6 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_4)
@@ -11046,7 +11053,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_7 =  \
 	corelib_darkmode.o \
 	corelib_msw_appprogress.o \
 	corelib_taskbarbutton.o \
-	corelib_msw_power.o
+	corelib_msw_power.o \
+	corelib_taskdlg.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_7 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_7)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_7 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_4)
@@ -18082,6 +18090,9 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@monodll_msw_power.o: $(srcdir)/src/msw/power.cpp $(MONODLL_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/power.cpp
 
+@COND_TOOLKIT_MSW_USE_GUI_1@monodll_taskdlg.o: $(srcdir)/src/msw/taskdlg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/taskdlg.cpp
+
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monodll_artmac.o: $(srcdir)/src/osx/artmac.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp
 
@@ -22875,6 +22886,9 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 
 @COND_TOOLKIT_MSW_USE_GUI_1@monolib_msw_power.o: $(srcdir)/src/msw/power.cpp $(MONOLIB_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/power.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@monolib_taskdlg.o: $(srcdir)/src/msw/taskdlg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/taskdlg.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monolib_artmac.o: $(srcdir)/src/osx/artmac.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp
@@ -27733,6 +27747,9 @@ coredll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(COREDLL_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@coredll_msw_power.o: $(srcdir)/src/msw/power.cpp $(COREDLL_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/power.cpp
 
+@COND_TOOLKIT_MSW_USE_GUI_1@coredll_taskdlg.o: $(srcdir)/src/msw/taskdlg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/taskdlg.cpp
+
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@coredll_artmac.o: $(srcdir)/src/osx/artmac.cpp $(COREDLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp
 
@@ -31488,6 +31505,9 @@ corelib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(CORELIB_ODEP)
 
 @COND_TOOLKIT_MSW_USE_GUI_1@corelib_msw_power.o: $(srcdir)/src/msw/power.cpp $(CORELIB_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/power.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@corelib_taskdlg.o: $(srcdir)/src/msw/taskdlg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/taskdlg.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@corelib_artmac.o: $(srcdir)/src/osx/artmac.cpp $(CORELIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -1765,6 +1765,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/msw/appprogress.cpp
     src/msw/taskbarbutton.cpp
     src/msw/power.cpp
+    src/msw/taskdlg.cpp
 </set>
 <set var="MSW_LOWLEVEL_HDR" hints="files">
     wx/msw/nonownedwnd.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -1641,6 +1641,7 @@ set(MSW_LOWLEVEL_SRC
     src/msw/appprogress.cpp
     src/msw/taskbarbutton.cpp
     src/msw/power.cpp
+    src/msw/taskdlg.cpp
 )
 
 set(MSW_LOWLEVEL_HDR

--- a/build/files
+++ b/build/files
@@ -1641,6 +1641,7 @@ MSW_LOWLEVEL_SRC =
     src/msw/sound.cpp
     src/msw/taskbar.cpp
     src/msw/taskbarbutton.cpp
+    src/msw/taskdlg.cpp
     src/msw/textmeasure.cpp
     src/msw/tooltip.cpp
     src/msw/toplevel.cpp

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -2145,6 +2145,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_appprogress.o \
 	$(OBJS)\monodll_taskbarbutton.o \
 	$(OBJS)\monodll_power.o \
+	$(OBJS)\monodll_taskdlg.o \
 	$(OBJS)\monodll_clrpickerg.o \
 	$(OBJS)\monodll_collpaneg.o \
 	$(OBJS)\monodll_filepickerg.o \
@@ -2498,6 +2499,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_appprogress.o \
 	$(OBJS)\monodll_taskbarbutton.o \
 	$(OBJS)\monodll_power.o \
+	$(OBJS)\monodll_taskdlg.o \
 	$(OBJS)\monodll_generic_accel.o \
 	$(OBJS)\monodll_clrpickerg.o \
 	$(OBJS)\monodll_collpaneg.o \
@@ -3015,6 +3017,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_appprogress.o \
 	$(OBJS)\monolib_taskbarbutton.o \
 	$(OBJS)\monolib_power.o \
+	$(OBJS)\monolib_taskdlg.o \
 	$(OBJS)\monolib_clrpickerg.o \
 	$(OBJS)\monolib_collpaneg.o \
 	$(OBJS)\monolib_filepickerg.o \
@@ -3368,6 +3371,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_appprogress.o \
 	$(OBJS)\monolib_taskbarbutton.o \
 	$(OBJS)\monolib_power.o \
+	$(OBJS)\monolib_taskdlg.o \
 	$(OBJS)\monolib_generic_accel.o \
 	$(OBJS)\monolib_clrpickerg.o \
 	$(OBJS)\monolib_collpaneg.o \
@@ -3760,6 +3764,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_appprogress.o \
 	$(OBJS)\coredll_taskbarbutton.o \
 	$(OBJS)\coredll_power.o \
+	$(OBJS)\coredll_taskdlg.o \
 	$(OBJS)\coredll_clrpickerg.o \
 	$(OBJS)\coredll_collpaneg.o \
 	$(OBJS)\coredll_filepickerg.o \
@@ -4113,6 +4118,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_appprogress.o \
 	$(OBJS)\coredll_taskbarbutton.o \
 	$(OBJS)\coredll_power.o \
+	$(OBJS)\coredll_taskdlg.o \
 	$(OBJS)\coredll_generic_accel.o \
 	$(OBJS)\coredll_clrpickerg.o \
 	$(OBJS)\coredll_collpaneg.o \
@@ -4461,6 +4467,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_appprogress.o \
 	$(OBJS)\corelib_taskbarbutton.o \
 	$(OBJS)\corelib_power.o \
+	$(OBJS)\corelib_taskdlg.o \
 	$(OBJS)\corelib_clrpickerg.o \
 	$(OBJS)\corelib_collpaneg.o \
 	$(OBJS)\corelib_filepickerg.o \
@@ -4814,6 +4821,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_appprogress.o \
 	$(OBJS)\corelib_taskbarbutton.o \
 	$(OBJS)\corelib_power.o \
+	$(OBJS)\corelib_taskdlg.o \
 	$(OBJS)\corelib_generic_accel.o \
 	$(OBJS)\corelib_clrpickerg.o \
 	$(OBJS)\corelib_collpaneg.o \
@@ -9298,6 +9306,11 @@ $(OBJS)\monodll_power.o: ../../src/msw/power.cpp
 endif
 
 ifeq ($(USE_GUI),1)
+$(OBJS)\monodll_taskdlg.o: ../../src/msw/taskdlg.cpp
+	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
 $(OBJS)\monodll_clrpickerg.o: ../../src/generic/clrpickerg.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 endif
@@ -11926,6 +11939,11 @@ $(OBJS)\monolib_power.o: ../../src/msw/power.cpp
 endif
 
 ifeq ($(USE_GUI),1)
+$(OBJS)\monolib_taskdlg.o: ../../src/msw/taskdlg.cpp
+	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
 $(OBJS)\monolib_clrpickerg.o: ../../src/generic/clrpickerg.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 endif
@@ -14494,6 +14512,11 @@ $(OBJS)\coredll_power.o: ../../src/msw/power.cpp
 endif
 
 ifeq ($(USE_GUI),1)
+$(OBJS)\coredll_taskdlg.o: ../../src/msw/taskdlg.cpp
+	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
 $(OBJS)\coredll_clrpickerg.o: ../../src/generic/clrpickerg.cpp
 	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
 endif
@@ -16275,6 +16298,11 @@ endif
 
 ifeq ($(USE_GUI),1)
 $(OBJS)\corelib_power.o: ../../src/msw/power.cpp
+	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
+$(OBJS)\corelib_taskdlg.o: ../../src/msw/taskdlg.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 endif
 

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -2531,6 +2531,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_appprogress.obj \
 	$(OBJS)\monodll_taskbarbutton.obj \
 	$(OBJS)\monodll_power.obj \
+	$(OBJS)\monodll_taskdlg.obj \
 	$(OBJS)\monodll_clrpickerg.obj \
 	$(OBJS)\monodll_collpaneg.obj \
 	$(OBJS)\monodll_filepickerg.obj \
@@ -2882,6 +2883,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_appprogress.obj \
 	$(OBJS)\monodll_taskbarbutton.obj \
 	$(OBJS)\monodll_power.obj \
+	$(OBJS)\monodll_taskdlg.obj \
 	$(OBJS)\monodll_generic_accel.obj \
 	$(OBJS)\monodll_clrpickerg.obj \
 	$(OBJS)\monodll_collpaneg.obj \
@@ -3401,6 +3403,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_appprogress.obj \
 	$(OBJS)\monolib_taskbarbutton.obj \
 	$(OBJS)\monolib_power.obj \
+	$(OBJS)\monolib_taskdlg.obj \
 	$(OBJS)\monolib_clrpickerg.obj \
 	$(OBJS)\monolib_collpaneg.obj \
 	$(OBJS)\monolib_filepickerg.obj \
@@ -3752,6 +3755,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_appprogress.obj \
 	$(OBJS)\monolib_taskbarbutton.obj \
 	$(OBJS)\monolib_power.obj \
+	$(OBJS)\monolib_taskdlg.obj \
 	$(OBJS)\monolib_generic_accel.obj \
 	$(OBJS)\monolib_clrpickerg.obj \
 	$(OBJS)\monolib_collpaneg.obj \
@@ -4196,6 +4200,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_appprogress.obj \
 	$(OBJS)\coredll_taskbarbutton.obj \
 	$(OBJS)\coredll_power.obj \
+	$(OBJS)\coredll_taskdlg.obj \
 	$(OBJS)\coredll_clrpickerg.obj \
 	$(OBJS)\coredll_collpaneg.obj \
 	$(OBJS)\coredll_filepickerg.obj \
@@ -4547,6 +4552,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_appprogress.obj \
 	$(OBJS)\coredll_taskbarbutton.obj \
 	$(OBJS)\coredll_power.obj \
+	$(OBJS)\coredll_taskdlg.obj \
 	$(OBJS)\coredll_generic_accel.obj \
 	$(OBJS)\coredll_clrpickerg.obj \
 	$(OBJS)\coredll_collpaneg.obj \
@@ -4895,6 +4901,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_appprogress.obj \
 	$(OBJS)\corelib_taskbarbutton.obj \
 	$(OBJS)\corelib_power.obj \
+	$(OBJS)\corelib_taskdlg.obj \
 	$(OBJS)\corelib_clrpickerg.obj \
 	$(OBJS)\corelib_collpaneg.obj \
 	$(OBJS)\corelib_filepickerg.obj \
@@ -5246,6 +5253,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_appprogress.obj \
 	$(OBJS)\corelib_taskbarbutton.obj \
 	$(OBJS)\corelib_power.obj \
+	$(OBJS)\corelib_taskdlg.obj \
 	$(OBJS)\corelib_generic_accel.obj \
 	$(OBJS)\corelib_clrpickerg.obj \
 	$(OBJS)\corelib_collpaneg.obj \
@@ -9800,6 +9808,11 @@ $(OBJS)\monodll_power.obj: ..\..\src\msw\power.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"
+$(OBJS)\monodll_taskdlg.obj: ..\..\src\msw\taskdlg.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\taskdlg.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
 $(OBJS)\monodll_clrpickerg.obj: ..\..\src\generic\clrpickerg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\generic\clrpickerg.cpp
 !endif
@@ -12428,6 +12441,11 @@ $(OBJS)\monolib_power.obj: ..\..\src\msw\power.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"
+$(OBJS)\monolib_taskdlg.obj: ..\..\src\msw\taskdlg.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\taskdlg.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
 $(OBJS)\monolib_clrpickerg.obj: ..\..\src\generic\clrpickerg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\generic\clrpickerg.cpp
 !endif
@@ -14996,6 +15014,11 @@ $(OBJS)\coredll_power.obj: ..\..\src\msw\power.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"
+$(OBJS)\coredll_taskdlg.obj: ..\..\src\msw\taskdlg.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\msw\taskdlg.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
 $(OBJS)\coredll_clrpickerg.obj: ..\..\src\generic\clrpickerg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\generic\clrpickerg.cpp
 !endif
@@ -16778,6 +16801,11 @@ $(OBJS)\corelib_taskbarbutton.obj: ..\..\src\msw\taskbarbutton.cpp
 !if "$(USE_GUI)" == "1"
 $(OBJS)\corelib_power.obj: ..\..\src\msw\power.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\msw\power.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
+$(OBJS)\corelib_taskdlg.obj: ..\..\src\msw\taskdlg.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\msw\taskdlg.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -1706,6 +1706,7 @@
     <ClCompile Include="..\..\src\common\curbndl.cpp" />
     <ClCompile Include="..\..\src\common\imagwebp.cpp" />
     <ClCompile Include="..\..\src\common\webpdecoder.cpp" />
+    <ClCompile Include="..\..\src\msw\taskdlg.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -1044,6 +1044,9 @@
     <ClCompile Include="..\..\src\msw\taskbarbutton.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\msw\taskdlg.cpp">
+      <Filter>MSW Sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\msw\textctrl.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>

--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -313,6 +313,12 @@ extern HICON wxBitmapToHICON(const wxBitmap& bmp);
 extern
 HCURSOR wxBitmapToHCURSOR(const wxBitmap& bmp, int hotSpotX, int hotSpotY);
 
+// Return DPI for the given window.
+//
+// Implemented in src/msw/window.cpp.
+wxSize wxGetWindowDPI(HWND hwnd);
+
+// Also implemented in src/msw/window.cpp.
 extern int wxGetSystemMetrics(int nIndex, const wxWindow* win);
 
 extern bool wxSystemParametersInfo(UINT uiAction, UINT uiParam,

--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -195,6 +195,23 @@ struct WinStruct : public T
     }
 };
 
+// Life wouldn't be fun if Windows didn't call the size member differently in
+// different structs, so define the equivalent of the above for the ones where
+// it's called dwSize.
+//
+// When we can require C++17 or preferably C++20 we could merge this with
+// WinStruct by detecting the presence of cbSize/dwSize member using SFINAE,
+// but for now just define it separately to keep things simple.
+template <class T>
+struct WinStructWordSize : public T
+{
+    WinStructWordSize()
+    {
+        wxZeroMemory(*this);
+
+        this->dwSize = sizeof(T);
+    }
+};
 
 // Macros for converting wxString to the type expected by API functions.
 //

--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -1165,6 +1165,21 @@ inline wxLayoutDirection wxGetEditLayoutDirection(WXHWND hWnd)
                                     : wxLayout_LeftToRight;
 }
 
+// Check if WM_SETTINGCHANGE notifies about the system colours change.
+inline bool wxIsSystemColourChange(LPARAM lParam)
+{
+    // Note that "ImmersiveColorSet" is set both when switching between
+    // light and dark themes and also when changing high contrast mode,
+    // for which an additional message with "WindowsThemeElement" is
+    // also sent, but we don't need to check for it as handling this
+    // one is enough
+    if ( !lParam )
+       return false;
+
+    auto* const what = reinterpret_cast<const TCHAR*>(lParam);
+    return wxStrcmp(what, wxT("ImmersiveColorSet")) == 0;
+}
+
 // ----------------------------------------------------------------------------
 // functions mapping HWND to wxWindow
 // ----------------------------------------------------------------------------

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -31,6 +31,11 @@ bool HasChanged();
 // Enable or disable dark mode for the given TLW if appropriate.
 void ConfigureTLW(HWND hwnd);
 
+// Helper function: call SetWindowTheme() and log a debug error if it fails.
+void SetTheme(HWND hwnd,
+              const wchar_t* themeName,
+              const wchar_t* themeId = nullptr);
+
 // Set dark theme for the given (child) window if appropriate.
 //
 // Optional theme name and ID can be specified if something other than the

--- a/include/wx/msw/private/taskdlg.h
+++ b/include/wx/msw/private/taskdlg.h
@@ -1,0 +1,56 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/msw/private/taskdlg.h
+// Purpose:     Dark mode support for native TaskDialog.
+// Author:      Mohmed Abdel-Fattah
+// Created:     2026-06-07
+// Copyright:   (c) 2026 wxWidgets development team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_MSW_PRIVATE_TASKDLG_H_
+#define _WX_MSW_PRIVATE_TASKDLG_H_
+
+#include "wx/msw/wrapcctl.h"
+
+namespace wxMSWDarkMode
+{
+
+// ----------------------------------------------------------------------------
+// TaskDialog dark mode helpers
+// ----------------------------------------------------------------------------
+//
+// These two functions bracket the lifetime of dark-mode theming for any
+// TaskDialog-based dialog (wxMessageDialog, wxRichMessageDialog,
+// wxProgressDialog, wxAboutBox).
+//
+// Typical usage inside a PFTASKDIALOGCALLBACK:
+//
+//   case TDN_CREATED:
+//       wxMSWDarkMode::ApplyToTaskDialog(hwnd, pCfg);
+//       break;
+//   case TDN_DESTROYED:
+//       wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
+//       break;
+//
+// Both functions are no-ops when IsActive() returns false, so no guard is
+// needed at the call site.
+
+// Apply dark mode theming to an existing TaskDialog window.
+//
+// Must be called from TDN_CREATED (not TDN_DIALOG_CONSTRUCTED) so that the
+// complete child-window hierarchy exists and UI Automation can walk it.
+//
+// pCfg may be nullptr; when provided it enables correct icon overdraw on
+// Windows 10 where there is no native dark TaskDialog theme.
+void AllowForTaskDialog(HWND hwnd, const TASKDIALOGCONFIG* pCfg = nullptr);
+
+// Remove all subclasses and free all GDI/theme resources installed by
+// ApplyToTaskDialog().
+//
+// Must be called from TDN_DESTROYED or WM_DESTROY.
+// Safe to call even if ApplyToTaskDialog() was never called for this HWND.
+void RemoveFromTaskDialog(HWND hwnd);
+
+} // namespace wxMSWDarkMode
+
+#endif // _WX_MSW_PRIVATE_TASKDLG_H_

--- a/include/wx/msw/private/taskdlg.h
+++ b/include/wx/msw/private/taskdlg.h
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Name:        wx/msw/private/taskdlg.h
 // Purpose:     Dark mode support for native TaskDialog.
-// Author:      Mohmed Abdel-Fattah
+// Author:      Mohmed Abdel-Fattah (memoarfaa)
 // Created:     2026-06-07
 // Copyright:   (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -204,9 +204,14 @@ public:
         return NewAtStdDPI(0, classes, classesDark);
     }
 
+    // Default ctor, use move assignment to really initialize this object later.
+    wxUxThemeHandle() = default;
+
     // wxWindow pointer here must be valid and its DPI is always used.
     // If classesDark is non-nullptr and the dark mode is active, it's used
     // instead of classes.
+    //
+    // Prefer using factory functions above instead of this ctor for clarity.
     wxUxThemeHandle(const wxWindow* win,
                     const wchar_t* classes,
                     const wchar_t* classesDark = nullptr);
@@ -217,14 +222,20 @@ public:
         other.m_hTheme = 0;
     }
 
+    wxUxThemeHandle& operator=(wxUxThemeHandle&& other)
+    {
+        Free();
+        m_hTheme = other.m_hTheme;
+        other.m_hTheme = 0;
+
+        return *this;
+    }
+
     operator HTHEME() const { return m_hTheme; }
 
     ~wxUxThemeHandle()
     {
-        if ( m_hTheme )
-        {
-            ::CloseThemeData(m_hTheme);
-        }
+        Free();
     }
 
     // Return the colour for the given part, property and state.
@@ -270,11 +281,18 @@ private:
     {
     }
 
+    void Free()
+    {
+        if ( m_hTheme )
+        {
+            ::CloseThemeData(m_hTheme);
+        }
+    }
+
     wxSize DoGetSize(int part, int state, THEMESIZE ts) const;
 
 
-    // This is almost, but not quite, const: it's only reset in move ctor.
-    HTHEME m_hTheme;
+    HTHEME m_hTheme = 0;
 
     wxDECLARE_NO_COPY_CLASS(wxUxThemeHandle);
 };

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -247,21 +247,34 @@ public:
     // Return the size of a theme element, either "as is" (TS_TRUE size) or as
     // it would be used for drawing (TS_DRAW size).
     //
-    // For now we don't allow specifying the HDC or rectangle as they don't
-    // seem to be useful.
-    wxSize GetTrueSize(int part, int state = 0) const
+    // For now we don't allow specifying the rectangle as it doesn't seem to be
+    // useful.
+    wxSize GetTrueSize(int part, int state = 0, HDC hdc = 0) const
     {
-        return DoGetSize(part, state, TS_TRUE);
+        return DoGetSize(hdc, part, state, TS_TRUE);
     }
 
-    wxSize GetDrawSize(int part, int state = 0) const
+    wxSize GetDrawSize(int part, int state = 0, HDC hdc = 0) const
     {
-        return DoGetSize(part, state, TS_DRAW);
+        return DoGetSize(hdc, part, state, TS_DRAW);
     }
+
+    // Get the margins of a theme element in the output parameter.
+    //
+    // The output parameter is not modified if the function fails, so it can be
+    // initialized with some default values before calling this function.
+    bool
+    GetMargins(MARGINS& margins,
+               int part, int prop, int state = 0, HDC hdc = 0) const;
+
+    // Get the font of a theme element.
+    bool GetFont(LOGFONTW& lf, HDC hdc, int part, int state = 0) const;
+
 
     // Draw theme background: if the caller already has a RECT, it can be
     // provided directly, otherwise wxRect is converted to it.
-    void DrawBackground(HDC hdc, const RECT& rc, int part, int state = 0);
+    void DrawBackground(HDC hdc, const RECT& rc, int part, int state = 0,
+                        const RECT* rcClip = nullptr);
     void DrawBackground(HDC hdc, const wxRect& rect, int part, int state = 0);
 
 private:
@@ -289,7 +302,7 @@ private:
         }
     }
 
-    wxSize DoGetSize(int part, int state, THEMESIZE ts) const;
+    wxSize DoGetSize(HDC hdc, int part, int state, THEMESIZE ts) const;
 
 
     HTHEME m_hTheme = 0;

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -774,8 +774,7 @@ HandleMenuMessage(WXLRESULT* result,
                 // We have to specify the text colour explicitly as by default
                 // black would be used, making the menu label unreadable on the
                 // (almost) black background.
-                DTTOPTS textOpts;
-                textOpts.dwSize = sizeof(textOpts);
+                WinStructWordSize<DTTOPTS> textOpts;
                 textOpts.dwFlags = DTT_TEXTCOLOR;
                 textOpts.crText = wxColourToRGB(GetMenuColour(colText));
 

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -492,6 +492,16 @@ void ConfigureTLW(HWND hwnd)
     wxMSWImpl::AllowDarkModeForWindow(hwnd, true);
 }
 
+void SetTheme(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
+{
+    HRESULT hr = ::SetWindowTheme(hwnd, themeName, themeId);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError(wxString::Format("SetWindowTheme(%p, %s, %s)",
+                                       hwnd, themeName, themeId), hr);
+    }
+}
+
 void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
 {
     if ( wxMSWImpl::AllowDarkModeForWindow(hwnd, true) )
@@ -499,12 +509,7 @@ void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
 
     if ( themeName || themeId )
     {
-        HRESULT hr = ::SetWindowTheme(hwnd, themeName, themeId);
-        if ( FAILED(hr) )
-        {
-            wxLogApiError(wxString::Format("SetWindowTheme(%p, %s, %s)",
-                                           hwnd, themeName, themeId), hr);
-        }
+        SetTheme(hwnd, themeName, themeId);
     }
 
     // Some native controls need this message to switch themes, such as

--- a/src/msw/datecontrols.cpp
+++ b/src/msw/datecontrols.cpp
@@ -51,8 +51,7 @@ bool wxMSWDateControls::CheckInitialization()
         // it's enough to give the error only once
         s_initResult = false;
 
-        INITCOMMONCONTROLSEX icex;
-        icex.dwSize = sizeof(icex);
+        WinStructWordSize<INITCOMMONCONTROLSEX> icex;
         icex.dwICC = ICC_DATE_CLASSES;
 
         // see comment in wxApp::GetComCtl32Version() explaining the

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -266,9 +266,8 @@ bool wxJoystick::GetButtonState(unsigned id) const
 int wxJoystick::GetPOVPosition() const
 {
 #ifndef NO_JOYGETPOSEX
-    JOYINFOEX joyInfo;
+    WinStructWordSize<JOYINFOEX> joyInfo;
     joyInfo.dwFlags = JOY_RETURNPOV;
-    joyInfo.dwSize = sizeof(joyInfo);
     MMRESULT res = joyGetPosEx(m_joystick, & joyInfo);
     if (res == JOYERR_NOERROR )
     {
@@ -288,9 +287,8 @@ int wxJoystick::GetPOVPosition() const
 int wxJoystick::GetPOVCTSPosition() const
 {
 #ifndef NO_JOYGETPOSEX
-    JOYINFOEX joyInfo;
+    WinStructWordSize<JOYINFOEX> joyInfo;
     joyInfo.dwFlags = JOY_RETURNPOVCTS;
-    joyInfo.dwSize = sizeof(joyInfo);
     MMRESULT res = joyGetPosEx(m_joystick, & joyInfo);
     if (res == JOYERR_NOERROR )
     {
@@ -306,9 +304,8 @@ int wxJoystick::GetPOVCTSPosition() const
 int wxJoystick::GetRudderPosition() const
 {
 #ifndef NO_JOYGETPOSEX
-    JOYINFOEX joyInfo;
+    WinStructWordSize<JOYINFOEX> joyInfo;
     joyInfo.dwFlags = JOY_RETURNR;
-    joyInfo.dwSize = sizeof(joyInfo);
     MMRESULT res = joyGetPosEx(m_joystick, & joyInfo);
     if (res == JOYERR_NOERROR )
     {
@@ -324,9 +321,8 @@ int wxJoystick::GetRudderPosition() const
 int wxJoystick::GetUPosition() const
 {
 #ifndef NO_JOYGETPOSEX
-    JOYINFOEX joyInfo;
+    WinStructWordSize<JOYINFOEX> joyInfo;
     joyInfo.dwFlags = JOY_RETURNU;
-    joyInfo.dwSize = sizeof(joyInfo);
     MMRESULT res = joyGetPosEx(m_joystick, & joyInfo);
     if (res == JOYERR_NOERROR )
     {
@@ -342,9 +338,8 @@ int wxJoystick::GetUPosition() const
 int wxJoystick::GetVPosition() const
 {
 #ifndef NO_JOYGETPOSEX
-    JOYINFOEX joyInfo;
+    WinStructWordSize<JOYINFOEX> joyInfo;
     joyInfo.dwFlags = JOY_RETURNV;
-    joyInfo.dwSize = sizeof(joyInfo);
     MMRESULT res = joyGetPosEx(m_joystick, & joyInfo);
     if (res == JOYERR_NOERROR )
     {

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -27,6 +27,7 @@
 #include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/metrics.h"
 #include "wx/msw/private/msgdlg.h"
+#include "wx/msw/private/taskdlg.h"
 #include "wx/modalhook.h"
 #include "wx/fontutil.h"
 #include "wx/textbuf.h"
@@ -588,12 +589,46 @@ namespace
 {
 
 HRESULT CALLBACK
-wxTaskDialogCallback(HWND hwnd, UINT msg, WPARAM, LPARAM, LONG_PTR)
+wxTaskDialogCallback(HWND hwnd,
+                     UINT msg,
+                     WPARAM wParam,
+                     LPARAM lParam,
+                     LONG_PTR refData)
 {
+    const auto* const
+        config = reinterpret_cast<const TASKDIALOGCONFIG*>(refData);
+
     switch ( msg )
     {
-        case TDN_DIALOG_CONSTRUCTED:
-            wxMSWDarkMode::ConfigureTLW(hwnd);
+        case TDN_CREATED:
+            // The dialog is fully constructed now, so we can enable dark mode
+            // for it if necessary (doing it on TDN_DIALOG_CONSTRUCTED wouldn't
+            // work because all dialog elements wouldn't be constructed yet).
+            wxMSWDarkMode::AllowForTaskDialog(hwnd, config);
+            break;
+
+        case TDN_EXPANDO_BUTTON_CLICKED:
+            // Store the expanded state as a window property so the subclassed
+            // TaskPage panel can read it during WM_PAINT without a UIA call.
+            SetProp(hwnd, L"IsExpanded",
+                reinterpret_cast<HANDLE>(static_cast<ULONG_PTR>(wParam)));
+            break;
+
+        case TDN_DESTROYED:
+            // Clean up all resources allocated by AllowForTaskDialog().
+            wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
+            break;
+
+        case WM_SETTINGCHANGE:
+            if ( wxIsSystemColourChange(lParam) )
+            {
+                // Re-apply (or remove) theming when the OS light/dark
+                // preference changes while the dialog is open.
+                if ( wxMSWDarkMode::IsActive() )
+                    wxMSWDarkMode::AllowForTaskDialog(hwnd, config);
+                else
+                    wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
+            }
             break;
     }
 
@@ -757,6 +792,7 @@ void wxMSWTaskDialogConfig::MSWCommonTaskDialogInit(TASKDIALOGCONFIG &tdc)
     }
 
     tdc.pfCallback = wxTaskDialogCallback;
+    tdc.lpCallbackData = (LONG_PTR) &tdc;
 }
 
 void wxMSWTaskDialogConfig::AddTaskDialogButton(TASKDIALOGCONFIG &tdc,

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -592,7 +592,7 @@ HRESULT CALLBACK
 wxTaskDialogCallback(HWND hwnd,
                      UINT msg,
                      WPARAM wParam,
-                     LPARAM lParam,
+                     LPARAM WXUNUSED(lParam),
                      LONG_PTR refData)
 {
     const auto* const
@@ -617,18 +617,6 @@ wxTaskDialogCallback(HWND hwnd,
         case TDN_DESTROYED:
             // Clean up all resources allocated by AllowForTaskDialog().
             wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
-            break;
-
-        case WM_SETTINGCHANGE:
-            if ( wxIsSystemColourChange(lParam) )
-            {
-                // Re-apply (or remove) theming when the OS light/dark
-                // preference changes while the dialog is open.
-                if ( wxMSWDarkMode::IsActive() )
-                    wxMSWDarkMode::AllowForTaskDialog(hwnd, config);
-                else
-                    wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
-            }
             break;
     }
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -30,8 +30,10 @@
     #include "wx/msw/private.h"
 #endif
 
-#include "wx/msw/private/msgdlg.h"
 #include "wx/evtloop.h"
+#include "wx/msw/private/darkmode.h"
+#include "wx/msw/private/msgdlg.h"
+#include "wx/msw/private/taskdlg.h"
 
 using namespace wxMSWMessageDialog;
 
@@ -1128,7 +1130,7 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                                 HWND hwnd,
                                 UINT uNotification,
                                 WPARAM wParam,
-                                LPARAM WXUNUSED(lParam),
+                                LPARAM lParam,
                                 LONG_PTR dwRefData
                             )
 {
@@ -1144,6 +1146,11 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
     switch ( uNotification )
     {
         case TDN_CREATED:
+            // The dialog is fully constructed now, so we can enable dark mode
+            // for it if necessary (doing it on TDN_DIALOG_CONSTRUCTED wouldn't
+            // work because all dialog elements wouldn't be constructed yet).
+            wxMSWDarkMode::AllowForTaskDialog(hwnd);
+
             // Let the main thread know that the dialog can be used.
             sharedData->m_status = wxProgressDialogStatus::Initialized;
 
@@ -1164,6 +1171,30 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
             // when the progress ends (and not even then with wxPD_AUTO_HIDE).
             if ( !(sharedData->m_style & wxPD_CAN_ABORT) )
                 EnableCloseButtons(hwnd, false);
+            break;
+
+        case TDN_EXPANDO_BUTTON_CLICKED:
+            // Store the expanded state as a window property so the subclassed
+            // TaskPage panel can read it during WM_PAINT without a UIA call.
+            SetProp(hwnd, L"IsExpanded",
+                reinterpret_cast<HANDLE>(static_cast<ULONG_PTR>(wParam)));
+            break;
+
+        case TDN_DESTROYED:
+            // Clean up all resources allocated by AllowForTaskDialog().
+            wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
+            break;
+
+        case WM_SETTINGCHANGE:
+            if ( wxIsSystemColourChange(lParam) )
+            {
+                // Re-apply (or remove) theming when the OS light/dark preference
+                // changes while the dialog is open.
+                if ( wxMSWDarkMode::IsActive() )
+                    wxMSWDarkMode::AllowForTaskDialog(hwnd);
+                else
+                    wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
+            }
             break;
 
         case TDN_BUTTON_CLICKED:

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -1130,7 +1130,7 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                                 HWND hwnd,
                                 UINT uNotification,
                                 WPARAM wParam,
-                                LPARAM lParam,
+                                LPARAM WXUNUSED(lParam),
                                 LONG_PTR dwRefData
                             )
 {
@@ -1183,18 +1183,6 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
         case TDN_DESTROYED:
             // Clean up all resources allocated by AllowForTaskDialog().
             wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
-            break;
-
-        case WM_SETTINGCHANGE:
-            if ( wxIsSystemColourChange(lParam) )
-            {
-                // Re-apply (or remove) theming when the OS light/dark preference
-                // changes while the dialog is open.
-                if ( wxMSWDarkMode::IsActive() )
-                    wxMSWDarkMode::AllowForTaskDialog(hwnd);
-                else
-                    wxMSWDarkMode::RemoveFromTaskDialog(hwnd);
-            }
             break;
 
         case TDN_BUTTON_CLICKED:

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -956,8 +956,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
     {
         RECT rc = ConvertToRECT(dc, rect);
 
-        DTTOPTS textOpts;
-        textOpts.dwSize = sizeof(textOpts);
+        WinStructWordSize<DTTOPTS> textOpts;
         textOpts.dwFlags = DTT_STATEID;
         textOpts.iStateId = itemState;
 

--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -604,15 +604,7 @@ void wxStaticBox::PaintForeground(wxDC& dc, const RECT&)
             if ( hTheme )
             {
                 LOGFONTW themeFont;
-                if ( ::GetThemeFont
-                                             (
-                                                hTheme,
-                                                hdc,
-                                                BP_GROUPBOX,
-                                                GBS_NORMAL,
-                                                TMT_FONT,
-                                                &themeFont
-                                             ) == S_OK )
+                if ( hTheme.GetFont(themeFont, hdc, BP_GROUPBOX, GBS_NORMAL) )
                 {
                     font.Init(themeFont);
                     if ( font )

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -1257,12 +1257,18 @@ void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
     if ( native )
         wxMSWDarkMode::AllowForWindow(hwndTD, L"DarkMode_Explorer", nullptr);
 
-    SetWindowSubclassIfNeeded(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId);
+    HBRUSH nb = GetSolidBrush(TDDarkCol::kPrimary);
+
+    SetWindowSubclassIfNeeded
+    (
+        hwndTD,
+        TDCtrlContainerSubclassProc,
+        kTDMainSubclassId,
+        [nb]() { return reinterpret_cast<DWORD_PTR>(nb); }
+    );
 
     // Dark title bar
     wxMSWDarkMode::ConfigureTLW(hwndTD);
-    HBRUSH nb = GetSolidBrush(TDDarkCol::kPrimary);
-    ::SetClassLongPtr(hwndTD, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb));
     ::EnumChildWindows(hwndTD, TDEnumSysColorProc, 0);
     ::SendMessage(hwndTD, WM_THEMECHANGED, 0, 0);
 }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -118,11 +118,6 @@ struct TDPageState
 
     const TASKDIALOGCONFIG* pCfg = nullptr;
 
-    void CloseThemes()
-    {
-        themesOk = false;
-    }
-
     using TDStateMap = std::unordered_map<HWND, TDPageState>;
 
     static TDStateMap& GetAll()
@@ -233,7 +228,6 @@ static bool TDHasNativeDarkTheme()
 
 static void TDRefreshThemes(HWND hwnd, TDPageState& s)
 {
-    s.CloseThemes();
     s.isDark = TDHasNativeDarkTheme();
     const int dpi = wxGetWindowDPI(hwnd).x;
 
@@ -715,7 +709,8 @@ static LRESULT CALLBACK TDPageSubclassProc(
     case WM_THEMECHANGED:
     {
         TDPageState& s = TDPageState::Get(hwnd);
-        s.CloseThemes(); s.elemsOk = false;
+        s.themesOk = false;
+        s.elemsOk = false;
         InvalidateRect(hwnd, nullptr, FALSE);
         break;
     }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #ifndef WX_PRECOMP
+    #include "wx/brush.h"
 #endif // WX_PRECOMP
 
 #include "wx/msw/private/taskdlg.h"

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -605,7 +605,8 @@ static void TDPaintText(HDC hdc, const TDPageState& s)
 
         if (!native)
         {
-            DTTOPTS opts = { sizeof(opts) }; opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
+            WinStructWordSize<DTTOPTS> opts;
+            opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
             opts.crText = TDGetTextColour(s, part);
             FillRect(hdc, &rcT, brBg);
             ::DrawThemeTextEx(s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, &rcT, &opts);
@@ -780,7 +781,8 @@ static LRESULT CALLBACK TDRadioButtonSubclassProc(
         GetWindowTextW(hwnd, text, static_cast<int>(std::size(text)));
         auto gs = hBtn.GetTrueSize(BP_RADIOBUTTON, RBS_UNCHECKEDNORMAL);
         RECT rcT = { gs.x + 2,0,rcC.right,rcC.bottom };
-        DTTOPTS opts = { sizeof(opts) };
+
+        WinStructWordSize<DTTOPTS> opts;
         opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
         opts.crText = TDDarkCol::kTextNormal;
         LOGFONT lf = {};

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -68,6 +68,19 @@ namespace TDDarkCol
 namespace
 {
 
+// Helper function create an HBRUSH from a brush stored in wxTheBrushList.
+// This allows not to recreate the brushes for the same colour and also ensures
+// that the brushes are eventually deleted.
+HBRUSH GetSolidBrush(COLORREF rgb)
+{
+    const wxColour col = wxRGBToColour(rgb);
+    wxBrush* const brush = wxTheBrushList->FindOrCreateBrush(col);
+    if ( !brush )
+        return 0;
+
+    return GetHbrushOf(*brush);
+}
+
 // Helper function to get an HWND from IUIAutomationElement.
 HWND GetHWNDFromElement(IUIAutomationElement* element)
 {
@@ -861,13 +874,12 @@ TDCtrlContainerSubclassProc(HWND hwnd,
                 ::SetTextColor(hdc, TDDarkCol::kTextNormal);
 
                 if ( !hbr )
-                    hbr = ::CreateSolidBrush(TDDarkCol::kSecondary);
+                    hbr = GetSolidBrush(TDDarkCol::kSecondary);
 
                 return reinterpret_cast<LRESULT>(hbr);
             }
 
         case WM_DESTROY:
-            ::DeleteObject(hbr);
             ::RemoveWindowSubclass(hwnd, TDCtrlContainerSubclassProc, uId);
             break;
     }
@@ -1003,14 +1015,12 @@ void TDSubclassContainer(HWND hwndParent, COLORREF bg)
     if ( !hwndParent )
         return;
 
-    // The brush created here is passed to the subclass procedure as reference
-    // data and is deleted in the WM_DESTROY handler there.
     SetWindowSubclassIfNeeded
     (
         hwndParent,
         TDCtrlContainerSubclassProc,
         kTDCtrlSubclassId,
-        [bg]() { return ::CreateSolidBrush(bg); }
+        [bg]() { return GetSolidBrush(bg); }
     );
 }
 
@@ -1144,7 +1154,7 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
 
     // Class background brush
     {
-        HBRUSH nb = ::CreateSolidBrush(TDDarkCol::kSecondary);
+        HBRUSH nb = GetSolidBrush(TDDarkCol::kSecondary);
 
         HBRUSH ob = reinterpret_cast<HBRUSH>(
             ::SetClassLongPtr(hDUI, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb))
@@ -1217,7 +1227,7 @@ void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
 
     // Dark title bar
     wxMSWDarkMode::ConfigureTLW(hwndTD);
-    HBRUSH nb = ::CreateSolidBrush(TDDarkCol::kPrimary);
+    HBRUSH nb = GetSolidBrush(TDDarkCol::kPrimary);
     ::SetClassLongPtr(hwndTD, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb));
     ::EnumChildWindows(hwndTD, TDEnumSysColorProc, 0);
     ::SendMessage(hwndTD, WM_THEMECHANGED, 0, 0);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -964,23 +964,6 @@ TDRadioButtonSubclassProc(HWND hwnd,
 // Helper which calls SetWindowSubclass() only if the subclass is not already
 // set.
 //
-// This is a simple overload when we don't need to pass any reference data to
-// the subclass procedure.
-void
-SetWindowSubclassIfNeeded(HWND hwnd,
-                           SUBCLASSPROC proc,
-                           UINT_PTR uId)
-{
-    DWORD_PTR dwRef = 0;
-    if ( ::GetWindowSubclass(hwnd, proc, uId, &dwRef) )
-        return;
-
-    if ( !::SetWindowSubclass(hwnd, proc, uId, 0) )
-    {
-        wxLogLastError("SetWindowSubclass");
-    }
-}
-
 // This overload takes a lambda as the last parameter which is called to create
 // the reference data if the subclass needs to be set and to avoid creating any
 // resources passed to the subclass procedure unnecessarily.
@@ -1000,6 +983,16 @@ SetWindowSubclassIfNeeded(HWND hwnd,
     {
         wxLogLastError("SetWindowSubclass");
     }
+}
+
+// This is a simple overload when we don't need to pass any reference data to
+// the subclass procedure.
+void
+SetWindowSubclassIfNeeded(HWND hwnd,
+                           SUBCLASSPROC proc,
+                           UINT_PTR uId)
+{
+    return SetWindowSubclassIfNeeded(hwnd, proc, uId, []() { return 0; });
 }
 
 // Remove the subclass if it was installed.

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -93,7 +93,6 @@ struct TDLayoutElement
 struct TDPageState
 {
     wxUxThemeHandle hTD ; // TaskDialog panel + glyph parts
-    wxUxThemeHandle hTDS ; // TaskDialogStyle / text fonts
     wxUxThemeHandle hButton ; // Button (checkbox glyph)
     bool   isDark = false;   // native dark theme available
     bool   themesOk = false;
@@ -231,27 +230,29 @@ static void TDRefreshThemes(HWND hwnd, TDPageState& s)
     s.isDark = TDHasNativeDarkTheme();
     const int dpi = wxGetWindowDPI(hwnd).x;
 
-    const wchar_t* mainClass = s.isDark
-        ? L"DarkMode_Explorer::TaskDialog"
-        : L"TaskDialog";
-    const wchar_t* btnClass = s.isDark
-        ? L"DarkMode_Explorer::Button" : L"Button";
-    // For TaskDialog style, likely same as mainClass; could be different.
-    const wchar_t* mainClassDark = s.isDark ? L"DarkMode_Explorer::TaskDialog" : nullptr; // or nullptr if not needed
+    if ( s.isDark )
+    {
+        const wchar_t* mainClass = L"DarkMode_Explorer::TaskDialog";
+        const wchar_t* btnClass = L"DarkMode_Explorer::Button";
 
-    s.hTD = wxUxThemeHandle::NewAtDPI(hwnd, mainClass, mainClassDark, dpi);
-    s.hTDS = wxUxThemeHandle::NewAtDPI(hwnd, mainClass, mainClassDark, dpi);
-    s.hButton = wxUxThemeHandle::NewAtDPI(hwnd, btnClass, dpi);
+        s.hTD = wxUxThemeHandle::NewAtDPI(hwnd, mainClass, mainClass, dpi);
+        s.hButton = wxUxThemeHandle::NewAtDPI(hwnd, btnClass, btnClass, dpi);
+    }
+    else // Try the best we can with the themes available on older OS versions.
+    {
+        s.hTD = wxUxThemeHandle::NewAtDPI(hwnd, L"TaskDialog", dpi);
+        s.hButton = wxUxThemeHandle::NewAtDPI(hwnd, L"Button", dpi);
+    }
 
     s.themesOk = true;
 }
 
 static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
 {
-    if (s.isDark && s.hTDS)
+    if (s.isDark)
     {
         COLORREF c = TDDarkCol::kTextNormal;
-        if (SUCCEEDED(GetThemeColor(s.hTDS, uiPart, 0, TMT_TEXTCOLOR, &c)))
+        if (SUCCEEDED(GetThemeColor(s.hTD, uiPart, 0, TMT_TEXTCOLOR, &c)))
             return c;
     }
     switch (uiPart)
@@ -543,7 +544,7 @@ static void TDPaintGlyphs(HDC hdc, TDPageState& s)
 
 static void TDPaintText(HDC hdc, const TDPageState& s)
 {
-    if (!s.hTDS && !s.hTD)
+    if ( !s.hTD )
         return;
      const bool native = TDHasNativeDarkTheme();
 
@@ -604,12 +605,12 @@ static void TDPaintText(HDC hdc, const TDPageState& s)
             DTTOPTS opts = { sizeof(opts) }; opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
             opts.crText = TDGetTextColour(s, part);
             FillRect(hdc, &rcT, brBg);
-            ::DrawThemeTextEx(s.hTDS ? s.hTDS : s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, &rcT, &opts);
+            ::DrawThemeTextEx(s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, &rcT, &opts);
         }
         else
         {
 
-            ::DrawThemeText(s.hTDS ? s.hTDS : s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, 0, &rcT);
+            ::DrawThemeText(s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, 0, &rcT);
         }
     }
 }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -19,8 +19,11 @@
 #include "wx/wxprec.h"
 
 #ifndef wxUSE_DARK_MODE
-    // Otherwise enable it by default.
-    #define wxUSE_DARK_MODE 1
+    #ifdef __WXUNIVERSAL__
+        #define wxUSE_DARK_MODE 0
+    #else
+        #define wxUSE_DARK_MODE 1
+    #endif
 #endif
 
 #ifndef WX_PRECOMP

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -88,12 +88,6 @@ struct TDPageState
 
     std::vector<TDLayoutElement> elements;
     bool elemsOk = false;
-    TDPageState()
-        : hTD(wxUxThemeHandle::NewAtStdDPI(L"")),   // Invalid class -> empty handle
-        hTDS(wxUxThemeHandle::NewAtStdDPI(L"")),
-        hButton(wxUxThemeHandle::NewAtStdDPI(L""))
-    {
-    }
 
     // Mouse interaction (message-driven, no polling)
     bool tracking = false;
@@ -200,13 +194,6 @@ static void TDRefreshThemes(HWND hwnd, TDPageState& s)
     s.CloseThemes();
     s.isDark = TDHasNativeDarkTheme();
     int dpi = GetWindowDPI(hwnd);
-    auto resetTheme = [&](wxUxThemeHandle& member, const wchar_t* classes, const wchar_t* classesDark)
-        {
-            // Destroy the old handle
-            member.~wxUxThemeHandle();
-            // Create a new temporary using the factory, then move-construct in place
-            new (&member) wxUxThemeHandle(wxUxThemeHandle::NewAtDPI(hwnd, classes, classesDark, dpi));
-        };
 
     const wchar_t* mainClass = s.isDark
         ? L"DarkMode_Explorer::TaskDialog"
@@ -216,9 +203,9 @@ static void TDRefreshThemes(HWND hwnd, TDPageState& s)
     // For TaskDialog style, likely same as mainClass; could be different.
     const wchar_t* mainClassDark = s.isDark ? L"DarkMode_Explorer::TaskDialog" : nullptr; // or nullptr if not needed
 
-    resetTheme(s.hTD, mainClass, mainClassDark);
-    resetTheme(s.hTDS, mainClass, mainClassDark);
-    resetTheme(s.hButton, btnClass, nullptr);
+    s.hTD = wxUxThemeHandle::NewAtDPI(hwnd, mainClass, mainClassDark, dpi);
+    s.hTDS = wxUxThemeHandle::NewAtDPI(hwnd, mainClass, mainClassDark, dpi);
+    s.hButton = wxUxThemeHandle::NewAtDPI(hwnd, btnClass, dpi);
 
     s.themesOk = true;
 }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -1183,6 +1183,16 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
         return TRUE;
     }
 
+    if ( wcscmp(cls, L"CCVScrollBar") == 0 || wcscmp(cls, L"CCHScrollBar") == 0 )
+    {
+        if ( const HWND hScroll = GetHWNDFromElement(pEl) )
+        {
+            wxMSWDarkMode::SetTheme(hScroll, L"DarkMode_Explorer");
+        }
+
+        return TRUE;
+    }
+
     // Main TaskPage (DirectUI "TaskDialog" class)
     if ( wcscmp(cls, L"TaskDialog") != 0 )
         return TRUE;

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -31,6 +31,8 @@
 #if wxUSE_DARK_MODE
 
 #include "wx/dynlib.h"
+#include "wx/log.h"
+#include "wx/module.h"
 
 #include "wx/msw/uxtheme.h"
 
@@ -106,43 +108,76 @@ struct TDPageState
     {
         themesOk = false;
     }
-};
 
-// Thread-local state map and UIA singleton
-static thread_local std::unordered_map<HWND, TDPageState> tls_tdStates;
+    using TDStateMap = std::unordered_map<HWND, TDPageState>;
 
-static TDPageState& GetTDPageState(HWND h) { return tls_tdStates[h]; }
-
-static void DestroyTDPageState(HWND h)
-{
-    auto it = tls_tdStates.find(h);
-    if ( it != tls_tdStates.end() )
+    static TDStateMap& GetAll()
     {
-        tls_tdStates.erase(it);
+        static TDStateMap s_states;
+        return s_states;
     }
-}
 
-// Function to get IUIAutomation instance
-static IUIAutomation* GetTDAutomation()
-{
-    static thread_local wxCOMPtr<IUIAutomation> tls_tdAutomation;
-
-    if (!tls_tdAutomation)
+    static TDPageState& Get(HWND h)
     {
-        HRESULT hr = CoCreateInstance
-                     (
-                        CLSID_CUIAutomation,
-                        nullptr,
-                        CLSCTX_INPROC_SERVER,
-                        wxIID_PPV_ARGS(IUIAutomation, &tls_tdAutomation)
-                     );
-        if (FAILED(hr))
+        return GetAll()[h];
+    }
+
+    static void Destroy(HWND h)
+    {
+        auto& states = GetAll();
+        auto const it = states.find(h);
+        if ( it != states.end() )
         {
-            tls_tdAutomation = nullptr;
+            states.erase(it);
         }
     }
-    return tls_tdAutomation;
-}
+};
+
+// ----------------------------------------------------------------------------
+// Module for cleaning up resources used by the code in this file
+// ----------------------------------------------------------------------------
+
+// Function to get IUIAutomation instance
+class wxTaskDialogDarkModule : public wxModule
+{
+public:
+    virtual bool OnInit() override { return true; }
+    virtual void OnExit() override
+    {
+        ms_uiAutomation.reset();
+        TDPageState::GetAll().clear();
+    }
+
+    static IUIAutomation* GetUIAutomation()
+    {
+        if ( !ms_uiAutomation )
+        {
+            HRESULT hr = CoCreateInstance
+                         (
+                            CLSID_CUIAutomation,
+                            nullptr,
+                            CLSCTX_INPROC_SERVER,
+                            wxIID_PPV_ARGS(IUIAutomation, &ms_uiAutomation)
+                         );
+            if ( FAILED(hr) )
+            {
+                wxLogLastError("CoCreateInstance(IUIAutomation)");
+            }
+        }
+
+        return ms_uiAutomation.get();
+    }
+
+private:
+    static wxCOMPtr<IUIAutomation> ms_uiAutomation;
+
+    wxDECLARE_DYNAMIC_CLASS(wxTaskDialogDarkModule);
+};
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxTaskDialogDarkModule, wxModule);
+
+wxCOMPtr<IUIAutomation> wxTaskDialogDarkModule::ms_uiAutomation;
+
 
 // Subclass IDs
 static constexpr UINT_PTR kTDMainSubclassId = 0xDEADBEEFul;
@@ -284,7 +319,7 @@ static HICON TDLoadStockIcon(const TASKDIALOGCONFIG* cfg, bool isMain)
 static void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
 {
     out.clear();
-    IUIAutomation* pAuto = GetTDAutomation();
+    IUIAutomation* const pAuto = wxTaskDialogDarkModule::GetUIAutomation();
     if (!pAuto)
         return;
 
@@ -623,7 +658,7 @@ static LRESULT CALLBACK TDPageSubclassProc(
     case WM_PAINT:
     {
         PAINTSTRUCT ps; HDC hdc = BeginPaint(hwnd, &ps);
-        TDPageState& s = GetTDPageState(hwnd);
+        TDPageState& s = TDPageState::Get(hwnd);
         s.isExpanded = !!GetProp(GetParent(hwnd), L"IsExpanded");
         s.elemsOk = false;
         TDUpdateLayoutCache(hwnd, s);
@@ -633,7 +668,7 @@ static LRESULT CALLBACK TDPageSubclassProc(
     }
     case WM_MOUSEMOVE:
     {
-        TDPageState& s = GetTDPageState(hwnd);
+        TDPageState& s = TDPageState::Get(hwnd);
         if (!s.tracking)
         {
             TRACKMOUSEEVENT tme = { sizeof(tme),TME_LEAVE,hwnd,0 };
@@ -650,7 +685,7 @@ static LRESULT CALLBACK TDPageSubclassProc(
     }
     case WM_MOUSELEAVE:
     {
-        TDPageState& s = GetTDPageState(hwnd);
+        TDPageState& s = TDPageState::Get(hwnd);
         s.tracking = false;
         s.pressing = false;
         if (s.hotIdx != -1)
@@ -661,24 +696,24 @@ static LRESULT CALLBACK TDPageSubclassProc(
         break;
     }
     case WM_LBUTTONDOWN:
-        GetTDPageState(hwnd).pressing = true;
-        TDUpdateLayoutCache(hwnd, GetTDPageState(hwnd));
+        TDPageState::Get(hwnd).pressing = true;
+        TDUpdateLayoutCache(hwnd, TDPageState::Get(hwnd));
         InvalidateRect(hwnd, nullptr, FALSE);
         break;
     case WM_LBUTTONUP:
-        GetTDPageState(hwnd).pressing = false;
-        TDUpdateLayoutCache(hwnd, GetTDPageState(hwnd));
+        TDPageState::Get(hwnd).pressing = false;
+        TDUpdateLayoutCache(hwnd, TDPageState::Get(hwnd));
         InvalidateRect(hwnd, nullptr, FALSE);
         break;
     case WM_THEMECHANGED:
     {
-        TDPageState& s = GetTDPageState(hwnd);
+        TDPageState& s = TDPageState::Get(hwnd);
         s.CloseThemes(); s.elemsOk = false;
         InvalidateRect(hwnd, nullptr, FALSE);
         break;
     }
     case WM_DESTROY:
-        DestroyTDPageState(hwnd);
+        TDPageState::Destroy(hwnd);
         RemoveWindowSubclass(hwnd, TDPageSubclassProc, uId);
         break;
     }
@@ -884,7 +919,7 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lp)
     SetWindowTheme(hDUI, L"DarkMode_Explorer", nullptr);
 
     // Initialise per-page state
-    TDPageState& s = GetTDPageState(hDUI);
+    TDPageState& s = TDPageState::Get(hDUI);
     s.pCfg = d->pCfg;
     s.defExpanded = d->pCfg && (d->pCfg->dwFlags & TDF_EXPANDED_BY_DEFAULT);
     s.defChecked = d->pCfg && (d->pCfg->dwFlags & TDF_VERIFICATION_FLAG_CHECKED);
@@ -912,7 +947,8 @@ static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
     DWORD_PTR ex = 0;
     if (GetWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId, &ex))
     {
-        RemoveWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId); DestroyTDPageState(hChild);
+        RemoveWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId);
+        TDPageState::Destroy(hChild);
     }
     if (GetWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &ex))
         RemoveWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId);
@@ -924,7 +960,7 @@ static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
 
 static void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
 {
-    IUIAutomation* pAuto = GetTDAutomation();
+    IUIAutomation* const pAuto = wxTaskDialogDarkModule::GetUIAutomation();
     if (!pAuto)
         return;
     const bool native = TDHasNativeDarkTheme();

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -202,17 +202,33 @@ static constexpr UINT_PTR kTDCtrlSubclassId = 0xC0FFEE01ul;
 // TaskDialog theme helpers
 // ============================================================================
 
+// Check if the theme with the "dark" name exists and is different from the
+// standard one.
+static bool
+wxHasRealDarkTheme(const wchar_t* stdClass, const wchar_t* darkClass)
+{
+    const auto darkTheme = wxUxThemeHandle::NewAtStdDPI(darkClass);
+    if ( darkTheme )
+    {
+        const auto stdTheme = wxUxThemeHandle::NewAtStdDPI(stdClass);
+        if ( stdTheme && stdTheme != darkTheme )
+            return true;
+    }
+
+    return false;
+}
+
 // Cached probe: does the OS have a native dark TaskDialog theme (Win11+)?
 static bool TDHasNativeDarkTheme()
 {
-    static int s_cached = -1;
-    if (s_cached == -1)
+    static int s_hasDarkTheme = -1;
+    if ( s_hasDarkTheme == -1 )
     {
-       wxUxThemeHandle hD (wxUxThemeHandle::NewAtStdDPI( L"DarkMode_DarkTheme::TaskDialog"));
-       wxUxThemeHandle hB(wxUxThemeHandle::NewAtStdDPI(L"TaskDialog"));
-        s_cached = (hD && hD != hB) ? 1 : 0;
+        s_hasDarkTheme = wxHasRealDarkTheme(L"TaskDialog",
+                                            L"DarkMode_DarkTheme::TaskDialog");
     }
-    return s_cached == 1;
+
+    return s_hasDarkTheme == 1;
 }
 
 static void TDRefreshThemes(HWND hwnd, TDPageState& s)
@@ -827,16 +843,19 @@ static void TDApplyToChildren(IUIAutomationElement* pEl)
 
                 if (ct == UIA_ProgressBarControlTypeId)
                 {
-                    wxUxThemeHandle hCE = wxUxThemeHandle::NewAtStdDPI(L"DarkMode_CopyEngine::Progress");
-                    wxUxThemeHandle hBase = wxUxThemeHandle::NewAtStdDPI(L"Progress");
-                    bool hasCE = (hCE && hCE != hBase);
-                    SetWindowTheme(hBtn, hasCE ? L"DarkMode_CopyEngine" : L"DarkMode_Explorer", nullptr);
+                    wxMSWDarkMode::SetTheme
+                    (
+                        hBtn,
+                        wxHasRealDarkTheme(L"Progress", L"DarkMode_CopyEngine::Progress")
+                            ? L"DarkMode_CopyEngine"
+                            : L"DarkMode_Explorer"
+                    );
                 }
                 else if (ct == UIA_RadioButtonControlTypeId || id.find(L"RadioButton_") == 0 || ct == UIA_HyperlinkControlTypeId)
                 {
                     if (native)
                     {
-                        SetWindowTheme(hBtn, L"DarkMode_DarkTheme", nullptr);
+                        wxMSWDarkMode::SetTheme(hBtn, L"DarkMode_DarkTheme");
                     }
                     else
                     {
@@ -848,12 +867,12 @@ static void TDApplyToChildren(IUIAutomationElement* pEl)
                 }
                 else if (id.find(L"CommandLink_") == 0 || id.find(L"CommandButton_") == 0)
                 {
-                    SetWindowTheme(hBtn, L"DarkMode_Explorer", nullptr);
+                    wxMSWDarkMode::SetTheme(hBtn, L"DarkMode_Explorer");
                     TDSubclassContainer(hP, TDDarkCol::kSecondary);
                 }
                 else
                 {
-                    SetWindowTheme(hBtn, L"DarkMode_Explorer", nullptr);
+                    wxMSWDarkMode::SetTheme(hBtn, L"DarkMode_Explorer");
                 }
             }
         }
@@ -914,7 +933,7 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     }
 
     TDApplyToChildren(pEl);
-    SetWindowTheme(hDUI, L"DarkMode_Explorer", nullptr);
+    wxMSWDarkMode::SetTheme(hDUI, L"DarkMode_Explorer");
 
     // Initialise per-page state
     TDEnumData* const d = reinterpret_cast<TDEnumData*>(lparam);
@@ -953,7 +972,9 @@ static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
         RemoveWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId);
     if (GetWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &ex))
         RemoveWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId);
-    SetWindowTheme(hChild, nullptr, nullptr);
+
+    ::SetWindowTheme(hChild, nullptr, nullptr);
+
     return TRUE;
 }
 

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -66,6 +66,21 @@ namespace TDDarkCol
 }
 namespace
 {
+
+// Helper function to get an HWND from IUIAutomationElement.
+HWND GetHWNDFromElement(IUIAutomationElement* element)
+{
+    UIA_HWND hwnd = 0;
+    HRESULT hr = element->get_CurrentNativeWindowHandle(&hwnd);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError("get_CurrentNativeWindowHandle", hr);
+        return 0;
+    }
+
+    return reinterpret_cast<HWND>(hwnd);
+}
+
 // Cached bounding rect + metadata for a single TaskDialog UI element.
 struct TDLayoutElement
 {
@@ -824,9 +839,7 @@ static void TDApplyToChildren(IUIAutomationElement* pEl, IUIAutomation* pAuto)
             ct == UIA_ProgressBarControlTypeId || ct == UIA_HyperlinkControlTypeId ||
             ct == UIA_ScrollBarControlTypeId || ct == UIA_PaneControlTypeId)
         {
-            HWND hBtn = nullptr;
-            pChild->get_CurrentNativeWindowHandle(reinterpret_cast<UIA_HWND*>(&hBtn));
-            if (hBtn)
+            if ( const HWND hBtn = GetHWNDFromElement(pChild) )
             {
                 BSTR bId; pChild->get_CurrentAutomationId(&bId);
                 const std::wstring id(bId ? static_cast<LPCWSTR>(bId) : L"");
@@ -890,8 +903,8 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lp)
     // SysLink controls (footnote / content hyperlinks)
     if (wxString(str).IsSameAs(wxS("CCSysLink")))
     {
-        HWND hL = nullptr; pEl->get_CurrentNativeWindowHandle(reinterpret_cast<UIA_HWND*>(&hL));
-        if (hL) {
+        if ( const HWND hL = GetHWNDFromElement(pEl) )
+        {
             BSTR bId;
             pEl->get_CurrentAutomationId(&bId);
             const std::wstring id(bId ? static_cast<LPCWSTR>(bId) : L"");
@@ -904,8 +917,9 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lp)
     // Main TaskPage (DirectUI "TaskDialog" class)
     if (!wxString(str).IsSameAs(wxS("TaskDialog")))
         return TRUE;
-    HWND hDUI = nullptr;
-    if (FAILED(pEl->get_CurrentNativeWindowHandle(reinterpret_cast<UIA_HWND*>(&hDUI))) || !hDUI)
+
+    const HWND hDUI = GetHWNDFromElement(pEl);
+    if ( !hDUI )
         return TRUE;
 
     // Class background brush

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -82,6 +82,18 @@ HWND GetHWNDFromElement(IUIAutomationElement* element)
     return reinterpret_cast<HWND>(hwnd);
 }
 
+// Another helper to get the automation ID of an element.
+std::wstring GetCurrentAutomationId(IUIAutomationElement* element)
+{
+    std::wstring result;
+
+    BSTR bstr;
+    if ( element->get_CurrentAutomationId(&bstr) == S_OK )
+        result = bstr;
+
+    return result;
+}
+
 // Cached bounding rect + metadata for a single TaskDialog UI element.
 struct TDLayoutElement
 {
@@ -348,10 +360,9 @@ static void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
         ::ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.left));
         ::ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.right));
 
-        BSTR b;
-        if ( pChild->get_CurrentAutomationId(&b) == S_OK )
-            info.automationId = b;
+        info.automationId = GetCurrentAutomationId(pChild);
 
+        BSTR b;
         if ( pChild->get_CurrentName(&b) == S_OK )
             info.name = b;
 
@@ -977,10 +988,7 @@ static void TDApplyToChildren(IUIAutomationElement* pEl)
         {
             if ( const HWND hBtn = GetHWNDFromElement(pChild) )
             {
-                BSTR bId;
-                pChild->get_CurrentAutomationId(&bId);
-
-                const std::wstring id(bId ? bId : L"");
+                const std::wstring id = GetCurrentAutomationId(pChild);
 
                 HWND hwndParent = ::GetParent(hBtn);
 
@@ -1056,10 +1064,7 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     {
         if ( const HWND hLink = GetHWNDFromElement(pEl) )
         {
-            BSTR bId;
-            pEl->get_CurrentAutomationId(&bId);
-
-            const std::wstring id(bId ? bId : L"");
+            const std::wstring id = GetCurrentAutomationId(pEl);
             bool isFn = id.find(L"Footnote") != std::wstring::npos ||
                             id.find(L"ExpandedFooter") != std::wstring::npos;
 

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -40,10 +40,6 @@
 #include "wx/msw/ole/oleutils.h"
 #include <uiautomation.h>
 
-#define GET_B(c) static_cast<BYTE>((c) & 0xFF)
-#define GET_G(c) static_cast<BYTE>(((c) >> 8) & 0xFF)
-#define GET_R(c) static_cast<BYTE>(((c) >> 16) & 0xFF)
-
 // ============================================================================
 // TaskDialog dark mode — implementation detail types
 // ============================================================================
@@ -417,6 +413,10 @@ static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
         GetThemeColor(hL, TDLG_FOOTNOTESEPARATOR, 0, TMT_FILLCOLOR, &srcSep);
     }
 
+#define GET_B(c) static_cast<BYTE>((c) & 0xFF)
+#define GET_G(c) static_cast<BYTE>(((c) >> 8) & 0xFF)
+#define GET_R(c) static_cast<BYTE>(((c) >> 16) & 0xFF)
+
     struct Rule { BYTE sR, sG, sB, dR, dG, dB; };
     const Rule rules[] =
     {
@@ -429,6 +429,10 @@ static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
         { GET_R(srcSp2), GET_G(srcSp2), GET_B(srcSp2),
           GET_R(TDDarkCol::kSeparator), GET_G(TDDarkCol::kSeparator), GET_B(TDDarkCol::kSeparator) },
     };
+
+#undef GET_B
+#undef GET_G
+#undef GET_R
 
     for (int y = 0; y < h; ++y)
     {

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -200,10 +200,10 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxTaskDialogDarkModule, wxModule);
 wxCOMPtr<IUIAutomation> wxTaskDialogDarkModule::ms_uiAutomation;
 
 
-// Subclass IDs
-static constexpr UINT_PTR kTDMainSubclassId = 0xDEADBEEFul;
-static constexpr UINT_PTR kTDPageSubclassId = 0xBADF00Dul;
-static constexpr UINT_PTR kTDCtrlSubclassId = 0xC0FFEE01ul;
+// Subclass IDs: 0x7778 == "wx"
+static constexpr UINT_PTR kTDMainSubclassId = 0x77780010ul;
+static constexpr UINT_PTR kTDPageSubclassId = 0x77780011ul;
+static constexpr UINT_PTR kTDCtrlSubclassId = 0x77780012ul;
 
 // ============================================================================
 // TaskDialog theme helpers

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -94,7 +94,6 @@ struct TDPageState
 {
     wxUxThemeHandle hTD ; // TaskDialog panel + glyph parts
     wxUxThemeHandle hButton ; // Button (checkbox glyph)
-    bool   isDark = false;   // native dark theme available
     bool   themesOk = false;
 
     AutoHBRUSH brPrimary{TDDarkCol::kPrimary};
@@ -227,10 +226,9 @@ static bool TDHasNativeDarkTheme()
 
 static void TDRefreshThemes(HWND hwnd, TDPageState& s)
 {
-    s.isDark = TDHasNativeDarkTheme();
     const int dpi = wxGetWindowDPI(hwnd).x;
 
-    if ( s.isDark )
+    if ( TDHasNativeDarkTheme() )
     {
         const wchar_t* mainClass = L"DarkMode_Explorer::TaskDialog";
         const wchar_t* btnClass = L"DarkMode_Explorer::Button";
@@ -249,7 +247,7 @@ static void TDRefreshThemes(HWND hwnd, TDPageState& s)
 
 static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
 {
-    if (s.isDark)
+    if ( TDHasNativeDarkTheme() )
     {
         COLORREF c = TDDarkCol::kTextNormal;
         if (SUCCEEDED(GetThemeColor(s.hTD, uiPart, 0, TMT_TEXTCOLOR, &c)))

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -402,17 +402,22 @@ static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
     RGBQUAD* pPx = nullptr; int rw = 0;
     if (FAILED(GetBufferedPaintBits(hbp, &pPx, &rw))) return;
 
-    COLORREF srcPri = RGB(255, 255, 255), srcSec = RGB(240, 240, 240);
-    COLORREF srcSep = RGB(128, 128, 128), srcSp2 = RGB(223, 223, 223);
+    wxColour srcPri(0xff, 0xff, 0xff),
+             srcSec(0xf0, 0xf0, 0xf0),
+             srcSep(0x80, 0x80, 0x80),
+             srcSp2(0xdf, 0xdf, 0xdf);
 
-    wxUxThemeHandle hL (wxUxThemeHandle ::NewAtStdDPI(L"TaskDialog"));
-    if (hL)
-    {
-        GetThemeColor(hL, TDLG_PRIMARYPANEL, 0, TMT_FILLCOLOR, &srcPri);
-        GetThemeColor(hL, TDLG_SECONDARYPANEL, 0, TMT_FILLCOLOR, &srcSec);
-        GetThemeColor(hL, TDLG_FOOTNOTESEPARATOR, 0, TMT_FILLCOLOR, &srcSep);
-    }
+    // Get the primary colour from the theme in case it's different.
+    //
+    // Note that under Windows 10 the theme doesn't define the other colours
+    // and under Windows 11 this code is not executed at all because it has
+    // native task dialog dark theme.
+    wxUxThemeHandle theme(wxUxThemeHandle::NewAtStdDPI(L"TaskDialog"));
+    if ( theme )
+        srcPri = theme.GetColour(TDLG_PRIMARYPANEL, TMT_FILLCOLOR);
 
+    // Define our own macros doing explicit cast because the standard
+    // Get[RGB]Value() result in warnings about "truncating constant value".
 #define GET_B(c) static_cast<BYTE>((c) & 0xFF)
 #define GET_G(c) static_cast<BYTE>(((c) >> 8) & 0xFF)
 #define GET_R(c) static_cast<BYTE>(((c) >> 16) & 0xFF)
@@ -420,13 +425,13 @@ static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
     struct Rule { BYTE sR, sG, sB, dR, dG, dB; };
     const Rule rules[] =
     {
-        { GET_R(srcPri), GET_G(srcPri), GET_B(srcPri),
+        { srcPri.Red(), srcPri.Green(), srcPri.Blue(),
           GET_R(TDDarkCol::kPrimary), GET_G(TDDarkCol::kPrimary), GET_B(TDDarkCol::kPrimary) },
-        { GET_R(srcSec), GET_G(srcSec), GET_B(srcSec),
+        { srcSec.Red(), srcSec.Green(), srcSec.Blue(),
           GET_R(TDDarkCol::kSecondary), GET_G(TDDarkCol::kSecondary), GET_B(TDDarkCol::kSecondary) },
-        { GET_R(srcSep), GET_G(srcSep), GET_B(srcSep),
+        { srcSep.Red(), srcSep.Green(), srcSep.Blue(),
           GET_R(TDDarkCol::kSeparator), GET_G(TDDarkCol::kSeparator), GET_B(TDDarkCol::kSeparator) },
-        { GET_R(srcSp2), GET_G(srcSp2), GET_B(srcSp2),
+        { srcSp2.Red(), srcSp2.Green(), srcSp2.Blue(),
           GET_R(TDDarkCol::kSeparator), GET_G(TDDarkCol::kSeparator), GET_B(TDDarkCol::kSeparator) },
     };
 

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -128,14 +128,6 @@ static void DestroyTDPageState(HWND h)
     }
 }
 
-// GUID definitions
-// {ff48dba4-60ef-4201-aa87-54103eef594e}
-const GUID CLSID_CUIAutomation = { 0xff48dba4, 0x60ef, 0x4201, { 0xaa, 0x87, 0x54, 0x10, 0x3e, 0xef, 0x59, 0x4e } };
-
-// Also usually paired with the IID for IUIAutomation:
-// {30cbe57d-d9d0-452a-ab13-7ac5ac4825ee}
-const IID IID_IUIAutomation = { 0x30cbe57d, 0xd9d0, 0x452a, { 0xab, 0x13, 0x7a, 0xc5, 0xac, 0x48, 0x25, 0xee } };
-
 // Function to get IUIAutomation instance
 static IUIAutomation* GetTDAutomation()
 {

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -152,8 +152,7 @@ static IUIAutomation* GetTDAutomation()
                         CLSID_CUIAutomation,
                         nullptr,
                         CLSCTX_INPROC_SERVER,
-                        IID_IUIAutomation,
-                        reinterpret_cast<void**>(&tls_tdAutomation)
+                        wxIID_PPV_ARGS(IUIAutomation, &tls_tdAutomation)
                      );
         if (FAILED(hr))
         {

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -1269,6 +1269,9 @@ void wxMSWDarkMode::AllowForTaskDialog(HWND hwnd, const TASKDIALOGCONFIG* pCfg)
     TDAttach(hwnd, pCfg);
 
     CoUninitialize();
+#else // !wxUSE_DARK_MODE
+    wxUnusedVar(hwnd);
+    wxUnusedVar(pCfg);
 #endif // wxUSE_DARK_MODE
 }
 
@@ -1276,5 +1279,7 @@ void wxMSWDarkMode::RemoveFromTaskDialog(HWND hwnd)
 {
 #if wxUSE_DARK_MODE
     TDDetach(hwnd);
+#else // !wxUSE_DARK_MODE
+    wxUnusedVar(hwnd);
 #endif // wxUSE_DARK_MODE
 }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -120,7 +120,6 @@ struct TDPageState
 
 // Thread-local state map and UIA singleton
 static thread_local std::unordered_map<HWND, TDPageState> tls_tdStates;
-static thread_local wxCOMPtr<IUIAutomation>                 tls_tdAutomation;
 
 static TDPageState& GetTDPageState(HWND h) { return tls_tdStates[h]; }
 
@@ -140,12 +139,22 @@ const GUID CLSID_CUIAutomation = { 0xff48dba4, 0x60ef, 0x4201, { 0xaa, 0x87, 0x5
 // Also usually paired with the IID for IUIAutomation:
 // {30cbe57d-d9d0-452a-ab13-7ac5ac4825ee}
 const IID IID_IUIAutomation = { 0x30cbe57d, 0xd9d0, 0x452a, { 0xab, 0x13, 0x7a, 0xc5, 0xac, 0x48, 0x25, 0xee } };
+
 // Function to get IUIAutomation instance
 static IUIAutomation* GetTDAutomation()
 {
+    static thread_local wxCOMPtr<IUIAutomation> tls_tdAutomation;
+
     if (!tls_tdAutomation)
     {
-        HRESULT hr = CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER, IID_IUIAutomation, reinterpret_cast<void**>(&tls_tdAutomation));
+        HRESULT hr = CoCreateInstance
+                     (
+                        CLSID_CUIAutomation,
+                        nullptr,
+                        CLSCTX_INPROC_SERVER,
+                        IID_IUIAutomation,
+                        reinterpret_cast<void**>(&tls_tdAutomation)
+                     );
         if (FAILED(hr))
         {
             tls_tdAutomation = nullptr;
@@ -153,6 +162,7 @@ static IUIAutomation* GetTDAutomation()
     }
     return tls_tdAutomation;
 }
+
 // Subclass IDs
 static constexpr UINT_PTR kTDMainSubclassId = 0xDEADBEEFul;
 static constexpr UINT_PTR kTDPageSubclassId = 0xBADF00Dul;

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -890,9 +890,9 @@ struct TDEnumData
     bool found;
 };
 
-static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lp)
+static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
 {
-    TDEnumData* d = reinterpret_cast<TDEnumData*>(lp);
+    TDEnumData* d = reinterpret_cast<TDEnumData*>(lparam);
     wxCOMPtr<IUIAutomationElement> pEl;
     if (FAILED(d->pAuto->ElementFromHandle(hwndChild, &pEl)))
         return TRUE;

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -40,6 +40,7 @@
 
 #include "wx/msw/private/comptr.h"
 #include <uiautomation.h>
+#include <windowsx.h>
 
 // ============================================================================
 // TaskDialog dark mode — implementation detail types
@@ -63,6 +64,7 @@ namespace TDDarkCol
     static constexpr COLORREF kTextFtrExp = RGB(0xb0, 0xb0, 0xb0);
     static constexpr COLORREF kTextRadio = RGB(0xe0, 0xe0, 0xe0);
 }
+
 namespace
 {
 
@@ -94,7 +96,7 @@ struct TDPageState
 {
     wxUxThemeHandle hTD ; // TaskDialog panel + glyph parts
     wxUxThemeHandle hButton ; // Button (checkbox glyph)
-    bool   themesOk = false;
+    bool themesOk = false;
 
     AutoHBRUSH brPrimary{TDDarkCol::kPrimary};
     AutoHBRUSH brSecondary{TDDarkCol::kSecondary};
@@ -254,24 +256,24 @@ static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
             return wxColourToRGB(col);
     }
 
-    switch (uiPart)
+    switch ( uiPart )
     {
-    case TDLG_MAININSTRUCTIONPANE:
-        return TDDarkCol::kTextInstruct;
-    case TDLG_CONTENTPANE:
-        return TDDarkCol::kTextContent;
-    case TDLG_EXPANDOTEXT:
-        return TDDarkCol::kTextExpando;
-    case TDLG_VERIFICATIONTEXT:
-        return TDDarkCol::kTextVerify;
-    case TDLG_FOOTNOTEPANE:
-        return TDDarkCol::kTextFootnote;
-    case TDLG_EXPANDEDFOOTERAREA:
-        return TDDarkCol::kTextFtrExp;
-    case TDLG_RADIOBUTTONPANE:
-        return TDDarkCol::kTextRadio;
-    default:
-        return TDDarkCol::kTextNormal;
+        case TDLG_MAININSTRUCTIONPANE:
+            return TDDarkCol::kTextInstruct;
+        case TDLG_CONTENTPANE:
+            return TDDarkCol::kTextContent;
+        case TDLG_EXPANDOTEXT:
+            return TDDarkCol::kTextExpando;
+        case TDLG_VERIFICATIONTEXT:
+            return TDDarkCol::kTextVerify;
+        case TDLG_FOOTNOTEPANE:
+            return TDDarkCol::kTextFootnote;
+        case TDLG_EXPANDEDFOOTERAREA:
+            return TDDarkCol::kTextFtrExp;
+        case TDLG_RADIOBUTTONPANE:
+            return TDDarkCol::kTextRadio;
+        default:
+            return TDDarkCol::kTextNormal;
     }
 }
 
@@ -281,36 +283,39 @@ static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
 
 static HICON TDLoadStockIcon(const TASKDIALOGCONFIG* cfg, bool isMain)
 {
-    if (!cfg)
+    if ( !cfg )
         return nullptr;
 
-    if (isMain && (cfg->dwFlags & TDF_USE_HICON_MAIN))
-        return cfg->hMainIcon;
-    if (!isMain && (cfg->dwFlags & TDF_USE_HICON_FOOTER))
-        return cfg->hFooterIcon;
+    if ( isMain )
+    {
+        if ( cfg->dwFlags & TDF_USE_HICON_MAIN )
+            return cfg->hMainIcon;
+    }
+    else
+    {
+        if ( cfg->dwFlags & TDF_USE_HICON_FOOTER )
+            return cfg->hFooterIcon;
+    }
 
-    LPCWSTR res = isMain ? cfg->pszMainIcon : cfg->pszFooterIcon;
-    if (!res || !IS_INTRESOURCE(res))
+    SHSTOCKICONID id;
+
+    const LPCWSTR res = isMain ? cfg->pszMainIcon : cfg->pszFooterIcon;
+    if ( res == TD_WARNING_ICON )
+        id = SIID_WARNING;
+    else if ( res == TD_ERROR_ICON )
+        id = SIID_ERROR;
+    else if ( res == TD_INFORMATION_ICON )
+        id = SIID_INFO;
+    else if ( res == TD_SHIELD_ICON )
+        id = SIID_SHIELD;
+    else
+         return nullptr;
+
+    WinStruct<SHSTOCKICONINFO> sii;
+    if ( ::SHGetStockIconInfo(id, SHGSI_ICON | SHGSI_LARGEICON, &sii) != S_OK )
         return nullptr;
 
-    auto Stock = [](SHSTOCKICONID id) -> HICON
-        {
-         SHSTOCKICONINFO sii = { sizeof(sii)
-        };
-        return SUCCEEDED(SHGetStockIconInfo(id,
-            SHGSI_ICON | SHGSI_LARGEICON, &sii))
-            ? sii.hIcon : nullptr;
-        };
-    if (res == TD_WARNING_ICON)
-        return Stock(SIID_WARNING);
-    if (res == TD_ERROR_ICON)
-        return Stock(SIID_ERROR);
-    if (res == TD_INFORMATION_ICON)
-        return Stock(SIID_INFO);
-    if (res == TD_SHIELD_ICON)
-        return Stock(SIID_SHIELD);
-
-    return nullptr;
+    return sii.hIcon;
 }
 
 // ============================================================================
@@ -321,58 +326,66 @@ static void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
 {
     out.clear();
     IUIAutomation* const pAuto = wxTaskDialogDarkModule::GetUIAutomation();
-    if (!pAuto)
+    if ( !pAuto )
         return;
 
-   wxCOMPtr <IUIAutomationElement> pRoot;
-    if (FAILED(pAuto->ElementFromHandle(hwnd, &pRoot)))
+    wxCOMPtr <IUIAutomationElement> pRoot;
+    if ( FAILED(pAuto->ElementFromHandle(hwnd, &pRoot)) )
         return;
 
     wxCOMPtr<IUIAutomationTreeWalker> pWalker;
     pAuto->get_ContentViewWalker(&pWalker);
-    if (!pWalker)
+    if ( !pWalker )
         return;
 
     wxCOMPtr<IUIAutomationElement> pChild;
     pWalker->GetFirstChildElement(pRoot, &pChild);
 
-    while (pChild)
+    while ( pChild )
     {
-        TDLayoutElement info{};
+        TDLayoutElement info;
         pChild->get_CurrentBoundingRectangle(&info.rect);
-        ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.left));
-        ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.right));
+        ::ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.left));
+        ::ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.right));
 
-        {
-            BSTR b;
-            pChild->get_CurrentAutomationId(&b);
-            if (b) info.automationId = static_cast<LPCWSTR>(b);
-        }
-        {
-            BSTR b;
-            pChild->get_CurrentName(&b);
-            if (b) info.name = static_cast<LPCWSTR>(b);
-        }
+        BSTR b;
+        if ( pChild->get_CurrentAutomationId(&b) == S_OK )
+            info.automationId = b;
 
-        if (info.automationId == L"VerificationCheckBox")
+        if ( pChild->get_CurrentName(&b) == S_OK )
+            info.name = b;
+
+        if ( info.automationId == L"VerificationCheckBox" )
         {
-            VARIANT v; VariantInit(&v);
-            if (SUCCEEDED(pChild->GetCurrentPropertyValue(
-                UIA_LegacyIAccessibleStatePropertyId, &v)) && v.vt == VT_I4)
+            VARIANT v;
+            ::VariantInit(&v);
+
+            if ( SUCCEEDED(pChild->GetCurrentPropertyValue
+                                   (
+                                    UIA_LegacyIAccessibleStatePropertyId,
+                                    &v
+                                   )) && v.vt == VT_I4 )
+            {
                 info.legacyState = v.lVal;
-            VariantClear(&v);
+            }
+
+            ::VariantClear(&v);
         }
 
-        if (!info.automationId.empty() && !IsRectEmpty(&info.rect))
+        if ( !info.automationId.empty() && !::IsRectEmpty(&info.rect) )
         {
             const std::wstring& id = info.automationId;
-            if (id == L"MainIcon" || id == L"FootnoteIcon" ||
-                id == L"MainInstruction" || id == L"ContentText" ||
-                id == L"ExpandedFooterText" || id == L"FootnoteText" ||
-                id == L"ExpandoButton" || id == L"VerificationCheckBox" ||
-                id.find(L"RadioButton_") == 0 ||
-                id.find(L"CommandLink_") == 0 ||
-                id.find(L"CommandButton_") == 0)
+            if ( id == L"MainIcon" ||
+                 id == L"FootnoteIcon" ||
+                 id == L"MainInstruction" ||
+                 id == L"ContentText" ||
+                 id == L"ExpandedFooterText" ||
+                 id == L"FootnoteText" ||
+                 id == L"ExpandoButton" ||
+                 id == L"VerificationCheckBox" ||
+                 id.find(L"RadioButton_") == 0 ||
+                 id.find(L"CommandLink_") == 0 ||
+                 id.find(L"CommandButton_") == 0 )
             {
                 out.push_back(std::move(info));
             }
@@ -386,25 +399,33 @@ static void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
 
 static void TDUpdateLayoutCache(HWND hwnd, TDPageState& s)
 {
-    if (!s.elemsOk)
+    if ( !s.elemsOk )
     {
         TDBuildLayoutCache(hwnd, s.elements);
         s.elemsOk = true;
     }
-    for (const auto& el : s.elements)
-        if (el.automationId == L"VerificationCheckBox")
+
+    for ( const auto& el : s.elements )
+    {
+        if ( el.automationId == L"VerificationCheckBox" )
         {
             s.isChecked = (el.legacyState & STATE_SYSTEM_CHECKED) != 0;
             break;
         }
-    if (s.defChecked)
+    }
+
+    if ( s.defChecked )
         s.isChecked = true;
 }
 
 static int TDHitTest(const std::vector<TDLayoutElement>& els, POINT pt)
 {
-    for (int i = 0; i < static_cast<int>(els.size()); ++i)
-        if (PtInRect(&els[i].rect, pt)) return i;
+    for ( int i = 0; i < wxSsize(els); ++i )
+    {
+        if ( ::PtInRect(&els[i].rect, pt) )
+            return i;
+    }
+
     return -1;
 }
 
@@ -414,8 +435,10 @@ static int TDHitTest(const std::vector<TDLayoutElement>& els, POINT pt)
 
 static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
 {
-    RGBQUAD* pPx = nullptr; int rw = 0;
-    if (FAILED(GetBufferedPaintBits(hbp, &pPx, &rw))) return;
+    RGBQUAD* pPx = nullptr;
+    int rw = 0;
+    if ( FAILED(::GetBufferedPaintBits(hbp, &pPx, &rw)) )
+        return;
 
     wxColour srcPri(0xff, 0xff, 0xff),
              srcSec(0xf0, 0xf0, 0xf0),
@@ -454,90 +477,122 @@ static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
 #undef GET_G
 #undef GET_R
 
-    for (int y = 0; y < h; ++y)
+    for ( int y = 0; y < h; ++y )
     {
         RGBQUAD* row = pPx + static_cast<ptrdiff_t>(y) * rw;
-        for (int x = 0; x < w; ++x)
+        for ( int x = 0; x < w; ++x )
         {
             RGBQUAD& p = row[x];
-            for (const Rule& r : rules)
-                if (p.rgbRed == r.sR && p.rgbGreen == r.sG && p.rgbBlue == r.sB)
+            for ( const Rule& r : rules )
+            {
+                if ( p.rgbRed == r.sR && p.rgbGreen == r.sG && p.rgbBlue == r.sB )
                 {
-                    p.rgbRed = r.dR; p.rgbGreen = r.dG; p.rgbBlue = r.dB;
+                    p.rgbRed = r.dR;
+                    p.rgbGreen = r.dG;
+                    p.rgbBlue = r.dB;
                     p.rgbReserved = 55;
                     break;
                 }
+            }
         }
     }
 }
 
 static void TDPaintIcons(HDC hdc, const TDPageState& s)
 {
-    if (!s.pCfg || TDHasNativeDarkTheme()) return;
-    for (const auto& el : s.elements)
+    if ( !s.pCfg || TDHasNativeDarkTheme() )
+        return;
+
+    for ( const auto& el : s.elements )
     {
-        if (IsRectEmpty(&el.rect)) continue;
-        HICON hIcon = nullptr; HBRUSH brBg = nullptr;
-        if (el.automationId == L"MainIcon")
+        if ( ::IsRectEmpty(&el.rect) )
+            continue;
+
+        HICON hIcon = nullptr;
+        HBRUSH brBg = nullptr;
+        if ( el.automationId == L"MainIcon" )
         {
             hIcon = TDLoadStockIcon(s.pCfg, true);
             brBg = s.brPrimary;
         }
-        else if (el.automationId == L"FootnoteIcon")
+        else if ( el.automationId == L"FootnoteIcon" )
         {
             hIcon = TDLoadStockIcon(s.pCfg, false);
             brBg = s.brFootnote;
         }
-        if (!hIcon || !brBg) continue;
-        FillRect(hdc, &el.rect, brBg);
-        DrawIconEx(hdc, el.rect.left, el.rect.top, hIcon,
-            el.rect.right - el.rect.left, el.rect.bottom - el.rect.top,
-            0, nullptr, DI_NORMAL);
+
+        if ( !hIcon )
+            continue;
+
+        ::FillRect(hdc, &el.rect, brBg);
+        ::DrawIconEx
+        (
+            hdc,
+            el.rect.left,
+            el.rect.top,
+            hIcon,
+            el.rect.right - el.rect.left,
+            el.rect.bottom - el.rect.top,
+            0,
+            nullptr,
+            DI_NORMAL
+        );
     }
 }
 
 static void TDPaintGlyphs(HDC hdc, TDPageState& s)
 {
-    if (!s.hTD && !s.hButton)
+    if ( !s.hTD && !s.hButton )
         return;
 
     if ( TDHasNativeDarkTheme() )
         return;
 
-    for (int i = 0; i < static_cast<int>(s.elements.size()); ++i)
+    for ( int i = 0; i < wxSsize(s.elements); ++i )
     {
         const TDLayoutElement& el = s.elements[i];
-        if (IsRectEmpty(&el.rect))
+        if ( ::IsRectEmpty(&el.rect) )
             continue;
-        const bool hot = (i == s.hotIdx), press = hot && s.pressing;
 
-        if (el.automationId == L"ExpandoButton" && s.hTD)
+        const bool hot = i == s.hotIdx;
+        const bool press = hot && s.pressing;
+
+        if ( el.automationId == L"ExpandoButton" && s.hTD )
         {
             const int width =
                 s.hTD.GetTrueSize(TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, hdc).x;
 
-            RECT rcG = el.rect; rcG.right = el.rect.left + width + 3;
-            int st = (press && s.isExpanded) ? TDLGEBS_EXPANDEDPRESSED :
-                press ? TDLGEBS_PRESSED :
-                (hot && s.isExpanded) ? TDLGEBS_EXPANDEDHOVER :
-                hot ? TDLGEBS_HOVER :
-                s.isExpanded ? TDLGEBS_EXPANDEDNORMAL : TDLGEBS_NORMAL;
-            FillRect(hdc, &rcG, s.brSecondary);
+            RECT rc = el.rect;
+            rc.right = el.rect.left + width + 3;
+
+            int state;
+            if ( press )
+                state = s.isExpanded ? TDLGEBS_EXPANDEDPRESSED : TDLGEBS_PRESSED;
+            else if ( hot )
+                state = s.isExpanded ? TDLGEBS_EXPANDEDHOVER : TDLGEBS_HOVER;
+            else
+                state = s.isExpanded ? TDLGEBS_EXPANDEDNORMAL : TDLGEBS_NORMAL;
+
+            ::FillRect(hdc, &rc, s.brSecondary);
             s.hTD.DrawBackground(hdc, rc, TDLG_EXPANDOBUTTON, state, &el.rect);
         }
-        else if (el.automationId == L"VerificationCheckBox" && s.hButton)
+        else if ( el.automationId == L"VerificationCheckBox" && s.hButton )
         {
             const wxSize size =
                 s.hButton.GetDrawSize(BP_CHECKBOX, CBS_UNCHECKEDNORMAL, hdc);
 
-            int mg = (el.rect.bottom - el.rect.top - size.y) / 3;
-            RECT rcG = { el.rect.left + mg + 1,el.rect.top + mg + 1,el.rect.left + mg + 1 + size.x,el.rect.bottom };
-            int st = (press && s.isChecked) ? CBS_CHECKEDPRESSED :
-                press ? CBS_UNCHECKEDPRESSED :
-                (hot && s.isChecked) ? CBS_CHECKEDHOT :
-                hot ? CBS_UNCHECKEDHOT :
-                s.isChecked ? CBS_CHECKEDNORMAL : CBS_UNCHECKEDNORMAL;
-            FillRect(hdc, &rcG, s.brSecondary);
+            const int mg = (el.rect.bottom - el.rect.top - size.y) / 3;
+            RECT rc = { el.rect.left + mg + 1,el.rect.top + mg + 1,el.rect.left + mg + 1 + size.x,el.rect.bottom };
+
+            int state;
+            if ( press )
+                state = s.isChecked ? CBS_CHECKEDPRESSED : CBS_UNCHECKEDPRESSED;
+            else if ( hot )
+                state = s.isChecked ? CBS_CHECKEDHOT : CBS_UNCHECKEDHOT;
+            else
+                state = s.isChecked ? CBS_CHECKEDNORMAL : CBS_UNCHECKEDNORMAL;
+
+            ::FillRect(hdc, &rc, s.brSecondary);
             s.hButton.DrawBackground(hdc, rc, BP_CHECKBOX, state);
         }
     }
@@ -547,97 +602,106 @@ static void TDPaintText(HDC hdc, const TDPageState& s)
 {
     if ( !s.hTD )
         return;
-     const bool native = TDHasNativeDarkTheme();
 
-    for (const auto& el : s.elements)
+    const bool native = TDHasNativeDarkTheme();
+
+    for ( const auto& el : s.elements )
     {
-        if (IsRectEmpty(&el.rect))
+        if ( ::IsRectEmpty(&el.rect) )
             continue;
-        RECT   rcT = el.rect;
+
+        RECT   rcText = el.rect;
         int    part = 0;
-        HBRUSH brBg = s.brPrimary;
+        HBRUSH brBg = 0;
         DWORD  dtF = DT_LEFT | DT_VCENTER | DT_WORDBREAK | DT_NOPREFIX;
 
-        if (el.automationId == L"MainInstruction")
+        if ( el.automationId == L"MainInstruction" )
         {
             part = TDLG_MAININSTRUCTIONPANE;
             brBg = s.brPrimary;
         }
-        else if (el.automationId == L"ContentText")
+        else if ( el.automationId == L"ContentText" )
         {
             part = TDLG_CONTENTPANE;
             brBg = s.brPrimary;
         }
-        else if (el.automationId == L"ExpandedFooterText")
+        else if ( el.automationId == L"ExpandedFooterText" )
         {
             part = TDLG_EXPANDEDFOOTERAREA;
             brBg = s.brFootnote;
         }
-        else if (el.automationId == L"FootnoteText")
+        else if ( el.automationId == L"FootnoteText" )
         {
             part = TDLG_FOOTNOTEPANE;
             brBg = s.brFootnote;
         }
-        else if (el.automationId == L"ExpandoButton" && s.hTD)
+        else if ( el.automationId == L"ExpandoButton" && s.hTD )
         {
             const int width =
                 s.hTD.GetTrueSize(TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, hdc).x;
 
             MARGINS vm = {};
             s.hTD.GetMargins(vm, TDLG_VERIFICATIONTEXT, TMT_CONTENTMARGINS, 0, hdc);
-            rcT.left += width + vm.cxLeftWidth - 2; rcT.top += 1;
-            part = TDLG_EXPANDOTEXT; brBg = s.brSecondary;
+            rcText.left += width + vm.cxLeftWidth - 2;
+            rcText.top += 1;
+
+            part = TDLG_EXPANDOTEXT;
+            brBg = s.brSecondary;
+
             dtF = DT_LEFT | DT_VCENTER | DT_NOPREFIX;
         }
-        else if (el.automationId == L"VerificationCheckBox" && s.hButton && s.hTD)
+        else if ( el.automationId == L"VerificationCheckBox" && s.hButton && s.hTD )
         {
             const int width =
                 s.hButton.GetDrawSize(BP_CHECKBOX, CBS_UNCHECKEDNORMAL, hdc).x;
 
             MARGINS tm = {};
             s.hTD.GetMargins(tm, TDLG_VERIFICATIONTEXT, TMT_CONTENTMARGINS, 0, hdc);
-            rcT.left = el.rect.left + width + tm.cxLeftWidth + 3; rcT.top += 5;
-            part = TDLG_VERIFICATIONTEXT; brBg = s.brSecondary;
+            rcText.left = el.rect.left + width + tm.cxLeftWidth + 3;
+            rcText.top += 5;
+
+            part = TDLG_VERIFICATIONTEXT;
+            brBg = s.brSecondary;
+
             dtF = DT_LEFT | DT_VCENTER | DT_NOPREFIX;
         }
-        if (!part)
+
+        if ( !part )
             continue;
 
-        if (!native)
+        WinStructWordSize<DTTOPTS> opts;
+        if ( !native )
         {
-            WinStructWordSize<DTTOPTS> opts;
             opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
             opts.crText = TDGetTextColour(s, part);
-            FillRect(hdc, &rcT, brBg);
-            ::DrawThemeTextEx(s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, &rcT, &opts);
-        }
-        else
-        {
 
-            ::DrawThemeText(s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, 0, &rcT);
+            ::FillRect(hdc, &rcText, brBg);
         }
+
+        ::DrawThemeTextEx(s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, &rcText, &opts);
     }
 }
 
 static void TDPaintPage(HWND hwnd, HDC hdcWin, TDPageState& s)
 {
-    if (!s.themesOk)
+    if ( !s.themesOk )
         TDRefreshThemes(hwnd, s);
 
-    RECT rc; GetClientRect(hwnd, &rc);
-    HDC hdcBuf = hdcWin;
-    HPAINTBUFFER hbp = BeginBufferedPaint(hdcWin, &rc, BPBF_TOPDOWNDIB, nullptr, &hdcBuf);
-    if (!hbp)
+    const RECT rc = wxGetClientRect(hwnd);
+    HDC hdcBuf = 0;
+    HPAINTBUFFER hbp = ::BeginBufferedPaint(hdcWin, &rc, BPBF_TOPDOWNDIB, nullptr, &hdcBuf);
+    if ( !hbp )
     {
-        DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcWin), PRF_CLIENT);
+        ::DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcWin), PRF_CLIENT);
         return;
     }
 
-    DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcBuf), PRF_CLIENT);
+    ::DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcBuf), PRF_CLIENT);
 
-    if (!TDHasNativeDarkTheme())
+    if ( !TDHasNativeDarkTheme() )
     {
-        RECT rcBuf; GetBufferedPaintTargetRect(hbp, &rcBuf);
+        RECT rcBuf;
+        ::GetBufferedPaintTargetRect(hbp, &rcBuf);
         TDPaintPixelSwap(hbp, rcBuf.right - rcBuf.left, rcBuf.bottom - rcBuf.top);
     }
 
@@ -645,173 +709,242 @@ static void TDPaintPage(HWND hwnd, HDC hdcWin, TDPageState& s)
     TDPaintGlyphs(hdcBuf, s);
     TDPaintText(hdcBuf, s);
 
-    EndBufferedPaint(hbp, TRUE);
+    ::EndBufferedPaint(hbp, TRUE);
 }
 
 // ============================================================================
 // Subclass procedures
 // ============================================================================
 
-static LRESULT CALLBACK TDPageSubclassProc(
-    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
-    UINT_PTR uId, DWORD_PTR)
+static LRESULT CALLBACK
+TDPageSubclassProc(HWND hwnd,
+                   UINT msg,
+                   WPARAM wParam,
+                   LPARAM lParam,
+                   UINT_PTR uId,
+                   DWORD_PTR WXUNUSED(dwRef))
 {
-    switch (msg)
+    switch ( msg )
     {
-    case WM_ERASEBKGND:
-        return TRUE;
+        case WM_ERASEBKGND:
+            return TRUE;
 
-    case WM_PAINT:
-    {
-        PAINTSTRUCT ps; HDC hdc = BeginPaint(hwnd, &ps);
-        TDPageState& s = TDPageState::Get(hwnd);
-        s.isExpanded = !!GetProp(GetParent(hwnd), L"IsExpanded");
-        s.elemsOk = false;
-        TDUpdateLayoutCache(hwnd, s);
-        TDPaintPage(hwnd, hdc, s);
-        EndPaint(hwnd, &ps);
-        return 0;
+        case WM_PAINT:
+            {
+                PAINTSTRUCT ps;
+                HDC hdc = ::BeginPaint(hwnd, &ps);
+                TDPageState& s = TDPageState::Get(hwnd);
+                s.isExpanded = ::GetPropW(GetParent(hwnd), L"IsExpanded");
+                s.elemsOk = false;
+                TDUpdateLayoutCache(hwnd, s);
+                TDPaintPage(hwnd, hdc, s);
+                ::EndPaint(hwnd, &ps);
+            }
+            return 0;
+
+        case WM_MOUSEMOVE:
+            {
+                TDPageState& s = TDPageState::Get(hwnd);
+                if ( !s.tracking )
+                {
+                    WinStruct<TRACKMOUSEEVENT> tme;
+                    tme.dwFlags = TME_LEAVE;
+                    tme.hwndTrack = hwnd;
+                    ::TrackMouseEvent(&tme);
+
+                    s.tracking = true;
+                }
+                POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+
+                const int nh = TDHitTest(s.elements, pt);
+                if ( nh != s.hotIdx )
+                {
+                    s.hotIdx = nh;
+                    ::InvalidateRect(hwnd, nullptr, FALSE);
+                }
+            }
+            break;
+
+        case WM_MOUSELEAVE:
+            {
+                TDPageState& s = TDPageState::Get(hwnd);
+                s.tracking = false;
+                s.pressing = false;
+
+                if ( s.hotIdx != -1 )
+                {
+                    s.hotIdx = -1;
+                    ::InvalidateRect(hwnd, nullptr, FALSE);
+                }
+            }
+            break;
+
+        case WM_LBUTTONDOWN:
+            TDPageState::Get(hwnd).pressing = true;
+            TDUpdateLayoutCache(hwnd, TDPageState::Get(hwnd));
+            ::InvalidateRect(hwnd, nullptr, FALSE);
+            break;
+
+        case WM_LBUTTONUP:
+            TDPageState::Get(hwnd).pressing = false;
+            TDUpdateLayoutCache(hwnd, TDPageState::Get(hwnd));
+            ::InvalidateRect(hwnd, nullptr, FALSE);
+            break;
+
+        case WM_THEMECHANGED:
+            {
+                TDPageState& s = TDPageState::Get(hwnd);
+                s.themesOk = false;
+                s.elemsOk = false;
+                ::InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            break;
+
+        case WM_DESTROY:
+            TDPageState::Destroy(hwnd);
+            ::RemoveWindowSubclass(hwnd, TDPageSubclassProc, uId);
+            break;
     }
-    case WM_MOUSEMOVE:
-    {
-        TDPageState& s = TDPageState::Get(hwnd);
-        if (!s.tracking)
-        {
-            TRACKMOUSEEVENT tme = { sizeof(tme),TME_LEAVE,hwnd,0 };
-            TrackMouseEvent(&tme); s.tracking = true;
-        }
-        POINT pt = { (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam) };
-        int nh = TDHitTest(s.elements, pt);
-        if (nh != s.hotIdx)
-        {
-            s.hotIdx = nh;
-            InvalidateRect(hwnd, nullptr, FALSE);
-        }
-        break;
-    }
-    case WM_MOUSELEAVE:
-    {
-        TDPageState& s = TDPageState::Get(hwnd);
-        s.tracking = false;
-        s.pressing = false;
-        if (s.hotIdx != -1)
-        {
-            s.hotIdx = -1;
-            InvalidateRect(hwnd, nullptr, FALSE);
-        }
-        break;
-    }
-    case WM_LBUTTONDOWN:
-        TDPageState::Get(hwnd).pressing = true;
-        TDUpdateLayoutCache(hwnd, TDPageState::Get(hwnd));
-        InvalidateRect(hwnd, nullptr, FALSE);
-        break;
-    case WM_LBUTTONUP:
-        TDPageState::Get(hwnd).pressing = false;
-        TDUpdateLayoutCache(hwnd, TDPageState::Get(hwnd));
-        InvalidateRect(hwnd, nullptr, FALSE);
-        break;
-    case WM_THEMECHANGED:
-    {
-        TDPageState& s = TDPageState::Get(hwnd);
-        s.themesOk = false;
-        s.elemsOk = false;
-        InvalidateRect(hwnd, nullptr, FALSE);
-        break;
-    }
-    case WM_DESTROY:
-        TDPageState::Destroy(hwnd);
-        RemoveWindowSubclass(hwnd, TDPageSubclassProc, uId);
-        break;
-    }
-    return DefSubclassProc(hwnd, msg, wParam, lParam);
+
+    return ::DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
-static LRESULT CALLBACK TDCtrlContainerSubclassProc(
-    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
-    UINT_PTR uId, DWORD_PTR dwRef)
+static LRESULT CALLBACK
+TDCtrlContainerSubclassProc(HWND hwnd,
+                            UINT msg,
+                            WPARAM wParam,
+                            LPARAM lParam,
+                            UINT_PTR uId,
+                            DWORD_PTR dwRef)
 {
-    switch (msg)
+    HBRUSH hbr = reinterpret_cast<HBRUSH>(dwRef);
+
+    switch ( msg )
     {
-    case WM_ERASEBKGND:
-        if (dwRef)
-        {
-            HDC hdc = reinterpret_cast<HDC>(wParam); RECT rc; GetClientRect(hwnd, &rc);
-            FillRect(hdc, &rc, reinterpret_cast<HBRUSH>(dwRef)); return 1;
-        }
-        break;
-    case WM_CTLCOLORMSGBOX:
-    case WM_CTLCOLOREDIT:
-    case WM_CTLCOLORLISTBOX:
-    case WM_CTLCOLORBTN:
-    case WM_CTLCOLORDLG:
-    case WM_CTLCOLORSCROLLBAR:
-    case WM_CTLCOLORSTATIC:
-    {
-        HDC hdc = reinterpret_cast<HDC>(wParam);
-        COLORREF bg = TDDarkCol::kSecondary;
-        if (dwRef) { LOGBRUSH lb = {}; GetObject(reinterpret_cast<HBRUSH>(dwRef), sizeof(lb), &lb); if (lb.lbStyle == BS_SOLID) bg = lb.lbColor; }
-        SetBkColor(hdc, bg); SetTextColor(hdc, TDDarkCol::kTextNormal);
-        return reinterpret_cast<LRESULT>(dwRef ? reinterpret_cast<HBRUSH>(dwRef) : CreateSolidBrush(TDDarkCol::kSecondary));
+        case WM_ERASEBKGND:
+            {
+                HDC hdc = reinterpret_cast<HDC>(wParam);
+                wxFillRect(hwnd, hdc, hbr);
+                return 1;
+            }
+
+        case WM_CTLCOLORMSGBOX:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORSCROLLBAR:
+        case WM_CTLCOLORSTATIC:
+            {
+                HDC hdc = reinterpret_cast<HDC>(wParam);
+                COLORREF bg = TDDarkCol::kSecondary;
+                if ( hbr )
+                {
+                    LOGBRUSH lb = {};
+                    ::GetObject(hbr, sizeof(lb), &lb);
+                    if ( lb.lbStyle == BS_SOLID )
+                        bg = lb.lbColor;
+                }
+
+                ::SetBkColor(hdc, bg);
+                ::SetTextColor(hdc, TDDarkCol::kTextNormal);
+
+                if ( !hbr )
+                    hbr = ::CreateSolidBrush(TDDarkCol::kSecondary);
+
+                return reinterpret_cast<LRESULT>(hbr);
+            }
+
+        case WM_DESTROY:
+            ::DeleteObject(hbr);
+            ::RemoveWindowSubclass(hwnd, TDCtrlContainerSubclassProc, uId);
+            break;
     }
-    case WM_DESTROY:
-        if (dwRef) DeleteObject(reinterpret_cast<HBRUSH>(dwRef));
-        RemoveWindowSubclass(hwnd, TDCtrlContainerSubclassProc, uId);
-        return DefSubclassProc(hwnd, msg, wParam, lParam);
-    }
-    return DefSubclassProc(hwnd, msg, wParam, lParam);
+
+    return ::DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
-static LRESULT CALLBACK TDRadioButtonSubclassProc(
-    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
-    UINT_PTR uId, DWORD_PTR)
+static LRESULT CALLBACK
+TDRadioButtonSubclassProc(HWND hwnd,
+                          UINT msg,
+                          WPARAM wParam,
+                          LPARAM lParam,
+                          UINT_PTR uId,
+                          DWORD_PTR WXUNUSED(dwRef))
 {
-    if (msg == WM_PAINT)
+    switch ( msg )
     {
-        PAINTSTRUCT ps;
-        HDC hdc = BeginPaint(hwnd, &ps);
-        const int dpi = wxGetWindowDPI(hwnd).x;
-        auto hStyle = wxUxThemeHandle::NewAtStdDPI(L"TaskDialogStyle");
-        auto  hBtn = wxUxThemeHandle::NewAtDPI(nullptr, L"Button",dpi);
-        RECT rcC; GetClientRect(hwnd, &rcC);
-        HDC hdcBuf = hdc;
-        HPAINTBUFFER hbp = BeginBufferedPaint(hdc, &rcC, BPBF_TOPDOWNDIB, nullptr, &hdcBuf);
-        DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcBuf), PRF_CLIENT);
-        wchar_t text[512] = {};
-        GetWindowTextW(hwnd, text, static_cast<int>(std::size(text)));
-        auto gs = hBtn.GetTrueSize(BP_RADIOBUTTON, RBS_UNCHECKEDNORMAL);
-        RECT rcT = { gs.x + 2,0,rcC.right,rcC.bottom };
+        case WM_PAINT:
+            {
+                PAINTSTRUCT ps;
+                HDC hdc = ::BeginPaint(hwnd, &ps);
 
-        WinStructWordSize<DTTOPTS> opts;
-        opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
-        opts.crText = TDDarkCol::kTextNormal;
-        LOGFONT lf = {};
-        if (SUCCEEDED(GetThemeFont(hStyle, hdcBuf, TDLG_RADIOBUTTONPANE, 0, TMT_FONT, &lf)))
-        {
-            HFONT hF = CreateFontIndirect(&lf), hO = static_cast<HFONT>(SelectObject(hdcBuf, hF));
-            DrawThemeTextEx(hStyle, hdcBuf, TDLG_RADIOBUTTONPANE, 0, text, -1, DT_LEFT | DT_VCENTER | DT_END_ELLIPSIS, &rcT, &opts);
-            SelectObject(hdcBuf, hO); DeleteObject(hF);
-        }
-        if (hbp)
-            EndBufferedPaint(hbp, TRUE);
-        EndPaint(hwnd, &ps); return 0;
+                const int dpi = wxGetWindowDPI(hwnd).x;
+                auto hStyle = wxUxThemeHandle::NewAtStdDPI(L"TaskDialogStyle");
+                auto hBtn = wxUxThemeHandle::NewAtDPI(nullptr, L"Button", dpi);
+
+                const RECT rcClient = wxGetClientRect(hwnd);
+                HDC hdcBuf = 0;
+                HPAINTBUFFER hbp = ::BeginBufferedPaint(hdc, &rcClient, BPBF_TOPDOWNDIB, nullptr, &hdcBuf);
+
+                ::DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcBuf), PRF_CLIENT);
+
+                wchar_t text[512] = {};
+                GetWindowTextW(hwnd, text, static_cast<int>(std::size(text)));
+
+                auto gs = hBtn.GetTrueSize(BP_RADIOBUTTON, RBS_UNCHECKEDNORMAL);
+                RECT rcText = { gs.x + 2, 0, rcClient.right, rcClient.bottom };
+
+                WinStructWordSize<DTTOPTS> opts;
+                opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
+                opts.crText = TDDarkCol::kTextNormal;
+
+                LOGFONT lf = {};
+                if ( hStyle.GetFont(lf, hdcBuf, TDLG_RADIOBUTTONPANE) )
+                {
+                    AutoHFONT hFont(lf);
+                    SelectInHDC sel(hdcBuf, hFont);
+
+                    ::DrawThemeTextEx(hStyle, hdcBuf, TDLG_RADIOBUTTONPANE, 0,
+                                      text, -1,
+                                      DT_LEFT | DT_VCENTER | DT_END_ELLIPSIS,
+                                      &rcText, &opts);
+                }
+
+                if ( hbp )
+                    ::EndBufferedPaint(hbp, TRUE);
+                ::EndPaint(hwnd, &ps);
+            }
+            return 0;
+
+        case WM_DESTROY:
+            ::RemoveWindowSubclass(hwnd, TDRadioButtonSubclassProc, uId);
+            break;
     }
-    if (msg == WM_DESTROY)
-        RemoveWindowSubclass(hwnd, TDRadioButtonSubclassProc, uId);
-    return DefSubclassProc(hwnd, msg, wParam, lParam);
+
+    return ::DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
 // ============================================================================
 // Attachment helpers
 // ============================================================================
 
-static void TDSubclassContainer(HWND hP, COLORREF bg)
+static void TDSubclassContainer(HWND hwndParent, COLORREF bg)
 {
-    if (!hP) return;
-    DWORD_PTR ex = 0;
-    if (!GetWindowSubclass(hP, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &ex))
-        SetWindowSubclass(hP, TDCtrlContainerSubclassProc, kTDCtrlSubclassId,
-            reinterpret_cast<DWORD_PTR>(CreateSolidBrush(bg)));
+    if ( !hwndParent )
+        return;
+
+    DWORD_PTR dwRef = 0;
+    if ( !::GetWindowSubclass(hwndParent, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &dwRef) )
+    {
+        ::SetWindowSubclass
+        (
+            hwndParent,
+            TDCtrlContainerSubclassProc,
+            kTDCtrlSubclassId,
+            reinterpret_cast<DWORD_PTR>(::CreateSolidBrush(bg))
+        );
+    }
 }
 
 static void TDApplyToChildren(IUIAutomationElement* pEl)
@@ -822,27 +955,36 @@ static void TDApplyToChildren(IUIAutomationElement* pEl)
 
     const bool native = TDHasNativeDarkTheme();
 
-    wxCOMPtr<IUIAutomationTreeWalker> pW;
-    uiAuto->get_ContentViewWalker(&pW);
-    if (!pW) return;
-    wxCOMPtr<IUIAutomationElement> pChild;
-    pW->GetFirstChildElement(pEl, &pChild);
+    wxCOMPtr<IUIAutomationTreeWalker> pWalker;
+    uiAuto->get_ContentViewWalker(&pWalker);
+    if ( !pWalker )
+        return;
 
-    while (pChild)
+    wxCOMPtr<IUIAutomationElement> pChild;
+    pWalker->GetFirstChildElement(pEl, &pChild);
+
+    while ( pChild )
     {
         CONTROLTYPEID ct = 0;
         pChild->get_CurrentControlType(&ct);
-        if (ct == UIA_ButtonControlTypeId || ct == UIA_RadioButtonControlTypeId ||
-            ct == UIA_ProgressBarControlTypeId || ct == UIA_HyperlinkControlTypeId ||
-            ct == UIA_ScrollBarControlTypeId || ct == UIA_PaneControlTypeId)
+
+        if ( ct == UIA_ButtonControlTypeId ||
+             ct == UIA_RadioButtonControlTypeId ||
+             ct == UIA_ProgressBarControlTypeId ||
+             ct == UIA_HyperlinkControlTypeId ||
+             ct == UIA_ScrollBarControlTypeId ||
+             ct == UIA_PaneControlTypeId)
         {
             if ( const HWND hBtn = GetHWNDFromElement(pChild) )
             {
-                BSTR bId; pChild->get_CurrentAutomationId(&bId);
-                const std::wstring id(bId ? static_cast<LPCWSTR>(bId) : L"");
-                HWND hP = GetParent(hBtn);
+                BSTR bId;
+                pChild->get_CurrentAutomationId(&bId);
 
-                if (ct == UIA_ProgressBarControlTypeId)
+                const std::wstring id(bId ? bId : L"");
+
+                HWND hwndParent = ::GetParent(hBtn);
+
+                if ( ct == UIA_ProgressBarControlTypeId )
                 {
                     wxMSWDarkMode::SetTheme
                     (
@@ -852,24 +994,27 @@ static void TDApplyToChildren(IUIAutomationElement* pEl)
                             : L"DarkMode_Explorer"
                     );
                 }
-                else if (ct == UIA_RadioButtonControlTypeId || id.find(L"RadioButton_") == 0 || ct == UIA_HyperlinkControlTypeId)
+                else if ( ct == UIA_RadioButtonControlTypeId ||
+                            id.find(L"RadioButton_") == 0 ||
+                                ct == UIA_HyperlinkControlTypeId )
                 {
-                    if (native)
+                    if ( native )
                     {
                         wxMSWDarkMode::SetTheme(hBtn, L"DarkMode_DarkTheme");
                     }
                     else
                     {
-                        DWORD_PTR ex = 0;
-                        if (!GetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &ex))
-                            SetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, 0);
+                        DWORD_PTR dwRef = 0;
+                        if ( !::GetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &dwRef) )
+                            ::SetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, 0);
                     }
-                    TDSubclassContainer(hP, native ? TDDarkCol::kSecondary : TDDarkCol::kPrimary);
+
+                    TDSubclassContainer(hwndParent, native ? TDDarkCol::kSecondary : TDDarkCol::kPrimary);
                 }
-                else if (id.find(L"CommandLink_") == 0 || id.find(L"CommandButton_") == 0)
+                else if ( id.find(L"CommandLink_") == 0 || id.find(L"CommandButton_") == 0 )
                 {
                     wxMSWDarkMode::SetTheme(hBtn, L"DarkMode_Explorer");
-                    TDSubclassContainer(hP, TDDarkCol::kSecondary);
+                    TDSubclassContainer(hwndParent, TDDarkCol::kSecondary);
                 }
                 else
                 {
@@ -877,7 +1022,9 @@ static void TDApplyToChildren(IUIAutomationElement* pEl)
                 }
             }
         }
-        wxCOMPtr<IUIAutomationElement> pNext; pW->GetNextSiblingElement(pChild, &pNext);
+
+        wxCOMPtr<IUIAutomationElement> pNext;
+        pWalker->GetNextSiblingElement(pChild, &pNext);
         pChild = pNext;
     }
 }
@@ -907,14 +1054,24 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     // SysLink controls (footnote / content hyperlinks)
     if ( wcscmp(cls, L"CCSysLink") == 0 )
     {
-        if ( const HWND hL = GetHWNDFromElement(pEl) )
+        if ( const HWND hLink = GetHWNDFromElement(pEl) )
         {
             BSTR bId;
             pEl->get_CurrentAutomationId(&bId);
-            const std::wstring id(bId ? static_cast<LPCWSTR>(bId) : L"");
-            bool isFn = id.find(L"Footnote") != std::wstring::npos || id.find(L"ExpandedFooter") != std::wstring::npos;
-            TDSubclassContainer(GetParent(hL), (isFn && !TDHasNativeDarkTheme()) ? TDDarkCol::kFootnote : TDDarkCol::kPrimary);
+
+            const std::wstring id(bId ? bId : L"");
+            bool isFn = id.find(L"Footnote") != std::wstring::npos ||
+                            id.find(L"ExpandedFooter") != std::wstring::npos;
+
+            TDSubclassContainer
+            (
+                GetParent(hLink),
+                isFn && !TDHasNativeDarkTheme()
+                    ? TDDarkCol::kFootnote
+                    : TDDarkCol::kPrimary
+            );
         }
+
         return TRUE;
     }
 
@@ -928,9 +1085,17 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
 
     // Class background brush
     {
-        HBRUSH nb = CreateSolidBrush(TDDarkCol::kSecondary);
-        HBRUSH ob = reinterpret_cast<HBRUSH>(SetClassLongPtr(hDUI, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb)));
-        if (ob && ob != GetSysColorBrush(COLOR_WINDOW) && ob != GetSysColorBrush(COLOR_BTNFACE)) DeleteObject(ob);
+        HBRUSH nb = ::CreateSolidBrush(TDDarkCol::kSecondary);
+
+        HBRUSH ob = reinterpret_cast<HBRUSH>(
+            ::SetClassLongPtr(hDUI, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb))
+        );
+        if ( ob &&
+                ob != ::GetSysColorBrush(COLOR_WINDOW) &&
+                    ob != ::GetSysColorBrush(COLOR_BTNFACE))
+        {
+            ::DeleteObject(ob);
+        }
     }
 
     TDApplyToChildren(pEl);
@@ -942,14 +1107,14 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     s.pCfg = d->pCfg;
     s.defExpanded = d->pCfg && (d->pCfg->dwFlags & TDF_EXPANDED_BY_DEFAULT);
     s.defChecked = d->pCfg && (d->pCfg->dwFlags & TDF_VERIFICATION_FLAG_CHECKED);
-    s.isExpanded = GetProp(d->hwndTD, L"IsExpanded");
-    s.isChecked = s.defChecked || GetProp(d->hwndTD, L"IsChecked");
+    s.isExpanded = ::GetPropW(d->hwndTD, L"IsExpanded");
+    s.isChecked = s.defChecked || ::GetPropW(d->hwndTD, L"IsChecked");
     s.elemsOk = false;
     TDUpdateLayoutCache(hDUI, s);
 
-    DWORD_PTR ex = 0;
-    if (!GetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, &ex))
-        SetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, 0);
+    DWORD_PTR dwRef = 0;
+    if ( !::GetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, &dwRef) )
+        ::SetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, 0);
 
     d->found = true;
     return TRUE;
@@ -957,22 +1122,24 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
 
 static BOOL CALLBACK TDEnumSysColorProc(HWND h, LPARAM)
 {
-    SendMessage(h, WM_SYSCOLORCHANGE, 0, 0);
+    ::SendMessage(h, WM_SYSCOLORCHANGE, 0, 0);
     return TRUE;
 }
 
 static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
 {
-    DWORD_PTR ex = 0;
-    if (GetWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId, &ex))
+    DWORD_PTR dwRef = 0;
+    if ( ::GetWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId, &dwRef) )
     {
-        RemoveWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId);
+        ::RemoveWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId);
         TDPageState::Destroy(hChild);
     }
-    if (GetWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &ex))
-        RemoveWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId);
-    if (GetWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &ex))
-        RemoveWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId);
+
+    if ( ::GetWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &dwRef) )
+        ::RemoveWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId);
+
+    if ( ::GetWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &dwRef) )
+        ::RemoveWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId);
 
     ::SetWindowTheme(hChild, nullptr, nullptr);
 
@@ -987,29 +1154,31 @@ static void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
     data.hwndTD = hwndTD;
     data.pCfg = pCfg;
 
-    EnumChildWindows(hwndTD, TDEnumAttachProc, reinterpret_cast<LPARAM>(&data));
+    ::EnumChildWindows(hwndTD, TDEnumAttachProc, reinterpret_cast<LPARAM>(&data));
 
-    if (!data.found)
+    if ( !data.found )
         return;
 
-    if (native)
+    if ( native )
         wxMSWDarkMode::AllowForWindow(hwndTD, L"DarkMode_Explorer", nullptr);
-    DWORD_PTR ex;
-    if (!GetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, &ex))
-        SetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, 0);
+
+    DWORD_PTR dwRef;
+    if ( !::GetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, &dwRef) )
+        ::SetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, 0);
+
     // Dark title bar
     wxMSWDarkMode::ConfigureTLW(hwndTD);
-    HBRUSH nb = CreateSolidBrush(TDDarkCol::kPrimary);
-    SetClassLongPtr(hwndTD, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb));
-    EnumChildWindows(hwndTD, TDEnumSysColorProc, 0);
-    SendMessage(hwndTD, WM_THEMECHANGED, 0, 0);
+    HBRUSH nb = ::CreateSolidBrush(TDDarkCol::kPrimary);
+    ::SetClassLongPtr(hwndTD, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb));
+    ::EnumChildWindows(hwndTD, TDEnumSysColorProc, 0);
+    ::SendMessage(hwndTD, WM_THEMECHANGED, 0, 0);
 }
 
 static void TDDetach(HWND hwndTD)
 {
-    EnumChildWindows(hwndTD, TDEnumDetachProc, 0);
+    ::EnumChildWindows(hwndTD, TDEnumDetachProc, 0);
+}
 
-} // TDDetach
 } // anonymous namespace
 
 #endif // wxUSE_DARK_MODE
@@ -1026,11 +1195,12 @@ void wxMSWDarkMode::AllowForTaskDialog(HWND hwnd, const TASKDIALOGCONFIG* pCfg)
 
     // Ensure COM is initialised for UIA on this thread.
     // S_FALSE means already initialised by the caller — that is fine.
-    const HRESULT hr = CoInitializeEx(
-        nullptr,
-        COINIT_APARTMENTTHREADED |
-        COINIT_DISABLE_OLE1DDE);
-    if (FAILED(hr) && hr != S_FALSE)
+    const HRESULT hr = CoInitializeEx
+                       (
+                        nullptr,
+                        COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE
+                       );
+    if ( FAILED(hr) && hr != S_FALSE )
         return;
 
     TDAttach(hwnd, pCfg);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -499,7 +499,9 @@ static void TDPaintGlyphs(HDC hdc, TDPageState& s)
 {
     if (!s.hTD && !s.hButton)
         return;
-    const bool native = TDHasNativeDarkTheme();
+
+    if ( TDHasNativeDarkTheme() )
+        return;
 
     for (int i = 0; i < static_cast<int>(s.elements.size()); ++i)
     {
@@ -517,10 +519,8 @@ static void TDPaintGlyphs(HDC hdc, TDPageState& s)
                 (hot && s.isExpanded) ? TDLGEBS_EXPANDEDHOVER :
                 hot ? TDLGEBS_HOVER :
                 s.isExpanded ? TDLGEBS_EXPANDEDNORMAL : TDLGEBS_NORMAL;
-            if (!native) {
-                FillRect(hdc, &rcG, s.brSecondary);
-                DrawThemeBackground(s.hTD, hdc, TDLG_EXPANDOBUTTON, st, &rcG, &el.rect);
-            }
+            FillRect(hdc, &rcG, s.brSecondary);
+            DrawThemeBackground(s.hTD, hdc, TDLG_EXPANDOBUTTON, st, &rcG, &el.rect);
         }
         else if (el.automationId == L"VerificationCheckBox" && s.hButton)
         {
@@ -532,10 +532,8 @@ static void TDPaintGlyphs(HDC hdc, TDPageState& s)
                 (hot && s.isChecked) ? CBS_CHECKEDHOT :
                 hot ? CBS_UNCHECKEDHOT :
                 s.isChecked ? CBS_CHECKEDNORMAL : CBS_UNCHECKEDNORMAL;
-            if (!native) {
-                FillRect(hdc, &rcG, s.brSecondary);
-                DrawThemeBackground(s.hButton, hdc, BP_CHECKBOX, st, &rcG, nullptr);
-            }
+            FillRect(hdc, &rcG, s.brSecondary);
+            DrawThemeBackground(s.hButton, hdc, BP_CHECKBOX, st, &rcG, nullptr);
         }
     }
 }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -39,7 +39,6 @@
 #include "wx/msw/private/darkmode.h"
 
 #include "wx/msw/private/comptr.h"
-#include "wx/msw/ole/oleutils.h"
 #include <uiautomation.h>
 
 // ============================================================================
@@ -899,9 +898,9 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lp)
         return TRUE;
     BSTR cls;
     pEl->get_CurrentClassName(&cls);
-    wxBasicString str = wxBasicString(cls);
+
     // SysLink controls (footnote / content hyperlinks)
-    if (wxString(str).IsSameAs(wxS("CCSysLink")))
+    if ( wcscmp(cls, L"CCSysLink") == 0 )
     {
         if ( const HWND hL = GetHWNDFromElement(pEl) )
         {
@@ -915,7 +914,7 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lp)
     }
 
     // Main TaskPage (DirectUI "TaskDialog" class)
-    if (!wxString(str).IsSameAs(wxS("TaskDialog")))
+    if ( wcscmp(cls, L"TaskDialog") != 0 )
         return TRUE;
 
     const HWND hDUI = GetHWNDFromElement(pEl);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -631,7 +631,7 @@ static LRESULT CALLBACK TDPageSubclassProc(
     switch (msg)
     {
     case WM_ERASEBKGND:
-        return 1;
+        return TRUE;
 
     case WM_PAINT:
     {

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -249,10 +249,11 @@ static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
 {
     if ( TDHasNativeDarkTheme() )
     {
-        COLORREF c = TDDarkCol::kTextNormal;
-        if (SUCCEEDED(GetThemeColor(s.hTD, uiPart, 0, TMT_TEXTCOLOR, &c)))
-            return c;
+        const wxColour col = s.hTD.GetColour(uiPart, TMT_TEXTCOLOR);
+        if ( col.IsOk() )
+            return wxColourToRGB(col);
     }
+
     switch (uiPart)
     {
     case TDLG_MAININSTRUCTIONPANE:
@@ -512,28 +513,32 @@ static void TDPaintGlyphs(HDC hdc, TDPageState& s)
 
         if (el.automationId == L"ExpandoButton" && s.hTD)
         {
-            SIZE sz = {}; GetThemePartSize(s.hTD, hdc, TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, nullptr, TS_TRUE, &sz);
-            RECT rcG = el.rect; rcG.right = el.rect.left + sz.cx + 3;
+            const int width =
+                s.hTD.GetTrueSize(TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, hdc).x;
+
+            RECT rcG = el.rect; rcG.right = el.rect.left + width + 3;
             int st = (press && s.isExpanded) ? TDLGEBS_EXPANDEDPRESSED :
                 press ? TDLGEBS_PRESSED :
                 (hot && s.isExpanded) ? TDLGEBS_EXPANDEDHOVER :
                 hot ? TDLGEBS_HOVER :
                 s.isExpanded ? TDLGEBS_EXPANDEDNORMAL : TDLGEBS_NORMAL;
             FillRect(hdc, &rcG, s.brSecondary);
-            DrawThemeBackground(s.hTD, hdc, TDLG_EXPANDOBUTTON, st, &rcG, &el.rect);
+            s.hTD.DrawBackground(hdc, rc, TDLG_EXPANDOBUTTON, state, &el.rect);
         }
         else if (el.automationId == L"VerificationCheckBox" && s.hButton)
         {
-            SIZE cs = {}; GetThemePartSize(s.hButton, hdc, BP_CHECKBOX, CBS_UNCHECKEDNORMAL, nullptr, TS_DRAW, &cs);
-            int mg = (el.rect.bottom - el.rect.top - cs.cy) / 3;
-            RECT rcG = { el.rect.left + mg + 1,el.rect.top + mg + 1,el.rect.left + mg + 1 + cs.cx,el.rect.bottom };
+            const wxSize size =
+                s.hButton.GetDrawSize(BP_CHECKBOX, CBS_UNCHECKEDNORMAL, hdc);
+
+            int mg = (el.rect.bottom - el.rect.top - size.y) / 3;
+            RECT rcG = { el.rect.left + mg + 1,el.rect.top + mg + 1,el.rect.left + mg + 1 + size.x,el.rect.bottom };
             int st = (press && s.isChecked) ? CBS_CHECKEDPRESSED :
                 press ? CBS_UNCHECKEDPRESSED :
                 (hot && s.isChecked) ? CBS_CHECKEDHOT :
                 hot ? CBS_UNCHECKEDHOT :
                 s.isChecked ? CBS_CHECKEDNORMAL : CBS_UNCHECKEDNORMAL;
             FillRect(hdc, &rcG, s.brSecondary);
-            DrawThemeBackground(s.hButton, hdc, BP_CHECKBOX, st, &rcG, nullptr);
+            s.hButton.DrawBackground(hdc, rc, BP_CHECKBOX, state);
         }
     }
 }
@@ -575,21 +580,23 @@ static void TDPaintText(HDC hdc, const TDPageState& s)
         }
         else if (el.automationId == L"ExpandoButton" && s.hTD)
         {
-            SIZE sz = {};
-            ::GetThemePartSize(s.hTD, hdc, TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, nullptr, TS_TRUE, &sz);
+            const int width =
+                s.hTD.GetTrueSize(TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, hdc).x;
+
             MARGINS vm = {};
-            ::GetThemeMargins(s.hTD, hdc, TDLG_VERIFICATIONTEXT, 0, TMT_CONTENTMARGINS, nullptr, &vm);
-            rcT.left += sz.cx + vm.cxLeftWidth - 2; rcT.top += 1;
+            s.hTD.GetMargins(vm, TDLG_VERIFICATIONTEXT, TMT_CONTENTMARGINS, 0, hdc);
+            rcT.left += width + vm.cxLeftWidth - 2; rcT.top += 1;
             part = TDLG_EXPANDOTEXT; brBg = s.brSecondary;
             dtF = DT_LEFT | DT_VCENTER | DT_NOPREFIX;
         }
         else if (el.automationId == L"VerificationCheckBox" && s.hButton && s.hTD)
         {
-            SIZE cs = {};
-            ::GetThemePartSize(s.hButton, hdc, BP_CHECKBOX, CBS_UNCHECKEDNORMAL, nullptr, TS_DRAW, &cs);
+            const int width =
+                s.hButton.GetDrawSize(BP_CHECKBOX, CBS_UNCHECKEDNORMAL, hdc).x;
+
             MARGINS tm = {};
-            ::GetThemeMargins(s.hTD, hdc, TDLG_VERIFICATIONTEXT, 0, TMT_CONTENTMARGINS, nullptr, &tm);
-            rcT.left = el.rect.left + cs.cx + tm.cxLeftWidth + 3; rcT.top += 5;
+            s.hTD.GetMargins(tm, TDLG_VERIFICATIONTEXT, TMT_CONTENTMARGINS, 0, hdc);
+            rcT.left = el.rect.left + width + tm.cxLeftWidth + 3; rcT.top += 5;
             part = TDLG_VERIFICATIONTEXT; brBg = s.brSecondary;
             dtF = DT_LEFT | DT_VCENTER | DT_NOPREFIX;
         }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -86,9 +86,9 @@ struct TDPageState
     bool   isDark = false;   // native dark theme available
     bool   themesOk = false;
 
-    HBRUSH brPrimary = nullptr;
-    HBRUSH brSecondary = nullptr;
-    HBRUSH brFootnote = nullptr;
+    AutoHBRUSH brPrimary{TDDarkCol::kPrimary};
+    AutoHBRUSH brSecondary{TDDarkCol::kSecondary};
+    AutoHBRUSH brFootnote{TDDarkCol::kFootnote};
 
     std::vector<TDLayoutElement> elements;
     bool elemsOk = false;
@@ -116,13 +116,6 @@ struct TDPageState
     {
         themesOk = false;
     }
-    void DestroyBrushes()
-    {
-        if (brPrimary) { DeleteObject(brPrimary);   brPrimary = nullptr; }
-        if (brSecondary) { DeleteObject(brSecondary); brSecondary = nullptr; }
-        if (brFootnote) { DeleteObject(brFootnote);  brFootnote = nullptr; }
-    }
-    void Destroy() { CloseThemes(); DestroyBrushes(); elements.clear(); elemsOk = false; }
 };
 
 // Thread-local state map and UIA singleton
@@ -134,7 +127,10 @@ static TDPageState& GetTDPageState(HWND h) { return tls_tdStates[h]; }
 static void DestroyTDPageState(HWND h)
 {
     auto it = tls_tdStates.find(h);
-    if (it != tls_tdStates.end()) { it->second.Destroy(); tls_tdStates.erase(it); }
+    if ( it != tls_tdStates.end() )
+    {
+        tls_tdStates.erase(it);
+    }
 }
 
 // GUID definitions
@@ -228,13 +224,6 @@ static void TDRefreshThemes(HWND hwnd, TDPageState& s)
     resetTheme(s.hButton, btnClass, nullptr);
 
     s.themesOk = true;
-}
-
-static void TDEnsureBrushes(TDPageState& s)
-{
-    if (!s.brPrimary)   s.brPrimary = CreateSolidBrush(TDDarkCol::kPrimary);
-    if (!s.brSecondary) s.brSecondary = CreateSolidBrush(TDDarkCol::kSecondary);
-    if (!s.brFootnote)  s.brFootnote = CreateSolidBrush(TDDarkCol::kFootnote);
 }
 
 static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
@@ -596,7 +585,6 @@ static void TDPaintPage(HWND hwnd, HDC hdcWin, TDPageState& s)
 {
     if (!s.themesOk)
         TDRefreshThemes(hwnd, s);
-    TDEnsureBrushes(s);
 
     RECT rc; GetClientRect(hwnd, &rc);
     HDC hdcBuf = hdcWin;

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Name:        src/msw/taskdlg.cpp
 // Purpose:     Dark mode support for native TaskDialog.
-// Author:      Mohmed Abdel-Fattah
+// Author:      Mohmed Abdel-Fattah (memoarfaa)
 // Created:     2026-06-07
 // Copyright:   (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -755,7 +755,7 @@ TDPageSubclassProc(HWND hwnd,
                    WPARAM wParam,
                    LPARAM lParam,
                    UINT_PTR uId,
-                   DWORD_PTR WXUNUSED(dwRef))
+                   DWORD_PTR dwRef)
 {
     switch ( msg )
     {
@@ -834,6 +834,8 @@ TDPageSubclassProc(HWND hwnd,
             break;
 
         case WM_DESTROY:
+            // Restore the original class brush we had changed.
+            ::SetClassLongPtr(hwnd, GCLP_HBRBACKGROUND, dwRef);
             TDPageState::Destroy(hwnd);
             ::RemoveWindowSubclass(hwnd, TDPageSubclassProc, uId);
             break;
@@ -978,7 +980,7 @@ SetWindowSubclassIfNeeded(HWND hwnd,
     if ( ::GetWindowSubclass(hwnd, proc, uId, &dwRef) )
         return;
 
-    dwRef = reinterpret_cast<DWORD_PTR>(initFunc());
+    dwRef = static_cast<DWORD_PTR>(initFunc());
     if ( !::SetWindowSubclass(hwnd, proc, uId, dwRef) )
     {
         wxLogLastError("SetWindowSubclass");
@@ -1022,7 +1024,7 @@ void TDSubclassContainer(HWND hwndParent, COLORREF bg)
         hwndParent,
         TDCtrlContainerSubclassProc,
         kTDCtrlSubclassId,
-        [bg]() { return GetSolidBrush(bg); }
+        [bg]() { return reinterpret_cast<DWORD_PTR>(GetSolidBrush(bg)); }
     );
 }
 
@@ -1154,21 +1156,6 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     if ( !hDUI )
         return TRUE;
 
-    // Class background brush
-    {
-        HBRUSH nb = GetSolidBrush(TDDarkCol::kSecondary);
-
-        HBRUSH ob = reinterpret_cast<HBRUSH>(
-            ::SetClassLongPtr(hDUI, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb))
-        );
-        if ( ob &&
-                ob != ::GetSysColorBrush(COLOR_WINDOW) &&
-                    ob != ::GetSysColorBrush(COLOR_BTNFACE))
-        {
-            ::DeleteObject(ob);
-        }
-    }
-
     TDApplyToChildren(pEl);
     wxMSWDarkMode::SetTheme(hDUI, L"DarkMode_Explorer");
 
@@ -1183,7 +1170,20 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     s.elemsOk = false;
     TDUpdateLayoutCache(hDUI, s);
 
-    SetWindowSubclassIfNeeded(hDUI, TDPageSubclassProc, kTDPageSubclassId);
+    SetWindowSubclassIfNeeded
+    (
+        hDUI,
+        TDPageSubclassProc,
+        kTDPageSubclassId,
+        [hDUI]()
+        {
+            // Change class background brush when subclassing.
+            const auto newBrush = reinterpret_cast<LONG_PTR>(
+                GetSolidBrush(TDDarkCol::kSecondary)
+            );
+            return ::SetClassLongPtr(hDUI, GCLP_HBRBACKGROUND, newBrush);
+        }
+    );
 
     d->found = true;
     return TRUE;

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -820,12 +820,16 @@ static void TDSubclassContainer(HWND hP, COLORREF bg)
             reinterpret_cast<DWORD_PTR>(CreateSolidBrush(bg)));
 }
 
-static void TDApplyToChildren(IUIAutomationElement* pEl, IUIAutomation* pAuto)
+static void TDApplyToChildren(IUIAutomationElement* pEl)
 {
+    IUIAutomation* const uiAuto = wxTaskDialogDarkModule::GetUIAutomation();
+    if ( !uiAuto )
+        return;
+
     const bool native = TDHasNativeDarkTheme();
 
     wxCOMPtr<IUIAutomationTreeWalker> pW;
-    pAuto->get_ContentViewWalker(&pW);
+    uiAuto->get_ContentViewWalker(&pW);
     if (!pW) return;
     wxCOMPtr<IUIAutomationElement> pChild;
     pW->GetFirstChildElement(pEl, &pChild);
@@ -932,7 +936,7 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
         if (ob && ob != GetSysColorBrush(COLOR_WINDOW) && ob != GetSysColorBrush(COLOR_BTNFACE)) DeleteObject(ob);
     }
 
-    TDApplyToChildren(pEl, uiAuto);
+    TDApplyToChildren(pEl);
     SetWindowTheme(hDUI, L"DarkMode_Explorer", nullptr);
 
     // Initialise per-page state

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -565,6 +565,11 @@ void TDPaintIcons(HDC hdc, const TDPageState& s)
             nullptr,
             DI_NORMAL
         );
+
+        if ( ::DestroyIcon(hIcon) == 0 )
+        {
+            wxLogLastError("DestroyIcon");
+        }
     }
 }
 

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -72,6 +72,38 @@ namespace TDDarkCol
 namespace
 {
 
+// Small helper class freeing BSTR automatically if necessary.
+class AutoBSTR
+{
+public:
+    AutoBSTR() = default;
+
+    AutoBSTR(const AutoBSTR&) = delete;
+    AutoBSTR& operator=(const AutoBSTR&) = delete;
+
+    ~AutoBSTR()
+    {
+        if ( m_bstr )
+            ::SysFreeString(m_bstr);
+    }
+
+    operator const wchar_t*() const
+    {
+        return m_bstr;
+    }
+
+    // May be called once to fill in the BSTR, which will be freed in dtor.
+    BSTR* Out()
+    {
+        wxASSERT_MSG( !m_bstr, "Can't reuse same object" );
+
+        return &m_bstr;
+    }
+
+private:
+    BSTR m_bstr = nullptr;
+};
+
 // Helper function create an HBRUSH from a brush stored in wxTheBrushList.
 // This allows not to recreate the brushes for the same colour and also ensures
 // that the brushes are eventually deleted.
@@ -104,8 +136,8 @@ std::wstring GetCurrentAutomationId(IUIAutomationElement* element)
 {
     std::wstring result;
 
-    BSTR bstr;
-    if ( element->get_CurrentAutomationId(&bstr) == S_OK )
+    AutoBSTR bstr;
+    if ( element->get_CurrentAutomationId(bstr.Out()) == S_OK && bstr )
         result = bstr;
 
     return result;
@@ -379,8 +411,8 @@ void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
 
         info.automationId = GetCurrentAutomationId(pChild);
 
-        BSTR b;
-        if ( pChild->get_CurrentName(&b) == S_OK )
+        AutoBSTR b;
+        if ( pChild->get_CurrentName(b.Out()) == S_OK && b )
             info.name = b;
 
         if ( info.automationId == L"VerificationCheckBox" )
@@ -1124,11 +1156,11 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     if ( FAILED(uiAuto->ElementFromHandle(hwndChild, &pEl)) )
         return TRUE;
 
-    BSTR cls;
-    pEl->get_CurrentClassName(&cls);
+    AutoBSTR cls;
+    pEl->get_CurrentClassName(cls.Out());
 
     // SysLink controls (footnote / content hyperlinks)
-    if ( wcscmp(cls, L"CCSysLink") == 0 )
+    if ( cls && wcscmp(cls, L"CCSysLink") == 0 )
     {
         if ( const HWND hLink = GetHWNDFromElement(pEl) )
         {
@@ -1149,7 +1181,7 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     }
 
     // Main TaskPage (DirectUI "TaskDialog" class)
-    if ( wcscmp(cls, L"TaskDialog") != 0 )
+    if ( cls && wcscmp(cls, L"TaskDialog") != 0 )
         return TRUE;
 
     const HWND hDUI = GetHWNDFromElement(pEl);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -198,29 +198,6 @@ static constexpr UINT_PTR kTDMainSubclassId = 0xDEADBEEFul;
 static constexpr UINT_PTR kTDPageSubclassId = 0xBADF00Dul;
 static constexpr UINT_PTR kTDCtrlSubclassId = 0xC0FFEE01ul;
 
-static int GetWindowDPI(HWND hwnd)
-{
-    typedef UINT(WINAPI* GetDpiForWindow_t)(HWND hwnd);
-    static GetDpiForWindow_t s_pfnGetDpiForWindow = nullptr;
-    static bool s_initDone = false;
-
-    if (!s_initDone)
-    {
-        wxLoadedDLL dllUser32("user32.dll");
-        wxDL_INIT_FUNC(s_pfn, GetDpiForWindow, dllUser32);
-        s_initDone = true;
-    }
-
-    if (s_pfnGetDpiForWindow)
-    {
-        const int dpi = static_cast<int>(s_pfnGetDpiForWindow(hwnd));
-        return dpi;
-    }
-
-    return 0;
-}
-
-
 // ============================================================================
 // TaskDialog theme helpers
 // ============================================================================
@@ -242,7 +219,7 @@ static void TDRefreshThemes(HWND hwnd, TDPageState& s)
 {
     s.CloseThemes();
     s.isDark = TDHasNativeDarkTheme();
-    int dpi = GetWindowDPI(hwnd);
+    const int dpi = wxGetWindowDPI(hwnd).x;
 
     const wchar_t* mainClass = s.isDark
         ? L"DarkMode_Explorer::TaskDialog"
@@ -777,7 +754,7 @@ static LRESULT CALLBACK TDRadioButtonSubclassProc(
     {
         PAINTSTRUCT ps;
         HDC hdc = BeginPaint(hwnd, &ps);
-        int dpi = GetWindowDPI(hwnd);
+        const int dpi = wxGetWindowDPI(hwnd).x;
         auto hStyle = wxUxThemeHandle::NewAtStdDPI(L"TaskDialogStyle");
         auto  hBtn = wxUxThemeHandle::NewAtDPI(nullptr, L"Button",dpi);
         RECT rcC; GetClientRect(hwnd, &rcC);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -1159,8 +1159,11 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     AutoBSTR cls;
     pEl->get_CurrentClassName(cls.Out());
 
+    if ( !cls )
+        return TRUE;
+
     // SysLink controls (footnote / content hyperlinks)
-    if ( cls && wcscmp(cls, L"CCSysLink") == 0 )
+    if ( wcscmp(cls, L"CCSysLink") == 0 )
     {
         if ( const HWND hLink = GetHWNDFromElement(pEl) )
         {
@@ -1181,7 +1184,7 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     }
 
     // Main TaskPage (DirectUI "TaskDialog" class)
-    if ( cls && wcscmp(cls, L"TaskDialog") != 0 )
+    if ( wcscmp(cls, L"TaskDialog") != 0 )
         return TRUE;
 
     const HWND hDUI = GetHWNDFromElement(pEl);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -735,7 +735,17 @@ void TDPaintText(HDC hdc, const TDPageState& s)
             continue;
 
         WinStructWordSize<DTTOPTS> opts;
-        if ( !native )
+        if ( native )
+        {
+            if (part == TDLG_EXPANDEDFOOTERAREA)
+            {
+                WinStructWordSize<DTBGOPTS> optsBg;
+                optsBg.dwFlags = DTBG_OMITBORDER;
+
+                ::DrawThemeBackgroundEx(s.hTD, hdc, TDLG_SECONDARYPANEL, 0, &el.rect, &optsBg);
+            }
+        }
+        else
         {
             opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
             opts.crText = TDGetTextColour(s, part);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -940,22 +940,78 @@ TDRadioButtonSubclassProc(HWND hwnd,
 // Attachment helpers
 // ============================================================================
 
+// Helper which calls SetWindowSubclass() only if the subclass is not already
+// set.
+//
+// This is a simple overload when we don't need to pass any reference data to
+// the subclass procedure.
+void
+SetWindowSubclassIfNeeded(HWND hwnd,
+                           SUBCLASSPROC proc,
+                           UINT_PTR uId)
+{
+    DWORD_PTR dwRef = 0;
+    if ( ::GetWindowSubclass(hwnd, proc, uId, &dwRef) )
+        return;
+
+    if ( !::SetWindowSubclass(hwnd, proc, uId, 0) )
+    {
+        wxLogLastError("SetWindowSubclass");
+    }
+}
+
+// This overload takes a lambda as the last parameter which is called to create
+// the reference data if the subclass needs to be set and to avoid creating any
+// resources passed to the subclass procedure unnecessarily.
+template <typename InitFunc>
+void
+SetWindowSubclassIfNeeded(HWND hwnd,
+                           SUBCLASSPROC proc,
+                           UINT_PTR uId,
+                           InitFunc initFunc)
+{
+    DWORD_PTR dwRef = 0;
+    if ( ::GetWindowSubclass(hwnd, proc, uId, &dwRef) )
+        return;
+
+    dwRef = reinterpret_cast<DWORD_PTR>(initFunc());
+    if ( !::SetWindowSubclass(hwnd, proc, uId, dwRef) )
+    {
+        wxLogLastError("SetWindowSubclass");
+    }
+}
+
+// Remove the subclass if it was installed.
+//
+// Return false if it wasn't.
+bool RemoveWindowSubclassIfNeeded(HWND hwnd, SUBCLASSPROC proc, UINT_PTR uId)
+{
+    DWORD_PTR dwRef = 0;
+    if ( !::GetWindowSubclass(hwnd, proc, uId, &dwRef) )
+        return false;
+
+    if ( !::RemoveWindowSubclass(hwnd, proc, uId) )
+    {
+        wxLogLastError("RemoveWindowSubclass");
+    }
+
+    return true;
+}
+
 void TDSubclassContainer(HWND hwndParent, COLORREF bg)
 {
     if ( !hwndParent )
         return;
 
-    DWORD_PTR dwRef = 0;
-    if ( !::GetWindowSubclass(hwndParent, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &dwRef) )
-    {
-        ::SetWindowSubclass
-        (
-            hwndParent,
-            TDCtrlContainerSubclassProc,
-            kTDCtrlSubclassId,
-            reinterpret_cast<DWORD_PTR>(::CreateSolidBrush(bg))
-        );
-    }
+    // The brush created here is passed to the subclass procedure as reference
+    // data and is deleted in the WM_DESTROY handler there.
+    SetWindowSubclassIfNeeded
+    (
+        hwndParent,
+        TDCtrlContainerSubclassProc,
+        kTDCtrlSubclassId,
+        [bg]() { return ::CreateSolidBrush(bg); }
+    );
 }
 
 void TDApplyToChildren(IUIAutomationElement* pEl)
@@ -1012,9 +1068,7 @@ void TDApplyToChildren(IUIAutomationElement* pEl)
                     }
                     else
                     {
-                        DWORD_PTR dwRef = 0;
-                        if ( !::GetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &dwRef) )
-                            ::SetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, 0);
+                        SetWindowSubclassIfNeeded(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId);
                     }
 
                     TDSubclassContainer(hwndParent, native ? TDDarkCol::kSecondary : TDDarkCol::kPrimary);
@@ -1117,9 +1171,7 @@ BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     s.elemsOk = false;
     TDUpdateLayoutCache(hDUI, s);
 
-    DWORD_PTR dwRef = 0;
-    if ( !::GetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, &dwRef) )
-        ::SetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, 0);
+    SetWindowSubclassIfNeeded(hDUI, TDPageSubclassProc, kTDPageSubclassId);
 
     d->found = true;
     return TRUE;
@@ -1133,18 +1185,12 @@ BOOL CALLBACK TDEnumSysColorProc(HWND h, LPARAM)
 
 BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
 {
-    DWORD_PTR dwRef = 0;
-    if ( ::GetWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId, &dwRef) )
-    {
-        ::RemoveWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId);
+    if ( RemoveWindowSubclassIfNeeded(hChild, TDPageSubclassProc, kTDPageSubclassId) )
         TDPageState::Destroy(hChild);
-    }
 
-    if ( ::GetWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &dwRef) )
-        ::RemoveWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId);
+    RemoveWindowSubclassIfNeeded(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId);
 
-    if ( ::GetWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &dwRef) )
-        ::RemoveWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId);
+    RemoveWindowSubclassIfNeeded(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId);
 
     ::SetWindowTheme(hChild, nullptr, nullptr);
 
@@ -1167,9 +1213,7 @@ void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
     if ( native )
         wxMSWDarkMode::AllowForWindow(hwndTD, L"DarkMode_Explorer", nullptr);
 
-    DWORD_PTR dwRef;
-    if ( !::GetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, &dwRef) )
-        ::SetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, 0);
+    SetWindowSubclassIfNeeded(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId);
 
     // Dark title bar
     wxMSWDarkMode::ConfigureTLW(hwndTD);

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -211,7 +211,7 @@ static constexpr UINT_PTR kTDCtrlSubclassId = 0xC0FFEE01ul;
 
 // Check if the theme with the "dark" name exists and is different from the
 // standard one.
-static bool
+bool
 wxHasRealDarkTheme(const wchar_t* stdClass, const wchar_t* darkClass)
 {
     const auto darkTheme = wxUxThemeHandle::NewAtStdDPI(darkClass);
@@ -226,7 +226,7 @@ wxHasRealDarkTheme(const wchar_t* stdClass, const wchar_t* darkClass)
 }
 
 // Cached probe: does the OS have a native dark TaskDialog theme (Win11+)?
-static bool TDHasNativeDarkTheme()
+bool TDHasNativeDarkTheme()
 {
     static int s_hasDarkTheme = -1;
     if ( s_hasDarkTheme == -1 )
@@ -238,7 +238,7 @@ static bool TDHasNativeDarkTheme()
     return s_hasDarkTheme == 1;
 }
 
-static void TDRefreshThemes(HWND hwnd, TDPageState& s)
+void TDRefreshThemes(HWND hwnd, TDPageState& s)
 {
     const int dpi = wxGetWindowDPI(hwnd).x;
 
@@ -259,7 +259,7 @@ static void TDRefreshThemes(HWND hwnd, TDPageState& s)
     s.themesOk = true;
 }
 
-static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
+COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
 {
     if ( TDHasNativeDarkTheme() )
     {
@@ -293,7 +293,7 @@ static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
 // Icon loading
 // ============================================================================
 
-static HICON TDLoadStockIcon(const TASKDIALOGCONFIG* cfg, bool isMain)
+HICON TDLoadStockIcon(const TASKDIALOGCONFIG* cfg, bool isMain)
 {
     if ( !cfg )
         return nullptr;
@@ -334,7 +334,7 @@ static HICON TDLoadStockIcon(const TASKDIALOGCONFIG* cfg, bool isMain)
 // UIA layout cache
 // ============================================================================
 
-static void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
+void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
 {
     out.clear();
     IUIAutomation* const pAuto = wxTaskDialogDarkModule::GetUIAutomation();
@@ -408,7 +408,7 @@ static void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
     }
 }
 
-static void TDUpdateLayoutCache(HWND hwnd, TDPageState& s)
+void TDUpdateLayoutCache(HWND hwnd, TDPageState& s)
 {
     if ( !s.elemsOk )
     {
@@ -429,7 +429,7 @@ static void TDUpdateLayoutCache(HWND hwnd, TDPageState& s)
         s.isChecked = true;
 }
 
-static int TDHitTest(const std::vector<TDLayoutElement>& els, POINT pt)
+int TDHitTest(const std::vector<TDLayoutElement>& els, POINT pt)
 {
     for ( int i = 0; i < wxSsize(els); ++i )
     {
@@ -444,7 +444,7 @@ static int TDHitTest(const std::vector<TDLayoutElement>& els, POINT pt)
 // Paint routines
 // ============================================================================
 
-static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
+void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
 {
     RGBQUAD* pPx = nullptr;
     int rw = 0;
@@ -509,7 +509,7 @@ static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
     }
 }
 
-static void TDPaintIcons(HDC hdc, const TDPageState& s)
+void TDPaintIcons(HDC hdc, const TDPageState& s)
 {
     if ( !s.pCfg || TDHasNativeDarkTheme() )
         return;
@@ -551,7 +551,7 @@ static void TDPaintIcons(HDC hdc, const TDPageState& s)
     }
 }
 
-static void TDPaintGlyphs(HDC hdc, TDPageState& s)
+void TDPaintGlyphs(HDC hdc, TDPageState& s)
 {
     if ( !s.hTD && !s.hButton )
         return;
@@ -609,7 +609,7 @@ static void TDPaintGlyphs(HDC hdc, TDPageState& s)
     }
 }
 
-static void TDPaintText(HDC hdc, const TDPageState& s)
+void TDPaintText(HDC hdc, const TDPageState& s)
 {
     if ( !s.hTD )
         return;
@@ -693,7 +693,7 @@ static void TDPaintText(HDC hdc, const TDPageState& s)
     }
 }
 
-static void TDPaintPage(HWND hwnd, HDC hdcWin, TDPageState& s)
+void TDPaintPage(HWND hwnd, HDC hdcWin, TDPageState& s)
 {
     if ( !s.themesOk )
         TDRefreshThemes(hwnd, s);
@@ -727,7 +727,7 @@ static void TDPaintPage(HWND hwnd, HDC hdcWin, TDPageState& s)
 // Subclass procedures
 // ============================================================================
 
-static LRESULT CALLBACK
+LRESULT CALLBACK
 TDPageSubclassProc(HWND hwnd,
                    UINT msg,
                    WPARAM wParam,
@@ -820,7 +820,7 @@ TDPageSubclassProc(HWND hwnd,
     return ::DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
-static LRESULT CALLBACK
+LRESULT CALLBACK
 TDCtrlContainerSubclassProc(HWND hwnd,
                             UINT msg,
                             WPARAM wParam,
@@ -875,7 +875,7 @@ TDCtrlContainerSubclassProc(HWND hwnd,
     return ::DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
-static LRESULT CALLBACK
+LRESULT CALLBACK
 TDRadioButtonSubclassProc(HWND hwnd,
                           UINT msg,
                           WPARAM wParam,
@@ -940,7 +940,7 @@ TDRadioButtonSubclassProc(HWND hwnd,
 // Attachment helpers
 // ============================================================================
 
-static void TDSubclassContainer(HWND hwndParent, COLORREF bg)
+void TDSubclassContainer(HWND hwndParent, COLORREF bg)
 {
     if ( !hwndParent )
         return;
@@ -958,7 +958,7 @@ static void TDSubclassContainer(HWND hwndParent, COLORREF bg)
     }
 }
 
-static void TDApplyToChildren(IUIAutomationElement* pEl)
+void TDApplyToChildren(IUIAutomationElement* pEl)
 {
     IUIAutomation* const uiAuto = wxTaskDialogDarkModule::GetUIAutomation();
     if ( !uiAuto )
@@ -1046,7 +1046,7 @@ struct TDEnumData
     bool found = false;
 };
 
-static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
+BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
 {
     IUIAutomation* const uiAuto = wxTaskDialogDarkModule::GetUIAutomation();
     if ( !uiAuto )
@@ -1125,13 +1125,13 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
     return TRUE;
 }
 
-static BOOL CALLBACK TDEnumSysColorProc(HWND h, LPARAM)
+BOOL CALLBACK TDEnumSysColorProc(HWND h, LPARAM)
 {
     ::SendMessage(h, WM_SYSCOLORCHANGE, 0, 0);
     return TRUE;
 }
 
-static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
+BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
 {
     DWORD_PTR dwRef = 0;
     if ( ::GetWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId, &dwRef) )
@@ -1151,7 +1151,7 @@ static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
     return TRUE;
 }
 
-static void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
+void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
 {
     const bool native = TDHasNativeDarkTheme();
 
@@ -1179,7 +1179,7 @@ static void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
     ::SendMessage(hwndTD, WM_THEMECHANGED, 0, 0);
 }
 
-static void TDDetach(HWND hwndTD)
+void TDDetach(HWND hwndTD)
 {
     ::EnumChildWindows(hwndTD, TDEnumDetachProc, 0);
 }

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -881,21 +881,25 @@ static void TDApplyToChildren(IUIAutomationElement* pEl, IUIAutomation* pAuto)
     }
 }
 
-// EnumData is used by TDEnumAttachProc below, so it lives at namespace scope.
+// EnumData is used by TDEnumAttachProc below to get the input parameters and
+// return the "found" result.
 struct TDEnumData
 {
-    HWND hwndTD;
-    const TASKDIALOGCONFIG* pCfg;
-    IUIAutomation* pAuto;
-    bool found;
+    HWND hwndTD = 0;
+    const TASKDIALOGCONFIG* pCfg = nullptr;
+    bool found = false;
 };
 
 static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
 {
-    TDEnumData* d = reinterpret_cast<TDEnumData*>(lparam);
+    IUIAutomation* const uiAuto = wxTaskDialogDarkModule::GetUIAutomation();
+    if ( !uiAuto )
+        return FALSE;
+
     wxCOMPtr<IUIAutomationElement> pEl;
-    if (FAILED(d->pAuto->ElementFromHandle(hwndChild, &pEl)))
+    if ( FAILED(uiAuto->ElementFromHandle(hwndChild, &pEl)) )
         return TRUE;
+
     BSTR cls;
     pEl->get_CurrentClassName(&cls);
 
@@ -928,10 +932,11 @@ static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lparam)
         if (ob && ob != GetSysColorBrush(COLOR_WINDOW) && ob != GetSysColorBrush(COLOR_BTNFACE)) DeleteObject(ob);
     }
 
-    TDApplyToChildren(pEl, d->pAuto);
+    TDApplyToChildren(pEl, uiAuto);
     SetWindowTheme(hDUI, L"DarkMode_Explorer", nullptr);
 
     // Initialise per-page state
+    TDEnumData* const d = reinterpret_cast<TDEnumData*>(lparam);
     TDPageState& s = TDPageState::Get(hDUI);
     s.pCfg = d->pCfg;
     s.defExpanded = d->pCfg && (d->pCfg->dwFlags & TDF_EXPANDED_BY_DEFAULT);
@@ -973,12 +978,11 @@ static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
 
 static void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
 {
-    IUIAutomation* const pAuto = wxTaskDialogDarkModule::GetUIAutomation();
-    if (!pAuto)
-        return;
     const bool native = TDHasNativeDarkTheme();
 
-    TDEnumData data = { hwndTD,pCfg,pAuto,false };
+    TDEnumData data;
+    data.hwndTD = hwndTD;
+    data.pCfg = pCfg;
 
     EnumChildWindows(hwndTD, TDEnumAttachProc, reinterpret_cast<LPARAM>(&data));
 

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -95,23 +95,10 @@ struct TDPageState
     TDPageState()
         : hTD(wxUxThemeHandle::NewAtStdDPI(L"")),   // Invalid class -> empty handle
         hTDS(wxUxThemeHandle::NewAtStdDPI(L"")),
-        hButton(wxUxThemeHandle::NewAtStdDPI(L"")),
-        isDark(false),
-        themesOk(false),
-        brPrimary(nullptr),
-        brSecondary(nullptr),
-        brFootnote(nullptr),
-        elemsOk(false),
-        tracking(false),
-        pressing(false),
-        hotIdx(-1),
-        isExpanded(false),
-        isChecked(false),
-        defExpanded(false),
-        defChecked(false),
-        pCfg(nullptr)
+        hButton(wxUxThemeHandle::NewAtStdDPI(L""))
     {
     }
+
     // Mouse interaction (message-driven, no polling)
     bool tracking = false;
     bool pressing = false;

--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -1,0 +1,1019 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        src/msw/taskdlg.cpp
+// Purpose:     Dark mode support for native TaskDialog.
+// Author:      Mohmed Abdel-Fattah
+// Created:     2026-06-07
+// Copyright:   (c) 2026 wxWidgets development team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+// ============================================================================
+// declarations
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+// for compilers that support precompilation, includes "wx.h".
+#include "wx/wxprec.h"
+
+#ifndef wxUSE_DARK_MODE
+    // Otherwise enable it by default.
+    #define wxUSE_DARK_MODE 1
+#endif
+
+#ifndef WX_PRECOMP
+#endif // WX_PRECOMP
+
+#include "wx/msw/private/taskdlg.h"
+
+#if wxUSE_DARK_MODE
+
+#include "wx/dynlib.h"
+
+#include "wx/msw/uxtheme.h"
+
+#include "wx/msw/private/darkmode.h"
+
+#include "wx/msw/private/comptr.h"
+#include "wx/msw/ole/oleutils.h"
+#include <uiautomation.h>
+
+#define GET_B(c) static_cast<BYTE>((c) & 0xFF)
+#define GET_G(c) static_cast<BYTE>(((c) >> 8) & 0xFF)
+#define GET_R(c) static_cast<BYTE>(((c) >> 16) & 0xFF)
+
+// ============================================================================
+// TaskDialog dark mode — implementation detail types
+// ============================================================================
+
+// Colour palette used for the dark TaskDialog panels.
+// Values match wxDarkModeSettings::GetColour() so dialogs blend with the app.
+namespace TDDarkCol
+{
+    static constexpr COLORREF kPrimary = RGB(0x20, 0x20, 0x20);
+    static constexpr COLORREF kSecondary = RGB(0x2c, 0x2c, 0x2c);
+    static constexpr COLORREF kFootnote = RGB(0x2c, 0x2c, 0x2c);
+    static constexpr COLORREF kSeparator = RGB(0x3c, 0x3c, 0x3c);
+
+    static constexpr COLORREF kTextNormal = RGB(0xe0, 0xe0, 0xe0);
+    static constexpr COLORREF kTextInstruct = RGB(0x00, 0x99, 0xff);
+    static constexpr COLORREF kTextContent = RGB(0xe0, 0xe0, 0xe0);
+    static constexpr COLORREF kTextExpando = RGB(0xe0, 0xe0, 0xe0);
+    static constexpr COLORREF kTextVerify = RGB(0xe0, 0xe0, 0xe0);
+    static constexpr COLORREF kTextFootnote = RGB(0xb0, 0xb0, 0xb0);
+    static constexpr COLORREF kTextFtrExp = RGB(0xb0, 0xb0, 0xb0);
+    static constexpr COLORREF kTextRadio = RGB(0xe0, 0xe0, 0xe0);
+}
+namespace
+{
+// Cached bounding rect + metadata for a single TaskDialog UI element.
+struct TDLayoutElement
+{
+    RECT         rect = {};
+    std::wstring automationId;
+    std::wstring name;        // visible text (used for overdraw)
+    LONG         legacyState = 0; // STATE_SYSTEM_* flags
+};
+
+// All per-dialog rendering state, stored in a thread_local map.
+struct TDPageState
+{
+    wxUxThemeHandle hTD ; // TaskDialog panel + glyph parts
+    wxUxThemeHandle hTDS ; // TaskDialogStyle / text fonts
+    wxUxThemeHandle hButton ; // Button (checkbox glyph)
+    bool   isDark = false;   // native dark theme available
+    bool   themesOk = false;
+
+    HBRUSH brPrimary = nullptr;
+    HBRUSH brSecondary = nullptr;
+    HBRUSH brFootnote = nullptr;
+
+    std::vector<TDLayoutElement> elements;
+    bool elemsOk = false;
+    TDPageState()
+        : hTD(wxUxThemeHandle::NewAtStdDPI(L"")),   // Invalid class -> empty handle
+        hTDS(wxUxThemeHandle::NewAtStdDPI(L"")),
+        hButton(wxUxThemeHandle::NewAtStdDPI(L"")),
+        isDark(false),
+        themesOk(false),
+        brPrimary(nullptr),
+        brSecondary(nullptr),
+        brFootnote(nullptr),
+        elemsOk(false),
+        tracking(false),
+        pressing(false),
+        hotIdx(-1),
+        isExpanded(false),
+        isChecked(false),
+        defExpanded(false),
+        defChecked(false),
+        pCfg(nullptr)
+    {
+    }
+    // Mouse interaction (message-driven, no polling)
+    bool tracking = false;
+    bool pressing = false;
+    int  hotIdx = -1;
+
+    // Logical dialog state
+    bool isExpanded = false;
+    bool isChecked = false;
+    bool defExpanded = false;
+    bool defChecked = false;
+
+    const TASKDIALOGCONFIG* pCfg = nullptr;
+
+    void CloseThemes()
+    {
+        themesOk = false;
+    }
+    void DestroyBrushes()
+    {
+        if (brPrimary) { DeleteObject(brPrimary);   brPrimary = nullptr; }
+        if (brSecondary) { DeleteObject(brSecondary); brSecondary = nullptr; }
+        if (brFootnote) { DeleteObject(brFootnote);  brFootnote = nullptr; }
+    }
+    void Destroy() { CloseThemes(); DestroyBrushes(); elements.clear(); elemsOk = false; }
+};
+
+// Thread-local state map and UIA singleton
+static thread_local std::unordered_map<HWND, TDPageState> tls_tdStates;
+static thread_local wxCOMPtr<IUIAutomation>                 tls_tdAutomation;
+
+static TDPageState& GetTDPageState(HWND h) { return tls_tdStates[h]; }
+
+static void DestroyTDPageState(HWND h)
+{
+    auto it = tls_tdStates.find(h);
+    if (it != tls_tdStates.end()) { it->second.Destroy(); tls_tdStates.erase(it); }
+}
+
+// GUID definitions
+// {ff48dba4-60ef-4201-aa87-54103eef594e}
+const GUID CLSID_CUIAutomation = { 0xff48dba4, 0x60ef, 0x4201, { 0xaa, 0x87, 0x54, 0x10, 0x3e, 0xef, 0x59, 0x4e } };
+
+// Also usually paired with the IID for IUIAutomation:
+// {30cbe57d-d9d0-452a-ab13-7ac5ac4825ee}
+const IID IID_IUIAutomation = { 0x30cbe57d, 0xd9d0, 0x452a, { 0xab, 0x13, 0x7a, 0xc5, 0xac, 0x48, 0x25, 0xee } };
+// Function to get IUIAutomation instance
+static IUIAutomation* GetTDAutomation()
+{
+    if (!tls_tdAutomation)
+    {
+        HRESULT hr = CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER, IID_IUIAutomation, reinterpret_cast<void**>(&tls_tdAutomation));
+        if (FAILED(hr))
+        {
+            tls_tdAutomation = nullptr;
+        }
+    }
+    return tls_tdAutomation;
+}
+// Subclass IDs
+static constexpr UINT_PTR kTDMainSubclassId = 0xDEADBEEFul;
+static constexpr UINT_PTR kTDPageSubclassId = 0xBADF00Dul;
+static constexpr UINT_PTR kTDCtrlSubclassId = 0xC0FFEE01ul;
+
+static int GetWindowDPI(HWND hwnd)
+{
+    typedef UINT(WINAPI* GetDpiForWindow_t)(HWND hwnd);
+    static GetDpiForWindow_t s_pfnGetDpiForWindow = nullptr;
+    static bool s_initDone = false;
+
+    if (!s_initDone)
+    {
+        wxLoadedDLL dllUser32("user32.dll");
+        wxDL_INIT_FUNC(s_pfn, GetDpiForWindow, dllUser32);
+        s_initDone = true;
+    }
+
+    if (s_pfnGetDpiForWindow)
+    {
+        const int dpi = static_cast<int>(s_pfnGetDpiForWindow(hwnd));
+        return dpi;
+    }
+
+    return 0;
+}
+
+
+// ============================================================================
+// TaskDialog theme helpers
+// ============================================================================
+
+// Cached probe: does the OS have a native dark TaskDialog theme (Win11+)?
+static bool TDHasNativeDarkTheme()
+{
+    static int s_cached = -1;
+    if (s_cached == -1)
+    {
+       wxUxThemeHandle hD (wxUxThemeHandle::NewAtStdDPI( L"DarkMode_DarkTheme::TaskDialog"));
+       wxUxThemeHandle hB(wxUxThemeHandle::NewAtStdDPI(L"TaskDialog"));
+        s_cached = (hD && hD != hB) ? 1 : 0;
+    }
+    return s_cached == 1;
+}
+
+static void TDRefreshThemes(HWND hwnd, TDPageState& s)
+{
+    s.CloseThemes();
+    s.isDark = TDHasNativeDarkTheme();
+    int dpi = GetWindowDPI(hwnd);
+    auto resetTheme = [&](wxUxThemeHandle& member, const wchar_t* classes, const wchar_t* classesDark)
+        {
+            // Destroy the old handle
+            member.~wxUxThemeHandle();
+            // Create a new temporary using the factory, then move-construct in place
+            new (&member) wxUxThemeHandle(wxUxThemeHandle::NewAtDPI(hwnd, classes, classesDark, dpi));
+        };
+
+    const wchar_t* mainClass = s.isDark
+        ? L"DarkMode_Explorer::TaskDialog"
+        : L"TaskDialog";
+    const wchar_t* btnClass = s.isDark
+        ? L"DarkMode_Explorer::Button" : L"Button";
+    // For TaskDialog style, likely same as mainClass; could be different.
+    const wchar_t* mainClassDark = s.isDark ? L"DarkMode_Explorer::TaskDialog" : nullptr; // or nullptr if not needed
+
+    resetTheme(s.hTD, mainClass, mainClassDark);
+    resetTheme(s.hTDS, mainClass, mainClassDark);
+    resetTheme(s.hButton, btnClass, nullptr);
+
+    s.themesOk = true;
+}
+
+static void TDEnsureBrushes(TDPageState& s)
+{
+    if (!s.brPrimary)   s.brPrimary = CreateSolidBrush(TDDarkCol::kPrimary);
+    if (!s.brSecondary) s.brSecondary = CreateSolidBrush(TDDarkCol::kSecondary);
+    if (!s.brFootnote)  s.brFootnote = CreateSolidBrush(TDDarkCol::kFootnote);
+}
+
+static COLORREF TDGetTextColour(const TDPageState& s, int uiPart)
+{
+    if (s.isDark && s.hTDS)
+    {
+        COLORREF c = TDDarkCol::kTextNormal;
+        if (SUCCEEDED(GetThemeColor(s.hTDS, uiPart, 0, TMT_TEXTCOLOR, &c)))
+            return c;
+    }
+    switch (uiPart)
+    {
+    case TDLG_MAININSTRUCTIONPANE:
+        return TDDarkCol::kTextInstruct;
+    case TDLG_CONTENTPANE:
+        return TDDarkCol::kTextContent;
+    case TDLG_EXPANDOTEXT:
+        return TDDarkCol::kTextExpando;
+    case TDLG_VERIFICATIONTEXT:
+        return TDDarkCol::kTextVerify;
+    case TDLG_FOOTNOTEPANE:
+        return TDDarkCol::kTextFootnote;
+    case TDLG_EXPANDEDFOOTERAREA:
+        return TDDarkCol::kTextFtrExp;
+    case TDLG_RADIOBUTTONPANE:
+        return TDDarkCol::kTextRadio;
+    default:
+        return TDDarkCol::kTextNormal;
+    }
+}
+
+// ============================================================================
+// Icon loading
+// ============================================================================
+
+static HICON TDLoadStockIcon(const TASKDIALOGCONFIG* cfg, bool isMain)
+{
+    if (!cfg)
+        return nullptr;
+
+    if (isMain && (cfg->dwFlags & TDF_USE_HICON_MAIN))
+        return cfg->hMainIcon;
+    if (!isMain && (cfg->dwFlags & TDF_USE_HICON_FOOTER))
+        return cfg->hFooterIcon;
+
+    LPCWSTR res = isMain ? cfg->pszMainIcon : cfg->pszFooterIcon;
+    if (!res || !IS_INTRESOURCE(res))
+        return nullptr;
+
+    auto Stock = [](SHSTOCKICONID id) -> HICON
+        {
+         SHSTOCKICONINFO sii = { sizeof(sii)
+        };
+        return SUCCEEDED(SHGetStockIconInfo(id,
+            SHGSI_ICON | SHGSI_LARGEICON, &sii))
+            ? sii.hIcon : nullptr;
+        };
+    if (res == TD_WARNING_ICON)
+        return Stock(SIID_WARNING);
+    if (res == TD_ERROR_ICON)
+        return Stock(SIID_ERROR);
+    if (res == TD_INFORMATION_ICON)
+        return Stock(SIID_INFO);
+    if (res == TD_SHIELD_ICON)
+        return Stock(SIID_SHIELD);
+
+    return nullptr;
+}
+
+// ============================================================================
+// UIA layout cache
+// ============================================================================
+
+static void TDBuildLayoutCache(HWND hwnd, std::vector<TDLayoutElement>& out)
+{
+    out.clear();
+    IUIAutomation* pAuto = GetTDAutomation();
+    if (!pAuto)
+        return;
+
+   wxCOMPtr <IUIAutomationElement> pRoot;
+    if (FAILED(pAuto->ElementFromHandle(hwnd, &pRoot)))
+        return;
+
+    wxCOMPtr<IUIAutomationTreeWalker> pWalker;
+    pAuto->get_ContentViewWalker(&pWalker);
+    if (!pWalker)
+        return;
+
+    wxCOMPtr<IUIAutomationElement> pChild;
+    pWalker->GetFirstChildElement(pRoot, &pChild);
+
+    while (pChild)
+    {
+        TDLayoutElement info{};
+        pChild->get_CurrentBoundingRectangle(&info.rect);
+        ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.left));
+        ScreenToClient(hwnd, reinterpret_cast<POINT*>(&info.rect.right));
+
+        {
+            BSTR b;
+            pChild->get_CurrentAutomationId(&b);
+            if (b) info.automationId = static_cast<LPCWSTR>(b);
+        }
+        {
+            BSTR b;
+            pChild->get_CurrentName(&b);
+            if (b) info.name = static_cast<LPCWSTR>(b);
+        }
+
+        if (info.automationId == L"VerificationCheckBox")
+        {
+            VARIANT v; VariantInit(&v);
+            if (SUCCEEDED(pChild->GetCurrentPropertyValue(
+                UIA_LegacyIAccessibleStatePropertyId, &v)) && v.vt == VT_I4)
+                info.legacyState = v.lVal;
+            VariantClear(&v);
+        }
+
+        if (!info.automationId.empty() && !IsRectEmpty(&info.rect))
+        {
+            const std::wstring& id = info.automationId;
+            if (id == L"MainIcon" || id == L"FootnoteIcon" ||
+                id == L"MainInstruction" || id == L"ContentText" ||
+                id == L"ExpandedFooterText" || id == L"FootnoteText" ||
+                id == L"ExpandoButton" || id == L"VerificationCheckBox" ||
+                id.find(L"RadioButton_") == 0 ||
+                id.find(L"CommandLink_") == 0 ||
+                id.find(L"CommandButton_") == 0)
+            {
+                out.push_back(std::move(info));
+            }
+        }
+
+        wxCOMPtr<IUIAutomationElement> pNext;
+        pWalker->GetNextSiblingElement(pChild, &pNext);
+        pChild = pNext;
+    }
+}
+
+static void TDUpdateLayoutCache(HWND hwnd, TDPageState& s)
+{
+    if (!s.elemsOk)
+    {
+        TDBuildLayoutCache(hwnd, s.elements);
+        s.elemsOk = true;
+    }
+    for (const auto& el : s.elements)
+        if (el.automationId == L"VerificationCheckBox")
+        {
+            s.isChecked = (el.legacyState & STATE_SYSTEM_CHECKED) != 0;
+            break;
+        }
+    if (s.defChecked)
+        s.isChecked = true;
+}
+
+static int TDHitTest(const std::vector<TDLayoutElement>& els, POINT pt)
+{
+    for (int i = 0; i < static_cast<int>(els.size()); ++i)
+        if (PtInRect(&els[i].rect, pt)) return i;
+    return -1;
+}
+
+// ============================================================================
+// Paint routines
+// ============================================================================
+
+static void TDPaintPixelSwap(HPAINTBUFFER hbp, int w, int h)
+{
+    RGBQUAD* pPx = nullptr; int rw = 0;
+    if (FAILED(GetBufferedPaintBits(hbp, &pPx, &rw))) return;
+
+    COLORREF srcPri = RGB(255, 255, 255), srcSec = RGB(240, 240, 240);
+    COLORREF srcSep = RGB(128, 128, 128), srcSp2 = RGB(223, 223, 223);
+
+    wxUxThemeHandle hL (wxUxThemeHandle ::NewAtStdDPI(L"TaskDialog"));
+    if (hL)
+    {
+        GetThemeColor(hL, TDLG_PRIMARYPANEL, 0, TMT_FILLCOLOR, &srcPri);
+        GetThemeColor(hL, TDLG_SECONDARYPANEL, 0, TMT_FILLCOLOR, &srcSec);
+        GetThemeColor(hL, TDLG_FOOTNOTESEPARATOR, 0, TMT_FILLCOLOR, &srcSep);
+    }
+
+    struct Rule { BYTE sR, sG, sB, dR, dG, dB; };
+    const Rule rules[] =
+    {
+        { GET_R(srcPri), GET_G(srcPri), GET_B(srcPri),
+          GET_R(TDDarkCol::kPrimary), GET_G(TDDarkCol::kPrimary), GET_B(TDDarkCol::kPrimary) },
+        { GET_R(srcSec), GET_G(srcSec), GET_B(srcSec),
+          GET_R(TDDarkCol::kSecondary), GET_G(TDDarkCol::kSecondary), GET_B(TDDarkCol::kSecondary) },
+        { GET_R(srcSep), GET_G(srcSep), GET_B(srcSep),
+          GET_R(TDDarkCol::kSeparator), GET_G(TDDarkCol::kSeparator), GET_B(TDDarkCol::kSeparator) },
+        { GET_R(srcSp2), GET_G(srcSp2), GET_B(srcSp2),
+          GET_R(TDDarkCol::kSeparator), GET_G(TDDarkCol::kSeparator), GET_B(TDDarkCol::kSeparator) },
+    };
+
+    for (int y = 0; y < h; ++y)
+    {
+        RGBQUAD* row = pPx + static_cast<ptrdiff_t>(y) * rw;
+        for (int x = 0; x < w; ++x)
+        {
+            RGBQUAD& p = row[x];
+            for (const Rule& r : rules)
+                if (p.rgbRed == r.sR && p.rgbGreen == r.sG && p.rgbBlue == r.sB)
+                {
+                    p.rgbRed = r.dR; p.rgbGreen = r.dG; p.rgbBlue = r.dB;
+                    p.rgbReserved = 55;
+                    break;
+                }
+        }
+    }
+}
+
+static void TDPaintIcons(HDC hdc, const TDPageState& s)
+{
+    if (!s.pCfg || TDHasNativeDarkTheme()) return;
+    for (const auto& el : s.elements)
+    {
+        if (IsRectEmpty(&el.rect)) continue;
+        HICON hIcon = nullptr; HBRUSH brBg = nullptr;
+        if (el.automationId == L"MainIcon")
+        {
+            hIcon = TDLoadStockIcon(s.pCfg, true);
+            brBg = s.brPrimary;
+        }
+        else if (el.automationId == L"FootnoteIcon")
+        {
+            hIcon = TDLoadStockIcon(s.pCfg, false);
+            brBg = s.brFootnote;
+        }
+        if (!hIcon || !brBg) continue;
+        FillRect(hdc, &el.rect, brBg);
+        DrawIconEx(hdc, el.rect.left, el.rect.top, hIcon,
+            el.rect.right - el.rect.left, el.rect.bottom - el.rect.top,
+            0, nullptr, DI_NORMAL);
+    }
+}
+
+static void TDPaintGlyphs(HDC hdc, TDPageState& s)
+{
+    if (!s.hTD && !s.hButton)
+        return;
+    const bool native = TDHasNativeDarkTheme();
+
+    for (int i = 0; i < static_cast<int>(s.elements.size()); ++i)
+    {
+        const TDLayoutElement& el = s.elements[i];
+        if (IsRectEmpty(&el.rect))
+            continue;
+        const bool hot = (i == s.hotIdx), press = hot && s.pressing;
+
+        if (el.automationId == L"ExpandoButton" && s.hTD)
+        {
+            SIZE sz = {}; GetThemePartSize(s.hTD, hdc, TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, nullptr, TS_TRUE, &sz);
+            RECT rcG = el.rect; rcG.right = el.rect.left + sz.cx + 3;
+            int st = (press && s.isExpanded) ? TDLGEBS_EXPANDEDPRESSED :
+                press ? TDLGEBS_PRESSED :
+                (hot && s.isExpanded) ? TDLGEBS_EXPANDEDHOVER :
+                hot ? TDLGEBS_HOVER :
+                s.isExpanded ? TDLGEBS_EXPANDEDNORMAL : TDLGEBS_NORMAL;
+            if (!native) {
+                FillRect(hdc, &rcG, s.brSecondary);
+                DrawThemeBackground(s.hTD, hdc, TDLG_EXPANDOBUTTON, st, &rcG, &el.rect);
+            }
+        }
+        else if (el.automationId == L"VerificationCheckBox" && s.hButton)
+        {
+            SIZE cs = {}; GetThemePartSize(s.hButton, hdc, BP_CHECKBOX, CBS_UNCHECKEDNORMAL, nullptr, TS_DRAW, &cs);
+            int mg = (el.rect.bottom - el.rect.top - cs.cy) / 3;
+            RECT rcG = { el.rect.left + mg + 1,el.rect.top + mg + 1,el.rect.left + mg + 1 + cs.cx,el.rect.bottom };
+            int st = (press && s.isChecked) ? CBS_CHECKEDPRESSED :
+                press ? CBS_UNCHECKEDPRESSED :
+                (hot && s.isChecked) ? CBS_CHECKEDHOT :
+                hot ? CBS_UNCHECKEDHOT :
+                s.isChecked ? CBS_CHECKEDNORMAL : CBS_UNCHECKEDNORMAL;
+            if (!native) {
+                FillRect(hdc, &rcG, s.brSecondary);
+                DrawThemeBackground(s.hButton, hdc, BP_CHECKBOX, st, &rcG, nullptr);
+            }
+        }
+    }
+}
+
+static void TDPaintText(HDC hdc, const TDPageState& s)
+{
+    if (!s.hTDS && !s.hTD)
+        return;
+     const bool native = TDHasNativeDarkTheme();
+
+    for (const auto& el : s.elements)
+    {
+        if (IsRectEmpty(&el.rect))
+            continue;
+        RECT   rcT = el.rect;
+        int    part = 0;
+        HBRUSH brBg = s.brPrimary;
+        DWORD  dtF = DT_LEFT | DT_VCENTER | DT_WORDBREAK | DT_NOPREFIX;
+
+        if (el.automationId == L"MainInstruction")
+        {
+            part = TDLG_MAININSTRUCTIONPANE;
+            brBg = s.brPrimary;
+        }
+        else if (el.automationId == L"ContentText")
+        {
+            part = TDLG_CONTENTPANE;
+            brBg = s.brPrimary;
+        }
+        else if (el.automationId == L"ExpandedFooterText")
+        {
+            part = TDLG_EXPANDEDFOOTERAREA;
+            brBg = s.brFootnote;
+        }
+        else if (el.automationId == L"FootnoteText")
+        {
+            part = TDLG_FOOTNOTEPANE;
+            brBg = s.brFootnote;
+        }
+        else if (el.automationId == L"ExpandoButton" && s.hTD)
+        {
+            SIZE sz = {};
+            ::GetThemePartSize(s.hTD, hdc, TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL, nullptr, TS_TRUE, &sz);
+            MARGINS vm = {};
+            ::GetThemeMargins(s.hTD, hdc, TDLG_VERIFICATIONTEXT, 0, TMT_CONTENTMARGINS, nullptr, &vm);
+            rcT.left += sz.cx + vm.cxLeftWidth - 2; rcT.top += 1;
+            part = TDLG_EXPANDOTEXT; brBg = s.brSecondary;
+            dtF = DT_LEFT | DT_VCENTER | DT_NOPREFIX;
+        }
+        else if (el.automationId == L"VerificationCheckBox" && s.hButton && s.hTD)
+        {
+            SIZE cs = {};
+            ::GetThemePartSize(s.hButton, hdc, BP_CHECKBOX, CBS_UNCHECKEDNORMAL, nullptr, TS_DRAW, &cs);
+            MARGINS tm = {};
+            ::GetThemeMargins(s.hTD, hdc, TDLG_VERIFICATIONTEXT, 0, TMT_CONTENTMARGINS, nullptr, &tm);
+            rcT.left = el.rect.left + cs.cx + tm.cxLeftWidth + 3; rcT.top += 5;
+            part = TDLG_VERIFICATIONTEXT; brBg = s.brSecondary;
+            dtF = DT_LEFT | DT_VCENTER | DT_NOPREFIX;
+        }
+        if (!part)
+            continue;
+
+        if (!native)
+        {
+            DTTOPTS opts = { sizeof(opts) }; opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
+            opts.crText = TDGetTextColour(s, part);
+            FillRect(hdc, &rcT, brBg);
+            ::DrawThemeTextEx(s.hTDS ? s.hTDS : s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, &rcT, &opts);
+        }
+        else
+        {
+
+            ::DrawThemeText(s.hTDS ? s.hTDS : s.hTD, hdc, part, 0, el.name.c_str(), -1, dtF, 0, &rcT);
+        }
+    }
+}
+
+static void TDPaintPage(HWND hwnd, HDC hdcWin, TDPageState& s)
+{
+    if (!s.themesOk)
+        TDRefreshThemes(hwnd, s);
+    TDEnsureBrushes(s);
+
+    RECT rc; GetClientRect(hwnd, &rc);
+    HDC hdcBuf = hdcWin;
+    HPAINTBUFFER hbp = BeginBufferedPaint(hdcWin, &rc, BPBF_TOPDOWNDIB, nullptr, &hdcBuf);
+    if (!hbp)
+    {
+        DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcWin), PRF_CLIENT);
+        return;
+    }
+
+    DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcBuf), PRF_CLIENT);
+
+    if (!TDHasNativeDarkTheme())
+    {
+        RECT rcBuf; GetBufferedPaintTargetRect(hbp, &rcBuf);
+        TDPaintPixelSwap(hbp, rcBuf.right - rcBuf.left, rcBuf.bottom - rcBuf.top);
+    }
+
+    TDPaintIcons(hdcBuf, s);
+    TDPaintGlyphs(hdcBuf, s);
+    TDPaintText(hdcBuf, s);
+
+    EndBufferedPaint(hbp, TRUE);
+}
+
+// ============================================================================
+// Subclass procedures
+// ============================================================================
+
+static LRESULT CALLBACK TDPageSubclassProc(
+    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR uId, DWORD_PTR)
+{
+    switch (msg)
+    {
+    case WM_ERASEBKGND:
+        return 1;
+
+    case WM_PAINT:
+    {
+        PAINTSTRUCT ps; HDC hdc = BeginPaint(hwnd, &ps);
+        TDPageState& s = GetTDPageState(hwnd);
+        s.isExpanded = !!GetProp(GetParent(hwnd), L"IsExpanded");
+        s.elemsOk = false;
+        TDUpdateLayoutCache(hwnd, s);
+        TDPaintPage(hwnd, hdc, s);
+        EndPaint(hwnd, &ps);
+        return 0;
+    }
+    case WM_MOUSEMOVE:
+    {
+        TDPageState& s = GetTDPageState(hwnd);
+        if (!s.tracking)
+        {
+            TRACKMOUSEEVENT tme = { sizeof(tme),TME_LEAVE,hwnd,0 };
+            TrackMouseEvent(&tme); s.tracking = true;
+        }
+        POINT pt = { (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam) };
+        int nh = TDHitTest(s.elements, pt);
+        if (nh != s.hotIdx)
+        {
+            s.hotIdx = nh;
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        break;
+    }
+    case WM_MOUSELEAVE:
+    {
+        TDPageState& s = GetTDPageState(hwnd);
+        s.tracking = false;
+        s.pressing = false;
+        if (s.hotIdx != -1)
+        {
+            s.hotIdx = -1;
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        break;
+    }
+    case WM_LBUTTONDOWN:
+        GetTDPageState(hwnd).pressing = true;
+        TDUpdateLayoutCache(hwnd, GetTDPageState(hwnd));
+        InvalidateRect(hwnd, nullptr, FALSE);
+        break;
+    case WM_LBUTTONUP:
+        GetTDPageState(hwnd).pressing = false;
+        TDUpdateLayoutCache(hwnd, GetTDPageState(hwnd));
+        InvalidateRect(hwnd, nullptr, FALSE);
+        break;
+    case WM_THEMECHANGED:
+    {
+        TDPageState& s = GetTDPageState(hwnd);
+        s.CloseThemes(); s.elemsOk = false;
+        InvalidateRect(hwnd, nullptr, FALSE);
+        break;
+    }
+    case WM_DESTROY:
+        DestroyTDPageState(hwnd);
+        RemoveWindowSubclass(hwnd, TDPageSubclassProc, uId);
+        break;
+    }
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+static LRESULT CALLBACK TDCtrlContainerSubclassProc(
+    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR uId, DWORD_PTR dwRef)
+{
+    switch (msg)
+    {
+    case WM_ERASEBKGND:
+        if (dwRef)
+        {
+            HDC hdc = reinterpret_cast<HDC>(wParam); RECT rc; GetClientRect(hwnd, &rc);
+            FillRect(hdc, &rc, reinterpret_cast<HBRUSH>(dwRef)); return 1;
+        }
+        break;
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSCROLLBAR:
+    case WM_CTLCOLORSTATIC:
+    {
+        HDC hdc = reinterpret_cast<HDC>(wParam);
+        COLORREF bg = TDDarkCol::kSecondary;
+        if (dwRef) { LOGBRUSH lb = {}; GetObject(reinterpret_cast<HBRUSH>(dwRef), sizeof(lb), &lb); if (lb.lbStyle == BS_SOLID) bg = lb.lbColor; }
+        SetBkColor(hdc, bg); SetTextColor(hdc, TDDarkCol::kTextNormal);
+        return reinterpret_cast<LRESULT>(dwRef ? reinterpret_cast<HBRUSH>(dwRef) : CreateSolidBrush(TDDarkCol::kSecondary));
+    }
+    case WM_DESTROY:
+        if (dwRef) DeleteObject(reinterpret_cast<HBRUSH>(dwRef));
+        RemoveWindowSubclass(hwnd, TDCtrlContainerSubclassProc, uId);
+        return DefSubclassProc(hwnd, msg, wParam, lParam);
+    }
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+static LRESULT CALLBACK TDRadioButtonSubclassProc(
+    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR uId, DWORD_PTR)
+{
+    if (msg == WM_PAINT)
+    {
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(hwnd, &ps);
+        int dpi = GetWindowDPI(hwnd);
+        auto hStyle = wxUxThemeHandle::NewAtStdDPI(L"TaskDialogStyle");
+        auto  hBtn = wxUxThemeHandle::NewAtDPI(nullptr, L"Button",dpi);
+        RECT rcC; GetClientRect(hwnd, &rcC);
+        HDC hdcBuf = hdc;
+        HPAINTBUFFER hbp = BeginBufferedPaint(hdc, &rcC, BPBF_TOPDOWNDIB, nullptr, &hdcBuf);
+        DefSubclassProc(hwnd, WM_PRINTCLIENT, reinterpret_cast<WPARAM>(hdcBuf), PRF_CLIENT);
+        wchar_t text[512] = {};
+        GetWindowTextW(hwnd, text, static_cast<int>(std::size(text)));
+        auto gs = hBtn.GetTrueSize(BP_RADIOBUTTON, RBS_UNCHECKEDNORMAL);
+        RECT rcT = { gs.x + 2,0,rcC.right,rcC.bottom };
+        DTTOPTS opts = { sizeof(opts) };
+        opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
+        opts.crText = TDDarkCol::kTextNormal;
+        LOGFONT lf = {};
+        if (SUCCEEDED(GetThemeFont(hStyle, hdcBuf, TDLG_RADIOBUTTONPANE, 0, TMT_FONT, &lf)))
+        {
+            HFONT hF = CreateFontIndirect(&lf), hO = static_cast<HFONT>(SelectObject(hdcBuf, hF));
+            DrawThemeTextEx(hStyle, hdcBuf, TDLG_RADIOBUTTONPANE, 0, text, -1, DT_LEFT | DT_VCENTER | DT_END_ELLIPSIS, &rcT, &opts);
+            SelectObject(hdcBuf, hO); DeleteObject(hF);
+        }
+        if (hbp)
+            EndBufferedPaint(hbp, TRUE);
+        EndPaint(hwnd, &ps); return 0;
+    }
+    if (msg == WM_DESTROY)
+        RemoveWindowSubclass(hwnd, TDRadioButtonSubclassProc, uId);
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+// ============================================================================
+// Attachment helpers
+// ============================================================================
+
+static void TDSubclassContainer(HWND hP, COLORREF bg)
+{
+    if (!hP) return;
+    DWORD_PTR ex = 0;
+    if (!GetWindowSubclass(hP, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &ex))
+        SetWindowSubclass(hP, TDCtrlContainerSubclassProc, kTDCtrlSubclassId,
+            reinterpret_cast<DWORD_PTR>(CreateSolidBrush(bg)));
+}
+
+static void TDApplyToChildren(IUIAutomationElement* pEl, IUIAutomation* pAuto)
+{
+    const bool native = TDHasNativeDarkTheme();
+
+    wxCOMPtr<IUIAutomationTreeWalker> pW;
+    pAuto->get_ContentViewWalker(&pW);
+    if (!pW) return;
+    wxCOMPtr<IUIAutomationElement> pChild;
+    pW->GetFirstChildElement(pEl, &pChild);
+
+    while (pChild)
+    {
+        CONTROLTYPEID ct = 0;
+        pChild->get_CurrentControlType(&ct);
+        if (ct == UIA_ButtonControlTypeId || ct == UIA_RadioButtonControlTypeId ||
+            ct == UIA_ProgressBarControlTypeId || ct == UIA_HyperlinkControlTypeId ||
+            ct == UIA_ScrollBarControlTypeId || ct == UIA_PaneControlTypeId)
+        {
+            HWND hBtn = nullptr;
+            pChild->get_CurrentNativeWindowHandle(reinterpret_cast<UIA_HWND*>(&hBtn));
+            if (hBtn)
+            {
+                BSTR bId; pChild->get_CurrentAutomationId(&bId);
+                const std::wstring id(bId ? static_cast<LPCWSTR>(bId) : L"");
+                HWND hP = GetParent(hBtn);
+
+                if (ct == UIA_ProgressBarControlTypeId)
+                {
+                    wxUxThemeHandle hCE = wxUxThemeHandle::NewAtStdDPI(L"DarkMode_CopyEngine::Progress");
+                    wxUxThemeHandle hBase = wxUxThemeHandle::NewAtStdDPI(L"Progress");
+                    bool hasCE = (hCE && hCE != hBase);
+                    SetWindowTheme(hBtn, hasCE ? L"DarkMode_CopyEngine" : L"DarkMode_Explorer", nullptr);
+                }
+                else if (ct == UIA_RadioButtonControlTypeId || id.find(L"RadioButton_") == 0 || ct == UIA_HyperlinkControlTypeId)
+                {
+                    if (native)
+                    {
+                        SetWindowTheme(hBtn, L"DarkMode_DarkTheme", nullptr);
+                    }
+                    else
+                    {
+                        DWORD_PTR ex = 0;
+                        if (!GetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &ex))
+                            SetWindowSubclass(hBtn, TDRadioButtonSubclassProc, kTDCtrlSubclassId, 0);
+                    }
+                    TDSubclassContainer(hP, native ? TDDarkCol::kSecondary : TDDarkCol::kPrimary);
+                }
+                else if (id.find(L"CommandLink_") == 0 || id.find(L"CommandButton_") == 0)
+                {
+                    SetWindowTheme(hBtn, L"DarkMode_Explorer", nullptr);
+                    TDSubclassContainer(hP, TDDarkCol::kSecondary);
+                }
+                else
+                {
+                    SetWindowTheme(hBtn, L"DarkMode_Explorer", nullptr);
+                }
+            }
+        }
+        wxCOMPtr<IUIAutomationElement> pNext; pW->GetNextSiblingElement(pChild, &pNext);
+        pChild = pNext;
+    }
+}
+
+// EnumData is used by TDEnumAttachProc below, so it lives at namespace scope.
+struct TDEnumData
+{
+    HWND hwndTD;
+    const TASKDIALOGCONFIG* pCfg;
+    IUIAutomation* pAuto;
+    bool found;
+};
+
+static BOOL CALLBACK TDEnumAttachProc(HWND hwndChild, LPARAM lp)
+{
+    TDEnumData* d = reinterpret_cast<TDEnumData*>(lp);
+    wxCOMPtr<IUIAutomationElement> pEl;
+    if (FAILED(d->pAuto->ElementFromHandle(hwndChild, &pEl)))
+        return TRUE;
+    BSTR cls;
+    pEl->get_CurrentClassName(&cls);
+    wxBasicString str = wxBasicString(cls);
+    // SysLink controls (footnote / content hyperlinks)
+    if (wxString(str).IsSameAs(wxS("CCSysLink")))
+    {
+        HWND hL = nullptr; pEl->get_CurrentNativeWindowHandle(reinterpret_cast<UIA_HWND*>(&hL));
+        if (hL) {
+            BSTR bId;
+            pEl->get_CurrentAutomationId(&bId);
+            const std::wstring id(bId ? static_cast<LPCWSTR>(bId) : L"");
+            bool isFn = id.find(L"Footnote") != std::wstring::npos || id.find(L"ExpandedFooter") != std::wstring::npos;
+            TDSubclassContainer(GetParent(hL), (isFn && !TDHasNativeDarkTheme()) ? TDDarkCol::kFootnote : TDDarkCol::kPrimary);
+        }
+        return TRUE;
+    }
+
+    // Main TaskPage (DirectUI "TaskDialog" class)
+    if (!wxString(str).IsSameAs(wxS("TaskDialog")))
+        return TRUE;
+    HWND hDUI = nullptr;
+    if (FAILED(pEl->get_CurrentNativeWindowHandle(reinterpret_cast<UIA_HWND*>(&hDUI))) || !hDUI)
+        return TRUE;
+
+    // Class background brush
+    {
+        HBRUSH nb = CreateSolidBrush(TDDarkCol::kSecondary);
+        HBRUSH ob = reinterpret_cast<HBRUSH>(SetClassLongPtr(hDUI, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb)));
+        if (ob && ob != GetSysColorBrush(COLOR_WINDOW) && ob != GetSysColorBrush(COLOR_BTNFACE)) DeleteObject(ob);
+    }
+
+    TDApplyToChildren(pEl, d->pAuto);
+    SetWindowTheme(hDUI, L"DarkMode_Explorer", nullptr);
+
+    // Initialise per-page state
+    TDPageState& s = GetTDPageState(hDUI);
+    s.pCfg = d->pCfg;
+    s.defExpanded = d->pCfg && (d->pCfg->dwFlags & TDF_EXPANDED_BY_DEFAULT);
+    s.defChecked = d->pCfg && (d->pCfg->dwFlags & TDF_VERIFICATION_FLAG_CHECKED);
+    s.isExpanded = GetProp(d->hwndTD, L"IsExpanded");
+    s.isChecked = s.defChecked || GetProp(d->hwndTD, L"IsChecked");
+    s.elemsOk = false;
+    TDUpdateLayoutCache(hDUI, s);
+
+    DWORD_PTR ex = 0;
+    if (!GetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, &ex))
+        SetWindowSubclass(hDUI, TDPageSubclassProc, kTDPageSubclassId, 0);
+
+    d->found = true;
+    return TRUE;
+}
+
+static BOOL CALLBACK TDEnumSysColorProc(HWND h, LPARAM)
+{
+    SendMessage(h, WM_SYSCOLORCHANGE, 0, 0);
+    return TRUE;
+}
+
+static BOOL CALLBACK TDEnumDetachProc(HWND hChild, LPARAM)
+{
+    DWORD_PTR ex = 0;
+    if (GetWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId, &ex))
+    {
+        RemoveWindowSubclass(hChild, TDPageSubclassProc, kTDPageSubclassId); DestroyTDPageState(hChild);
+    }
+    if (GetWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId, &ex))
+        RemoveWindowSubclass(hChild, TDCtrlContainerSubclassProc, kTDCtrlSubclassId);
+    if (GetWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId, &ex))
+        RemoveWindowSubclass(hChild, TDRadioButtonSubclassProc, kTDCtrlSubclassId);
+    SetWindowTheme(hChild, nullptr, nullptr);
+    return TRUE;
+}
+
+static void TDAttach(HWND hwndTD, const TASKDIALOGCONFIG* pCfg)
+{
+    IUIAutomation* pAuto = GetTDAutomation();
+    if (!pAuto)
+        return;
+    const bool native = TDHasNativeDarkTheme();
+
+    TDEnumData data = { hwndTD,pCfg,pAuto,false };
+
+    EnumChildWindows(hwndTD, TDEnumAttachProc, reinterpret_cast<LPARAM>(&data));
+
+    if (!data.found)
+        return;
+
+    if (native)
+        wxMSWDarkMode::AllowForWindow(hwndTD, L"DarkMode_Explorer", nullptr);
+    DWORD_PTR ex;
+    if (!GetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, &ex))
+        SetWindowSubclass(hwndTD, TDCtrlContainerSubclassProc, kTDMainSubclassId, 0);
+    // Dark title bar
+    wxMSWDarkMode::ConfigureTLW(hwndTD);
+    HBRUSH nb = CreateSolidBrush(TDDarkCol::kPrimary);
+    SetClassLongPtr(hwndTD, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR>(nb));
+    EnumChildWindows(hwndTD, TDEnumSysColorProc, 0);
+    SendMessage(hwndTD, WM_THEMECHANGED, 0, 0);
+}
+
+static void TDDetach(HWND hwndTD)
+{
+    EnumChildWindows(hwndTD, TDEnumDetachProc, 0);
+
+} // TDDetach
+} // anonymous namespace
+
+#endif // wxUSE_DARK_MODE
+
+// ----------------------------------------------------------------------------
+// TaskDialog dark mode — public entry points
+// ----------------------------------------------------------------------------
+
+void wxMSWDarkMode::AllowForTaskDialog(HWND hwnd, const TASKDIALOGCONFIG* pCfg)
+{
+#if wxUSE_DARK_MODE
+    if ( !wxMSWDarkMode::IsActive() )
+        return;
+
+    // Ensure COM is initialised for UIA on this thread.
+    // S_FALSE means already initialised by the caller — that is fine.
+    const HRESULT hr = CoInitializeEx(
+        nullptr,
+        COINIT_APARTMENTTHREADED |
+        COINIT_DISABLE_OLE1DDE);
+    if (FAILED(hr) && hr != S_FALSE)
+        return;
+
+    TDAttach(hwnd, pCfg);
+
+    CoUninitialize();
+#endif // wxUSE_DARK_MODE
+}
+
+void wxMSWDarkMode::RemoveFromTaskDialog(HWND hwnd)
+{
+#if wxUSE_DARK_MODE
+    TDDetach(hwnd);
+#endif // wxUSE_DARK_MODE
+}

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -734,8 +734,7 @@ void wxToolBar::MSWSetDarkOrLightMode(SetMode setmode)
 
     // Update the separator above the toolbar which is drawn partially in
     // white by default and so looks very ugly in dark mode.
-    COLORSCHEME colScheme;
-    colScheme.dwSize = sizeof(COLORSCHEME);
+    WinStructWordSize<COLORSCHEME> colScheme;
     colScheme.clrBtnHighlight =
     colScheme.clrBtnShadow = wxSysColourToRGB(wxSYS_COLOUR_WINDOW);
     ::SendMessage(GetHwnd(), TB_SETCOLORSCHEME, 0, (LPARAM)&colScheme);

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -818,9 +818,7 @@ int wxKillAllChildren(long pid, wxSignal sig, wxKillError *krc, int flags)
     }
 
     //Fill in the size of the structure before using it.
-    PROCESSENTRY32 pe;
-    wxZeroMemory(pe);
-    pe.dwSize = sizeof(PROCESSENTRY32);
+    WinStructWordSize<PROCESSENTRY32> pe;
 
     // Walk the snapshot of the processes, and for each process,
     // kill it if its parent is pid.

--- a/src/msw/uxtheme.cpp
+++ b/src/msw/uxtheme.cpp
@@ -110,10 +110,11 @@ wxColour wxUxThemeHandle::GetColour(int part, int prop, int state) const
     return wxRGBToColour(col);
 }
 
-wxSize wxUxThemeHandle::DoGetSize(int part, int state, THEMESIZE ts) const
+wxSize
+wxUxThemeHandle::DoGetSize(HDC hdc, int part, int state, THEMESIZE ts) const
 {
     SIZE size;
-    HRESULT hr = ::GetThemePartSize(m_hTheme, nullptr, part, state, nullptr, ts,
+    HRESULT hr = ::GetThemePartSize(m_hTheme, hdc, part, state, nullptr, ts,
                                     &size);
     if ( FAILED(hr) )
     {
@@ -127,10 +128,51 @@ wxSize wxUxThemeHandle::DoGetSize(int part, int state, THEMESIZE ts) const
     return wxSize{size.cx, size.cy};
 }
 
-void
-wxUxThemeHandle::DrawBackground(HDC hdc, const RECT& rc, int part, int state)
+bool
+wxUxThemeHandle::GetMargins(MARGINS& margins,
+                            int part,
+                            int prop,
+                            int state,
+                            HDC hdc) const
 {
-    HRESULT hr = ::DrawThemeBackground(m_hTheme, hdc, part, state, &rc, nullptr);
+    HRESULT hr = ::GetThemeMargins(m_hTheme, hdc, part, state, prop, nullptr,
+                                   &margins);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError(
+            wxString::Format("GetThemeMargins(%i, %i, %i)", part, state, prop),
+            hr
+        );
+        return false;
+    }
+
+    return true;
+}
+
+bool
+wxUxThemeHandle::GetFont(LOGFONTW& lf, HDC hdc, int part, int state) const
+{
+    HRESULT hr = ::GetThemeFont(m_hTheme, hdc, part, state, TMT_FONT, &lf);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError(
+            wxString::Format("GetThemeFont(%i, %i)", part, state),
+            hr
+        );
+        return false;
+    }
+
+    return true;
+}
+
+void
+wxUxThemeHandle::DrawBackground(HDC hdc,
+                                const RECT& rc,
+                                int part,
+                                int state,
+                                const RECT* rcClip)
+{
+    HRESULT hr = ::DrawThemeBackground(m_hTheme, hdc, part, state, &rc, rcClip);
     if ( FAILED(hr) )
     {
         wxLogApiError(

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3566,12 +3566,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
         case WM_SETTINGCHANGE:
             // Check for the special case of the message which notifies about
             // the colours change.
-            // Note that "ImmersiveColorSet" is set both when switching between
-            // light and dark themes and also when changing high contrast mode,
-            // for which an additional message with "WindowsThemeElement" is
-            // also sent, but we don't need to check for it as handling this
-            // one is enough
-            if ( lParam && wxStrcmp((TCHAR*)lParam, wxT("ImmersiveColorSet")) == 0 )
+            if ( wxIsSystemColourChange(lParam) )
                 processed = HandleSysColorChange();
             else
                 processed = HandleSettingChange(wParam, lParam);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4862,10 +4862,7 @@ wxWindowMSW::MSWOnMeasureItem(int id, WXMEASUREITEMSTRUCT *itemStruct)
 // DPI
 // ---------------------------------------------------------------------------
 
-namespace
-{
-
-static wxSize GetWindowDPI(HWND hwnd)
+wxSize wxGetWindowDPI(HWND hwnd)
 {
     typedef UINT (WINAPI *GetDpiForWindow_t)(HWND hwnd);
     static GetDpiForWindow_t s_pfnGetDpiForWindow = nullptr;
@@ -4885,8 +4882,6 @@ static wxSize GetWindowDPI(HWND hwnd)
     }
 
     return wxSize();
-}
-
 }
 
 /*extern*/
@@ -4979,7 +4974,7 @@ wxSize wxWindowMSW::GetDPI() const
         }
     }
 
-    wxSize dpi = GetWindowDPI(hwnd);
+    wxSize dpi = wxGetWindowDPI(hwnd);
 
     if ( !dpi.x || !dpi.y )
     {


### PR DESCRIPTION
This is #26311 with cleanup and some fixes.

Unfortunately there are still ressource leaks remaining under Windows 10: every time a message box is shown, 3 GDI handles (and 1 USER one) are leaked. I can't figure out what they are: Application Verifier doesn't show anything at all and [GDIView](https://www.nirsoft.net/utils/gdi_handles.html) shows the total number of handles growing while each column remains stable. It also shows the total number increasing by 6, unlike the task manager which only shows 3 leaked handles.

P.S. There are no leaks under Windows 11, but this is not really surprising, a lot of drawing code is skipped entirely there as native dark mode support is available.