### PR TITLE
MSW: Return generic icon location for .exe file types

### DIFF
--- a/src/msw/mimetype.cpp
+++ b/src/msw/mimetype.cpp
@@ -4,6 +4,7 @@
 // Author:      Vadim Zeitlin
 // Created:     23.09.98
 // Copyright:   (c) 1998 Vadim Zeitlin <zeitlin@dptmaths.ens-cachan.fr>
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWidgets licence (part of base library)
 /////////////////////////////////////////////////////////////////////////////
 
@@ -288,6 +289,55 @@ wxString wxAssocQueryString(ASSOCSTR assoc,
     return wxString(bufOut);
 }
 
+static bool MSWGetStockApplicationIconLocation(wxIconLocation *iconLoc)
+{
+#ifdef SHGSI_ICON
+    WinStruct<SHSTOCKICONINFO> sii;
+
+    if ( ::SHGetStockIconInfo(SIID_APPLICATION, SHGSI_ICONLOCATION, &sii) != S_OK ||
+            !sii.szPath[0] )
+        return false;
+
+    if ( iconLoc )
+    {
+        iconLoc->SetFileName(sii.szPath);
+        iconLoc->SetIndex(sii.iIcon);
+    }
+
+    return true;
+#else
+    wxUnusedVar(iconLoc);
+
+    return false;
+#endif // SHGSI_ICON
+}
+
+static bool MSWGetIconLocationForExtension(const wxString& ext,
+                                           wxIconLocation *iconLoc)
+{
+    SHFILEINFO fi = {};
+
+    if ( !::SHGetFileInfo(ext.t_str(), FILE_ATTRIBUTE_NORMAL,
+                          &fi, sizeof(SHFILEINFO),
+                          SHGFI_USEFILEATTRIBUTES | SHGFI_ICONLOCATION) )
+        return false;
+
+    if ( !fi.szDisplayName[0] )
+        return MSWGetStockApplicationIconLocation(iconLoc);
+
+    if ( iconLoc )
+    {
+        iconLoc->SetFileName(fi.szDisplayName);
+        iconLoc->SetIndex(fi.iIcon);
+    }
+
+    return true;
+}
+
+static bool MSWIsFileIconPlaceholder(const wxString& iconFile)
+{
+    return iconFile == "%1" || iconFile == "%L";
+}
 
 wxString wxFileTypeImpl::GetCommand(const wxString& verb) const
 {
@@ -413,10 +463,14 @@ bool wxFileTypeImpl::GetIcon(wxIconLocation *iconLoc) const
         if ( strFullPath.StartsWith('"') && strFullPath.EndsWith('"') )
             strFullPath = strFullPath.substr(1, strFullPath.length() - 2);
 
+        const wxString iconFile = wxExpandEnvVars(strFullPath);
+        if ( m_ext.IsSameAs(".exe", false) &&
+                MSWIsFileIconPlaceholder(iconFile) )
+            return MSWGetIconLocationForExtension(m_ext, iconLoc);
+
         if ( iconLoc )
         {
-            iconLoc->SetFileName(wxExpandEnvVars(strFullPath));
-
+            iconLoc->SetFileName(iconFile);
             iconLoc->SetIndex(wxAtoi(strIndex));
         }
 

--- a/tests/misc/misctests.cpp
+++ b/tests/misc/misctests.cpp
@@ -5,6 +5,7 @@
 // Created:     2008-07-10
 // Copyright:   (c) 2008 Peter Most
 //              (c) 2009 Vadim Zeitlin
+//              (c) 2026 wxWidgets development team
 ///////////////////////////////////////////////////////////////////////////////
 
 // ----------------------------------------------------------------------------
@@ -16,6 +17,7 @@
 
 #include "wx/defs.h"
 
+#include "wx/iconloc.h"
 #include "wx/math.h"
 #include "wx/mimetype.h"
 #include "wx/versioninfo.h"
@@ -26,6 +28,8 @@
 // just some classes using wxRTTI for wxStaticCast() test
 #include "wx/tarstrm.h"
 #include "wx/zipstrm.h"
+
+#include <memory>
 
 #ifdef __WINDOWS__
     // Needed for wxMulDivInt32().
@@ -273,6 +277,22 @@ TEST_CASE("wxFileType::ExpandCommand", "[mime]")
     // string; check that the trailing '%' is just copied verbatim instead.
     CHECK( wxFileType::ExpandCommand("show %s %", params) == "show file.txt %" );
 }
+
+#ifdef __WINDOWS__
+TEST_CASE("wxFileType::ExecutableIcon", "[mime][msw]")
+{
+    std::unique_ptr<wxFileType> fileType(
+        wxTheMimeTypesManager->GetFileTypeFromExtension("exe"));
+    REQUIRE( fileType );
+
+    wxIconLocation iconLoc;
+    REQUIRE( fileType->GetIcon(&iconLoc) );
+
+    CHECK( iconLoc.IsOk() );
+    CHECK( iconLoc.GetFileName() != "%1" );
+    CHECK( iconLoc.GetFileName() != "%L" );
+}
+#endif // __WINDOWS__
 #endif // wxUSE_MIMETYPE
 
 TEST_CASE("wxVersionInfo", "[version]")


### PR DESCRIPTION
Handle executable DefaultIcon values such as %1/%L by asking the shell for an icon location and falling back to the stock application icon when SHGetFileInfo() does not provide a file/index location.

Add a base test covering the .exe icon location path.

Fixes #21794