### PR TITLE
Add parent distro info to wxLinuxDistributionInfo/wxGetOsDescription

### DIFF
--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -125,13 +125,17 @@ struct wxLinuxDistributionInfo
     wxString Release;
     wxString CodeName;
     wxString Description;
+    wxString ParentName;
+    wxString ParentCodeName;
 
     bool operator==(const wxLinuxDistributionInfo& ldi) const
     {
         return Id == ldi.Id &&
                Release == ldi.Release &&
                CodeName == ldi.CodeName &&
-               Description == ldi.Description;
+               Description == ldi.Description &&
+               ParentName == ldi.ParentName &&
+               ParentCodeName == ldi.ParentCodeName;
     }
 
     bool operator!=(const wxLinuxDistributionInfo& ldi) const

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -131,6 +131,18 @@ struct wxLinuxDistributionInfo
     wxString Release;           //!< The version of the distribution; e.g. "9.04"
     wxString CodeName;          //!< The code name of the distribution; e.g. "jaunty"
     wxString Description;       //!< The description of the distribution; e.g. "Ubuntu 9.04"
+    /**
+        The parent distribution name; e.g. "ubuntu debian".
+
+        @since 3.3.3
+    */
+    wxString ParentName;
+    /**
+        The upstream release codename; e.g. "noble".
+
+        @since 3.3.3
+    */
+    wxString ParentCodeName;
 
     bool operator==(const wxLinuxDistributionInfo& ldi) const;
     bool operator!=(const wxLinuxDistributionInfo& ldi) const;

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -844,6 +844,7 @@ bool wxGetUserName(char* buf, int sz);
     Returns the string containing the description of the current platform in a
     user-readable form. For example, this function may return strings like
     "Windows 10 Pro 22H2 (build 19045), 64-bit edition",
+    "Linux Mint 22.3, based on ubuntu debian (noble), 6.18.36-generic x86_64",
     "AlmaLinux 10.1 (Heliotrope Lion), 6.12.0-55.9.1.el10_0.x86_64",
     or "Linux 4.1.4 i386".
 

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1281,8 +1281,8 @@ wxGetDescFromOSRelease(wxString* distName, wxString* version,
 
             *version = fc.Read("VERSION");
 
-            *parentName = fc.Read("ID_LIKE", wxEmptyString);
-            *parentCodeName = fc.Read("UBUNTU_CODENAME", wxEmptyString);
+            *parentName = fc.Read("ID_LIKE");
+            *parentCodeName = fc.Read("UBUNTU_CODENAME");
 
             return true;
         }

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1152,6 +1152,8 @@ wxGetValuesFromOSRelease(const wxString& filename, wxLinuxDistributionInfo& ret)
     ret.Description = fc.Read(wxS("PRETTY_NAME"), wxEmptyString);
     ret.Release = fc.Read(wxS("VERSION_ID"), wxEmptyString);
     ret.CodeName = fc.Read(wxS("VERSION_CODENAME"), wxEmptyString);
+    ret.ParentName = fc.Read(wxS("ID_LIKE"), wxEmptyString);
+    ret.ParentCodeName = fc.Read(wxS("UBUNTU_CODENAME"), wxEmptyString);
 
     return true;
 #else
@@ -1254,7 +1256,8 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 }
 
 static bool
-wxGetDescFromOSRelease(wxString* distName, wxString* version)
+wxGetDescFromOSRelease(wxString* distName, wxString* version,
+                       wxString* parentName, wxString* parentCodeName)
 {
 #if wxUSE_CONFIG
     // Read /etc/os-release and fall back to /usr/lib/os-release per below
@@ -1278,6 +1281,9 @@ wxGetDescFromOSRelease(wxString* distName, wxString* version)
 
             *version = fc.Read("VERSION");
 
+            *parentName = fc.Read("ID_LIKE", wxEmptyString);
+            *parentCodeName = fc.Read("UBUNTU_CODENAME", wxEmptyString);
+
             return true;
         }
     }
@@ -1291,13 +1297,31 @@ wxString wxGetOsDescription()
 #ifdef __VMS
     return wxGetCommandOutput(wxT("uname -s -v -m"));
 #else
-    wxString distName, version;
-    if ( wxGetDescFromOSRelease(&distName, &version) )
+    wxString distName, version, parentName, parentCodeName;
+    if ( wxGetDescFromOSRelease(&distName, &version, &parentName, &parentCodeName) )
     {
         wxString osDesc = distName;
         if ( !version.empty() )
         {
             osDesc += " " + version;
+        }
+        if ( !parentName.empty() )
+        {
+            if ( !parentCodeName.empty() )
+            {
+                /* TRANSLATORS: first %s is a Linux distribution parent name, second %s is its codename. */
+                osDesc += wxString::Format(_(", based on %s (%s)"), parentName, parentCodeName);
+            }
+            else
+            {
+                /* TRANSLATORS: %s is a Linux distribution parent name. */
+                osDesc += wxString::Format(_(", based on %s"), parentName);
+            }
+        }
+        else if ( !parentCodeName.empty() )
+        {
+            /* TRANSLATORS: %s is an upstream codename. */
+            osDesc += wxString::Format(_(", based on %s"), parentCodeName);
         }
         osDesc += ",";
 


### PR DESCRIPTION
Include the distro name and (Ubuntu) code name (if available/applicable).