### PR TITLE
MSW: Fix Darkmode NoneClient border flicker via GDI region partitioning

### DIFF
--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -11,7 +11,6 @@
 #define _WX_MSW_PRIVATE_DARKMODE_H_
 
 #include "wx/settings.h"
-
 namespace wxMSWDarkMode
 {
 
@@ -27,6 +26,19 @@ bool IsActive();
 // background and foreground colours.
 WXDLLIMPEXP_CORE
 bool HasChanged();
+
+/**
+ * @brief Dynamic Runtime Check for Aero.msstyles Dark Mode Support
+ *
+ * Verifies if a specific dark-theme class variant is actively supported and
+ * distinct from the standard light-theme appearance inside the active OS visual style.
+ *
+ * @param stdClass The standard/light window class name (e.g., L"EDIT", L"Button").
+ * @param darkClass The specialized dark mode class path (e.g., L"DarkMode_DarkTheme::ListView").
+ * @return true If the dark class successfully loads and provides a unique theme handle.
+ * @return false If the theme subsystem falls back to light styles or fails to load.
+ */
+bool IsDarkThemeActive(const wchar_t* stdClass, const wchar_t* darkClass);
 
 // Enable or disable dark mode for the given TLW if appropriate.
 void ConfigureTLW(HWND hwnd);
@@ -45,13 +57,13 @@ void AllowForWindow(HWND hwnd,
                     const wchar_t* themeName = L"Explorer",
                     const wchar_t* themeId = nullptr);
 
-// Draws a raised or sunken border using two shades (light/dark)
-// for dark mode. The rectangle `rc` is in device coordinates (e.g., window).
-// Draws a raised or sunken border with three shades (light, mid, dark)
-// to mimic the classic Windows 3D effect, using dark-mode colours.
-// The rectangle `rc` is in device coordinates (e.g., the full window).
-void DrawDarkModeEdge(HDC hdc, const RECT& rc, int borderStyle, int thickness);
-
+// Draws a custom dark mode border for controls (e.g. EDIT, STATIC, etc.).
+// Supports flat (SIMPLE/STATIC/THEME) and 3D (RAISED/SUNKEN) styles.
+// Uses multi-tone dark colours to simulate classic Windows 3D depth.
+// The rectangle `rc` is in device coordinates (full window size).
+// `state` is one of ETS_NORMAL, ETS_DISABLED, ETS_FOCUSED, ETS_HOT, ETS_READONLY.
+void DrawDarkModeBorder(wxDC& dc, const wxRect& rc, wxBorder borderStyle,
+    int thickness, int state = ETS_NORMAL);
 // Return the colour value appropriate for dark mode if it's used or an invalid
 // colour if it isn't.
 wxColour GetColour(wxSystemColour index);

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -11,6 +11,8 @@
 #define _WX_MSW_PRIVATE_DARKMODE_H_
 
 #include "wx/settings.h"
+#include <vsstyle.h>
+
 namespace wxMSWDarkMode
 {
 

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -45,6 +45,13 @@ void AllowForWindow(HWND hwnd,
                     const wchar_t* themeName = L"Explorer",
                     const wchar_t* themeId = nullptr);
 
+// Draws a raised or sunken border using two shades (light/dark)
+// for dark mode. The rectangle `rc` is in device coordinates (e.g., window).
+// Draws a raised or sunken border with three shades (light, mid, dark)
+// to mimic the classic Windows 3D effect, using dark-mode colours.
+// The rectangle `rc` is in device coordinates (e.g., the full window).
+void DrawDarkModeEdge(HDC hdc, const RECT& rc, int borderStyle, int thickness);
+
 // Return the colour value appropriate for dark mode if it's used or an invalid
 // colour if it isn't.
 wxColour GetColour(wxSystemColour index);

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -461,6 +461,21 @@ bool HasChanged()
     return gs_hasChanged;
 }
 
+
+
+bool IsDarkThemeActive(const wchar_t* stdClass, const wchar_t* darkClass)
+{
+    const auto darkTheme = wxUxThemeHandle::NewAtStdDPI(darkClass);
+    if (darkTheme)
+    {
+        const auto stdTheme = wxUxThemeHandle::NewAtStdDPI(stdClass);
+        if (stdTheme && stdTheme != darkTheme)
+            return true;
+    }
+
+    return false;
+}
+
 void ConfigureTLW(HWND hwnd)
 {
     BOOL useDarkMode = wxMSWImpl::ShouldUseDarkMode();
@@ -517,99 +532,148 @@ void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
     ::SendMessage(hwnd, WM_THEMECHANGED, 0, 0);
 }
 
-// Draws a raised or sunken border using two shades (light/dark)
-// for dark mode. The rectangle `rc` is in device coordinates (e.g., window).
-// Draws a raised or sunken border with three shades (light, mid, dark)
-// to mimic the classic Windows 3D effect, using dark-mode colours.
-// The rectangle `rc` is in device coordinates (e.g., the full window).
-void DrawDarkModeEdge(HDC hdc, const RECT& rc, int borderStyle, int thickness)
+
+void DrawDarkModeBorder(wxDC& dc, const wxRect& rc, wxBorder borderStyle, int thickness, int state)
 {
-    // Dark mode colours – adjust to match your theme
-    COLORREF clrHighlight = RGB(90, 90, 90);   // lightest (top/left outer)
-    COLORREF clrMid = RGB(65, 65, 65);   // middle (inner band)
-    COLORREF clrShadow = RGB(35, 35, 35);   // darkest (bottom/right outer)
+    // Colour palette converted to wxColour
+    const wxColour clrNormalFlat(100, 100, 100);
+    const wxColour clrHoverFlat(140, 140, 140);
+    const wxColour clrDisabledFlat(60, 60, 60);
+    const wxColour clrReadonlyFlat(80, 80, 80);
 
-    // For sunken edges, the colours are reversed: top/left use shadow,
-    // bottom/right use highlight, and the middle band is still mid-tone.
-    bool raised = (borderStyle == wxBORDER_RAISED);
+    const wxColour clrHighlight(90, 90, 90);
+    const wxColour clrMid(65, 65, 65);
+    const wxColour clrShadow(35, 35, 35);
 
-    // Determine which colour to use for each side
-    COLORREF colTopLeftOuter = raised ? clrHighlight : clrShadow;
-    COLORREF colBottomRightOuter = raised ? clrShadow : clrHighlight;
+    const wxColour clrHoverHL(120, 120, 120);
+    const wxColour clrHoverMid(86, 86, 86);
+    const wxColour clrHoverShadow(50, 50, 50);
 
-    // If thickness is 1, we only draw a single band (the outer edge).
-    // For thickness >= 2, we draw outer and inner bands.
-    // We'll create brushes for each colour only once.
-    HBRUSH brushOuterTL = CreateSolidBrush(colTopLeftOuter);
-    HBRUSH brushInner = CreateSolidBrush(clrMid);
-    HBRUSH brushOuterBR = CreateSolidBrush(colBottomRightOuter);
+    const wxColour clrDisabled3D(60, 60, 60);
 
-    // Helper to fill a rectangle safely
-    auto FillRectSafe = [&](const RECT& rect, HBRUSH brush) {
-        if (rect.right > rect.left && rect.bottom > rect.top)
-            FillRect(hdc, &rect, brush);
+    // Focus ring: use system accent colour
+    const wxColour clrFocus = wxDarkModeModule::GetSettings().GetColour(wxSYS_COLOUR_HIGHLIGHT);
+
+    // Safe fill helper using wxDC methods
+    auto Fill = [&](const wxRect& r, const wxColour& c)
+        {
+            dc.SetBrush(wxBrush(c));
+            dc.SetPen(*wxTRANSPARENT_PEN);
+            dc.DrawRectangle(r);
         };
 
-    // We'll draw the border as a set of non-overlapping rectangles.
-    // The border occupies the outer 'thickness' pixels of `rc`.
-    // We'll split into layers: outer layer (first pixel) and inner layer (remaining).
-
-    // Outer layer (1 pixel thick) – always present
-    if (thickness >= 1)
-    {
-        // Top outer
-        RECT rcTopOuter = { rc.left, rc.top, rc.right, rc.top + 1 };
-        FillRectSafe(rcTopOuter, brushOuterTL);
-
-        // Left outer
-        RECT rcLeftOuter = { rc.left, rc.top + 1, rc.left + 1, rc.bottom - 1 };
-        FillRectSafe(rcLeftOuter, brushOuterTL);
-
-        // Bottom outer
-        RECT rcBottomOuter = { rc.left, rc.bottom - 1, rc.right, rc.bottom };
-        FillRectSafe(rcBottomOuter, brushOuterBR);
-
-        // Right outer
-        RECT rcRightOuter = { rc.right - 1, rc.top + 1, rc.right, rc.bottom - 1 };
-        FillRectSafe(rcRightOuter, brushOuterBR);
-    }
-
-    // Inner layer(s) – for thickness >= 2
-    if (thickness >= 2)
-    {
-        // The inner band occupies the remaining pixels (from pixel 1 to thickness-1)
-        // We draw it as a continuous band of mid colour, but we need to handle corners.
-        // To avoid overlaps, we shrink the rectangle by 1 on each side.
-        RECT innerRect = rc;
-        InflateRect(&innerRect, -1, -1); // remove outer pixel
-
-        // Now draw a full inner border of thickness (thickness - 1) using the mid colour.
-        // We'll draw top, left, bottom, right bands within innerRect.
-        int innerThick = thickness - 1;
-        if (innerThick > 0)
+    // Draw a uniform 1-pixel border of one colour
+    auto DrawFlat = [&](const wxRect& r, const wxColour& c)
         {
-            // Top inner band
-            RECT rcTopInner = { innerRect.left, innerRect.top, innerRect.right, innerRect.top + innerThick };
-            FillRectSafe(rcTopInner, brushInner);
+            Fill({ r.x,             r.y,              r.width,     1 }, c);
+            Fill({ r.x,             r.y + 1,          1,           r.height - 2 }, c);
+            Fill({ r.x,             r.y + r.height - 1, r.width,     1 }, c);
+            Fill({ r.x + r.width - 1, r.y + 1,          1,           r.height - 2 }, c);
+        };
 
-            // Left inner band
-            RECT rcLeftInner = { innerRect.left, innerRect.top + innerThick, innerRect.left + innerThick, innerRect.bottom - innerThick };
-            FillRectSafe(rcLeftInner, brushInner);
+    // Draw 3D border (outer 1px asymmetric + inner band of mid colour)
+    auto Draw3D = [&](const wxRect& r, const wxColour& tlOuter, const wxColour& mid, const wxColour& brOuter)
+        {
+            // Outer layer
+            Fill({ r.x,             r.y,              r.width,     1 }, tlOuter);
+            Fill({ r.x,             r.y + 1,          1,           r.height - 2 }, tlOuter);
+            Fill({ r.x,             r.y + r.height - 1, r.width,     1 }, brOuter);
+            Fill({ r.x + r.width - 1, r.y + 1,          1,           r.height - 2 }, brOuter);
 
-            // Bottom inner band
-            RECT rcBottomInner = { innerRect.left, innerRect.bottom - innerThick, innerRect.right, innerRect.bottom };
-            FillRectSafe(rcBottomInner, brushInner);
+            if (thickness < 2) return;
 
-            // Right inner band
-            RECT rcRightInner = { innerRect.right - innerThick, innerRect.top + innerThick, innerRect.right, innerRect.bottom - innerThick };
-            FillRectSafe(rcRightInner, brushInner);
-        }
+            // Inner band
+            wxRect inner = r;
+            inner.Deflate(1);
+            int t = thickness - 1;
+
+            Fill({ inner.x,                 inner.y,                 inner.width,     t }, mid);
+            Fill({ inner.x,                 inner.y + t,             t,               inner.height - (2 * t) }, mid);
+            Fill({ inner.x,                 inner.y + inner.height - t, inner.width,     t }, mid);
+            Fill({ inner.x + inner.width - t, inner.y + t,             t,               inner.height - (2 * t) }, mid);
+        };
+
+    // Draw focus ring 1px outside rc
+    auto DrawFocusRing = [&](const wxRect& r)
+        {
+            wxRect ring = r;
+            ring.Inflate(1);
+            DrawFlat(ring, clrFocus);
+        };
+
+    const bool disabled = (state == ETS_DISABLED);
+    const bool focused = (state == ETS_FOCUSED);
+    const bool hovered = (state == ETS_HOT);
+    const bool readonly = (state == ETS_READONLY);
+
+    // ── Flat styles ──────────────────────────────────────────────────────────
+    if (borderStyle == wxBORDER_SIMPLE || borderStyle == wxBORDER_STATIC)
+    {
+        wxColour c = disabled ? clrDisabledFlat : clrNormalFlat;
+        DrawFlat(rc, c);
+        return;
     }
 
-    // Clean up brushes
-    DeleteObject(brushOuterTL);
-    DeleteObject(brushInner);
-    DeleteObject(brushOuterBR);
+    if (borderStyle == wxBORDER_THEME)
+    {
+        wxColour c;
+        if (disabled)      c = clrDisabledFlat;
+        else if (readonly) c = clrReadonlyFlat;
+        else if (focused)
+        {
+            DrawFlat(rc, clrFocus);
+            return;
+        }
+        else if (hovered)  c = clrHoverFlat;
+        else               c = clrNormalFlat;
+
+        DrawFlat(rc, c);
+        return;
+    }
+
+    // ── 3D styles ─────────────────────────────────────────────────────────────
+    const bool raised = (borderStyle == wxBORDER_RAISED);
+
+    if (disabled)
+    {
+        DrawFlat(rc, clrDisabled3D);
+        return;
+    }
+
+    if (focused)
+    {
+        if(borderStyle == wxBORDER_RAISED || borderStyle == wxBORDER_SUNKEN)
+            DrawFocusRing(rc);
+        if (raised)
+            Draw3D(rc, clrHighlight, clrMid, clrShadow);
+        else
+            Draw3D(rc, clrShadow, clrMid, clrHighlight);
+        DrawFlat(rc, clrFocus);
+        return;
+    }
+
+    if (hovered)
+    {
+        if (raised)
+            Draw3D(rc, clrHoverHL, clrHoverMid, clrHoverShadow);
+        else
+            Draw3D(rc, clrHoverShadow, clrHoverMid, clrHoverHL);
+        return;
+    }
+
+    if (readonly && !raised)
+    {
+        const wxColour clrROShadow(50, 50, 50);
+        const wxColour clrROMid(45, 45, 45);
+        const wxColour clrROHL(80, 80, 80);
+        Draw3D(rc, clrROShadow, clrROMid, clrROHL);
+        return;
+    }
+
+    if (raised)
+        Draw3D(rc, clrHighlight, clrMid, clrShadow);
+    else
+        Draw3D(rc, clrShadow, clrMid, clrHighlight);
 }
 
 wxColour GetColour(wxSystemColour index)

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -535,8 +535,6 @@ void DrawDarkModeEdge(HDC hdc, const RECT& rc, int borderStyle, int thickness)
 
     // Determine which colour to use for each side
     COLORREF colTopLeftOuter = raised ? clrHighlight : clrShadow;
-    COLORREF colTopLeftInner = clrMid;
-    COLORREF colBottomRightInner = clrMid;
     COLORREF colBottomRightOuter = raised ? clrShadow : clrHighlight;
 
     // If thickness is 1, we only draw a single band (the outer edge).

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -517,6 +517,103 @@ void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
     ::SendMessage(hwnd, WM_THEMECHANGED, 0, 0);
 }
 
+// Draws a raised or sunken border using two shades (light/dark)
+// for dark mode. The rectangle `rc` is in device coordinates (e.g., window).
+// Draws a raised or sunken border with three shades (light, mid, dark)
+// to mimic the classic Windows 3D effect, using dark-mode colours.
+// The rectangle `rc` is in device coordinates (e.g., the full window).
+void DrawDarkModeEdge(HDC hdc, const RECT& rc, int borderStyle, int thickness)
+{
+    // Dark mode colours – adjust to match your theme
+    COLORREF clrHighlight = RGB(90, 90, 90);   // lightest (top/left outer)
+    COLORREF clrMid = RGB(65, 65, 65);   // middle (inner band)
+    COLORREF clrShadow = RGB(35, 35, 35);   // darkest (bottom/right outer)
+
+    // For sunken edges, the colours are reversed: top/left use shadow,
+    // bottom/right use highlight, and the middle band is still mid-tone.
+    bool raised = (borderStyle == wxBORDER_RAISED);
+
+    // Determine which colour to use for each side
+    COLORREF colTopLeftOuter = raised ? clrHighlight : clrShadow;
+    COLORREF colTopLeftInner = clrMid;
+    COLORREF colBottomRightInner = clrMid;
+    COLORREF colBottomRightOuter = raised ? clrShadow : clrHighlight;
+
+    // If thickness is 1, we only draw a single band (the outer edge).
+    // For thickness >= 2, we draw outer and inner bands.
+    // We'll create brushes for each colour only once.
+    HBRUSH brushOuterTL = CreateSolidBrush(colTopLeftOuter);
+    HBRUSH brushInner = CreateSolidBrush(clrMid);
+    HBRUSH brushOuterBR = CreateSolidBrush(colBottomRightOuter);
+
+    // Helper to fill a rectangle safely
+    auto FillRectSafe = [&](const RECT& rect, HBRUSH brush) {
+        if (rect.right > rect.left && rect.bottom > rect.top)
+            FillRect(hdc, &rect, brush);
+        };
+
+    // We'll draw the border as a set of non-overlapping rectangles.
+    // The border occupies the outer 'thickness' pixels of `rc`.
+    // We'll split into layers: outer layer (first pixel) and inner layer (remaining).
+
+    // Outer layer (1 pixel thick) – always present
+    if (thickness >= 1)
+    {
+        // Top outer
+        RECT rcTopOuter = { rc.left, rc.top, rc.right, rc.top + 1 };
+        FillRectSafe(rcTopOuter, brushOuterTL);
+
+        // Left outer
+        RECT rcLeftOuter = { rc.left, rc.top + 1, rc.left + 1, rc.bottom - 1 };
+        FillRectSafe(rcLeftOuter, brushOuterTL);
+
+        // Bottom outer
+        RECT rcBottomOuter = { rc.left, rc.bottom - 1, rc.right, rc.bottom };
+        FillRectSafe(rcBottomOuter, brushOuterBR);
+
+        // Right outer
+        RECT rcRightOuter = { rc.right - 1, rc.top + 1, rc.right, rc.bottom - 1 };
+        FillRectSafe(rcRightOuter, brushOuterBR);
+    }
+
+    // Inner layer(s) – for thickness >= 2
+    if (thickness >= 2)
+    {
+        // The inner band occupies the remaining pixels (from pixel 1 to thickness-1)
+        // We draw it as a continuous band of mid colour, but we need to handle corners.
+        // To avoid overlaps, we shrink the rectangle by 1 on each side.
+        RECT innerRect = rc;
+        InflateRect(&innerRect, -1, -1); // remove outer pixel
+
+        // Now draw a full inner border of thickness (thickness - 1) using the mid colour.
+        // We'll draw top, left, bottom, right bands within innerRect.
+        int innerThick = thickness - 1;
+        if (innerThick > 0)
+        {
+            // Top inner band
+            RECT rcTopInner = { innerRect.left, innerRect.top, innerRect.right, innerRect.top + innerThick };
+            FillRectSafe(rcTopInner, brushInner);
+
+            // Left inner band
+            RECT rcLeftInner = { innerRect.left, innerRect.top + innerThick, innerRect.left + innerThick, innerRect.bottom - innerThick };
+            FillRectSafe(rcLeftInner, brushInner);
+
+            // Bottom inner band
+            RECT rcBottomInner = { innerRect.left, innerRect.bottom - innerThick, innerRect.right, innerRect.bottom };
+            FillRectSafe(rcBottomInner, brushInner);
+
+            // Right inner band
+            RECT rcRightInner = { innerRect.right - innerThick, innerRect.top + innerThick, innerRect.right, innerRect.bottom - innerThick };
+            FillRectSafe(rcRightInner, brushInner);
+        }
+    }
+
+    // Clean up brushes
+    DeleteObject(brushOuterTL);
+    DeleteObject(brushInner);
+    DeleteObject(brushOuterBR);
+}
+
 wxColour GetColour(wxSystemColour index)
 {
     return wxDarkModeModule::GetSettings().GetColour(index);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4019,7 +4019,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     ReleaseDC(hwnd, dc);
 
-                    /* Call default proc with our Clip Riogn to get the scrollbars etc. also painted */
+                    /* Call default proc with our clip region to get the scrollbars etc. also painted */
                     rc.result = MSWDefWindowProc(message, (WXWPARAM)(HRGN)cliprgn, lParam);
                     processed = true;
                 }

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3119,10 +3119,35 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
         case WM_SETFOCUS:
             processed = HandleSetFocus((WXHWND)wParam);
+
+            if (wxMSWDarkMode::IsActive())
+            {
+                wxBorder border = DoTranslateBorder(GetBorder());
+                if (border == wxBORDER_SIMPLE ||
+                    border == wxBORDER_STATIC ||
+                    border == wxBORDER_RAISED ||
+                    border == wxBORDER_SUNKEN ||
+                    border == wxBORDER_THEME)
+                {
+                    RedrawWindow(GetHwnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_FRAME);
+                }
+            }
             break;
 
         case WM_KILLFOCUS:
             processed = HandleKillFocus((WXHWND)wParam);
+            if (wxMSWDarkMode::IsActive())
+            {
+                wxBorder border = DoTranslateBorder(GetBorder());
+                if (border == wxBORDER_SIMPLE ||
+                    border == wxBORDER_STATIC ||
+                    border == wxBORDER_RAISED ||
+                    border == wxBORDER_SUNKEN ||
+                    border == wxBORDER_THEME)
+                {
+                    RedrawWindow(GetHwnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_FRAME);
+                }
+            }
             break;
 
         case WM_PRINTCLIENT:
@@ -3835,13 +3860,13 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             {
                 // Determine whether we should draw a border.
                 bool drawBorder = false;
-                int border = DoTranslateBorder(GetBorder());
+                wxBorder border = DoTranslateBorder(GetBorder());
                 switch (border)
                 {
                     case wxBORDER_THEME:
                         drawBorder = true;
                         break;
-
+                    case wxBORDER_SIMPLE:
                     case wxBORDER_STATIC:
                     case wxBORDER_RAISED:
                     case wxBORDER_SUNKEN:
@@ -3849,9 +3874,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         // the default drawing uses light mode colours.
                         drawBorder = wxMSWDarkMode::IsActive();
                         break;
-
                     case wxBORDER_NONE:
-                    case wxBORDER_SIMPLE:
                     default:
                         break;
                 }
@@ -3859,23 +3882,54 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                 if ( drawBorder )
                 {
                     HWND hwnd = GetHWND();
+
+                    // Skip windows with WS_CAPTION for now because full title bar /
+                    // non-client caption painting is not yet implemented .
+                    // We only handle simple bordered controls (EDIT, STATIC, etc.).
+                    LONG style = GetWindowLong(hwnd, GWL_STYLE);
+                    if(style & WS_CAPTION)
+                        break;
+
+                    // Prepare DC flags
+                    DWORD flags = DCX_WINDOW | DCX_CACHE;
+                    if (style & WS_CLIPCHILDREN) flags |= DCX_CLIPCHILDREN;
+                    if (style & WS_CLIPSIBLINGS) flags |= DCX_CLIPSIBLINGS;
+
                     RECT rcWin, rcClient;
                     RECT  rcVscroll = {};
                     RECT rcHscroll = {};
-                    ::GetWindowRect(hwnd, &rcWin);
-                    ::GetClientRect(hwnd, &rcClient); // Get the client area dimensions.
                     const auto thickness = MSWGetBorderThickness();
+
+                    // Prepare border states.
+                    int nState = ETS_NORMAL;
+                    if (!::IsWindowEnabled(hwnd))
+                        nState = ETS_DISABLED;
+                    else if (::GetFocus() == hwnd)
+                        nState = ETS_FOCUSED;
+
+                    // Get rectangles with screen coordinates.
+                    ::GetWindowRect(hwnd, &rcWin);
+                    ::GetClientRect(hwnd, &rcClient);
                     RECT rcClip = rcWin;
+
+                    // Map from screen → window coordinates. MapWindowPoints() is used
+                    // (instead of ScreenToClient) because it properly supports RTL/mirrored windows.
+                    ::MapWindowPoints(nullptr, hwnd, (LPPOINT)&rcWin, 2);
+
+                    // Adjust to (0,0) origin.
+                    ::OffsetRect(&rcClient, -rcWin.left, -rcWin.top);
+                    ::OffsetRect(&rcWin, -rcWin.left, -rcWin.top);
+
+                    // Shrink rcClip to exclude the custom border area
                     rcClip.left += thickness;
                     rcClip.top += thickness;
                     rcClip.right -= thickness;
                     rcClip.bottom -= thickness;
 
                     /* New clipping region passed to default proc to exclude border */
-                    HRGN cliprgn = CreateRectRgnIndirect(&rcClip);
-                    ::MapWindowPoints(nullptr, hwnd, (LPPOINT)&rcWin, 2); // useful for right to left;
-                    ::OffsetRect(&rcClient, -rcWin.left, -rcWin.top); // Adjust to (0,0) origin.
-                    ::OffsetRect(&rcWin, -rcWin.left, -rcWin.top);
+                    AutoHRGN cliprgn = CreateRectRgnIndirect(&rcClip);
+
+                    //Prepare scrollbars states.
                     SCROLLBARINFO vSbi = { sizeof(vSbi) };
                     if (GetScrollBarInfo(hwnd, OBJID_VSCROLL, &vSbi)
                         && vSbi.rcScrollBar.bottom > vSbi.rcScrollBar.top)
@@ -3890,24 +3944,29 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         && hSbi.rcScrollBar.bottom > hSbi.rcScrollBar.top)
                     {
                         MapWindowPoints(nullptr, hwnd, (POINT*)&hSbi.rcScrollBar, 2);
-                        OffsetRect(&hSbi.rcScrollBar, -rcWin.left, -rcWin.top);
+                         OffsetRect(&hSbi.rcScrollBar, -rcWin.left, -rcWin.top);
                         rcHscroll = hSbi.rcScrollBar;
                         rcHscroll.left += thickness;
                     }
+
+                    // Check if wParam is real Region int
                     bool hasRegion = ::GetObjectType(reinterpret_cast<HGDIOBJ>(wParam)) == OBJ_REGION;
-                    DWORD flags = DCX_WINDOW | DCX_CACHE;
-                    LONG style = GetWindowLong(GetHWND(), GWL_STYLE);
-                    if (style & WS_CLIPCHILDREN) flags |= DCX_CLIPCHILDREN;
-                    if (style & WS_CLIPSIBLINGS) flags |= DCX_CLIPSIBLINGS;
-                    HRGN hNewRgn = CreateRectRgn(0, 0, 0, 0);
+                    HRGN intersectRgnCopy = nullptr;
                     if (hasRegion)
                     {
-                        CombineRgn(hNewRgn, (HRGN)wParam, nullptr, RGN_COPY);
-                        CombineRgn(cliprgn, cliprgn, hNewRgn, RGN_AND);
+                        // We duplicate the region because we later call MSWDefWindowProc()
+                        // with our clipped region (cliprgn).
+                        //
+                        // DCX_INTERSECTRGN makes the OS take ownership and destroy the
+                        // region during ReleaseDC(). We must make our own copy of the
+                        // original wParam region to prevent destroying the system region
+                        // while still being able to draw over it and call the default proc.
+                        intersectRgnCopy = CreateRectRgn(0, 0, 0, 0);
+                        CombineRgn(intersectRgnCopy, (HRGN)wParam, nullptr, RGN_COPY);
+                        CombineRgn(cliprgn, cliprgn, intersectRgnCopy, RGN_AND);
                     }
 
-                     HRGN regionCopy = hasRegion ? hNewRgn : nullptr;
-                    if (regionCopy)
+                    if (intersectRgnCopy)
                     {
                         flags |= DCX_INTERSECTRGN;
                     }
@@ -3916,7 +3975,8 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         flags |= DCX_LOCKWINDOWUPDATE;
                     }
 
-                    HDC  dc = GetDCEx(hwnd, regionCopy, flags);
+                    HDC  dc = GetDCEx(hwnd, intersectRgnCopy, flags);
+
                     ::ExcludeClipRect(dc, rcClient.left, rcClient.top, rcClient.right, rcClient.bottom);
                     if (vSbi.rcScrollBar.bottom > vSbi.rcScrollBar.top)
                     {
@@ -3927,51 +3987,41 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         ::ExcludeClipRect(dc, rcHscroll.left, rcHscroll.top, rcHscroll.right, rcHscroll.bottom);
                     }
 
-                    RECT rcBorder;
-                    wxCopyRectToRECT(GetSize(), rcBorder);
-                    if ((border == wxBORDER_RAISED || border == wxBORDER_SUNKEN) && wxMSWDarkMode::IsActive())
+                    if (wxMSWDarkMode::IsActive())
                     {
-                         // Draw with dark-mode edge colours
-
-                        wxMSWDarkMode::DrawDarkModeEdge(dc, rcBorder, border, thickness);
+                        wxPaintDCEx wxWindc(this, dc);
+                        wxBitmap bufferBitmap(rcWin.right - rcWin.left, rcWin.bottom - rcWin.top, -1);
+                        wxMemoryDC memDC;
+                        memDC.SelectObject(bufferBitmap);
+                        memDC.Clear();
+                        // Draw the background
+                        memDC.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)));
+                        memDC.SetPen(*wxTRANSPARENT_PEN);
+                        memDC.DrawRectangle(rcWin.left, rcWin.top, rcWin.right, rcWin.bottom);
+                        // Draw The Border
+                        wxMSWDarkMode::DrawDarkModeBorder(memDC, wxRect(GetSize()), border, thickness, nState);
+                        wxWindc.Blit(rcWin.left, rcWin.top, rcWin.right, rcWin.bottom, &memDC, 0, 0, wxCOPY);
+                        memDC.SelectObject(wxNullBitmap);
                     }
                     else
                     {
-                        // For flat styles (wxBORDER_THEME, wxBORDER_STATIC, wxBORDER_SIMPLE)
-                        // Keep your themed drawing:
-                        //
-                        // The EDIT class gives a good general purpose border in light mode.
-                        // There does not seem to be a dark mode EDIT class that looks good.
-                        // The ListView class below looks good in dark mode but was not
-                        // available until Windows 11 build 26200. The Button class below
-                         // looks OK in dark mode on older Windows.
-                        const auto darkClass = wxCheckOsVersion(10, 0, 26200) ?
-                            L"DarkMode_DarkTheme::ListView" :
-                            L"DarkMode_Explorer::Button";
-                        wxUxThemeHandle hTheme(this, L"EDIT", darkClass);
 
-                        // The part and state values match for the themes we use.
-                        static_assert((int)EP_EDITTEXT == (int)BP_PUSHBUTTON, "parts differ?");
-                        static_assert((int)ETS_NORMAL == (int)LISS_NORMAL, "states differ?");
-
+                        wxUxThemeHandle hTheme(this, L"EDIT");
                         // Make sure the background is in a proper state
-                        if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
+                        if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, nState))
                         {
-                            ::DrawThemeParentBackground(GetHwnd(), dc, &rcBorder);
+                            ::DrawThemeParentBackground(hwnd, dc, &rcWin);
                         }
 
                         // Draw the border
