### PR TITLE
MSW: Dark mode switching for wxCheckBox and wxRadioButton

### DIFF
--- a/include/wx/msw/ownerdrawnbutton.h
+++ b/include/wx/msw/ownerdrawnbutton.h
@@ -39,6 +39,9 @@ protected:
     // pointers to this class (and protected dtor enforces this).
     ~wxMSWOwnerDrawnButtonBase() = default;
 
+    // Make the control owner drawn or reset it to normal style.
+    void MSWMakeOwnerDrawn(bool ownerDrawn);
+
     // Make the control owner drawn if necessary to implement support for the
     // given foreground colour.
     void MSWMakeOwnerDrawnIfNecessary(const wxColour& colFg);
@@ -73,9 +76,6 @@ protected:
 
 
 private:
-    // Make the control owner drawn or reset it to normal style.
-    void MSWMakeOwnerDrawn(bool ownerDrawn);
-
     // Event handlers used to update the appearance of owner drawn button.
     void OnMouseEnterOrLeave(wxMouseEvent& event);
     void OnMouseLeft(wxMouseEvent& event);
@@ -100,7 +100,7 @@ private:
 template <class T>
 class wxMSWOwnerDrawnButton
     : public T,
-      private wxMSWOwnerDrawnButtonBase
+      protected wxMSWOwnerDrawnButtonBase
 {
 private:
     typedef T Base;

--- a/include/wx/msw/radiobut.h
+++ b/include/wx/msw/radiobut.h
@@ -68,6 +68,7 @@ protected:
     virtual void
         MSWDrawButtonBitmap(wxDC& dc, const wxRect& rect, int flags) override;
 
+    virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
 
 private:
     // common part of all ctors

--- a/src/msw/checkbox.cpp
+++ b/src/msw/checkbox.cpp
@@ -96,10 +96,8 @@ void wxCheckBox::MSWSetDarkOrLightMode(SetMode setmode)
 {
     wxCheckBoxBase::MSWSetDarkOrLightMode(setmode);
 
-    // On Windows 11, the control properly handles switching to dark mode. But
-    // when switching to light mode, the text color remains the same.
-    // On Windows 10, the text color is always wrong.
-    MSWMakeOwnerDrawn(true);
+    // Use owner-draw mode if needed for dark mode or custom text colour
+    MSWMakeOwnerDrawn(wxMSWDarkMode::IsActive() || m_hasFgCol);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/checkbox.cpp
+++ b/src/msw/checkbox.cpp
@@ -96,11 +96,10 @@ void wxCheckBox::MSWSetDarkOrLightMode(SetMode setmode)
 {
     wxCheckBoxBase::MSWSetDarkOrLightMode(setmode);
 
-    // The control properly handles switching to dark mode. But when switching
-    // to light mode, the text color remains the same. We must explicitly
-    // update the color.
-    if ( setmode == SetMode::Change )
-        SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
+    // On Windows 11, the control properly handles switching to dark mode. But
+    // when switching to light mode, the text color remains the same.
+    // On Windows 10, the text color is always wrong.
+    SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/checkbox.cpp
+++ b/src/msw/checkbox.cpp
@@ -99,7 +99,7 @@ void wxCheckBox::MSWSetDarkOrLightMode(SetMode setmode)
     // On Windows 11, the control properly handles switching to dark mode. But
     // when switching to light mode, the text color remains the same.
     // On Windows 10, the text color is always wrong.
-    SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
+    MSWMakeOwnerDrawn(true);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/radiobut.cpp
+++ b/src/msw/radiobut.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/private/window.h"
 #include "wx/renderer.h"
 #include "wx/msw/uxtheme.h"
@@ -336,6 +337,14 @@ int wxRadioButton::MSWGetButtonCheckedFlag() const
 void wxRadioButton::MSWDrawButtonBitmap(wxDC& dc, const wxRect& rect, int flags)
 {
     wxRendererNative::Get().DrawRadioBitmap(this, dc, rect, flags);
+}
+
+void wxRadioButton::MSWSetDarkOrLightMode(SetMode setmode)
+{
+    wxRadioButtonBase::MSWSetDarkOrLightMode(setmode);
+
+    // Use owner-draw mode if needed for dark mode or custom text colour
+    MSWMakeOwnerDrawn(wxMSWDarkMode::IsActive() || m_hasFgCol);
 }
 
 #if wxUSE_ACCESSIBILITY


### PR DESCRIPTION
MSWSetDarkOrLightMode() always sets the text color, for Windows 10. See #26569.

@ryancog I was not able to reproduce one of your two symptoms. Please test this fix.
