### PR TITLE
Support pen and brush styles in wxSVGGraphicsContext

### DIFF
--- a/include/wx/private/svg.h
+++ b/include/wx/private/svg.h
@@ -26,6 +26,7 @@
 #endif
 
 #include <memory>
+#include <set>
 
 class WXDLLIMPEXP_FWD_CORE wxBitmap;
 
@@ -46,7 +47,7 @@ wxString GetPenStroke(const wxColour& c, int style = wxPENSTYLE_SOLID);
 wxString GetBrushFill(const wxColour& c, int style = wxBRUSHSTYLE_SOLID);
 
 // Returns a <pattern> element definition for hatched brushes, or empty.
-wxString CreateBrushFill(const wxBrush& brush, wxSVGShapeRenderingMode mode);
+wxString CreateBrushFill(const wxBrush& brush, wxSVGShapeRenderingMode mode, wxString& patternName);
 
 // Returns a "shape-rendering=..." attribute fragment.
 wxString GetRenderMode(wxSVGShapeRenderingMode style);
@@ -123,6 +124,9 @@ public:
     // handler on first use). Sets the write-error flag on failure.
     void WriteBitmap(const wxBitmap& bmp, wxCoord x, wxCoord y);
 
+    // Writes a brush fill pattern if it has not been written before
+    void WriteBrushFill(const wxBrush& brush);
+
     // Returns the next gradient/clip id and increments the shared counter.
     size_t GetNextGradientId() { return ms_gradientUniqueId++; }
     size_t GetNextClipId() { return ms_clipUniqueId++; }
@@ -181,6 +185,8 @@ private:
     int m_accessibleGroupDepth = 0;
     int m_layerDepth = 0;
     int m_clipNestingLevel = 0;
+
+    std::set<wxString> m_usedBrushPatterns;
 
     static size_t ms_clipUniqueId;
     static size_t ms_gradientUniqueId;

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -39,6 +39,7 @@
 #include "wx/stdpaths.h"
 #if wxUSE_SVG
 #include "wx/dcsvg.h"
+#include "wx/svggc.h"
 #endif
 #if wxUSE_POSTSCRIPT
 #include "wx/dcps.h"
@@ -2160,6 +2161,12 @@ void MyCanvas::Draw(wxDC& pdc)
             context = m_renderer->CreateContext(*metadc);
         }
 #endif
+#if wxUSE_SVG
+        else if ( wxSVGFileDC *svgdc = wxDynamicCast(&pdc, wxSVGFileDC) )
+        {
+            context = wxSVGGraphicsContext::Create(*svgdc);
+        }
+#endif
         else
         {
             wxFAIL_MSG( "Unknown wxDC kind" );
@@ -2851,15 +2858,6 @@ void MyFrame::OnSave(wxCommandEvent& WXUNUSED(event))
 #if wxUSE_SVG
         if (ext == "svg")
         {
-#if wxUSE_GRAPHICS_CONTEXT
-            // Graphics screen can only be drawn using GraphicsContext
-            if (m_canvas->GetPage() == File_ShowGraphics) {
-                wxLogMessage("Graphics screen can not be saved as SVG.");
-                return;
-            }
-            wxGraphicsRenderer* tempRenderer = m_canvas->GetRenderer();
-            m_canvas->UseGraphicRenderer(nullptr);
-#endif
             wxSize svgSize;
             wxSVGFileDC tempSvgDC(svgSize);
             m_canvas->Draw(tempSvgDC);
@@ -2870,9 +2868,6 @@ void MyFrame::OnSave(wxCommandEvent& WXUNUSED(event))
             wxSVGFileDC svgDC(svgSize, dlg.GetPath(), "Drawing sample");
             svgDC.SetBitmapHandler(new wxSVGBitmapEmbedHandler());
             m_canvas->Draw(svgDC);
-#if wxUSE_GRAPHICS_CONTEXT
-            m_canvas->UseGraphicRenderer(tempRenderer);
-#endif
         }
         else
 #endif

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -2339,8 +2339,10 @@ void MyCanvas::OnMouseMove(wxMouseEvent &event)
         m_currentpoint = wxPoint( xx , yy ) ;
         wxRect newrect ( m_anchorpoint , m_currentpoint ) ;
 
+#if wxUSE_GRAPHICS_CONTEXT
         // This is required with wxMSW to allow per-pixel transparency.
         m_overlay.SetOpacity(-1);
+#endif
 
         wxOverlayDC dc(m_overlay, this);
         PrepareDC(dc);
@@ -2348,12 +2350,21 @@ void MyCanvas::OnMouseMove(wxMouseEvent &event)
         // Note: this must be called on the overlay DC, not wxGCDC.
         dc.Clear();
 
+#if wxUSE_GRAPHICS_CONTEXT
         // Use wxGCDC to ensure that brush transparency is taken into account
         // even under wxMSW where plain wxDC doesn't support it.
         wxGCDC gdc(dc);
         gdc.SetPen( *wxGREY_PEN );
         gdc.SetBrush( wxColour( 192,192,192,64 ) );
         gdc.DrawRectangle( newrect );
+#else
+        // Set the overlay opacity instead of brush transparency.
+        m_overlay.SetOpacity(64);
+
+        dc.SetPen( *wxGREY_PEN );
+        dc.SetBrush( wxColour( 192,192,192 ) );
+        dc.DrawRectangle( newrect );
+#endif
     }
 #else
     wxUnusedVar(event);

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -319,10 +319,10 @@ wxString GetRenderMode(wxSVGShapeRenderingMode style)
     return s;
 }
 
