### PR TITLE
Fix event loop used by console applications in monolithic build

### DIFF
--- a/src/msw/basemsw.cpp
+++ b/src/msw/basemsw.cpp
@@ -115,7 +115,11 @@ wxTimerImpl *wxConsoleAppTraits::CreateTimerImpl(wxTimer *timer)
 wxEventLoopBase *wxConsoleAppTraits::CreateEventLoop()
 {
 #if wxUSE_CONSOLE_EVENTLOOP
-    return new wxEventLoop();
+    // Use wxConsoleEventLoop explicitly and not wxEventLoop because the
+    // latter is defined as wxGUIEventLoop when this file is compiled as part
+    // of a monolithic library (which is always built with wxUSE_GUI==1) and
+    // using a GUI event loop in console applications doesn't work, see #24909.
+    return new wxConsoleEventLoop();
 #else // !wxUSE_CONSOLE_EVENTLOOP
     return nullptr;
 #endif // wxUSE_CONSOLE_EVENTLOOP/!wxUSE_CONSOLE_EVENTLOOP

--- a/src/unix/evtloopunix.cpp
+++ b/src/unix/evtloopunix.cpp
@@ -222,7 +222,11 @@ void wxConsoleEventLoop::DoYieldFor(long eventsToProcess)
 
 wxEventLoopBase *wxConsoleAppTraits::CreateEventLoop()
 {
-    return new wxEventLoop();
+    // Use wxConsoleEventLoop explicitly and not wxEventLoop because the
+    // latter is defined as wxGUIEventLoop when this file is compiled as part
+    // of a monolithic library (which is always built with wxUSE_GUI==1) and
+    // using a GUI event loop in console applications doesn't work, see #24909.
+    return new wxConsoleEventLoop();
 }
 
 #endif // wxUSE_CONSOLE_EVENTLOOP

--- a/tests/events/evtlooptest.cpp
+++ b/tests/events/evtlooptest.cpp
@@ -13,7 +13,12 @@
 #include "testprec.h"
 
 
+#include "wx/app.h"
+#include "wx/apptrait.h"
+#include "wx/evtloop.h"
 #include "wx/timer.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // constants
@@ -48,6 +53,28 @@ CPPUNIT_TEST_SUITE_REGISTRATION( EvtloopTestCase );
 // also include in its own registry so that these tests can be run alone
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( EvtloopTestCase, "EvtloopTestCase" );
 
+
+// Check that the application traits create an event loop of the appropriate
+// kind: this notably would not be the case for console applications using a
+// monolithic build of the library before the fix for #24909.
+#if wxUSE_GUI || wxUSE_CONSOLE_EVENTLOOP
+
+TEST_CASE("EventLoop::CreateFromTraits", "[evtloop]")
+{
+    wxAppTraits* const traits = wxTheApp->GetTraits();
+    REQUIRE( traits );
+
+    std::unique_ptr<wxEventLoopBase> loop(traits->CreateEventLoop());
+    REQUIRE( loop );
+
+#if wxUSE_GUI
+    CHECK( dynamic_cast<wxGUIEventLoop*>(loop.get()) );
+#else // console application
+    CHECK( dynamic_cast<wxConsoleEventLoop*>(loop.get()) );
+#endif
+}
+
+#endif // wxUSE_GUI || wxUSE_CONSOLE_EVENTLOOP
 
 // Helper class to schedule exit of the given event loop after the specified
 // delay.


### PR DESCRIPTION
From issue #24909: in a monolithic build, the console applications of the sockets sample fail to communicate: `baseserver` never receives anything from `baseclient`. The problem was found via the wxIPC tests for PR #24858 and is not specific to the sample: it affects any console application relying on the default event loop in a monolithic build. The same `baseserver`/`baseclient` failure is also mentioned in #25005.

A backtrace of the listening server shows that the console application is erroneously running a GUI event loop (`gtk_main()` under wxGTK).

Note that the assert also quoted in these reports,

```
../src/common/timercmn.cpp(58): assert "traits" failed in Init(): Can't create timer, is wxApp fully initialized?
```

is a separate problem (#24856, already fixed on master) and is not affected by this change.

### Root cause

`wxConsoleAppTraits::CreateEventLoop()` returns `new wxEventLoop()`, and the meaning of `wxEventLoop` is fixed by the preprocessor when the *library* is compiled (`include/wx/evtloop.h`):

- with `wxUSE_GUI==0`, `wxEventLoop` is `#define`d to `wxConsoleEventLoop`;
- with `wxUSE_GUI==1`, `wxEventLoop` is a class deriving from `wxGUIEventLoop`.

In multilib builds the base library is compiled with `-DwxUSE_GUI=0`, so the console traits create the right loop. In a monolithic build every file is compiled with `wxUSE_GUI==1` from `setup.h`, so the same line hands a `wxGUIEventLoop` to `wxAppConsole`. This also explains the observation in the issue discussion that the console application appeared to be using GUI code: the traits themselves were the correct `wxConsoleAppTraits`, but the loop they created was not.

### The fix

Return `new wxConsoleEventLoop()` explicitly from `wxConsoleAppTraits::CreateEventLoop()` in both `src/unix/evtloopunix.cpp` and `src/msw/basemsw.cpp` (which has the same latent problem). For multilib builds this is a no-op, as `wxEventLoop` already expands to `wxConsoleEventLoop` in these files; for monolithic builds it selects the correct loop. The unix file also covers macOS, where `wxConsoleEventLoop` derives from `wxCFEventLoop`.

A second commit adds `EventLoop::CreateFromTraits` to `tests/events/evtlooptest.cpp`, checking that the application traits create an event loop of the appropriate kind; as this file is compiled into both test binaries, the same test case covers both console and GUI applications. The test fails against the unfixed monolithic library and passes with the fix, which also makes the sockets sample round-trip work again on wxGTK.
