### PR TITLE
Correct translation of "Del" key in some languages

### DIFF
--- a/locale/da.po
+++ b/locale/da.po
@@ -226,7 +226,7 @@ msgstr "Slet"
 #: ../src/common/accelcmn.cpp:48
 msgctxt "keyboard key"
 msgid "Del"
-msgstr "Slet"
+msgstr "Del"
 
 #: ../src/common/accelcmn.cpp:49
 msgctxt "keyboard key"

--- a/locale/es.po
+++ b/locale/es.po
@@ -221,7 +221,7 @@ msgstr "Eliminar"
 #: ../src/common/accelcmn.cpp:48
 msgctxt "keyboard key"
 msgid "Del"
-msgstr "Eliminar"
+msgstr "Supr"
 
 #: ../src/common/accelcmn.cpp:49
 msgctxt "keyboard key"

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -230,10 +230,9 @@ msgid "Delete"
 msgstr "&Törlés"
 
 #: ../src/common/accelcmn.cpp:48
-#, fuzzy
 msgctxt "keyboard key"
 msgid "Del"
-msgstr "&Törlés"
+msgstr "Del"
 
 #: ../src/common/accelcmn.cpp:49
 #, fuzzy


### PR DESCRIPTION
Use the key name that is used by Windows itself (for example, on its on-screen keyboard as well as an accelerator in its notepad).

While I am not a native speaker of any of these languages, I think Windows and its applications are a good and reliable source for which keyboard key name should be used in each language.

For the record, the keyboard key names used by Windows were determined under Windows 10.