### PR TITLE
Clarify RequestUserAttention() behaviour under wxGTK

### DIFF
--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -388,6 +388,12 @@ public:
         the window icon in the taskbar, and for wxGTK with task bars
         supporting it.
 
+
+        Note that under wxGTK this function relies on support from the
+        desktop environment or window manager: if the current environment
+        does not support window urgency hints, calling this function has no
+        visible effect and no error is reported.
+
     */
     virtual void RequestUserAttention(int flags = wxUSER_ATTENTION_INFO);
 


### PR DESCRIPTION
While using RequestUserAttention() on a Linux/wxGTK setup, I found that the call had no visible effect and produced no error, which made it hard to tell whether the function was failing or my code was wrong. It turned out the desktop environment simply did not support the urgency hint. The current documentation states the function is implemented "for wxGTK with task bars supporting it", but does not make clear that it silently does nothing when the environment lacks this support. This small documentation change clarifies that behaviour to help users avoid the same confusion.