### PR TITLE
Fix system colour change for wxVListBox

### DIFF
--- a/src/generic/vlbox.cpp
+++ b/src/generic/vlbox.cpp
@@ -82,10 +82,6 @@ bool wxVListBox::Create(wxWindow *parent,
     if ( style & wxLB_MULTIPLE )
         m_selStore = new wxSelectionStore;
 
-    // make sure the native widget has the right colour since we do
-    // transparent drawing by default
-    SetBackgroundColour(GetBackgroundColour());
-
     // leave m_colBgSel in an invalid state: it means for OnDrawBackground()
     // to use wxRendererNative instead of painting selection bg ourselves
     m_colBgSel = wxNullColour;


### PR DESCRIPTION
Remove the background colour setting from `wxVListBox::Create()` so that the control uses the up-to-date background colour in the paint event handler. This way the control responds to system colour changes.

The comment about transparent drawing is wrong since 0975a8a065 (Applied patch [ 1405821 ] wxVListBox double-buffering + fix to a scrolling issue By Jaakko Salli, 2006-01-17).