### PR TITLE
Fix HTML MIME fallback without registry content type

### DIFF
--- a/src/common/filesys.cpp
+++ b/src/common/filesys.cpp
@@ -3,6 +3,7 @@
 // Purpose:     wxFileSystem class - interface for opening files
 // Author:      Vaclav Slavik
 // Copyright:   (c) 1999 Vaclav Slavik
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
@@ -47,6 +48,25 @@ const wxString& wxFSFile::GetMimeType() const
 // ----------------------------------------------------------------------------
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxFileSystemHandler, wxObject);
+
+
+static wxString GetMimeTypeFromExtFallback(const wxString& ext)
+{
+    if ( ext.IsSameAs("htm", false) ||
+         ext.IsSameAs("html", false) )
+        return "text/html";
+    if ( ext.IsSameAs("jpg", false) ||
+         ext.IsSameAs("jpeg", false) )
+        return "image/jpeg";
+    if ( ext.IsSameAs("gif", false) )
+        return "image/gif";
+    if ( ext.IsSameAs("png", false) )
+        return "image/png";
+    if ( ext.IsSameAs("bmp", false) )
+        return "image/bmp";
+
+    return wxString();
+}
 
 
 /* static */
@@ -118,30 +138,19 @@ wxString wxFileSystemHandler::GetMimeTypeFromExt(const wxString& location)
         }
 
         wxFileType *ft = wxTheMimeTypesManager->GetFileTypeFromExtension(ext);
-        if ( !ft || !ft -> GetMimeType(&mime) )
+        if ( ft && ft->GetMimeType(&mime) && !mime.empty() )
         {
-            mime.clear();
+            delete ft;
+            return mime;
         }
 
         delete ft;
-
-        return mime;
     }
 #endif // wxUSE_MIMETYPE
 
-    // Without wxUSE_MIMETYPE, recognize just a few hardcoded special cases.
-    if ( ext.IsSameAs(wxT("htm"), false) || ext.IsSameAs(wxT("html"), false) )
-        return wxT("text/html");
-    if ( ext.IsSameAs(wxT("jpg"), false) || ext.IsSameAs(wxT("jpeg"), false) )
-        return wxT("image/jpeg");
-    if ( ext.IsSameAs(wxT("gif"), false) )
-        return wxT("image/gif");
-    if ( ext.IsSameAs(wxT("png"), false) )
-        return wxT("image/png");
-    if ( ext.IsSameAs(wxT("bmp"), false) )
-        return wxT("image/bmp");
-
-    return wxString();
+    // Recognize just a few hardcoded special cases if wxUSE_MIMETYPE is
+    // disabled or if the MIME manager did not know the MIME type.
+    return GetMimeTypeFromExtFallback(ext);
 }
 
 

--- a/tests/filesys/filesystest.cpp
+++ b/tests/filesys/filesystest.cpp
@@ -4,6 +4,7 @@
 // Author:      Vaclav Slavik, Vyacheslav Lisovski
 // Created:     2004-03-28
 // Copyright:   (c) 2004 Vaclav Slavik
+//              (c) 2026 wxWidgets development team
 ///////////////////////////////////////////////////////////////////////////////
 
 // ----------------------------------------------------------------------------
@@ -18,6 +19,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/filesys.h"
+#include "wx/sysopt.h"
 
 #if wxUSE_FILESYSTEM
 
@@ -48,6 +50,32 @@ public:
 
 
 };
+
+
+#if wxUSE_SYSTEM_OPTIONS
+class TempSystemOption
+{
+public:
+    TempSystemOption(const wxString& name, int value)
+        : m_name(name),
+          m_value(wxSystemOptions::GetOption(name)),
+          m_hadValue(wxSystemOptions::HasOption(name))
+    {
+        wxSystemOptions::SetOption(name, value);
+    }
+
+    ~TempSystemOption()
+    {
+        wxSystemOptions::SetOption(m_name,
+                                   m_hadValue ? m_value : wxString());
+    }
+
+private:
+    const wxString m_name;
+    const wxString m_value;
+    const bool m_hadValue;
+};
+#endif // wxUSE_SYSTEM_OPTIONS
 
 
 // ----------------------------------------------------------------------------
@@ -135,6 +163,20 @@ TEST_CASE("wxFileSystem::URLParsing", "[filesys][url][parse]")
         CHECK( tst.RightLocation(d.url) == d.right );
         CHECK( tst.Anchor(d.url) == d.anchor );
     }
+}
+
+TEST_CASE("wxFileSystem::HTMLMimeFallback", "[filesys][mime]")
+{
+#if wxUSE_MIMETYPE && wxUSE_SYSTEM_OPTIONS
+    TempSystemOption noMimeManager("filesys.no-mimetypesmanager", 1);
+#endif
+
+    CHECK(wxFileSystemHandler::GetMimeTypeFromExt("index.htm") ==
+          "text/html");
+    CHECK(wxFileSystemHandler::GetMimeTypeFromExt("index.html") ==
+          "text/html");
+    CHECK(wxFileSystemHandler::GetMimeTypeFromExt("INDEX.HTML") ==
+          "text/html");
 }
 
 TEST_CASE("wxFileSystem::FileNameToUrlConversion", "[filesys][url][filename]")


### PR DESCRIPTION
Let wxFileSystemHandler fall back to its built-in extension MIME map when the MIME manager finds a file type but cannot return a MIME type. This keeps .htm and .html files recognized as text/html on stripped Windows systems missing the registry Content Type value.

Fixes #20967