### PR TITLE
Fix wxPropertyGrid dark mode switching

### DIFF
--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1356,12 +1356,13 @@ void wxPropertyGrid::CalculateFontAndBitmapStuff( int vspacing )
 
 // -----------------------------------------------------------------------
 
-void wxPropertyGrid::OnSysColourChanged( wxSysColourChangedEvent &WXUNUSED(event) )
+void wxPropertyGrid::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
     if ((m_iFlags & wxPG_FL_INITIALIZED)!=0) {
         RegainColours();
         Refresh();
     }
+    event.Skip();
 }
 
 void wxPropertyGrid::OnDPIChanged(wxDPIChangedEvent &event)


### PR DESCRIPTION
Add `event.Skip()` to `wxPropertyGrid::OnSysColourChanged()` so that upon switching to or from dark mode, the scroll bar switches modes.