### PR TITLE
MSW: Dark mode switching for wxWindow

### DIFF
--- a/include/wx/msw/mdi.h
+++ b/include/wx/msw/mdi.h
@@ -226,6 +226,8 @@ public:
 
     void OnIdle(wxIdleEvent& event);
 
+    virtual wxVisualAttributes GetDefaultAttributes() const override;
+
 protected:
     virtual void DoGetScreenPosition(int *x, int *y) const override;
     virtual void DoGetPosition(int *x, int *y) const override;

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -564,15 +564,6 @@ const wxChar *wxApp::GetRegisteredClassName(const wxChar *name,
             return gs_regClassesInfo[n].GetRequestedName(flags);
     }
 
-    // In dark mode, use the dark background brush instead of specified colour
-    // which would result in light background.
-    HBRUSH hbrBackground;
-    if ( wxMSWDarkMode::IsActive() )
-        hbrBackground = wxMSWDarkMode::GetBackgroundBrush();
-    else
-        hbrBackground = (HBRUSH)wxUIntToPtr(bgBrushCol + 1);
-
-
     // we need to register this class
     WNDCLASS wndclass;
     wxZeroMemory(wndclass);
@@ -580,7 +571,7 @@ const wxChar *wxApp::GetRegisteredClassName(const wxChar *name,
     wndclass.lpfnWndProc   = (WNDPROC)wxWndProc;
     wndclass.hInstance     = wxGetInstance();
     wndclass.hCursor       = ::LoadCursor(nullptr, IDC_ARROW);
-    wndclass.hbrBackground = hbrBackground;
+    wndclass.hbrBackground = (HBRUSH)wxUIntToPtr(bgBrushCol + 1);
     wndclass.style         = CS_HREDRAW | CS_VREDRAW | CS_DBLCLKS | extraStyles;
 
 

--- a/src/msw/mdi.cpp
+++ b/src/msw/mdi.cpp
@@ -1466,6 +1466,13 @@ void wxMDIChildFrame::OnIdle(wxIdleEvent& event)
     event.Skip();
 }
 
+wxVisualAttributes wxMDIChildFrame::GetDefaultAttributes() const
+{
+    auto attrs = wxMDIChildFrameBase::GetDefaultAttributes();
+    attrs.colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    return attrs;
+}
+
 // ---------------------------------------------------------------------------
 // private helper functions
 // ---------------------------------------------------------------------------

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5555,6 +5555,24 @@ void wxWindowMSW::MSWSetEraseBgHook(wxWindow *child)
 bool wxWindowMSW::DoEraseBackground(WXHDC hDC)
 {
     HBRUSH hbr = (HBRUSH)MSWGetBgBrush(hDC);
+
+    // If we have no custom brush and we are in dark mode and there is a
+    // system colour background, make a dark mode brush. Otherwise, the
+    // default system erase would be light mode.
+    if ( !hbr && wxMSWDarkMode::IsActive() )
+    {
+        // Get window class background, which is WNDCLASS::hbrBackground.
+        const auto bg = GetClassLongPtr(m_hWnd, GCLP_HBRBACKGROUND);
+        // Check if background is a system colour index plus 1.
+        if ( bg > 0 && bg <= wxSYS_COLOUR_MAX )
+        {
+            // Make brush for that colour.
+            wxColour col = wxSystemSettings::GetColour(wxSystemColour(bg - 1));
+            wxBrush* brush = wxTheBrushList->FindOrCreateBrush(col);
+            hbr = GetHbrushOf(*brush);
+        }
+    }
+
     if ( !hbr )
         return false;
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4118,6 +4118,19 @@ void wxWindowMSW::MSWSetDarkOrLightMode(SetMode WXUNUSED(setmode))
 
     // This updates scroll bars, if there are any.
     wxMSWDarkMode::AllowForWindow(m_hWnd, support.themeName, support.themeId);
+
+    // If the window class has a background brush, update it.
+    // This is the value in WNDCLASS::hbrBackground.
+    if ( GetClassLongPtr(m_hWnd, GCLP_HBRBACKGROUND) != 0 )
+    {
+        // The brush value was originally a colour index plus 1, for example
+        // wxSYS_COLOUR_WINDOW+1. Assume that colour index matches the colour
+        // returned by GetDefaultAttributes().
+        wxColour colBg = GetDefaultAttributes().colBg;
+        wxBrush* brush = wxTheBrushList->FindOrCreateBrush(colBg);
+        HBRUSH hbr = GetHbrushOf(*brush);
+        SetClassLongPtr(m_hWnd, GCLP_HBRBACKGROUND, LONG_PTR(hbr));
+    }
 }
 
 // ===========================================================================
@@ -5555,24 +5568,6 @@ void wxWindowMSW::MSWSetEraseBgHook(wxWindow *child)
 bool wxWindowMSW::DoEraseBackground(WXHDC hDC)
 {
     HBRUSH hbr = (HBRUSH)MSWGetBgBrush(hDC);
-
-    // If we have no custom brush and we are in dark mode and there is a
-    // system colour background, make a dark mode brush. Otherwise, the
-    // default system erase would be light mode.
-    if ( !hbr && wxMSWDarkMode::IsActive() )
-    {
-        // Get window class background, which is WNDCLASS::hbrBackground.
-        const auto bg = GetClassLongPtr(m_hWnd, GCLP_HBRBACKGROUND);
-        // Check if background is a system colour index plus 1.
-        if ( bg > 0 && bg <= wxSYS_COLOUR_MAX )
-        {
-            // Make brush for that colour.
-            wxColour col = wxSystemSettings::GetColour(wxSystemColour(bg - 1));
-            wxBrush* brush = wxTheBrushList->FindOrCreateBrush(col);
-            hbr = GetHbrushOf(*brush);
-        }
-    }
-
     if ( !hbr )
         return false;
 


### PR DESCRIPTION
Default window background erasing responds to dark mode switching for wxWindow and derived windows such as wxPanel. This is done by adapting the default window erasing for dark mode in the background erase handling rather than when the window class is registered. 
