### PR TITLE
MSW: Dark mode switching for non-rich read-only multiline wxTextCtrl

### DIFF
--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -360,7 +360,7 @@ WXHBRUSH wxControl::DoMSWControlColor(WXHDC pDC, wxColour colBg, WXHWND hWnd)
     // finally also set the background colour for text drawing: without this,
     // the text in an edit control is drawn using the default background even
     // if we return a valid brush
-    if ( colBg.IsOk() || m_hasBgCol )
+    if ( colBg.IsOk() || m_backgroundColour.IsOk() )
     {
         if ( !colBg.IsOk() )
             colBg = GetBackgroundColour();

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -723,12 +723,7 @@ bool wxTextCtrl::MSWCreateText(const wxString& value,
         // non-rich read-only multiline controls have grey background by
         // default under MSW but this is not always appropriate, so forcefully
         // reset the background colour to normal default
-        //
-        // this is not ideal but, after a long discussion on wx-dev (see
-        // http://thread.gmane.org/gmane.comp.lib.wxwidgets.devel/116360/) it
-        // was finally deemed to be the best behaviour by default (and ideally
-        // we'd have a way to change this, see #11521)
-        SetBackgroundColour(GetClassDefaultAttributes().colBg);
+        m_backgroundColour = GetClassDefaultAttributes().colBg;
     }
 
     // Without this, if we pass the size in the constructor and then don't change it,
@@ -2930,6 +2925,15 @@ void wxTextCtrl::MSWSetRichZoom()
 void wxTextCtrl::MSWSetDarkOrLightMode(SetMode setmode)
 {
     wxTextCtrlBase::MSWSetDarkOrLightMode(setmode);
+
+    // Update the background for non-rich read-only multiline, unless there
+    // are custom colours. The foreground is updated by
+    // wxControl::DoMSWControlColor().
+    if ( !IsRich() && HasFlag(wxTE_MULTILINE) && HasFlag(wxTE_READONLY) &&
+        !m_hasBgCol && !m_hasFgCol )
+    {
+        m_backgroundColour = GetClassDefaultAttributes().colBg;
+    }
 
 #if wxUSE_RICHEDIT
     // The rich edit control does not change colours automatically. We adjust

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5592,9 +5592,9 @@ wxWindowMSW::MSWGetBgBrushForChild(WXHDC hDC, wxWindowMSW *child)
         return hbrush;
     }
 
-    // Otherwise see if we have a custom background colour or if we're a TLW,
+    // Otherwise see if we have a background colour or if we're a TLW,
     // as nothing else would provide the brush in the latter case.
-    if ( m_hasBgCol || IsTopLevel() )
+    if ( m_backgroundColour.IsOk() || IsTopLevel() )
     {
         wxBrush *
             brush = wxTheBrushList->FindOrCreateBrush(GetBackgroundColour());


### PR DESCRIPTION
For dark mode switching, update the background colour for non-rich read-only multiline `wxTextCtrl` controls. The foreground colour is already updated.

The background colour is controlled by assigning `m_backgroundColour` rather than calling `SetBackgroundColour()`. This leaves the `m_hasBgCol` member untouched so that it distinguishes custom colours set by the user which should not be overwritten, from colours set internally which can be overwritten.

Some checks on the value of `hasBgCol` are changed to `m_backgroundColour.IsOK()`. When `m_backgroundColour.IsOK()` is true, there is either a custom colour or an internally set colour.
