### PR TITLE
MSW: Fix dark mode wxSpinCtrl border

### DIFF
--- a/include/wx/msw/spinctrl.h
+++ b/include/wx/msw/spinctrl.h
@@ -132,6 +132,7 @@ protected:
     virtual bool MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result) override;
     virtual bool MSWOnScroll(int orientation, WXWORD wParam,
                              WXWORD pos, WXHWND control) override;
+    virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
     virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI) override;
 
     // handle processing of special keys
@@ -175,6 +176,11 @@ private:
 
     // Calculate the best size for the number with the given number of digits.
     wxSize GetBestSizeFromDigitsCount(int digitsCount) const;
+
+    // The window style and extended style that the buddy text control was
+    // created with.
+    WXDWORD m_buddyStyle;
+    WXDWORD m_buddyExStyle;
 
     wxDECLARE_DYNAMIC_CLASS(wxSpinCtrl);
     wxDECLARE_EVENT_TABLE();

--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -134,14 +134,11 @@ bool wxSpinButton::Create(wxWindow *parent,
     SubclassWin(m_hWnd);
 
     Bind(wxEVT_PAINT, &wxSpinButton::OnPaint, this);
-    Bind(wxEVT_ERASE_BACKGROUND, [](wxEraseEvent& event)
-    {
-        // Do nothing in dark mode, the background will be erased in OnPaint().
-        if ( !wxMSWDarkMode::IsActive() )
-            event.Skip();
-    });
 
     SetInitialSize(size);
+
+    if ( wxMSWDarkMode::IsActive() )
+        MSWSetDarkOrLightMode(SetMode::Initial);
 
     return true;
 }
@@ -175,7 +172,10 @@ wxSize wxSpinButton::DoGetBestSize() const
 
 void wxSpinButton::OnPaint(wxPaintEvent& event)
 {
-    if ( wxMSWDarkMode::IsActive() )
+    // The underlying control responds properly to dark mode starting with
+    // Windows 11 22H2. If we're in dark mode on an older OS, invert the
+    // result of the control's light mode painting.
+    if ( wxMSWDarkMode::IsActive() && !wxCheckOsVersion(10, 0, 22621) )
     {
         // Unfortunately PaintIfNecessary() can't be used here as we need to
         // handle the extra border below, so duplicate what it does here.

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -33,6 +33,7 @@
 #include "wx/private/spinctrl.h"
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/winstyle.h"
 
 #include "wx/scopeguard.h"
@@ -326,6 +327,8 @@ bool wxSpinCtrl::Create(wxWindow *parent,
         return false;
     }
 
+    m_buddyStyle = msStyle;
+    m_buddyExStyle = exStyle;
 
     // create the spin button without any border as it doesn't make sense for
     // it (even if it doesn't seem to be actually taken into account anyhow)
@@ -733,6 +736,46 @@ bool wxSpinCtrl::MSWOnNotify(int WXUNUSED(idCtrl), WXLPARAM lParam, WXLPARAM *re
     *result = 0;  // never reject UP and DOWN events
 
     return TRUE;
+}
+
+void wxSpinCtrl::MSWSetDarkOrLightMode(SetMode setmode)
+{
+    wxSpinButton::MSWSetDarkOrLightMode(setmode);
+
+    // In dark mode, set the buddy text control border to wxBORDER_SIMPLE
+    // (WS_BORDER), unless the original border style was wxBORDER_NONE. When
+    // switching to light mode, restore the border to the original style.
+    //
+    // The control has an anomaly to work around: We do not set WS_BORDER if
+    // the control was created with WS_BORDER because then the control
+    // incorrectly shows a 2-pixel thick border. The control remembers how it
+    // was created and shows the WS_BORDER without WS_BORDER being set again.
+
+    // Get current window style and extended style, without border flags.
+    auto style = ::GetWindowLongPtr(m_hwndBuddy, GWL_STYLE) & ~WS_BORDER;
+    const auto exMask = WS_EX_CLIENTEDGE | WS_EX_DLGMODALFRAME | WS_EX_STATICEDGE;
+    auto exStyle = ::GetWindowLongPtr(m_hwndBuddy, GWL_EXSTYLE) & ~exMask;
+
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        // Set WSBORDER unless the control was created with WS_BORDER (and the
+        // anomaly described above would occur) or the control should have no
+        // border.
+        if ( !(m_buddyStyle & WS_BORDER) && (m_buddyExStyle & exMask) )
+            style |= WS_BORDER;
+    }
+    else
+    {
+        // Restore exStyle border flags. Do not restore WS_BORDER due to the
+        // anomaly described above.
+        exStyle |= m_buddyExStyle & exMask;
+    }
+
+    // Set new border.
+    ::SetWindowLongPtr(m_hwndBuddy, GWL_STYLE, style);
+    ::SetWindowLongPtr(m_hwndBuddy, GWL_EXSTYLE, exStyle);
+    ::SetWindowPos(m_hwndBuddy, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED |
+        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
 // Reuse the function defined in src/msw/textentry.cpp.


### PR DESCRIPTION
On Windows in dark mode, set the border on the wxSpinCtrl's text control to a simple gray 1-pixel thick border. See #26655.

~~This also fixes dark mode switching for wxSpinButton, for Windows 11 22H2 and later.~~

This is a relatively low-risk solution with an imminent upcoming release in mind. A more complicated idea is for the spin control's text control to be managed using wxTextCtrl rather than an HWND to a low-level EDIT control. The low-level control does not get the WM_NCPAINT handling that draws dark mode and themed borders.