-wxString CreateBrushFill(const wxBrush& brush, wxSVGShapeRenderingMode mode)
+wxString CreateBrushFill(const wxBrush& brush, wxSVGShapeRenderingMode mode, wxString& patternName)
 {
     wxString s;
-    wxString patternName = GetBrushStyleName(brush);
+    patternName = GetBrushStyleName(brush);
 
     if (!patternName.empty())
     {
@@ -1455,13 +1455,7 @@ void wxSVGFileDCImpl::SetBrush(const wxBrush& brush)
 
     m_writer->MarkGraphicsChanged();
 
-    wxString pattern = CreateBrushFill(m_brush, m_writer->GetShapeRenderingMode());
-    if ( !pattern.empty() )
-    {
-        NewGraphicsIfNeeded();
-
-        write(pattern);
-    }
+    m_writer->WriteBrushFill(m_brush);
 }
 
 void wxSVGFileDCImpl::SetPen(const wxPen& pen)
@@ -1813,6 +1807,19 @@ void wxSVGWriter::WriteBitmap(const wxBitmap& bmp, wxCoord x, wxCoord y)
     wxStringOutputStream stream(&m_svgDocument);
     if ( !m_bmpHandler->ProcessBitmap(bmp, x, y, stream) )
         m_writeError = true;
+}
+
+void wxSVGWriter::WriteBrushFill(const wxBrush& brush)
+{
+    if ( !brush.IsOk() )
+        return;
+
+    wxString patternName;
+    wxString pattern = CreateBrushFill(brush, GetShapeRenderingMode(), patternName);
+    if ( !pattern.empty() && !patternName.empty() && m_usedBrushPatterns.insert(patternName).second )
+    {
+        Write(pattern);
+    }
 }
 
 #if wxUSE_GRAPHICS_CONTEXT

--- a/src/common/svggc.cpp
+++ b/src/common/svggc.cpp
@@ -786,6 +786,21 @@ wxSVGGraphicsPenData::wxSVGGraphicsPenData(wxGraphicsRenderer* renderer,
     m_pen.SetColour(info.GetColour());
     m_pen.SetWidth(static_cast<int>(info.GetWidth() + 0.5));
     m_pen.SetStyle(info.GetStyle());
+    m_pen.SetCap(info.GetCap());
+    m_pen.SetJoin(info.GetJoin());
+
+    if (m_pen.GetStyle() == wxPENSTYLE_USER_DASH)
+    {
+        wxDash* dashes;
+        if (int nb_dashes = info.GetDashes(&dashes))
+            m_pen.SetDashes(nb_dashes, dashes);
+    }
+
+    if (m_pen.GetStyle() == wxPENSTYLE_STIPPLE)
+    {
+        m_pen.SetStipple(info.GetStipple());
+    }
+
 }
 
 wxSVGGraphicsBrushData::wxSVGGraphicsBrushData(wxGraphicsRenderer* renderer, const wxBrush& brush)
