### PR TITLE
MSW: Fix wxSpinButton background in dark mode

### DIFF
--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -30,6 +30,7 @@
 
 #include "wx/spinbutt.h"
 
+#include "wx/dcbuffer.h"
 #include "wx/msw/dc.h"
 #include "wx/msw/private.h"
 #include "wx/msw/private/darkmode.h"
@@ -252,7 +253,10 @@ void wxSpinButton::OnPaint(wxPaintEvent& event)
         bmp = wxBitmap(image);
 #endif // wxUSE_IMAGE
 
-        wxPaintDC dc(this);
+        wxBufferedPaintDC dc(this);
+        // Clear the background, otherwise alpha transparency in the bitmap
+        // appears white.
+        dc.Clear();
         dc.DrawBitmap(bmp, 0, 0);
     }
     else


### PR DESCRIPTION
On Windows in dark mode, the `wxSpinButton` incorrectly has a white line between the up and down arrows. This is due to alpha transparency in the bitmap that gets drawn. The fix is to clear the DC to the background colour before drawing the bitmap.

Before:
<img width="114" height="186" alt="image" src="https://github.com/user-attachments/assets/96f1b5df-8382-499d-8039-35afa9190b14" />

After:
<img width="113" height="186" alt="image" src="https://github.com/user-attachments/assets/31cf795d-7212-4b56-b305-0de66de0eab7" />
