### PR TITLE
MSW: Minimize dark mode border flicker

### DIFF
--- a/include/wx/msw/listbox.h
+++ b/include/wx/msw/listbox.h
@@ -135,6 +135,7 @@ public:
     bool MSWCommand(WXUINT param, WXWORD id) override;
     WXDWORD MSWGetStyle(long style, WXDWORD *exstyle) const override;
     void MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
+    virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
 
     // under XP when using "transition effect for menus and tooltips" if we
     // return true for WM_PRINTCLIENT here then it causes noticeable slowdown

--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -204,6 +204,8 @@ public:
     virtual bool MSWShouldPreProcessMessage(WXMSG* pMsg) override;
     virtual WXDWORD MSWGetStyle(long style, WXDWORD *exstyle) const override;
 
+    void MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
+
 protected:
     // common part of all ctors
     void Init();

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -628,6 +628,12 @@ protected:
         // The theme IDs to use. If neither this field nor the theme name is
         // set, no theme is applied to the window.
         const wchar_t* themeId = nullptr;
+
+        // If true, draw our themed border. Set this false when a control
+        // draws a good dark mode border. This reduces flicker that happens
+        // when a control generates too many WM_NCPAINT messages which cause
+        // the border to be redrawn repeatedly.
+        bool drawBorder = true;
     };
 
     virtual void MSWGetDarkModeSupport(MSWDarkModeSupport& support) const;

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -179,7 +179,13 @@ void wxListBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
     // build 26300.8553. DarkMode_DarkTheme looks OK and was available
     // starting with Windows 11 build 26200.
     if ( wxCheckOsVersion(10, 0, 26200) )
+    {
         support.themeName = L"DarkMode_DarkTheme";
+        // The static and raised style borders look bad.
+        const auto border = GetBorder();
+        support.drawBorder = border == wxBORDER_STATIC ||
+                             border == wxBORDER_RAISED;
+    }
     else
         wxListBoxBase::MSWGetDarkModeSupport(support);
 }

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -190,6 +190,29 @@ void wxListBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
         wxListBoxBase::MSWGetDarkModeSupport(support);
 }
 
+void wxListBox::MSWSetDarkOrLightMode(SetMode setmode)
+{
+    wxListBoxBase::MSWSetDarkOrLightMode(setmode);
+
+    // Convert border styles that flicker to wxBORDER_SIMPLE. With
+    // DarkMode_DarkTheme (Windows 11 build 26200 and later), wxBORDER_STATIC
+    // and wxBORDER_RAISED flicker. Otherwise, all border styles except
+    // wxBORDER_SIMPLE flicker. Unfortunately, if the system switches back to
+    // light mode, the original border style will not be restored.
+    const auto border = GetBorder();
+    if ( border == wxBORDER_STATIC ||
+         border == wxBORDER_RAISED ||
+         !wxCheckOsVersion(10, 0, 26200) )
+    {
+        auto style = GetWindowStyleFlag();
+        style &= ~wxBORDER_MASK;
+        style |= wxBORDER_SIMPLE;
+        SetWindowStyleFlag(style);
+        ::SetWindowPos(m_hWnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+            SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    }
+}
+
 void wxListBox::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
 {
     wxListBoxBase::MSWUpdateFontOnDPIChange(newDPI);

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -889,6 +889,26 @@ WXDWORD wxTextCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
     return msStyle;
 }
 
+void wxTextCtrl::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    // Use DarkMode_DarkTheme if available. This theme draws good dark mode
+    // borders for most styles including the default, wxBORDER_THEME. This
+    // eliminates border flicker that occurs with the non-rich edit with most
+    // border styles.
+    if ( wxCheckOsVersion(10, 0, 26200) )
+    {
+        support.themeName = L"DarkMode_DarkTheme";
+        // With the rich edit, all border styles look bad.
+        // With the non-rich, the static and raised styles look bad.
+        const auto border = GetBorder();
+        support.drawBorder = IsRich() ||
+                             border == wxBORDER_STATIC ||
+                             border == wxBORDER_RAISED;
+    }
+    else
+        wxTextCtrlBase::MSWGetDarkModeSupport(support);
+}
+
 #if wxUSE_RICHEDIT && wxUSE_SPELLCHECK
 
 bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -3012,6 +3012,25 @@ void wxTextCtrl::MSWSetDarkOrLightMode(SetMode setmode)
             ::SendMessage(m_hWnd, EM_SETBKGNDCOLOR, 0, wxColourToRGB(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)));
     }
 #endif
+
+    // Convert border styles that flicker to wxBORDER_SIMPLE. With the rich
+    // edit, no borders flicker. Otherwise, with DarkMode_DarkTheme (Windows
+    // 11 build 26200 and later), wxBORDER_STATIC and wxBORDER_RAISED flicker.
+    // Otherwise, all border styles except wxBORDER_SIMPLE flicker.
+    // Unfortunately, if the system switches back to light mode, the original
+    // border style will not be restored.
+    const auto border = GetBorder();
+    if ( !IsRich() && (border == wxBORDER_STATIC ||
+                       border == wxBORDER_RAISED ||
+                       !wxCheckOsVersion(10, 0, 26200)) )
+    {
+        auto style = GetWindowStyleFlag();
+        style &= ~wxBORDER_MASK;
+        style |= wxBORDER_SIMPLE;
+        SetWindowStyleFlag(style);
+        ::SetWindowPos(m_hWnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+            SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    }
 }
 
 void wxTextCtrl::MSWUpdateFontOnDPIChange(const wxSize& newDPI)

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3855,6 +3855,13 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         break;
                 }
 
+                if ( drawBorder && wxMSWDarkMode::IsActive() )
+                {
+                    MSWDarkModeSupport support;
+                    MSWGetDarkModeSupport(support);
+                    drawBorder = support.drawBorder;
+                }
+
                 if ( drawBorder )
                 {
                     // first ask the widget to paint its non-client area, such as scrollbars, etc.


### PR DESCRIPTION
These changes address flickering borders in dark mode, primarily with the non-rich `wxTextCtrl`. The `wxListBox` border also flickers, but is less noticeable. See #26630.

The flicker occurs when the mouse moves over the border or scroll bar. The problem might not be reproducible on all systems, perhaps depending on graphics drivers. The cause is that these controls generate many unnecessary `WM_NCPAINT` messages. In our `WM_NCPAINT` handler, the the light mode border gets drawn and the dark mode border over that.

The solution is to use the `DarkMode_DarkTheme` theme when available. With this theme, these controls draw a good dark border for most border styles, including the default style. In this case, we do not draw over the border. A new member is introduced to the `MSWDarkModeSupport` struct to indicate whether we need the custom border drawing.

When `DarkMode_DarkTheme` is not available, and for the border styles that flicker even with `DarkMode_DarkTheme`, convert the border style to `wxBORDER_SIMPLE`, which never flickers.