### PR TITLE
Fix dark mode and DPI issues with ribbon's control buttons

### DIFF
--- a/include/wx/ribbon/art.h
+++ b/include/wx/ribbon/art.h
@@ -667,10 +667,6 @@ protected:
     wxBitmapBundle m_gallery_extension_bundle[4];
     wxBitmapBundle m_toolbar_drop_bundle;
     wxBitmapBundle m_panel_extension_bundle[2];
-    wxBitmapBundle m_ribbon_toggle_up_bundle[2];
-    wxBitmapBundle m_ribbon_toggle_down_bundle[2];
-    wxBitmapBundle m_ribbon_toggle_pin_bundle[2];
-    wxBitmapBundle m_ribbon_bar_help_button_bundle[2];
 
     wxColour m_primary_scheme_colour;
     wxColour m_secondary_scheme_colour;

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -88,179 +88,6 @@ static const char* const panel_extension_xpm[] = {
   "x   xxx",
   "   xxxx"};
 
-static const char* const panel_toggle_down_xpm[] = {
-  "7 9 2 1",
-  "  c None",
-  "x c #FF00FF",
-  "       ",
-  "x     x",
-  "xx   xx",
-  " xx xx ",
-  "x xxx x",
-  "xx x xx",
-  " xx xx ",
-  "  xxx  ",
-  "   x   ",};
-
-static const char* const panel_toggle_up_xpm[] = {
-  "7 9 2 1",
-  "  c None",
-  "x c #FF00FF",
-  "   x   ",
-  "  xxx  ",
-  " xx xx ",
-  "xx x xx",
-  "x xxx x",
-  " xx xx ",
-  "xx   xx",
-  "x     x",
-  "       ",};
-
-static const char* const ribbon_toggle_pin_xpm[] = {
-  "12 9 3 1",
-  "  c None",
-  "x c #FF00FF",
-  ". c #FF00FF",
-  "   xx       ",
-  "   x.x   xxx",
-  "   x..xxx..x",
-  "xxxx.......x",
-  "x..........x",
-  "xxxx.......x",
-  "   x..xxx..x",
-  "   x.x   xxx",
-  "   xx       "
-};
-
-static const char * const ribbon_help_button_xpm[] = {
-"12 12 112 2",
-"   c #163B95",
-".  c none",
-"X  c #1B3F98",
-"o  c #1B4097",
-"O  c #1D4198",
-"+  c #1E4298",
-"@  c #1E439B",
-"#  c #1A419F",
-"$  c #1E439D",
-"%  c #204398",
-"&  c #204399",
-"*  c #25479B",
-"=  c #25489A",
-"-  c #284A9D",
-";  c #2A4C9D",
-":  c #30519E",
-">  c #3B589A",
-",  c #3D599B",
-"<  c #1840A2",
-"1  c #1E45A1",
-"2  c #1E4AB4",
-"3  c #2D4FA0",
-"4  c #224AAC",
-"5  c #254DAC",
-"6  c #294FA9",
-"7  c #2B52AE",
-"8  c #3051A0",
-"9  c #3354A0",
-"0  c #3354A2",
-"q  c #3454A3",
-"w  c #3456A4",
-"e  c #3556A4",
-"r  c #3C5BA3",
-"t  c #395AA6",
-"y  c #3E5CA6",
-"u  c #3E5DA7",
-"i  c #3F5EA6",
-"p  c #2A51B0",
-"a  c #2E55B5",
-"s  c #2752BA",
-"d  c #3058B8",
-"f  c #3F61B2",
-"g  c #415FA7",
-"h  c #4562A7",
-"j  c #4864A7",
-"k  c #4D67A5",
-"l  c #4361A8",
-"z  c #4361A9",
-"x  c #4663A8",
-"c  c #4563AA",
-"v  c #4764AA",
-"b  c #4B68AE",
-"n  c #506AA8",
-"m  c #516DAD",
-"M  c #546EAC",
-"N  c #5F75AB",
-"B  c #5A72AC",
-"V  c #5C77B6",
-"C  c #6C7DA7",
-"Z  c #6077AD",
-"A  c #687DAF",
-"S  c #637BB4",
-"D  c #687FB7",
-"F  c #2D59C1",
-"G  c #2E5AC2",
-"H  c #2F5ECE",
-"J  c #3763CC",
-"K  c #4169CB",
-"L  c #7787AC",
-"P  c #7E8CAE",
-"I  c #7A8BB5",
-"U  c #7B8CB4",
-"Y  c #7C8FBD",
-"T  c #758FCA",
-"R  c #808CA8",
-"E  c #969DAF",
-"W  c #8291B4",
-"Q  c #8A95B0",
-"!  c #8B96B1",
-"~  c #8F9AB3",
-"^  c #8D98B5",
-"/  c #8E9AB7",
-"(  c #8997B8",
-")  c #949EB9",
-"_  c #99A1B4",
-"`  c #ADAFB7",
-"'  c #A5ABB8",
-"]  c #A6ABB8",
-"[  c #AAAFBE",
-"{  c #AFB2BE",
-"}  c #B0B1B6",
-"|  c #BAB8B6",
-" . c #B4B5BC",
-".. c #B6B9BF",
-"X. c #BBB9B8",
-"o. c #8C9DC3",
-"O. c #8EA3D4",
-"+. c #97AAD4",
-"@. c #ACB5C9",
-"#. c #B3B7C0",
-"$. c #A1B1D5",
-"%. c #BAC3D7",
-"&. c #BEC6D6",
-"*. c #D7D2C7",
-"=. c #C2C8D6",
-"-. c #D2D6DF",
-";. c #E8E4DA",
-":. c #CED5E4",
-">. c #FFF9EC",
-",. c #F3F4F5",
-"<. c #F6F8FB",
-"1. c None",
-/* pixels */
-"1.1.1.1.#./ W ~ } 1.1.1.",
-"1.1.1.U r c b t h Q 1.1.",
-"1.1.A 3 $.<.,.&.m w ^ 1.",
-"1.( 0 z :.%.=.;.) e x ` ",
-"1.n u v M * B *.R O @ P ",
-"' i z l - 9 { | > $ # Z ",
-"_ y l ; & [ X., 1 6 4 D ",
-"] g 8 o :  .C < 7 a s o.",
-"1.k X % = I S 5 d G K ..",
-"1.! .   j >.-.p F H +.1.",
-"1.1.L X + Y V 2 J O.1.1.",
-"1.1.1.E N q f T @.1.1.1."
-};
-
 wxRibbonMSWArtProvider::wxRibbonMSWArtProvider(bool set_colour_scheme)
 #if defined( __WXOSX__ )
     : m_tab_label_font(*wxSMALL_FONT)
