### PR TITLE
Bug: OSS-Fuzz: Deny an unreasonably large header to avoid OOM

### DIFF
--- a/include/wx/tarstrm.h
+++ b/include/wx/tarstrm.h
@@ -166,6 +166,10 @@ public:
     wxFileOffset GetLength() const override      { return m_size; }
     bool IsSeekable() const override { return m_parent_i_stream->IsSeekable(); }
 
+    // Limit on the extended header size, to avoid excessive allocation.
+    static size_t GetMaxExtendedHeaderSize() { return sm_maxExtendedHeaderSize; }
+    static void SetMaxExtendedHeaderSize(size_t size) { sm_maxExtendedHeaderSize = size; }
+
 protected:
     size_t OnSysRead(void *buffer, size_t size) override;
     wxFileOffset OnSysTell() const override      { return m_pos; }
@@ -198,6 +202,8 @@ private:
     class wxTarHeaderBlock *m_hdr;
     wxTarHeaderRecords *m_HeaderRecs;
     wxTarHeaderRecords *m_GlobalHeaderRecs;
+
+    static size_t sm_maxExtendedHeaderSize;
 
     wxDECLARE_NO_COPY_CLASS(wxTarInputStream);
 };

--- a/interface/wx/tarstrm.h
+++ b/interface/wx/tarstrm.h
@@ -91,6 +91,25 @@ public:
         seekable stream.
     */
     bool OpenEntry(wxTarEntry& entry);
+
+    /**
+        Returns the maximum allowed size of a tar extended header.
+
+        @see SetMaxExtendedHeaderSize()
+
+        @since 3.3.3
+    */
+    static size_t GetMaxExtendedHeaderSize();
+
+    /**
+        Sets the maximum allowed size of a tar extended header.
+
+        Extended headers larger than this are rejected to avoid excessive
+        memory allocation. The default is 10 MiB.
+
+        @since 3.3.3
+    */
+    static void SetMaxExtendedHeaderSize(size_t size);
 };
 
 

--- a/src/common/tarstrm.cpp
+++ b/src/common/tarstrm.cpp
@@ -622,6 +622,9 @@ void wxTarEntry::SetMode(int mode)
 /////////////////////////////////////////////////////////////////////////////
 // Input stream
 
+// Default cap of 10 MiB; can be changed with SetMaxExtendedHeaderSize().
+size_t wxTarInputStream::sm_maxExtendedHeaderSize = 10 * 1024 * 1024;
+
 wxTarInputStream::wxTarInputStream(wxInputStream& stream,
                                    wxMBConv& conv /*=wxConvLocal*/)
  :  wxArchiveInputStream(stream, conv)
@@ -909,16 +912,16 @@ bool wxTarInputStream::ReadExtendedHeader(wxTarHeaderRecords*& recs)
     if (!recs)
         recs = new wxTarHeaderRecords;
 
-    // round length up to a whole number of blocks
     size_t len = m_hdr->GetOctal(TAR_SIZE);
 
-    // An extended header just holds metadata records and is meant to be small.
-    static const size_t MAX_EXTENDED_HEADER = 1024 * 1024;
-    if (len > MAX_EXTENDED_HEADER) {
-        wxLogWarning(_("invalid data in extended tar header"));
+    // reject an unreasonably large extended header to avoid excessive allocation
+    if (len > GetMaxExtendedHeaderSize())
+    {
+        wxLogError(_("Extended tar header size %zu is greater than maximum allowed."), len);
         return false;
     }
 
+    // round length up to a whole number of blocks
     size_t size = RoundUpSize(len);
 
     // read in the whole header since it should be small

--- a/src/common/tarstrm.cpp
+++ b/src/common/tarstrm.cpp
@@ -911,6 +911,14 @@ bool wxTarInputStream::ReadExtendedHeader(wxTarHeaderRecords*& recs)
 
     // round length up to a whole number of blocks
     size_t len = m_hdr->GetOctal(TAR_SIZE);
+
+    // An extended header just holds metadata records and is meant to be small.
+    static const size_t MAX_EXTENDED_HEADER = 1024 * 1024;
+    if (len > MAX_EXTENDED_HEADER) {
+        wxLogWarning(_("invalid data in extended tar header"));
+        return false;
+    }
+
     size_t size = RoundUpSize(len);
 
     // read in the whole header since it should be small


### PR DESCRIPTION
This PR adds a guard to deny an unreasonably large header to avoid possible OOM in `wxTarInputStream` processing, discovered by OSS-Fuzz fuzzer (#26588).