### PR TITLE
reject out-of-range parent index in LoadCachedBook

### DIFF
--- a/build/cmake/tests/gui/CMakeLists.txt
+++ b/build/cmake/tests/gui/CMakeLists.txt
@@ -98,6 +98,7 @@ set(TEST_GUI_SRC
     image/image.cpp
     image/imagwebp.cpp
     image/rawbmp.cpp
+    html/helpdata.cpp
     html/htmlparser.cpp
     html/htmlwindow.cpp
     html/htmprint.cpp

--- a/src/html/helpdata.cpp
+++ b/src/html/helpdata.cpp
@@ -394,7 +394,16 @@ bool wxHtmlHelpData::LoadCachedBook(wxHtmlBookRecord *book, wxInputStream *f)
         item->book = book;
         int parentShift = CacheReadInt32(f);
         if (parentShift != 0)
+        {
+            // parentShift is a back-reference into the index entries loaded so
+            // far; it comes straight from the (possibly malicious) .cached file
+            // so an out-of-range value would make the subtraction below wrap
+            // around and leave item->parent pointing outside m_index, which is
+            // later dereferenced when the index is sorted.
+            if (parentShift < 0 || (size_t)parentShift > m_index.size())
+                return false;
             item->parent = &m_index[m_index.size() - parentShift];
+        }
         m_index.Add(item);
     }
     return true;

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -263,6 +263,7 @@ TEST_GUI_OBJECTS =  \
 	test_gui_image.o \
 	test_gui_imagwebp.o \
 	test_gui_rawbmp.o \
+	test_gui_helpdata.o \
 	test_gui_htmlparser.o \
 	test_gui_htmlwindow.o \
 	test_gui_htmprint.o \
@@ -1211,6 +1212,9 @@ test_gui_imagwebp.o: $(srcdir)/image/imagwebp.cpp $(TEST_GUI_ODEP)
 
 test_gui_rawbmp.o: $(srcdir)/image/rawbmp.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/image/rawbmp.cpp
+
+test_gui_helpdata.o: $(srcdir)/html/helpdata.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/html/helpdata.cpp
 
 test_gui_htmlparser.o: $(srcdir)/html/htmlparser.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/html/htmlparser.cpp

--- a/tests/html/helpdata.cpp
+++ b/tests/html/helpdata.cpp
@@ -1,0 +1,81 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/html/helpdata.cpp
+// Purpose:     wxHtmlHelpData tests
+// Author:      dxbjavid
+// Copyright:   (c) 2026 wxWidgets dev team
+///////////////////////////////////////////////////////////////////////////////
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+#include "testprec.h"
+
+#if wxUSE_HTML
+
+#include "wx/html/helpdata.h"
+#include "wx/mstream.h"
+
+#include <cstring>
+
+namespace
+{
+
+// helpers writing the .cached binary help book format exactly the way
+// wxHtmlHelpData::SaveCachedBook() does, so the stream we build is what
+// LoadCachedBook() expects to read
+
+void CacheWriteInt32(wxMemoryOutputStream& s, wxInt32 value)
+{
+    wxInt32 x = wxINT32_SWAP_ON_BE(value);
+    s.Write(&x, sizeof(x));
+}
+
+void CacheWriteString(wxMemoryOutputStream& s, const char* str)
+{
+    const size_t len = strlen(str) + 1;
+    CacheWriteInt32(s, (wxInt32)len);
+    s.Write(str, len);
+}
+
+// expose the protected loader
+class TestHelpData : public wxHtmlHelpData
+{
+public:
+    bool DoLoadCachedBook(wxHtmlBookRecord* book, wxInputStream& f)
+    {
+        return LoadCachedBook(book, &f);
+    }
+};
+
+} // anonymous namespace
+
+// A crafted .cached file whose single index entry carries a parent
+// back-reference pointing outside the index must be rejected and must not
+// read out of bounds (it previously did, see helpdata.cpp:LoadCachedBook).
+TEST_CASE("wxHtmlHelpData::BadCachedParent", "[html][help][error]")
+{
+    wxMemoryOutputStream os;
+    CacheWriteInt32(os, 5); // CURRENT_CACHED_BOOK_VERSION
+    CacheWriteInt32(os, 1); // CACHED_BOOK_FORMAT_FLAGS
+
+    CacheWriteInt32(os, 0); // contents count
+
+    CacheWriteInt32(os, 1); // index count
+    CacheWriteString(os, "name");
+    CacheWriteString(os, "page.htm");
+    CacheWriteInt32(os, 1);       // level
+    CacheWriteInt32(os, 1000000); // parentShift, way past the index size
+
+    wxStreamBuffer* buf = os.GetOutputStreamBuffer();
+    wxMemoryInputStream is(buf->GetBufferStart(), buf->GetIntPosition());
+
+    wxHtmlBookRecord book("test.hhp", "", "Test", "page.htm");
+    TestHelpData data;
+
+    // before the fix this indexes m_index out of bounds; with it the file is
+    // simply rejected
+    CHECK( !data.DoLoadCachedBook(&book, is) );
+}
+
+#endif // wxUSE_HTML

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -283,6 +283,7 @@
             image/image.cpp
             image/imagwebp.cpp
             image/rawbmp.cpp
+            html/helpdata.cpp
             html/htmlparser.cpp
             html/htmlwindow.cpp
             html/htmprint.cpp


### PR DESCRIPTION
LoadCachedBook reads each index entry's parent back-reference straight from the .cached file and uses it as m_index[m_index.size() - parentShift] with no check, so a crafted cached file (which can sit inside a .htb help archive opened through AddBook) makes the subtraction wrap and leaves the parent pointer outside the array; that pointer is later dereferenced when the index is sorted at the end of AddBookParam. The change rejects the file when parentShift is negative or larger than the number of index entries loaded so far, matching the existing version and flags checks just above. There's a small test under tests/html that feeds such a cached stream and confirms it is now refused rather than reading out of bounds.