### PR TITLE
MSW: Dark mode cleanup for unsupported Windows version

### DIFF
--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -465,10 +465,6 @@ void ConfigureTLW(HWND hwnd)
 {
     BOOL useDarkMode = wxMSWImpl::ShouldUseDarkMode();
 
-    // DWMWA_USE_IMMERSIVE_DARK_MODE is 19 for v1809, but is 20 for later
-    // versions, so to set title bar black for both v1809 and later versions,
-    // we try to call GetDwmSetWindowAttribute() with the current value first,
-    // but if it fails, we also retry with the old one.
     HRESULT hr = wxDarkModeModule::GetDwmSetWindowAttribute()
                  (
                     hwnd,
@@ -476,16 +472,6 @@ void ConfigureTLW(HWND hwnd)
                     &useDarkMode,
                     sizeof(useDarkMode)
                  );
-    if ( FAILED(hr) )
-    {
-        hr = wxDarkModeModule::GetDwmSetWindowAttribute()
-             (
-                hwnd,
-                19,
-                &useDarkMode,
-                sizeof(useDarkMode)
-             );
-    }
     if ( FAILED(hr) )
         wxLogApiError("DwmSetWindowAttribute(USE_IMMERSIVE_DARK_MODE)", hr);
 


### PR DESCRIPTION
Remove some dark mode code that was intended for Windows 1809, which we no longer support with dark mode.