### PR TITLE
MSW: Only use DarkMode_DarkTheme if available

### DIFF
--- a/src/gtk/win_gtk.cpp
+++ b/src/gtk/win_gtk.cpp
@@ -438,7 +438,10 @@ void wxPizza::put(GtkWidget* widget, int x, int y, int width, int height)
     // Re-parenting a TLW under a child window is possible at wx level but
     // using a TLW as child at GTK+ level results in problems, so don't do it.
     if (!gtk_widget_is_toplevel(GTK_WIDGET(widget)))
+    {
         gtk_fixed_put(GTK_FIXED(this), widget, 0, 0);
+        gtk_widget_set_size_request(widget, -1, -1);
+    }
 
     wxPizzaChild* child = new wxPizzaChild;
     child->widget = widget;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2678,9 +2678,14 @@ static void frame_clock_layout_after(GdkFrameClock*, wxWindowGTK* win)
 
             wxWindowGTK* w = static_cast<wxWindowGTK*>(p->data);
             g_object_remove_weak_pointer(G_OBJECT(w->m_widget), &p->data);
-            GtkAllocation a;
-            gtk_widget_get_allocation(w->m_widget, &a);
-            gtk_widget_set_size_request(w->m_widget, a.width, a.height);
+            if (WX_IS_PIZZA(gtk_widget_get_parent(w->m_widget)))
+                gtk_widget_queue_resize(w->m_widget);
+            else
+            {
+                GtkAllocation a;
+                gtk_widget_get_allocation(w->m_widget, &a);
+                gtk_widget_set_size_request(w->m_widget, a.width, a.height);
+            }
         }
         g_slist_free(gs_setSizeRequestList);
         gs_setSizeRequestList = nullptr;
@@ -4280,17 +4285,7 @@ void wxWindowGTK::DoMoveWindow(int x, int y, int width, int height)
     {
         pizza = WX_PIZZA(parent);
         pizza->move(m_widget, x, y, width, height);
-        if (
-#ifdef __WXGTK3__
-            !g_inSizeAllocate &&
-#endif
-            gtk_widget_get_visible(m_widget))
-        {
-            // in case only the position is changing
-            gtk_widget_queue_resize(m_widget);
-        }
     }
-
 
 #ifdef __WXGTK3__
     // With GTK3, gtk_widget_queue_resize() is ignored while a size-allocate
@@ -4298,7 +4293,7 @@ void wxWindowGTK::DoMoveWindow(int x, int y, int width, int height)
     // size-allocate can generate wxSizeEvent and size event handlers often
     // call SetSize(), directly or indirectly. It should be fine to call
     // gtk_widget_size_allocate() immediately in this case.
-    if (g_inSizeAllocate && gtk_widget_get_visible(m_widget) && width > 0 && height > 0)
+    if (g_inSizeAllocate)
     {
         // obligatory size request before size allocate to avoid GTK3 warnings
         GtkRequisition req;
@@ -4318,18 +4313,16 @@ void wxWindowGTK::DoMoveWindow(int x, int y, int width, int height)
             // causes GTK's sizing state to become inconsistent
             gs_setSizeRequestList = g_slist_prepend(gs_setSizeRequestList, this);
             g_object_add_weak_pointer(G_OBJECT(m_widget), &gs_setSizeRequestList->data);
+            return;
         }
-        else
 #endif
-        {
-            gtk_widget_set_size_request(m_widget, width, height);
-        }
     }
-    else
 #endif // __WXGTK3__
