### PR TITLE
Add wxGrid::GetFrozenRowLabelWindow() and GetFrozenColLabelWindow().

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -487,6 +487,7 @@ All (GUI):
 - Add wxApp::SetAppearance() to explicitly set dark or light mode (#24461).
 - Add wxAuiManager::{Save,Load}Layout() (#24235).
 - Add wxGrid::CopySelection() (Blake Madden, #24124).
+- Add wxGrid::GetFrozenRowLabelWindow() and GetFrozenColLabelWindow() accessors.
 - Add wxInfoBar::ShowCheckBox() (Blake Madden, #25394).
 - Add wxRadioButton group support to wxGenericValidator (Bill Su, #24264).
 - Add wxRibbonBar::GetPageById() (Blake Madden, #24211).

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2456,6 +2456,8 @@ public:
     wxWindow* GetFrozenCornerGridWindow()const { return (wxWindow*)m_frozenCornerGridWin; }
     wxWindow* GetFrozenRowGridWindow() const   { return (wxWindow*)m_frozenRowGridWin; }
     wxWindow* GetFrozenColGridWindow() const   { return (wxWindow*)m_frozenColGridWin; }
+    wxWindow* GetFrozenRowLabelWindow() const  { return (wxWindow*)m_rowFrozenLabelWin; }
+    wxWindow* GetFrozenColLabelWindow() const  { return m_colFrozenLabelWin; }
     wxWindow* GetGridRowLabelWindow() const    { return (wxWindow*)m_rowLabelWin; }
     wxWindow* GetGridColLabelWindow() const    { return m_colLabelWin; }
     wxWindow* GetGridCornerLabelWindow() const { return (wxWindow*)m_cornerLabelWin; }

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -6183,6 +6183,28 @@ public:
     wxWindow* GetFrozenColGridWindow() const;
 
     /**
+        Return the row labels window containing frozen cells.
+
+        This window is shown only when there are frozen rows.
+        This window is not shown if the rows labels were hidden using
+        HideRowLabels().
+
+        @since 3.3.3
+     */
+    wxWindow* GetFrozenRowLabelWindow() const;
+
+    /**
+        Return the column labels window containing frozen cells.
+
+        This window is shown only when there are frozen columns.
+        This window is not shown if the columns labels were hidden using
+        HideColLabels().
+
+        @since 3.3.3
+     */
+    wxWindow* GetFrozenColLabelWindow()() const;
+
+    /**
         Return the row labels window.
 
         This window is not shown if the row labels were hidden using


### PR DESCRIPTION
These accessors for the frozen row and column label sub-windows were missing from the public API even though the equivalent data cell windows (GetFrozenRowGridWindow/GetFrozenColGridWindow) are already public. Without them it is impossible to bind events (e.g. EVT_MOTION) to the frozen label strips from outside the wxGrid implementation.