### PR TITLE
Stop setting GTK size-request on widgets managed by wxPizza

### DIFF
--- a/src/gtk/win_gtk.cpp
+++ b/src/gtk/win_gtk.cpp
@@ -438,7 +438,10 @@ void wxPizza::put(GtkWidget* widget, int x, int y, int width, int height)
     // Re-parenting a TLW under a child window is possible at wx level but
     // using a TLW as child at GTK+ level results in problems, so don't do it.
     if (!gtk_widget_is_toplevel(GTK_WIDGET(widget)))
+    {
         gtk_fixed_put(GTK_FIXED(this), widget, 0, 0);
+        gtk_widget_set_size_request(widget, -1, -1);
+    }
 
     wxPizzaChild* child = new wxPizzaChild;
     child->widget = widget;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2678,9 +2678,14 @@ static void frame_clock_layout_after(GdkFrameClock*, wxWindowGTK* win)
 
             wxWindowGTK* w = static_cast<wxWindowGTK*>(p->data);
             g_object_remove_weak_pointer(G_OBJECT(w->m_widget), &p->data);
-            GtkAllocation a;
-            gtk_widget_get_allocation(w->m_widget, &a);
-            gtk_widget_set_size_request(w->m_widget, a.width, a.height);
+            if (WX_IS_PIZZA(gtk_widget_get_parent(w->m_widget)))
+                gtk_widget_queue_resize(w->m_widget);
+            else
+            {
+                GtkAllocation a;
+                gtk_widget_get_allocation(w->m_widget, &a);
+                gtk_widget_set_size_request(w->m_widget, a.width, a.height);
+            }
         }
         g_slist_free(gs_setSizeRequestList);
         gs_setSizeRequestList = nullptr;
@@ -4280,17 +4285,7 @@ void wxWindowGTK::DoMoveWindow(int x, int y, int width, int height)
     {
         pizza = WX_PIZZA(parent);
         pizza->move(m_widget, x, y, width, height);
-        if (
-#ifdef __WXGTK3__
-            !g_inSizeAllocate &&
-#endif
-            gtk_widget_get_visible(m_widget))
-        {
-            // in case only the position is changing
-            gtk_widget_queue_resize(m_widget);
-        }
     }
-
 
 #ifdef __WXGTK3__
     // With GTK3, gtk_widget_queue_resize() is ignored while a size-allocate
@@ -4298,7 +4293,7 @@ void wxWindowGTK::DoMoveWindow(int x, int y, int width, int height)
     // size-allocate can generate wxSizeEvent and size event handlers often
     // call SetSize(), directly or indirectly. It should be fine to call
     // gtk_widget_size_allocate() immediately in this case.
-    if (g_inSizeAllocate && gtk_widget_get_visible(m_widget) && width > 0 && height > 0)
+    if (g_inSizeAllocate)
     {
         // obligatory size request before size allocate to avoid GTK3 warnings
         GtkRequisition req;
@@ -4318,18 +4313,16 @@ void wxWindowGTK::DoMoveWindow(int x, int y, int width, int height)
             // causes GTK's sizing state to become inconsistent
             gs_setSizeRequestList = g_slist_prepend(gs_setSizeRequestList, this);
             g_object_add_weak_pointer(G_OBJECT(m_widget), &gs_setSizeRequestList->data);
+            return;
         }
-        else
 #endif
-        {
-            gtk_widget_set_size_request(m_widget, width, height);
-        }
     }
-    else
 #endif // __WXGTK3__
-    {
+
+    if (pizza)
+        gtk_widget_queue_resize(m_widget);
+    else
         gtk_widget_set_size_request(m_widget, width, height);
-    }
 }
 
 void wxWindowGTK::ConstrainSize()


### PR DESCRIPTION
Setting the size-request is not necessary, as wxPizza does not use it to determine the sizes of its children. But it can cause GTK to complain, when resizing a window smaller. Not setting avoids many Gtk-WARNING debug messages of the form:
"gtk_widget_size_allocate(): attempt to underallocate wxPizza's child X"