### PR TITLE
webview: add a minimal local HTML RunScript sample

### DIFF
--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -1512,7 +1512,7 @@ public:
 
     /**
         Runs the given JavaScript code.
-        
+
         See @ref wxWebViewScriptResult for information about the script result and
         errors.
 
@@ -1531,10 +1531,10 @@ public:
         @param output The string containing the result of the script execution,
             if not @NULL.
         @return @true if there is a result and @a output is filled.
-        
+
         @note When using @c wxWebViewIE, @a output will contain the string
         representation of the executed JavaScript.
-        
+
         @since 2.9.5
         @see RunScriptAsync()
     */

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -1509,6 +1509,36 @@ public:
 
         @see RunScriptAsync()
     */
+
+    /**
+        Runs the given JavaScript code.
+        
+        See @ref wxWebViewScriptResult for information about the script result and
+        errors.
+
+        A simple example using @c RunScript() is available in
+        @c samples/webview/localhtml. It demonstrates loading a local HTML file
+        into @c wxWebView and calling JavaScript functions from C++ to switch
+        between sections in the displayed page.
+
+        The sample can also be built as a standalone program on systems providing
+        @c wx-config using:
+        @code
+        g++ runscript.cpp -o wxWebViewExample `wx-config --cxxflags --libs std,webview`
+        @endcode
+
+        @param javascript JavaScript code to execute.
+        @param output The string containing the result of the script execution,
+            if not @NULL.
+        @return @true if there is a result and @a output is filled.
+        
+        @note When using @c wxWebViewIE, @a output will contain the string
+        representation of the executed JavaScript.
+        
+        @since 2.9.5
+        @see RunScriptAsync()
+    */
+
     virtual bool RunScript(const wxString& javascript, wxString* output = nullptr) const = 0;
 
     /**

--- a/samples/webview/localhtml/CMakeLists.txt
+++ b/samples/webview/localhtml/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+project(wxWebViewExample LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(wxWidgets REQUIRED COMPONENTS core base webview)
+include(${wxWidgets_USE_FILE})
+
+add_executable(wxWebViewExample
+    runscript.cpp
+)
+
+target_link_libraries(wxWebViewExample ${wxWidgets_LIBRARIES})
+
+add_custom_command(TARGET wxWebViewExample POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_SOURCE_DIR}/runscript.html
+        $<TARGET_FILE_DIR:wxWebViewExample>/runscript.html
+)
+
+add_custom_command(TARGET wxWebViewExample POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_SOURCE_DIR}/runscript.js
+        $<TARGET_FILE_DIR:wxWebViewExample>/runscript.js
+)

--- a/samples/webview/localhtml/runscript.cpp
+++ b/samples/webview/localhtml/runscript.cpp
@@ -1,0 +1,89 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        samples/webview/localhtml/runscript.cpp
+// Purpose:     Simple wxWebView sample loading a local HTML page and executing JavaScript from C++.
+// Author:      Drazen Plavsic <drazen.p@live.com>
+// Created:     2026-06-15
+// Copyright:   (c) 2019 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#include <wx/wx.h>
+#include <wx/webview.h>
+#include <wx/filename.h>
+#include <wx/stdpaths.h>
+
+class RunScriptFrame : public wxFrame
+{
+public:
+    RunScriptFrame()
+        : wxFrame(nullptr, wxID_ANY, "wxWebView Example", wxDefaultPosition, wxSize(900, 600))
+    {
+        auto* panel = new wxPanel(this);
+        auto* mainSizer = new wxBoxSizer(wxVERTICAL);
+        auto* buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+
+        webView_ = wxWebView::New(panel, wxID_ANY);
+
+        auto* page1Button = new wxButton(panel, wxID_ANY, "Show Page 1");
+        auto* page2Button = new wxButton(panel, wxID_ANY, "Show Page 2");
+
+        buttonSizer->Add(page1Button, 0, wxALL, 5);
+        buttonSizer->Add(page2Button, 0, wxALL, 5);
+
+        mainSizer->Add(buttonSizer, 0, wxEXPAND);
+        mainSizer->Add(webView_, 1, wxEXPAND | wxALL, 5);
+
+        panel->SetSizer(mainSizer);
+
+        Bind(wxEVT_BUTTON, &RunScriptFrame::OnShowPage1, this, page1Button->GetId());
+        Bind(wxEVT_BUTTON, &RunScriptFrame::OnShowPage2, this, page2Button->GetId());
+
+        LoadLocalPage();
+    }
+
+private:
+    wxWebView* webView_ = nullptr;
+
+    void LoadLocalPage()
+    {
+        wxFileName file(wxStandardPaths::Get().GetExecutablePath());
+        file.SetFullName("runscript.html");
+
+        if (!file.FileExists())
+        {
+            wxMessageBox("Could not find runscript.html next to executable.", "Error", wxOK | wxICON_ERROR);
+            return;
+        }
+
+        webView_->LoadURL(wxFileName::FileNameToURL(file));
+    }
+
+    void OnShowPage1(wxCommandEvent&)
+    {
+        if (webView_)
+        {
+            webView_->RunScript("showPage('page1');");
+        }
+    }
+
+    void OnShowPage2(wxCommandEvent&)
+    {
+        if (webView_)
+        {
+            webView_->RunScript("showPage('page2');");
+        }
+    }
+};
+
+class MyApp : public wxApp
+{
+public:
+    bool OnInit() override
+    {
+        auto* frame = new RunScriptFrame();
+        frame->Show();
+        return true;
+    }
+};
+
+wxIMPLEMENT_APP(MyApp);

--- a/samples/webview/localhtml/runscript.html
+++ b/samples/webview/localhtml/runscript.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Run Script Demo</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+
+        .page {
+            display: none;
+            padding: 20px;
+            border-radius: 10px;
+            background: white;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+        }
+
+        h1 {
+            margin-top: 0;
+        }
+    </style>
+</head>
+<body onload="showPage('page1')">
+    <div id="page1" class="page">
+        <h1>Page 1</h1>
+        <p>This is the first page.</p>
+        <p>Click the second button in the wxWidgets window to switch to Page 2.</p>
+    </div>
+
+    <div id="page2" class="page">
+        <h1>Page 2</h1>
+        <p>This is the second page.</p>
+        <p>Click the first button in the wxWidgets window to go back to Page 1.</p>
+    </div>
+
+    <script src="runscript.js"></script>
+</body>
+</html>

--- a/samples/webview/localhtml/runscript.js
+++ b/samples/webview/localhtml/runscript.js
@@ -1,0 +1,13 @@
+function showPage(pageId) {
+    const pages = document.querySelectorAll('.page');
+
+    pages.forEach(function(page) {
+        page.style.display = 'none';
+    });
+
+    const selectedPage = document.getElementById(pageId);
+
+    if (selectedPage) {
+        selectedPage.style.display = 'block';
+    }
+}


### PR DESCRIPTION
This PR adds a small wxWebView sample that loads a local HTML file and calls JavaScript from C++ with RunScript().

The goal of this sample is to make wxWebView easier to try out quickly, especially for developers who are new to GUI development with C++ and wxWidgets. A very small, copy-paste-friendly example is often much easier to learn from than a larger demo project, so this sample is intentionally kept minimal and focused.

The idea was inspired by the way C++ reference material often includes small method-level examples that can be copied, compiled, and tested immediately. This sample follows the same approach: it is simple to build, easy to understand, and useful as a starting point for experimenting with wxWebView.

The PR also adds a short documentation reference in webview.h pointing to the sample.