### PR TITLE
reject short reads in wxIPCSocketStreams::ReadData

### DIFF
--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -241,7 +241,13 @@ public:
         void * const data = conn->GetBufferAtLeast(*size);
         wxCHECK_MSG( data, nullptr, "IPC buffer allocation failed" );
 
-        m_socketStream.Read(data, *size);
+        // The buffer returned by GetBufferAtLeast() is not zero-filled: it is
+        // either freshly allocated (so uninitialised) or reused from a previous,
+        // possibly larger, message. If the peer announces more data than it
+        // actually sends, the unread tail would leak that memory to the caller,
+        // so refuse the truncated message instead of using the partial buffer.
+        if ( m_socketStream.Read(data, *size).LastRead() != *size )
+            return nullptr;
 
         return data;
     }


### PR DESCRIPTION
wxIPCSocketStreams::ReadData reads a length prefix from the connection and then reads that many bytes into the buffer returned by GetBufferAtLeast, but it never checks how many bytes actually arrived. That buffer is either freshly allocated and so uninitialised or, more commonly, the connection's own buffer reused from an earlier and possibly larger message, so a peer that announces more data than it sends and then drops the link leaves the unread tail untouched and it gets handed to OnExecute/OnPoke/OnAdvise with the full announced size, quietly leaking stale process memory across the connection. The socket reads are done in WAITALL mode so a short read only happens when the peer is broken or hostile, and every caller already treats a null return from ReadData as an error, so the safe thing is to return nullptr when fewer bytes than announced were read instead of using the partial buffer.