### PR TITLE
MSW: Only use DarkMode_DarkTheme if available

### DIFF
--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -225,7 +225,13 @@ void wxChoice::MSWSetDarkOrLightMode(SetMode setmode)
     WinStruct<COMBOBOXINFO> info;
     if ( ::GetComboBoxInfo(GetHwnd(), &info) && info.hwndList )
     {
-        wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
+        // The default theme does not look good on starting with Windows 11
+        // build 26300.8553. DarkMode_DarkTheme looks OK and was available
+        // starting with Windows 11 build 26200.
+        if ( wxCheckOsVersion(10, 0, 26200) )
+            wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
+        else
+            wxMSWDarkMode::AllowForWindow(info.hwndList);
     }
 }
 

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -175,8 +175,13 @@ WXDWORD wxListBox::MSWGetStyle(long style, WXDWORD *exstyle) const
 
 void wxListBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
-    support.themeName = L"Explorer";
-    support.themeId = L"ScrollBar";
+    // The default theme does not look good on starting with Windows 11
+    // build 26300.8553. DarkMode_DarkTheme looks OK and was available
+    // starting with Windows 11 build 26200.
+    if ( wxCheckOsVersion(10, 0, 26200) )
+        support.themeName = L"DarkMode_DarkTheme";
+    else
+        wxListBoxBase::MSWGetDarkModeSupport(support);
 }
 
 void wxListBox::MSWUpdateFontOnDPIChange(const wxSize& newDPI)

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3875,15 +3875,21 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     // Draw the theme border and background.
 
-                    // The EDIT theme gives a good general purpose border in light mode.
-                    // There does not seem to be a dark mode EDIT theme that looks good.
-                    // The ListView theme below looks good in dark mode.
-                    wxUxThemeHandle hTheme(this, L"EDIT", L"DarkMode_DarkTheme::ListView");
+                    // The EDIT class gives a good general purpose border in light mode.
+                    // There does not seem to be a dark mode EDIT class that looks good.
+                    // The ListView class below looks good in dark mode but was not
+                    // available until Windows 11 build 26200. The Button class below
+                    // looks OK in dark mode on older Windows.
+                    const auto darkClass = wxCheckOsVersion(10, 0, 26200) ?
+                        L"DarkMode_DarkTheme::ListView" :
+                        L"DarkMode_Explorer::Button";
+                    wxUxThemeHandle hTheme(this, L"EDIT", darkClass);
 
-                    // Ensure that the part and state we use have the same
-                    // values for both EDIT and ListView.
+                    // The part and state values match for the themes we use.
                     static_assert((int)EP_EDITTEXT == (int)LVP_LISTITEM, "parts differ?");
+                    static_assert((int)EP_EDITTEXT == (int)BP_PUSHBUTTON, "parts differ?");
                     static_assert((int)ETS_NORMAL == (int)LISS_NORMAL, "states differ?");
+                    static_assert((int)ETS_NORMAL == (int)PBS_NORMAL, "states differ?");
 
                     // Make sure the background is in a proper state
                     if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))


### PR DESCRIPTION
Check windows version before using theme "DarkMode_DarkTheme" and use alternative theme if it is not available.