### PR TITLE
Fix wxStyledTextCtrl dark mode switching

### DIFF
--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -5810,8 +5810,10 @@ void wxStyledTextCtrl::OnDPIChanged(wxDPIChangedEvent& evt) {
 }
 
 
-void wxStyledTextCtrl::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(evt)) {
+void wxStyledTextCtrl::OnSysColourChanged(wxSysColourChangedEvent& evt)
+{
     m_swx->DoInvalidateStyleData();
+    evt.Skip();
 }
 
 

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -1002,8 +1002,10 @@ void wxStyledTextCtrl::OnDPIChanged(wxDPIChangedEvent& evt) {
 }
 
 
-void wxStyledTextCtrl::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(evt)) {
+void wxStyledTextCtrl::OnSysColourChanged(wxSysColourChangedEvent& evt)
+{
     m_swx->DoInvalidateStyleData();
+    evt.Skip();
 }
 
 


### PR DESCRIPTION
Add `event.Skip()` to `wxStyledTextCtrl::OnSysColourChanged()` so that upon switching to or from dark mode, the scroll bar switches modes.