-    {
+
+    if (pizza)
+        gtk_widget_queue_resize(m_widget);
+    else
         gtk_widget_set_size_request(m_widget, width, height);
-    }
 }
 
 void wxWindowGTK::ConstrainSize()

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -225,7 +225,13 @@ void wxChoice::MSWSetDarkOrLightMode(SetMode setmode)
     WinStruct<COMBOBOXINFO> info;
     if ( ::GetComboBoxInfo(GetHwnd(), &info) && info.hwndList )
     {
-        wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
+        // The default theme does not look good on Windows 11 starting with
+        // build 26300.8553. DarkMode_DarkTheme looks OK, but Windows 10 does
+        // not have that.
+        if ( wxGetWinVersion() > wxWinVersion_10 )
+            wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
+        else
+            wxMSWDarkMode::AllowForWindow(info.hwndList);
     }
 }
 

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -225,10 +225,10 @@ void wxChoice::MSWSetDarkOrLightMode(SetMode setmode)
     WinStruct<COMBOBOXINFO> info;
     if ( ::GetComboBoxInfo(GetHwnd(), &info) && info.hwndList )
     {
-        // The default theme does not look good on Windows 11 starting with
-        // build 26300.8553. DarkMode_DarkTheme looks OK, but Windows 10 does
-        // not have that.
-        if ( wxGetWinVersion() > wxWinVersion_10 )
+        // The default theme does not look good on starting with Windows 11
+        // build 26300.8553. DarkMode_DarkTheme looks OK and was available
+        // starting with Windows 11 build 26200.
+        if ( wxCheckOsVersion(10, 0, 26200) )
             wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
         else
             wxMSWDarkMode::AllowForWindow(info.hwndList);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3877,13 +3877,19 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     // The EDIT theme gives a good general purpose border in light mode.
                     // There does not seem to be a dark mode EDIT theme that looks good.
-                    // The ListView theme below looks good in dark mode.
-                    wxUxThemeHandle hTheme(this, L"EDIT", L"DarkMode_DarkTheme::ListView");
+                    // The ListView class below looks good in dark mode on Windows 11.
+                    // Windows 10 does not have DarkMode_DarkTheme. The Button class
+                    // below looks good in dark mode on Windows 10 (but not Windows 11).
+                    const auto darkTheme = wxGetWinVersion() > wxWinVersion_10 ?
+                        L"DarkMode_DarkTheme::ListView" :
+                        L"DarkMode_Explorer::Button";
+                    wxUxThemeHandle hTheme(this, L"EDIT", darkTheme);
 
-                    // Ensure that the part and state we use have the same
-                    // values for both EDIT and ListView.
+                    // The part and state values match for the themes we use.
                     static_assert((int)EP_EDITTEXT == (int)LVP_LISTITEM, "parts differ?");
+                    static_assert((int)EP_EDITTEXT == (int)BP_PUSHBUTTON, "parts differ?");
                     static_assert((int)ETS_NORMAL == (int)LISS_NORMAL, "states differ?");
+                    static_assert((int)ETS_NORMAL == (int)PBS_NORMAL, "states differ?");
 
                     // Make sure the background is in a proper state
                     if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3875,15 +3875,15 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     // Draw the theme border and background.
 
-                    // The EDIT theme gives a good general purpose border in light mode.
-                    // There does not seem to be a dark mode EDIT theme that looks good.
-                    // The ListView class below looks good in dark mode on Windows 11.
-                    // Windows 10 does not have DarkMode_DarkTheme. The Button class
-                    // below looks good in dark mode on Windows 10 (but not Windows 11).
-                    const auto darkTheme = wxGetWinVersion() > wxWinVersion_10 ?
+                    // The EDIT class gives a good general purpose border in light mode.
+                    // There does not seem to be a dark mode EDIT class that looks good.
+                    // The ListView class below looks good in dark mode but was not
+                    // available until Windows 11 build 26200. The Button class below
+                    // looks OK in dark mode on older Windows.
+                    const auto darkClass = wxCheckOsVersion(10, 0, 26200) ?
                         L"DarkMode_DarkTheme::ListView" :
                         L"DarkMode_Explorer::Button";
-                    wxUxThemeHandle hTheme(this, L"EDIT", darkTheme);
+                    wxUxThemeHandle hTheme(this, L"EDIT", darkClass);
 
                     // The part and state values match for the themes we use.
                     static_assert((int)EP_EDITTEXT == (int)LVP_LISTITEM, "parts differ?");


### PR DESCRIPTION
For Windows 10, use alternatives to the "DarkMode_DarkTheme" theme, which only became available in Windows 11.