@@ -527,10 +354,6 @@ void wxRibbonMSWArtProvider::CloneTo(wxRibbonMSWArtProvider* copy) const
     for(i = 0; i < 2; ++i)
     {
         copy->m_panel_extension_bundle[i] = m_panel_extension_bundle[i];
-        copy->m_ribbon_toggle_up_bundle[i] = m_ribbon_toggle_up_bundle[i];
-        copy->m_ribbon_toggle_down_bundle[i] = m_ribbon_toggle_down_bundle[i];
-        copy->m_ribbon_toggle_pin_bundle[i] = m_ribbon_toggle_pin_bundle[i];
-        copy->m_ribbon_bar_help_button_bundle[i] = m_ribbon_bar_help_button_bundle[i];
     }
     copy->m_toolbar_drop_bundle = m_toolbar_drop_bundle;
 
@@ -1276,17 +1099,9 @@ void wxRibbonMSWArtProvider::SetColour(int id, const wxColor& colour)
             break;
         case wxRIBBON_ART_PAGE_TOGGLE_FACE_COLOUR:
             m_page_toggle_face_colour = colour;
-            m_ribbon_toggle_down_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_down_xpm, colour));
-            m_ribbon_toggle_up_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_up_xpm, colour));
-            m_ribbon_toggle_pin_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_toggle_pin_xpm, colour));
-            m_ribbon_bar_help_button_bundle[0] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_help_button_xpm, colour));
             break;
         case wxRIBBON_ART_PAGE_TOGGLE_HOVER_FACE_COLOUR:
             m_page_toggle_hover_face_colour = colour;
-            m_ribbon_toggle_down_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_down_xpm, colour));
-            m_ribbon_toggle_up_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(panel_toggle_up_xpm, colour));
-            m_ribbon_toggle_pin_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_toggle_pin_xpm, colour));
-            m_ribbon_bar_help_button_bundle[1] = wxBitmapBundle::FromBitmap(wxRibbonLoadPixmap(ribbon_help_button_xpm, colour));
             break;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_TOP_COLOUR:
            m_tab_highlight_top_colour = colour;
