### PR TITLE
Fix wxHTML BODY background colour in print rendering

### DIFF
--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -4,6 +4,7 @@
 // Author:      Vaclav Slavik
 // Created:     25/09/99
 // Copyright:   (c) Vaclav Slavik, 1999
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
@@ -112,6 +113,10 @@ void wxHtmlDCRenderer::SetHtmlText(const wxString& html, const wxString& basepat
     wxHtmlContainerCell* const cell = (wxHtmlContainerCell*) m_Parser.Parse(html);
     wxCHECK_RET( cell, "Failed to parse HTML" );
 
+    const wxColour bg = m_Parser.GetActualBackgroundColor();
+    if ( bg.IsOk() )
+        cell->SetBackgroundColour(bg);
+
     DoSetHtmlCell(cell);
 
     m_ownsCells = true;
@@ -187,8 +192,15 @@ void wxHtmlDCRenderer::Render(int x, int y, int from, int to)
     wxHtmlRenderingInfo rinfo;
     wxDefaultHtmlRenderingStyle rstyle;
     rinfo.SetStyle(&rstyle);
-    m_DC->SetBrush(*wxWHITE_BRUSH);
     wxDCClipper clip(*m_DC, x, y, m_Width, hght);
+    {
+        wxColour bg = m_Cells->GetBackgroundColour();
+        if ( !bg.IsOk() )
+            bg = *wxWHITE;
+        wxDCBrushChanger brushChanger(*m_DC, wxBrush(bg));
+        wxDCPenChanger penChanger(*m_DC, *wxTRANSPARENT_PEN);
+        m_DC->DrawRectangle(x, y, m_Width, hght);
+    }
     m_Cells->Draw(*m_DC,
                   x, (y - from),
                   y, y + hght,

--- a/src/html/m_layout.cpp
+++ b/src/html/m_layout.cpp
@@ -3,6 +3,7 @@
 // Purpose:     wxHtml module for basic paragraphs/layout handling
 // Author:      Vaclav Slavik
 // Copyright:   (c) 1999 Vaclav Slavik
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
@@ -12,6 +13,7 @@
 #if wxUSE_HTML && wxUSE_STREAMS
 
 #ifndef WX_PRECOMP
+    #include "wx/brush.h"
     #include "wx/image.h"
 #endif
 
@@ -313,34 +315,39 @@ TAG_HANDLER_BEGIN(BODY, "BODY")
         if (tag.GetParamAsColour(wxT("LINK"), &clr))
             m_WParser->SetLinkColor(clr);
 
-        wxHtmlWindowInterface *winIface = m_WParser->GetWindowInterface();
-        // the rest of this function requires a window:
-        if ( !winIface )
-            return false;
-
-        wxString bg;
-        if (tag.GetParamAsString(wxT("BACKGROUND"), &bg))
+        const bool hasBgColour = tag.GetParamAsColour("BGCOLOR", &clr);
+        if ( hasBgColour )
         {
-            wxFSFile *fileBgImage = m_WParser->OpenURL(wxHTML_URL_IMAGE, bg);
-            if ( fileBgImage )
-            {
-                wxInputStream *is = fileBgImage->GetStream();
-                if ( is )
-                {
-                    wxImage image(*is);
-                    if ( image.IsOk() )
-                        winIface->SetHTMLBackgroundImage(image);
-                }
-
-                delete fileBgImage;
-            }
-        }
-
-        if (tag.GetParamAsColour(wxT("BGCOLOR"), &clr))
-        {
+            m_WParser->SetActualBackgroundColor(clr);
+            m_WParser->SetActualBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
             m_WParser->GetContainer()->InsertCell(
                 new wxHtmlColourCell(clr, wxHTML_CLR_TRANSPARENT_BACKGROUND));
-            winIface->SetHTMLBackgroundColour(clr);
+        }
+
+        wxHtmlWindowInterface *winIface = m_WParser->GetWindowInterface();
+        if ( winIface )
+        {
+            if ( hasBgColour )
+                winIface->SetHTMLBackgroundColour(clr);
+
+            wxString bg;
+            if (tag.GetParamAsString("BACKGROUND", &bg))
+            {
+                wxFSFile *fileBgImage =
+                    m_WParser->OpenURL(wxHTML_URL_IMAGE, bg);
+                if ( fileBgImage )
+                {
+                    wxInputStream *is = fileBgImage->GetStream();
+                    if ( is )
+                    {
+                        wxImage image(*is);
+                        if ( image.IsOk() )
+                            winIface->SetHTMLBackgroundImage(image);
+                    }
+
+                    delete fileBgImage;
+                }
+            }
         }
 
         return false;

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -4,6 +4,7 @@
 // Author:      Vadim Zeitlin
 // Created:     2018-05-22
 // Copyright:   (c) 2018 Vadim Zeitlin <vadim@wxwidgets.org>
+//              (c) 2026 wxWidgets development team
 ///////////////////////////////////////////////////////////////////////////////
 
 // ----------------------------------------------------------------------------
@@ -16,7 +17,10 @@
 #if wxUSE_PRINTING_ARCHITECTURE
 
 #ifndef WX_PRECOMP
+    #include "wx/bitmap.h"
+    #include "wx/brush.h"
     #include "wx/dcmemory.h"
+    #include "wx/image.h"
 #endif // WX_PRECOMP
 
 #include "wx/html/htmprint.h"
@@ -43,6 +47,31 @@ int CountPages(wxHtmlPrintout& pr)
 }
 
 } // anonymous namespace
+
+TEST_CASE("wxHtmlDCRenderer::BodyBgColour", "[html][print]")
+{
+    const wxColour bg(0x12, 0x34, 0x56);
+    wxBitmap bmp(100, 100);
+    {
+        wxMemoryDC dc(bmp);
+        dc.SetBackground(*wxWHITE_BRUSH);
+        dc.Clear();
+
+        wxHtmlDCRenderer renderer;
+        renderer.SetDC(&dc);
+        renderer.SetSize(bmp.GetWidth(), bmp.GetHeight());
+        renderer.SetHtmlText("<body bgcolor=\"#123456\">"
+                             "<p>Hello world!</p>"
+                             "</body>");
+        renderer.Render(0, 0);
+    }
+
+    const wxImage image = bmp.ConvertToImage();
+    const wxColour actual(image.GetRed(90, 90),
+                          image.GetGreen(90, 90),
+                          image.GetBlue(90, 90));
+    CHECK(actual == bg);
+}
 
 TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
 {


### PR DESCRIPTION
Store BODY BGCOLOR in the wxHTML parser state even when there is no window interface, then carry the parsed colour onto the renderer root cell so wxHtmlDCRenderer fills printed pages with it instead of white.

Add a renderer regression test covering BODY BGCOLOR output.

Fixes #20652.