### PR TITLE
MSW: Fix dark mode border flicker

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3858,7 +3858,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                 if ( drawBorder )
                 {
                     // Have the window draw its scrollbars, if any. To avoid flicker,
-                    // prevent the border from being drawn by specifing a clipping,
+                    // prevent the border from being drawn by specifing a clipping
                     // region with everything inside the border. For simplicity,
                     // ignore any existing clipping region in the wParam argument.
                     RECT rcClip;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3857,8 +3857,16 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                 if ( drawBorder )
                 {
-                    // first ask the widget to paint its non-client area, such as scrollbars, etc.
-                    rc.result = MSWDefWindowProc(message, wParam, lParam);
+                    // Have the window draw its scrollbars, if any. To avoid flicker,
+                    // prevent the border from being drawn by specifing a clipping,
+                    // region with everything inside the border. For simplicity,
+                    // ignore any existing clipping region in the wParam argument.
+                    RECT rcClip;
+                    ::GetWindowRect(m_hWnd, &rcClip);
+                    const auto thickness = MSWGetBorderThickness();
+                    ::InflateRect(&rcClip, -thickness, -thickness);
+                    AutoHRGN cliprgn = ::CreateRectRgnIndirect(&rcClip);
+                    rc.result = MSWDefWindowProc(message, (WXWPARAM)(HRGN)cliprgn, lParam);
                     processed = true;
 
                     wxWindowDC dc((wxWindow *)this);
@@ -3868,7 +3876,6 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     // Exclude the client area and any scroll bars.
                     RECT rcClient = rcBorder;
-                    const auto thickness = MSWGetBorderThickness();
                     InflateRect(&rcClient, -thickness, -thickness);
                     ::ExcludeClipRect(GetHdcOf(*impl), rcClient.left, rcClient.top,
                                       rcClient.right, rcClient.bottom);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3881,31 +3881,35 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                                       rcClient.right, rcClient.bottom);
 
                     // Draw the theme border and background.
-
-                    // The EDIT class gives a good general purpose border in light mode.
-                    // There does not seem to be a dark mode EDIT class that looks good.
-                    // The ListView class below looks good in dark mode but was not
-                    // available until Windows 11 build 26200. The Button class below
-                    // looks OK in dark mode on older Windows.
-                    const auto darkClass = wxCheckOsVersion(10, 0, 26200) ?
-                        L"DarkMode_DarkTheme::ListView" :
-                        L"DarkMode_Explorer::Button";
-                    wxUxThemeHandle hTheme(this, L"EDIT", darkClass);
-
-                    // The part and state values match for the themes we use.
-                    static_assert((int)EP_EDITTEXT == (int)LVP_LISTITEM, "parts differ?");
-                    static_assert((int)EP_EDITTEXT == (int)BP_PUSHBUTTON, "parts differ?");
-                    static_assert((int)ETS_NORMAL == (int)LISS_NORMAL, "states differ?");
-                    static_assert((int)ETS_NORMAL == (int)PBS_NORMAL, "states differ?");
-
-                    // Make sure the background is in a proper state
-                    if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
+                    if ( wxMSWDarkMode::IsActive() )
                     {
-                        ::DrawThemeParentBackground(GetHwnd(), GetHdcOf(*impl), &rcBorder);
+                        // There does not seem to be a theme class that draws a good
+                        // border on all supported versions of Windows. Manually draw a
+                        // 1-pixel thick border. Use the observed colour of the simple
+                        // border, WS_BORDER.
+                        AutoHBRUSH brushBorder(0x646464);
+                        ::FrameRect(GetHdcOf(*impl), &rcBorder, brushBorder);
+                        // Draw the background with consecutively smaller 1-pixel thick
+                        // rectangles.
+                        AutoHBRUSH brushBg(GetBackgroundColour().GetPixel());
+                        for (int count = 1; count < thickness; count++)
+                        {
+                            ::InflateRect(&rcBorder, -1, -1);
+                            ::FrameRect(GetHdcOf(*impl), &rcBorder, brushBg);
+                        }
                     }
-
-                    // Draw the border
-                    hTheme.DrawBackground(GetHdcOf(*impl), rcBorder, EP_EDITTEXT, ETS_NORMAL);
+                    else
+                    {
+                        // The EDIT class gives a good general purpose border in light mode.
+                        wxUxThemeHandle hTheme(this, L"EDIT");
+                        // Make sure the background is in a proper state
+                        if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
+                        {
+                            ::DrawThemeParentBackground(GetHwnd(), GetHdcOf(*impl), &rcBorder);
+                        }
+                        // Draw the border
+                        hTheme.DrawBackground(GetHdcOf(*impl), rcBorder, EP_EDITTEXT, ETS_NORMAL);
+                    }
                 }
             }
             break;


### PR DESCRIPTION
This is a proposed alternative to #26635. This is starkly minimalistic while retaining the two essential ideas proposed by @memoarfaa.

1. The flicker problem is solved by using a clipping region when calling `MSWDefWindowProc()` to prevent drawing the light mode border.

2. The dark mode border is drawn explicitly instead of using UxTheme so that it looks good on older versions of windows. This is extremely simple for now. The border is always a 1-pixel thick gray rectangle, regardless of border style. The color is hard-coded to what I see with `wxBORDER_SIMPLE`/`WS_BORDER`. A possible improvement is to get the color by querying a theme class with `TMT_BORDERCOLOR`. I experimented with this but was not able to get a satisfactory color. Other possible improvements might be rounded corners or an indication of focus for some controls. For example, in light mode, the edit control shows a blue line at the bottom when focused.