@@ -1307,7 +1322,11 @@ void wxSVGGraphicsContext::SetBrush(const wxGraphicsBrush& brush)
 
     auto* data = static_cast<wxSVGGraphicsBrushData*>(brush.GetRefData());
     if ( data != nullptr )
+    {
+        m_writer->WriteBrushFill(data->GetBrush());
+
         SyncBrushToDC(data->GetBrush());
+    }
 }
 
 void wxSVGGraphicsContext::SetFont(const wxGraphicsFont& font)
@@ -1408,11 +1427,12 @@ void wxSVGGraphicsContext::StrokePath(const wxGraphicsPath& path)
                                      m_currentPen.GetStyle());
     }
 
+    const wxString penPattern = wxSVG::GetPenPattern(m_currentPen);
     const wxString transform = GetCurrentTransformAttr();
 
     const wxString s = wxString::Format(
-        wxS("  <path d=\"%s\" fill=\"none\" %s stroke-width=\"%d\"%s/>\n"),
-        data->GetDString(), stroke, m_currentPen.GetWidth(), transform);
+        wxS("  <path d=\"%s\" fill=\"none\" %s stroke-width=\"%d\" %s%s/>\n"),
+        data->GetDString(), stroke, m_currentPen.GetWidth(), penPattern, transform);
 
     m_writer->Write(s);
 
@@ -1437,19 +1457,27 @@ void wxSVGGraphicsContext::FillPath(const wxGraphicsPath& path, wxPolygonFillMod
 
     if ( fill.empty() )
     {
+        auto* brushData = static_cast<wxSVGGraphicsBrushData*>(m_brush.GetRefData());
+        if ( brushData )
+            fill = wxSVG::GetBrushPattern(brushData->GetBrush());
+    }
+
+    if ( fill.empty() )
+    {
         fill = m_currentBrush.GetStyle() == wxBRUSHSTYLE_TRANSPARENT
             ? wxString(wxS("fill=\"none\""))
             : wxSVG::GetBrushFill(m_currentBrush.GetColour(),
                                   m_currentBrush.GetStyle());
     }
 
+    const wxString penPattern = wxSVG::GetPenPattern(m_currentPen);
     const wxString transform = GetCurrentTransformAttr();
     const wxString rule = (fillStyle == wxODDEVEN_RULE)
         ? wxS("evenodd") : wxS("nonzero");
 
     const wxString s = wxString::Format(
-        wxS("  <path d=\"%s\" %s fill-rule=\"%s\" stroke=\"none\"%s/>\n"),
-        data->GetDString(), fill, rule, transform);
+        wxS("  <path d=\"%s\" %s fill-rule=\"%s\" stroke=\"none\" %s%s/>\n"),
+        data->GetDString(), fill, rule, penPattern, transform);
 
     m_writer->Write(s);
 

--- a/src/msw/overlay.cpp
+++ b/src/msw/overlay.cpp
@@ -274,6 +274,8 @@ void wxOverlayImpl::SetOpacity(int alpha)
         m_alpha = wxClip(alpha, -1, 255);
     }
     else if ( IsUsingConstantOpacity() )
+#else
+    if ( IsOk() )
 #endif // wxUSE_GRAPHICS_CONTEXT
     {
         m_alpha = wxClip(alpha, 0, 255);


### PR DESCRIPTION
Enable saving as SVG in the drawing sample using graphics context, and enable saving the graphics page as SVG.

Add missing pen and brush styles that `wxSVGFileDC` does support but `wxSVGGraphicsContext` did not.
Prevent SVG patterns with the same ID from being added multiple times, which would not pass SVG validation.

Fix `wxOverlayDC` in the drawing sample when `wxGraphicsContext` is disabled.

@Blake-Madden If possible, please check I didn't break anything. Thanks!