### PR TITLE
Fix wxHTML line breaks around NBSP-only segments

### DIFF
--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -3,6 +3,7 @@
 // Purpose:     wxHtmlCell - basic element of HTML output
 // Author:      Vaclav Slavik
 // Copyright:   (c) 1999 Vaclav Slavik
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
@@ -306,6 +307,18 @@ wxString wxHtmlCell::Dump(int indent) const
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxHtmlWordCell, wxHtmlCell);
 
+static constexpr unsigned NBSP_VALUE = 0x00a0;
+
+static bool wxHtmlIsNBSP(wxUniChar c)
+{
+    return c == wxUniChar(NBSP_VALUE);
+}
+
+static bool wxHtmlIsLineBreakingSpace(wxUniChar c)
+{
+    return !wxHtmlIsNBSP(c) && wxIsspace(c);
+}
+
 wxHtmlWordCell::wxHtmlWordCell(const wxString& word, const wxDC& dc) : wxHtmlCell()
     , m_Word(word)
 {
@@ -316,12 +329,15 @@ wxHtmlWordCell::wxHtmlWordCell(const wxString& word, const wxDC& dc) : wxHtmlCel
     m_Descent = d;
     SetCanLiveOnPagebreak(false);
     m_allowLinebreak = true;
+    if ( !m_Word.empty() && wxHtmlIsNBSP(m_Word[0u]) )
+        m_allowLinebreak = false;
 }
 
 void wxHtmlWordCell::SetPreviousWord(wxHtmlWordCell *cell)
 {
     if ( cell && m_Parent == cell->m_Parent &&
-         !wxIsspace(cell->m_Word.Last()) && !wxIsspace(m_Word[0u]) )
+         !wxHtmlIsLineBreakingSpace(cell->m_Word.Last()) &&
+         !wxHtmlIsLineBreakingSpace(m_Word[0u]) )
     {
         m_allowLinebreak = false;
     }

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -3,6 +3,7 @@
 // Purpose:     wxHtmlParser class (generic parser)
 // Author:      Vaclav Slavik
 // Copyright:   (c) 1999 Vaclav Slavik
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
@@ -316,8 +317,6 @@ wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
     return GetFS()->OpenFile(myurl, flags);
 }
 
-static constexpr wxChar CUR_NBSP_VALUE = L'\xA0';
-
 void wxHtmlWinParser::AddText(const wxString& txt)
 {
     if ( m_whitespaceMode == Whitespace_Normal )
@@ -362,7 +361,6 @@ void wxHtmlWinParser::AddText(const wxString& txt)
             if (x)
             {
                 m_tmpStrBuf.append(' ');
-                m_tmpStrBuf.Replace(CUR_NBSP_VALUE, ' ');
                 AddWord(m_tmpStrBuf);
                 m_tmpStrBuf.clear();
 
@@ -394,18 +392,7 @@ void wxHtmlWinParser::AddText(const wxString& txt)
     }
     else // m_whitespaceMode == Whitespace_Pre
     {
-        if ( txt.find(CUR_NBSP_VALUE) != wxString::npos )
-        {
-            // we need to substitute spaces for &nbsp; here just like we
-            // did in the Whitespace_Normal branch above
-            wxString txt2(txt);
-            txt2.Replace(CUR_NBSP_VALUE, ' ');
-            AddPreBlock(txt2);
-        }
-        else
-        {
-            AddPreBlock(txt);
-        }
+        AddPreBlock(txt);
 
         // don't eat any whitespace in <pre> block
         m_tmpLastWasSpace = false;

--- a/tests/html/htmlparser.cpp
+++ b/tests/html/htmlparser.cpp
@@ -4,6 +4,7 @@
 // Author:      Vadim Zeitlin
 // Created:     2011-01-13
 // Copyright:   (c) 2011 Vadim Zeitlin <vadim@wxwidgets.org>
+//              (c) 2026 wxWidgets development team
 ///////////////////////////////////////////////////////////////////////////////
 
 // ----------------------------------------------------------------------------
@@ -16,12 +17,46 @@
 
 
 #ifndef WX_PRECOMP
+    #include "wx/bitmap.h"
     #include "wx/dcmemory.h"
 #endif // WX_PRECOMP
 
 #include "wx/html/winpars.h"
 
 #include <memory>
+#include <vector>
+
+namespace
+{
+
+static constexpr unsigned NBSP_VALUE = 0x00a0;
+
+void AddTextCells(const wxHtmlCell *cell,
+                  std::vector<const wxHtmlCell *>& cells)
+{
+    if ( !cell )
+        return;
+
+    const wxString text = cell->ConvertToText(nullptr);
+    if ( !text.empty() )
+        cells.push_back(cell);
+
+    for ( const wxHtmlCell *child = cell->GetFirstChild(); child;
+          child = child->GetNext() )
+    {
+        AddTextCells(child, cells);
+    }
+}
+
+wxString GetNBSP(size_t count)
+{
+    wxString s;
+    for ( size_t n = 0; n < count; n++ )
+        s += wxUniChar(NBSP_VALUE);
+    return s;
+}
+
+} // anonymous namespace
 
 // Test that parsing invalid HTML simply fails but doesn't crash for example.
 TEST_CASE("wxHtmlParser::ParseInvalid", "[html][parser][error]")
@@ -40,6 +75,32 @@ TEST_CASE("wxHtmlParser::ParseInvalid", "[html][parser][error]")
     delete p.Parse("<foo");
     delete p.Parse("<!--");
     delete p.Parse("<!---");
+}
+
+TEST_CASE("wxHtmlParser::NBSPLineBreak", "[html][parser]")
+{
+    wxBitmap bmp(100, 100);
+    wxMemoryDC dc(bmp);
+    wxHtmlWinParser p;
+    p.SetDC(&dc);
+
+    const wxString html = "aaa <font color=\"#ff0000\">"
+                          "&nbsp;&nbsp;</font>bbb";
+    std::unique_ptr<wxHtmlContainerCell> const top(
+        static_cast<wxHtmlContainerCell *>(p.Parse(html)));
+    REQUIRE(top);
+
+    top->Layout(1);
+
+    std::vector<const wxHtmlCell *> cells;
+    AddTextCells(top.get(), cells);
+
+    REQUIRE(cells.size() >= 3);
+    CHECK(cells[0]->ConvertToText(nullptr) == "aaa ");
+    CHECK(cells[1]->ConvertToText(nullptr) == GetNBSP(2));
+    CHECK(cells[2]->ConvertToText(nullptr) == "bbb");
+    CHECK(cells[0]->GetAbsPos().y == cells[1]->GetAbsPos().y);
+    CHECK(cells[1]->GetAbsPos().y == cells[2]->GetAbsPos().y);
 }
 
 TEST_CASE("wxHtmlCell::Detach", "[html][cell]")


### PR DESCRIPTION
Preserve non-breaking spaces in wxHtmlWinParser instead of converting them to normal spaces, and prevent wxHtmlWordCell from allowing a line break before NBSP-only text segments.

Add a parser regression test covering an &nbsp;-only segment between words.

Fixes #20399.