-                        hTheme.DrawBackground(dc, rcBorder, EP_EDITTEXT, ETS_NORMAL);
+                        hTheme.DrawBackground(dc, rcWin, EP_EDITTEXT, nState);
                     }
 
                     ReleaseDC(hwnd, dc);
 
                     /* Call default proc with our Clip Riogn to get the scrollbars etc. also painted */
-                    rc.result = MSWDefWindowProc(message, (WPARAM)cliprgn, lParam);
+                    rc.result = MSWDefWindowProc(message, (WXWPARAM)(HRGN)cliprgn, lParam);
                     processed = true;
-
-                    if (cliprgn != nullptr)
-                        DeleteObject(cliprgn);
                 }
             }
             break;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3859,7 +3859,9 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                 if ( drawBorder )
                 {
                     HWND hwnd = GetHWND();
-                    RECT rcWin, rcClient, rcVscroll, rcHscroll;
+                    RECT rcWin, rcClient;
+                    RECT  rcVscroll = {};
+                    RECT rcHscroll = {};
                     ::GetWindowRect(hwnd, &rcWin);
                     ::GetClientRect(hwnd, &rcClient); // Get the client area dimensions.
                     const auto thickness = MSWGetBorderThickness();
@@ -3875,7 +3877,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                     ::OffsetRect(&rcClient, -rcWin.left, -rcWin.top); // Adjust to (0,0) origin.
                     ::OffsetRect(&rcWin, -rcWin.left, -rcWin.top);
                     SCROLLBARINFO vSbi = { sizeof(vSbi) };
-                    if (GetScrollBarInfo((HWND)GetHWND(), OBJID_VSCROLL, &vSbi)
+                    if (GetScrollBarInfo(hwnd, OBJID_VSCROLL, &vSbi)
                         && vSbi.rcScrollBar.bottom > vSbi.rcScrollBar.top)
                     {
                         MapWindowPoints(nullptr, hwnd, (POINT*)&vSbi.rcScrollBar, 2);
@@ -3884,7 +3886,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         rcVscroll.top += thickness;
                     }
                     SCROLLBARINFO hSbi = { sizeof(vSbi) };
-                    if (GetScrollBarInfo((HWND)GetHWND(), OBJID_HSCROLL, &hSbi)
+                    if (GetScrollBarInfo(hwnd, OBJID_HSCROLL, &hSbi)
                         && hSbi.rcScrollBar.bottom > hSbi.rcScrollBar.top)
                     {
                         MapWindowPoints(nullptr, hwnd, (POINT*)&hSbi.rcScrollBar, 2);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3989,7 +3989,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     if (wxMSWDarkMode::IsActive())
                     {
-                        wxPaintDCEx wxWindc(this, dc);
+                        wxPaintDCEx wxWindc(wxGetWindowFromHWND(hwnd), dc);
                         wxBitmap bufferBitmap(rcWin.right - rcWin.left, rcWin.bottom - rcWin.top, -1);
                         wxMemoryDC memDC;
                         memDC.SelectObject(bufferBitmap);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3835,7 +3835,8 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             {
                 // Determine whether we should draw a border.
                 bool drawBorder = false;
-                switch ( DoTranslateBorder(GetBorder()) )
+                int border = DoTranslateBorder(GetBorder());
+                switch (border)
                 {
                     case wxBORDER_THEME:
                         drawBorder = true;
@@ -3857,48 +3858,118 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                 if ( drawBorder )
                 {
-                    // first ask the widget to paint its non-client area, such as scrollbars, etc.
-                    rc.result = MSWDefWindowProc(message, wParam, lParam);
-                    processed = true;
-
-                    wxWindowDC dc((wxWindow *)this);
-                    wxMSWDCImpl *impl = (wxMSWDCImpl*) dc.GetImpl();
-                    RECT rcBorder;
-                    wxCopyRectToRECT(GetSize(), rcBorder);
-
-                    // Exclude the client area and any scroll bars.
-                    RECT rcClient = rcBorder;
+                    HWND hwnd = GetHWND();
+                    RECT rcWin, rcClient, rcVscroll, rcHscroll;
+                    ::GetWindowRect(hwnd, &rcWin);
+                    ::GetClientRect(hwnd, &rcClient); // Get the client area dimensions.
                     const auto thickness = MSWGetBorderThickness();
-                    InflateRect(&rcClient, -thickness, -thickness);
-                    ::ExcludeClipRect(GetHdcOf(*impl), rcClient.left, rcClient.top,
-                                      rcClient.right, rcClient.bottom);
+                    RECT rcClip = rcWin;
+                    rcClip.left += thickness;
+                    rcClip.top += thickness;
+                    rcClip.right -= thickness;
+                    rcClip.bottom -= thickness;
 
-                    // Draw the theme border and background.
-
-                    // The EDIT class gives a good general purpose border in light mode.
-                    // There does not seem to be a dark mode EDIT class that looks good.
-                    // The ListView class below looks good in dark mode but was not
-                    // available until Windows 11 build 26200. The Button class below
-                    // looks OK in dark mode on older Windows.
-                    const auto darkClass = wxCheckOsVersion(10, 0, 26200) ?
-                        L"DarkMode_DarkTheme::ListView" :
-                        L"DarkMode_Explorer::Button";
-                    wxUxThemeHandle hTheme(this, L"EDIT", darkClass);
-
-                    // The part and state values match for the themes we use.
-                    static_assert((int)EP_EDITTEXT == (int)LVP_LISTITEM, "parts differ?");
-                    static_assert((int)EP_EDITTEXT == (int)BP_PUSHBUTTON, "parts differ?");
-                    static_assert((int)ETS_NORMAL == (int)LISS_NORMAL, "states differ?");
-                    static_assert((int)ETS_NORMAL == (int)PBS_NORMAL, "states differ?");
-
-                    // Make sure the background is in a proper state
-                    if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
+                    /* New clipping region passed to default proc to exclude border */
+                    HRGN cliprgn = CreateRectRgnIndirect(&rcClip);
+                    ::MapWindowPoints(nullptr, hwnd, (LPPOINT)&rcWin, 2); // useful for right to left;
+                    ::OffsetRect(&rcClient, -rcWin.left, -rcWin.top); // Adjust to (0,0) origin.
+                    ::OffsetRect(&rcWin, -rcWin.left, -rcWin.top);
+                    SCROLLBARINFO vSbi = { sizeof(vSbi) };
+                    if (GetScrollBarInfo((HWND)GetHWND(), OBJID_VSCROLL, &vSbi)
+                        && vSbi.rcScrollBar.bottom > vSbi.rcScrollBar.top)
                     {
-                        ::DrawThemeParentBackground(GetHwnd(), GetHdcOf(*impl), &rcBorder);
+                        MapWindowPoints(nullptr, hwnd, (POINT*)&vSbi.rcScrollBar, 2);
+                        OffsetRect(&vSbi.rcScrollBar, -rcWin.left, -rcWin.top);
+                        rcVscroll = vSbi.rcScrollBar;
+                        rcVscroll.top += thickness;
+                    }
+                    SCROLLBARINFO hSbi = { sizeof(vSbi) };
+                    if (GetScrollBarInfo((HWND)GetHWND(), OBJID_HSCROLL, &hSbi)
+                        && hSbi.rcScrollBar.bottom > hSbi.rcScrollBar.top)
+                    {
+                        MapWindowPoints(nullptr, hwnd, (POINT*)&hSbi.rcScrollBar, 2);
+                        OffsetRect(&hSbi.rcScrollBar, -rcWin.left, -rcWin.top);
+                        rcHscroll = hSbi.rcScrollBar;
+                        rcHscroll.left += thickness;
+                    }
+                    bool hasRegion = ::GetObjectType(reinterpret_cast<HGDIOBJ>(wParam)) == OBJ_REGION;
+                    DWORD flags = DCX_WINDOW | DCX_CACHE;
+                    LONG style = GetWindowLong(GetHWND(), GWL_STYLE);
+                    if (style & WS_CLIPCHILDREN) flags |= DCX_CLIPCHILDREN;
+                    if (style & WS_CLIPSIBLINGS) flags |= DCX_CLIPSIBLINGS;
+                    HRGN hNewRgn = CreateRectRgn(0, 0, 0, 0);
+                    if (hasRegion)
+                    {
+                        CombineRgn(hNewRgn, (HRGN)wParam, nullptr, RGN_COPY);
+                        CombineRgn(cliprgn, cliprgn, hNewRgn, RGN_AND);
                     }
 
-                    // Draw the border
-                    hTheme.DrawBackground(GetHdcOf(*impl), rcBorder, EP_EDITTEXT, ETS_NORMAL);
+                     HRGN regionCopy = hasRegion ? hNewRgn : nullptr;
+                    if (regionCopy)
+                    {
+                        flags |= DCX_INTERSECTRGN;
+                    }
+                    else
+                    {
+                        flags |= DCX_LOCKWINDOWUPDATE;
+                    }
+
+                    HDC  dc = GetDCEx(hwnd, regionCopy, flags);
+                    ::ExcludeClipRect(dc, rcClient.left, rcClient.top, rcClient.right, rcClient.bottom);
+                    if (vSbi.rcScrollBar.bottom > vSbi.rcScrollBar.top)
+                    {
+                        ::ExcludeClipRect(dc, rcVscroll.left, rcVscroll.top, rcVscroll.right, rcVscroll.bottom);
+                    }
+                    if (hSbi.rcScrollBar.bottom > hSbi.rcScrollBar.top)
+                    {
+                        ::ExcludeClipRect(dc, rcHscroll.left, rcHscroll.top, rcHscroll.right, rcHscroll.bottom);
+                    }
+
+                    RECT rcBorder;
+                    wxCopyRectToRECT(GetSize(), rcBorder);
+                    if ((border == wxBORDER_RAISED || border == wxBORDER_SUNKEN) && wxMSWDarkMode::IsActive())
+                    {
+                         // Draw with dark-mode edge colours
+
+                        wxMSWDarkMode::DrawDarkModeEdge(dc, rcBorder, border, thickness);
+                    }
+                    else
+                    {
+                        // For flat styles (wxBORDER_THEME, wxBORDER_STATIC, wxBORDER_SIMPLE)
+                        // Keep your themed drawing:
+                        //
+                        // The EDIT class gives a good general purpose border in light mode.
+                        // There does not seem to be a dark mode EDIT class that looks good.
+                        // The ListView class below looks good in dark mode but was not
+                        // available until Windows 11 build 26200. The Button class below
+                         // looks OK in dark mode on older Windows.
+                        const auto darkClass = wxCheckOsVersion(10, 0, 26200) ?
+                            L"DarkMode_DarkTheme::ListView" :
+                            L"DarkMode_Explorer::Button";
+                        wxUxThemeHandle hTheme(this, L"EDIT", darkClass);
+
+                        // The part and state values match for the themes we use.
+                        static_assert((int)EP_EDITTEXT == (int)BP_PUSHBUTTON, "parts differ?");
+                        static_assert((int)ETS_NORMAL == (int)LISS_NORMAL, "states differ?");
+
+                        // Make sure the background is in a proper state
+                        if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
+                        {
+                            ::DrawThemeParentBackground(GetHwnd(), dc, &rcBorder);
+                        }
+
+                        // Draw the border
+                        hTheme.DrawBackground(dc, rcBorder, EP_EDITTEXT, ETS_NORMAL);
+                    }
+
+                    ReleaseDC(hwnd, dc);
+
+                    /* Call default proc with our Clip Riogn to get the scrollbars etc. also painted */
+                    rc.result = MSWDefWindowProc(message, (WPARAM)cliprgn, lParam);
+                    processed = true;
+
+                    if (cliprgn != nullptr)
+                        DeleteObject(cliprgn);
                 }
             }
             break;


### PR DESCRIPTION
Fixes #26630
Closes #26631
- Invert WM_NCPAINT execution flow to draw custom dark borders before DefProc runs.
- Construct a clipped inner region to pass to MSWDefWindowProc, preventing the system from flashing the light-mode border.
- Implement strict GDI validation using GetObjectType to safely screen out internal window manager sentinels (like wParam == 1).
- Migrate from high-level wxWindowDC/wxMSWDCImpl abstraction to low-level GetDCEx to achieve fine-grained control over region clipping flags.
- Duplicate the region handle because the OS assumes absolute ownership under the DCX_INTERSECTRGN flag and destroys it during ReleaseDC.
- Explicitly exclude active scrollbar bounds via GetScrollBarInfo to prevent border bleed.
- Integrate DrawDarkModeEdge to render custom 3D raised and sunken frames using multi-tone dark-mode color structures, maintaining clear control depth without relying on system themes.
- ### before 

https://github.com/user-attachments/assets/64629375-1a0c-49ea-b974-0f5b2d8c2a63

- ### after


https://github.com/user-attachments/assets/b02640f4-dbce-4a94-a438-bfa20faab7e5

<img width="517" height="888" alt="Fix Darkmode NoneClient border flicker via GDI region partitioning" src="https://github.com/user-attachments/assets/ce1a1aa2-f2a4-4cb9-b51c-4072a648ed44" />
