### PR TITLE
Fix wxHTML nested definition-list indentation

### DIFF
--- a/samples/html/test/test.htm
+++ b/samples/html/test/test.htm
@@ -322,6 +322,14 @@ This is definition list (DL,DT,DD):
     <dd> operating system
     <dd> huh?
 
+    <dt> Nested list
+    <dd> add
+        <dl>
+            <dd> ducts
+            <dd> links
+            <dd> nodes
+        </dl>
+
 </dl>
 ...end of DD
 

--- a/src/html/m_dflist.cpp
+++ b/src/html/m_dflist.cpp
@@ -3,6 +3,7 @@
 // Purpose:     wxHtml module for definition lists (DL,DT,DD)
 // Author:      Vaclav Slavik
 // Copyright:   (c) 1999 Vaclav Slavik
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
@@ -26,7 +27,13 @@ FORCE_LINK_ME(m_dflist)
 
 TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
 
-    TAG_HANDLER_CONSTR(DEFLIST) { }
+    TAG_HANDLER_VARS
+        int m_ListDepth;
+
+    TAG_HANDLER_CONSTR(DEFLIST)
+    {
+        m_ListDepth = 0;
+    }
 
     TAG_HANDLER_PROC(tag)
     {
@@ -44,7 +51,9 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
             m_WParser->GetContainer()->CopyId(tag);
             m_WParser->GetContainer()->SetIndent(m_WParser->GetCharHeight(), wxHTML_INDENT_TOP);
 
+            m_ListDepth++;
             ParseInner(tag);
+            m_ListDepth--;
 
             if (m_WParser->GetContainer()->GetFirstChild() != nullptr ||
                     m_WParser->GetContainer()->HasId())
@@ -67,10 +76,15 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
         }
         else // "DD"
         {
+            // m_ListDepth is already incremented while parsing a DL body.
+            // Treat a standalone DD as first-level for compatibility.
+            const int depth = m_ListDepth == 0 ? 1 : m_ListDepth;
+
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
             c->CopyId(tag);
-            c->SetIndent(5 * m_WParser->GetCharWidth(), wxHTML_INDENT_LEFT);
+            c->SetIndent(5 * depth * m_WParser->GetCharWidth(),
+                         wxHTML_INDENT_LEFT);
             return false;
         }
     }

--- a/tests/html/htmlparser.cpp
+++ b/tests/html/htmlparser.cpp
@@ -4,6 +4,7 @@
 // Author:      Vadim Zeitlin
 // Created:     2011-01-13
 // Copyright:   (c) 2011 Vadim Zeitlin <vadim@wxwidgets.org>
+//              (c) 2026 wxWidgets development team
 ///////////////////////////////////////////////////////////////////////////////
 
 // ----------------------------------------------------------------------------
@@ -16,12 +17,35 @@
 
 
 #ifndef WX_PRECOMP
+    #include "wx/bitmap.h"
     #include "wx/dcmemory.h"
 #endif // WX_PRECOMP
 
 #include "wx/html/winpars.h"
 
 #include <memory>
+
+namespace
+{
+
+wxHtmlCell* FindTextCell(wxHtmlCell* cell, const wxString& text)
+{
+    if ( cell->ConvertToText(nullptr) == text )
+        return cell;
+
+    for ( wxHtmlCell* child = cell->GetFirstChild();
+          child;
+          child = child->GetNext() )
+    {
+        wxHtmlCell* found = FindTextCell(child, text);
+        if ( found )
+            return found;
+    }
+
+    return nullptr;
+}
+
+} // anonymous namespace
 
 // Test that parsing invalid HTML simply fails but doesn't crash for example.
 TEST_CASE("wxHtmlParser::ParseInvalid", "[html][parser][error]")
@@ -40,6 +64,36 @@ TEST_CASE("wxHtmlParser::ParseInvalid", "[html][parser][error]")
     delete p.Parse("<foo");
     delete p.Parse("<!--");
     delete p.Parse("<!---");
+}
+
+TEST_CASE("wxHtmlParser::NestedDefinitionList", "[html][parser]")
+{
+    wxBitmap bmp(400, 400);
+    wxMemoryDC dc(bmp);
+
+    wxHtmlWinParser p;
+    p.SetDC(&dc);
+
+    std::unique_ptr<wxHtmlContainerCell> const top
+    (
+        static_cast<wxHtmlContainerCell*>
+        (
+            p.Parse("<dl><dd>add<dl><dd>ducts</dd><dd>links</dd>"
+                    "<dd>nodes</dd></dl></dd></dl>")
+        )
+    );
+
+    REQUIRE(top.get());
+
+    top->Layout(400);
+
+    wxHtmlCell* const add = FindTextCell(top.get(), "add");
+    wxHtmlCell* const ducts = FindTextCell(top.get(), "ducts");
+
+    REQUIRE(add);
+    REQUIRE(ducts);
+
+    CHECK(ducts->GetAbsPos().x > add->GetAbsPos().x);
 }
 
 TEST_CASE("wxHtmlCell::Detach", "[html][cell]")


### PR DESCRIPTION
Track the active DL nesting depth while parsing definition lists and use it when indenting DD content, so nested definition lists are laid out deeper than their parent item. Add parser coverage and a sample case for the old nested DL repro.

Fixes #20752