@@ -2855,30 +2670,50 @@ wxRibbonMSWArtProvider::DrawToggleButton(wxDC& dc,
                                          const wxRect& rect,
                                          wxRibbonDisplayMode mode)
 {
-    int bindex = 0;
     DrawPartialPageBackground(dc, wnd, rect, false);
 
     dc.DestroyClippingRegion();
     dc.SetClippingRegion(rect);
 
-    if(wnd->IsToggleButtonHovered())
+    const bool isHovered = wnd->IsToggleButtonHovered();
+    if(isHovered)
     {
         dc.SetPen(m_ribbon_toggle_pen);
         dc.SetBrush(m_ribbon_toggle_brush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
-        bindex = 1;
     }
+
+    const wxColour& faceColour = isHovered ? m_page_toggle_hover_face_colour : m_page_toggle_face_colour;
+    dc.SetPen(wxPen(faceColour, 2));
+    dc.SetBrush(wxBrush(faceColour));
+
+    const int cx = rect.GetX() + 10;
+
     switch(mode)
     {
         case wxRIBBON_BAR_PINNED:
-            dc.DrawBitmap(m_ribbon_toggle_up_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawLine(cx - 3, rect.GetY() + 13, cx, rect.GetY() + 10);
+            dc.DrawLine(cx, rect.GetY() + 10, cx + 3, rect.GetY() + 13);
+            dc.DrawLine(cx - 3, rect.GetY() + 9, cx, rect.GetY() + 6);
+            dc.DrawLine(cx, rect.GetY() + 6, cx + 3, rect.GetY() + 9);
             break;
         case wxRIBBON_BAR_MINIMIZED:
-            dc.DrawBitmap(m_ribbon_toggle_down_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawLine(cx - 3, rect.GetY() + 7, cx, rect.GetY() + 10);
+            dc.DrawLine(cx, rect.GetY() + 10, cx + 3, rect.GetY() + 7);
+            dc.DrawLine(cx - 3, rect.GetY() + 11, cx, rect.GetY() + 14);
+            dc.DrawLine(cx, rect.GetY() + 14, cx + 3, rect.GetY() + 11);
             break;
         case wxRIBBON_BAR_EXPANDED:
-            dc.DrawBitmap(m_ribbon_toggle_pin_bundle[bindex].GetBitmapFor(wnd), rect.GetX ()+4, rect.GetY ()+5, true);
+        {
+            const int x = rect.GetX() + 4;
+            const int y = rect.GetY() + 10;
+            dc.DrawLine(x + 2, y, x + 6, y);
+            const wxPoint body[] = {{x + 6, y}, {x + 14, y - 3}, {x + 14, y + 3}};
+            dc.DrawPolygon(3, body);
+            const wxPoint flare[] = {{x + 8, y - 3}, {x + 12, y}, {x + 8, y + 3}};
+            dc.DrawPolygon(3, flare);
             break;
+        }
     }
 }
 
@@ -2891,18 +2726,21 @@ void wxRibbonMSWArtProvider::DrawHelpButton(wxDC& dc,
     dc.DestroyClippingRegion();
     dc.SetClippingRegion(rect);
 
-    if ( wnd->IsHelpButtonHovered() )
+    const bool isHovered = wnd->IsHelpButtonHovered();
+    if ( isHovered )
     {
         dc.SetPen(m_ribbon_toggle_pen);
         dc.SetBrush(m_ribbon_toggle_brush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[1].GetBitmapFor(wnd), rect.GetX ()+4, rect.GetY()+5, true);
-    }
-    else
-    {
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[0].GetBitmapFor(wnd), rect.GetX ()+4, rect.GetY()+5, true);
     }
 
+    dc.SetFont(m_tab_label_font);
+    dc.SetTextForeground(isHovered ? m_page_toggle_hover_face_colour : m_page_toggle_face_colour);
+    const wxString label("?");
+    wxSize sz = dc.GetTextExtent(label);
+    dc.DrawText(label,
+                rect.GetX() + (20 - sz.GetWidth()) / 2,
+                rect.GetY() + (20 - sz.GetHeight()) / 2);
 }
 
 void wxRibbonMSWArtProvider::GetBarTabWidth(

--- a/src/ribbon/art_msw_flat.cpp
+++ b/src/ribbon/art_msw_flat.cpp
@@ -1042,30 +1042,50 @@ wxRibbonMSWFlatArtProvider::DrawToggleButton(wxDC& dc,
                                          const wxRect& rect,
                                          wxRibbonDisplayMode mode)
 {
-    int bindex = 0;
     DrawPartialPageBackground(dc, wnd, rect, false);
 
     dc.DestroyClippingRegion();
     dc.SetClippingRegion(rect);
 
-    if ( wnd->IsToggleButtonHovered() )
+    const bool isHovered = wnd->IsToggleButtonHovered();
+    if ( isHovered )
     {
         dc.SetPen(m_ribbon_toggle_pen);
         dc.SetBrush(m_ribbon_toggle_brush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
-        bindex = 1;
     }
+
+    const wxColour& faceColour = isHovered ? m_page_toggle_hover_face_colour : m_page_toggle_face_colour;
+    dc.SetPen(wxPen(faceColour, 2));
+    dc.SetBrush(wxBrush(faceColour));
+
+    const int cx = rect.GetX() + 10;
+
     switch ( mode )
     {
         case wxRIBBON_BAR_PINNED:
-            dc.DrawBitmap(m_ribbon_toggle_up_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawLine(cx - 3, rect.GetY() + 13, cx, rect.GetY() + 10);
+            dc.DrawLine(cx, rect.GetY() + 10, cx + 3, rect.GetY() + 13);
+            dc.DrawLine(cx - 3, rect.GetY() + 9, cx, rect.GetY() + 6);
+            dc.DrawLine(cx, rect.GetY() + 6, cx + 3, rect.GetY() + 9);
             break;
         case wxRIBBON_BAR_MINIMIZED:
-            dc.DrawBitmap(m_ribbon_toggle_down_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+7, rect.GetY()+6, true);
+            dc.DrawLine(cx - 3, rect.GetY() + 7, cx, rect.GetY() + 10);
+            dc.DrawLine(cx, rect.GetY() + 10, cx + 3, rect.GetY() + 7);
+            dc.DrawLine(cx - 3, rect.GetY() + 11, cx, rect.GetY() + 14);
+            dc.DrawLine(cx, rect.GetY() + 14, cx + 3, rect.GetY() + 11);
             break;
         case wxRIBBON_BAR_EXPANDED:
-            dc.DrawBitmap(m_ribbon_toggle_pin_bundle[bindex].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
+        {
+            const int x = rect.GetX() + 4;
+            const int y = rect.GetY() + 10;
+            dc.DrawLine(x + 2, y, x + 6, y);
+            const wxPoint body[] = {{x + 6, y}, {x + 14, y - 3}, {x + 14, y + 3}};
+            dc.DrawPolygon(3, body);
+            const wxPoint flare[] = {{x + 8, y - 3}, {x + 12, y}, {x + 8, y + 3}};
+            dc.DrawPolygon(3, flare);
             break;
+        }
     }
 }
 
@@ -1078,17 +1098,21 @@ void wxRibbonMSWFlatArtProvider::DrawHelpButton(wxDC& dc,
     dc.DestroyClippingRegion();
     dc.SetClippingRegion(rect);
 
-    if ( wnd->IsHelpButtonHovered() )
+    const bool isHovered = wnd->IsHelpButtonHovered();
+    if ( isHovered )
     {
         dc.SetPen(m_ribbon_toggle_pen);
         dc.SetBrush(m_ribbon_toggle_brush);
         dc.DrawRoundedRectangle(rect.GetX(), rect.GetY(), 20, 20, 1.0);
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[1].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
     }
-    else
-    {
-        dc.DrawBitmap(m_ribbon_bar_help_button_bundle[0].GetBitmapFor(wnd), rect.GetX()+4, rect.GetY()+5, true);
-    }
+
+    dc.SetFont(m_tab_label_font);
+    dc.SetTextForeground(isHovered ? m_page_toggle_hover_face_colour : m_page_toggle_face_colour);
+    const wxString label("?");
+    wxSize sz = dc.GetTextExtent(label);
+    dc.DrawText(label,
+                rect.GetX() + (20 - sz.GetWidth()) / 2,
+                rect.GetY() + (20 - sz.GetHeight()) / 2);
 }
 
 void wxRibbonMSWFlatArtProvider::DrawTool(


### PR DESCRIPTION
Replaces XPM images with actual drawing commands that scale well, look less cluttered, don't look pixelated, and match the ribbon's theme.

BEFORE (HiDPI on Windows [gets clipped], GTK [looks pixelated and bad under dark mode[):

<img width="74" height="48" alt="hiDPI Windows" src="https://github.com/user-attachments/assets/b4868801-f318-4d0b-9ccd-6b714234728a" />
<img width="68" height="58" alt="Screenshot from 2026-07-07 08-12-38" src="https://github.com/user-attachments/assets/add2c9a3-bcb5-4725-9747-23134d1e4c2b" />

AFTER:

<img width="62" height="24" alt="image" src="https://github.com/user-attachments/assets/7fcccc1f-c885-4a3e-8458-960ef4ff6409" />
<img width="50" height="19" alt="image" src="https://github.com/user-attachments/assets/676868df-9e34-4097-a45e-649594f21b8d" />



