### PR TITLE
MSW: Fix wxSpinButton dark mode switching

### DIFF
--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -143,6 +143,9 @@ bool wxSpinButton::Create(wxWindow *parent,
 
     SetInitialSize(size);
 
+    if ( wxMSWDarkMode::IsActive() )
+        MSWSetDarkOrLightMode(SetMode::Initial);
+
     return true;
 }
 
@@ -177,8 +180,9 @@ void wxSpinButton::OnPaint(wxPaintEvent& event)
 {
     if ( wxMSWDarkMode::IsActive() )
     {
-        // Unfortunately PaintIfNecessary() can't be used here as we need to
-        // handle the extra border below, so duplicate what it does here.
+        // Have the updown control draw itself, then modify the result with a
+        // border and possibly inverted colours.
+
         const RECT rc = wxGetClientRect(GetHwnd());
         const wxSize size{rc.right - rc.left, rc.bottom - rc.top};
 
@@ -212,6 +216,10 @@ void wxSpinButton::OnPaint(wxPaintEvent& event)
 
         wxImage image = bmp.ConvertToImage();
 
+        // Prior to Windows 11 22H2 (build 22621), the updown control always
+        // draws in light mode, so invert the colours to make it dark.
+        const bool shouldInvert = !wxCheckOsVersion(10, 0, 22621);
+
         const int width = image.GetWidth();
         const int height = image.GetHeight();
         unsigned char *data = image.GetData();
@@ -229,7 +237,7 @@ void wxSpinButton::OnPaint(wxPaintEvent& event)
                     if ( alpha )
                         *alpha = wxALPHA_OPAQUE;
                 }
-                else
+                else if ( shouldInvert )
                 {
                     // This uses a slightly different formula than the one in
                     // InvertBitmapPixel() because the one there results in the


### PR DESCRIPTION
This fixes the `wxSpinButton` when switching to dark mode. Starting with Windows 11 22H2, the updown control draws properly in dark mode after `wxMSWDarkMode::AllowForWindow()` is applied to it. Switching to dark mode makes that call happen. After the updown control is drawn properly dark, `wxSpinButton::OnPaint()` inverts the colours, making it look light instead of dark.

The fix has two parts:

1. Call `MSWSetDarkOrLightMode()` upon control creation. This causes the control to draw properly on Windows 11 22H2 and later.
2. Avoid inverting the colours for Windows 11 22H2 and later because they are already dark mode.
