### PR TITLE
MSW: Fix dark mode switching for wxStatusBar

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4105,6 +4105,7 @@ WXHWND wxWindowMSW::MSWCreateWindowAtAnyPosition(WXDWORD exStyle, const wxChar* 
 
 void wxWindowMSW::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
+    // This is the default theme name for dark mode.
     // This theme works for a few controls (buttons, texts, comboboxes) and
     // doesn't seem to do any harm for those that don't support it, so use it
     // by default.
@@ -4114,7 +4115,13 @@ void wxWindowMSW::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 void wxWindowMSW::MSWSetDarkOrLightMode(SetMode WXUNUSED(setmode))
 {
     MSWDarkModeSupport support;
-    MSWGetDarkModeSupport(support);
+    if ( wxMSWDarkMode::IsActive() )
+        MSWGetDarkModeSupport(support);
+    else
+    {
+        // This is the theme name for light mode.
+        support.themeName = L"Explorer";
+    }
 
     // This updates scroll bars, if there are any.
     wxMSWDarkMode::AllowForWindow(m_hWnd, support.themeName, support.themeId);


### PR DESCRIPTION
When switching to light mode, always use the theme name L"Explorer" rather than using MSWGetDarkModeSupport(). The theme name and id needed for dark mode does not always work for light mode. For example, the wxStatusBar combination name=nullptr id=L"ExplorerStatusBar" results in an un-themed status bar with strange internal borders and missing gripper.
