### PR TITLE
avoid uninitialised palette read in wxXPMDecoder::ReadData

### DIFF
--- a/src/common/xpmdecod.cpp
+++ b/src/common/xpmdecod.cpp
@@ -819,9 +819,15 @@ wxImage wxXPMDecoder::ReadData(const char* const* xpm_data)
         }
     }
 #if wxUSE_PALETTE
-    unsigned char* r = new unsigned char[colors_cnt];
-    unsigned char* g = new unsigned char[colors_cnt];
-    unsigned char* b = new unsigned char[colors_cnt];
+    // The header colour count can be larger than the number of entries
+    // actually in the map if a malformed XPM reuses the same key on several
+    // colour lines, as the map then collapses them into a single entry. Build
+    // the palette from the real number of distinct colours so we don't read
+    // past the part of the arrays we filled in below.
+    const size_t palette_cnt = clr_tbl.size();
+    unsigned char* r = new unsigned char[palette_cnt];
+    unsigned char* g = new unsigned char[palette_cnt];
+    unsigned char* b = new unsigned char[palette_cnt];
 
     for (it = clr_tbl.begin(), i = 0; it != clr_tbl.end(); ++it, ++i)
     {
@@ -829,8 +835,8 @@ wxImage wxXPMDecoder::ReadData(const char* const* xpm_data)
         g[i] = it->second.G;
         b[i] = it->second.B;
     }
-    wxASSERT(i == colors_cnt);
-    img.SetPalette(wxPalette(colors_cnt, r, g, b));
+    wxASSERT(i == palette_cnt);
+    img.SetPalette(wxPalette(palette_cnt, r, g, b));
     delete[] r;
     delete[] g;
     delete[] b;

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1680,6 +1680,30 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPMWidthOverflow",
     REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_XPM) );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadXPMDuplicateColourKey",
+                 "[image][xpm][error]")
+{
+    // The colour table declares two colours but reuses the same key on both
+    // lines, so the colour map only ends up with one distinct entry.
+    // wxXPMDecoder::ReadData() sized the palette arrays by the declared colour
+    // count while filling only the entries actually in the map, so the last
+    // palette entry was left uninitialised for wxPalette() to read (and the
+    // wxASSERT() in debug builds fired). The image data itself is valid and
+    // must still load, now with a palette holding only the distinct colour.
+    const std::string xpm = R"(/* XPM */
+"2 1 2 1"
+"a c #ff0000"
+"a c #0000ff"
+"aa"
+)";
+    wxMemoryInputStream mis(xpm.data(), xpm.size());
+    wxImage img;
+    REQUIRE( img.LoadFile(mis, wxBITMAP_TYPE_XPM) );
+#if wxUSE_PALETTE
+    CHECK( img.GetPalette().GetColoursCount() == 1 );
+#endif
+}
+
 #endif // wxUSE_XPM
 
 #if wxUSE_IFF


### PR DESCRIPTION
wxXPMDecoder::ReadData allocates the palette r/g/b arrays from the colour count given in the XPM header but fills them by walking the colour map, so a malformed file that reuses the same key on more than one colour line collapses those lines into a single map entry and leaves the tail of the arrays uninitialised. wxPalette() then copies that uninitialised memory into the palette later returned by GetPalette(), and in debug builds the wxASSERT(i == colors_cnt) at the end fires. The fix sizes the arrays and the palette by the number of distinct colours actually in the map. I added a small test loading such an XPM, which trips the assertion before the change and loads with a one-colour palette after it.