### PR TITLE
Preserve custom colours upon dark mode switch

### DIFF
--- a/include/wx/msw/stattext.h
+++ b/include/wx/msw/stattext.h
@@ -57,8 +57,6 @@ protected:
                                   WXWPARAM wParam,
                                   WXLPARAM lParam) override;
 
-    virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
-
     virtual wxString WXGetVisibleLabel() const override;
     virtual void WXSetVisibleLabel(const wxString& str) override;
 

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -271,8 +271,9 @@ void wxNotebook::MSWSetDarkOrLightMode(SetMode setmode)
 {
     wxNotebookBase::MSWSetDarkOrLightMode(setmode);
 
-    // Background must always be set.
-    SetBackgroundColour(GetDefaultAttributes().colBg);
+    // Background must always be set, unless there is a custom colour.
+    if ( !m_hasBgCol )
+        m_backgroundColour = GetDefaultAttributes().colBg;
 }
 
 int wxNotebook::MSWGetToolTipMessage() const
@@ -1344,19 +1345,19 @@ void wxNotebook::MSWNotebookPaint()
 
 void wxNotebook::OnPaint(wxPaintEvent& event)
 {
-    // We can rely on the default implementation if we don't have a custom
-    // background colour (note that it is always set when using dark mode).
-    if ( !m_hasBgCol )
-    {
-        event.Skip();
-        return;
-    }
-
     if ( wxMSWDarkMode::IsActive() )
     {
         // We can't use default painting in dark mode, it just doesn't work
         // there, whichever theme we use, so draw everything ourselves.
         MSWNotebookPaint();
+        return;
+    }
+
+    // We can rely on the default implementation if we don't have a custom
+    // background colour.
+    if ( !m_hasBgCol )
+    {
+        event.Skip();
         return;
     }
 

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -214,16 +214,6 @@ wxStaticText::MSWHandleMessage(WXLRESULT *result,
     return false;
 }
 
-void wxStaticText::MSWSetDarkOrLightMode(SetMode setmode)
-{
-    wxStaticTextBase::MSWSetDarkOrLightMode(setmode);
-
-    // When switching to light mode, the text color remains the same. We must
-    // explicitly update the color.
-    if ( setmode == SetMode::Change && !m_hasFgCol )
-        m_foregroundColour = GetDefaultAttributes().colFg;
-}
-
 void wxStaticText::SetLabel(const wxString& label)
 {
     // If the label doesn't really change, avoid flicker by not doing anything.

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -220,8 +220,8 @@ void wxStaticText::MSWSetDarkOrLightMode(SetMode setmode)
 
     // When switching to light mode, the text color remains the same. We must
     // explicitly update the color.
-    if ( setmode == SetMode::Change )
-        SetForegroundColour(GetDefaultAttributes().colFg);
+    if ( setmode == SetMode::Change && !m_hasFgCol )
+        m_foregroundColour = GetDefaultAttributes().colFg;
 }
 
 void wxStaticText::SetLabel(const wxString& label)


### PR DESCRIPTION
For wxNotebook and wxStaticText, preserve custom colours upon dark mode switch.

Not sure why wxStaticText::MSWSetDarkOrLightMode() was ever added. The control seems to respond fine to dark mode switching without it.