### PR TITLE
MSW: Fix wxNotebook dark mode spin control upon AddPage()

### DIFF
--- a/include/wx/msw/notebook.h
+++ b/include/wx/msw/notebook.h
@@ -202,6 +202,9 @@ private:
   // It has the same semantics as HitTest().
   int MSWHitTestLeftRight(const wxPoint& pt, long *flags) const;
 
+  // Subclass the spin button if it exists.
+  void MSWSubclassSpin();
+
   wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxNotebook);
   wxDECLARE_EVENT_TABLE();
 };

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -730,6 +730,7 @@ bool wxNotebook::InsertPage(size_t nPage,
     DoSetSelectionAfterInsertion(nPage, bSelect);
 
     InvalidateBestSize();
+    MSWSubclassSpin();
 
     return true;
 }
@@ -994,6 +995,24 @@ wxNotebookSpinBtnWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
     return ::CallWindowProc(CASTWNDPROC gs_wndprocNotebookSpinBtn,
                             hwnd, message, wParam, lParam);
+}
+
+void wxNotebook::MSWSubclassSpin()
+{
+    if ( !m_hasSubclassedUpdown )
+    {
+        // Find the spin button.
+        HWND hwndSpin = FindWindowExA(m_hWnd, nullptr, UPDOWN_CLASSA, nullptr);
+        if ( hwndSpin )
+        {
+            // Subclass the spin button.
+            if ( !gs_wndprocNotebookSpinBtn )
+                gs_wndprocNotebookSpinBtn = wxGetWindowProc(hwndSpin);
+
+            wxSetWindowProc(hwndSpin, wxNotebookSpinBtnWndProc);
+            m_hasSubclassedUpdown = true;
+        }
+    }
 }
 
 LRESULT APIENTRY
@@ -1547,31 +1566,7 @@ void wxNotebook::OnSize(wxSizeEvent& event)
     }
 
 #if USE_NOTEBOOK_ANTIFLICKER
-    // subclass the spin control used by the notebook to scroll pages to
-    // prevent it from flickering on resize
-    if ( !m_hasSubclassedUpdown )
-    {
-        // iterate over all child windows to find spin button
-        for ( HWND child = ::GetWindow(GetHwnd(), GW_CHILD);
-              child;
-              child = ::GetWindow(child, GW_HWNDNEXT) )
-        {
-            wxWindow *childWindow = wxFindWinFromHandle((WXHWND)child);
-
-            // see if it exists, if no wxWindow found then assume it's the spin
-            // btn
-            if ( !childWindow )
-            {
-                // subclass the spin button to override WM_ERASEBKGND
-                if ( !gs_wndprocNotebookSpinBtn )
-                    gs_wndprocNotebookSpinBtn = wxGetWindowProc(child);
-
-                wxSetWindowProc(child, wxNotebookSpinBtnWndProc);
-                m_hasSubclassedUpdown = true;
-                break;
-            }
-        }
-    }
+    MSWSubclassSpin();
 #endif // USE_NOTEBOOK_ANTIFLICKER
 
     event.Skip();


### PR DESCRIPTION
In dark mode, when the `wxNotebook` spin control appears as a result of `AddPage()`, it is light mode. The fix is to subclass the spin control from both `OnSize()` and `AddPage()`.

The method of finding the spin control is simplified to use `FindWindowEx()` rather than enumerating child windows with a loop.
