### PR TITLE
avoid wxAuiNotebook center pane unexpected settings

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -243,9 +243,16 @@ public:
     wxAuiPaneInfo& Right() { dock_direction = wxAUI_DOCK_RIGHT; return *this; }
     wxAuiPaneInfo& Top() { dock_direction = wxAUI_DOCK_TOP; return *this; }
     wxAuiPaneInfo& Bottom() { dock_direction = wxAUI_DOCK_BOTTOM; return *this; }
-    wxAuiPaneInfo& Center() { dock_direction = wxAUI_DOCK_CENTER; return *this; }
-    wxAuiPaneInfo& Centre() { dock_direction = wxAUI_DOCK_CENTRE; return *this; }
-    wxAuiPaneInfo& Direction(int direction) { dock_direction = direction; return *this; }
+    wxAuiPaneInfo& Center() { dock_direction = wxAUI_DOCK_CENTER; return Layer(0).Row(0).Position(0); }
+    wxAuiPaneInfo& Centre() { dock_direction = wxAUI_DOCK_CENTRE; return Layer(0).Row(0).Position(0); }
+    wxAuiPaneInfo& Direction(int direction)
+    {
+        if (dock_direction == wxAUI_DOCK_CENTRE)
+        {
+            return Centre();
+        }
+        dock_direction = direction; return *this;
+    }
     wxAuiPaneInfo& Layer(int layer) { dock_layer = layer; return *this; }
     wxAuiPaneInfo& Row(int row) { dock_row = row; return *this; }
     wxAuiPaneInfo& Position(int pos) { dock_pos = pos; return *this; }

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -85,8 +85,7 @@ void wxAuiFloatingFrame::SetPaneWindow(const wxAuiPaneInfo& pane)
     wxAuiPaneInfo contained_pane = pane;
     contained_pane.Dock().Center().Show().
                     CaptionVisible(false).
-                    PaneBorder(false).
-                    Layer(0).Row(0).Position(0);
+                    PaneBorder(false);
 
     // Carry over the minimum size
     wxSize pane_min_size = pane.window->GetMinSize();

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -532,6 +532,12 @@ static int PaneSortFunc(wxAuiPaneInfo** p1, wxAuiPaneInfo** p2)
 
 bool wxAuiPaneInfo::IsValid() const
 {
+    if ( dock_direction == wxAUI_DOCK_CENTRE &&
+        !(dock_layer == 0 && dock_row == 0 && dock_pos == 0) )
+    {
+        return false;
+    }
+
     // Should this RTTI and function call be rewritten as
     // sending a new event type to allow other window types
     // to check the pane settings?


### PR DESCRIPTION
Avoid the wxAuiNotebook center pane having non-zero dock_layer, dock_row, or dock_pos values