### PR TITLE
MSW: Fix wxNotebook dark mode background colour

### DIFF
--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1077,7 +1077,7 @@ DrawNotebookTab(wxWindow* win,
     {
         dc.SetClippingRegion(ExpandSelectedTab(rectTab, tabOrient));
 
-        colTab = win->GetBackgroundColour();
+        colTab = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
     }
     else // not the selected tab
     {
@@ -1273,7 +1273,7 @@ void wxNotebook::MSWNotebookPaint()
         rectTabArea.SetRight(sizeWindow.x);
     else
         rectTabArea.SetBottom(sizeWindow.y);
-    dc.SetBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+    dc.SetBrush(GetBackgroundColour());
     dc.SetPen(*wxTRANSPARENT_PEN);
     dc.DrawRectangle(rectTabArea);
 

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1063,8 +1063,7 @@ ExpandSelectedTab(wxRect& rectTab, wxDirection tabOrient)
 // Note that this function relies on the appropriate pen being selected into
 // the DC and uses the current pen for drawing the tab borders.
 void
-DrawNotebookTab(wxWindow* win,
-                wxDC& dc,
+DrawNotebookTab(wxDC& dc,
                 const wxRect& rectOrig,
                 const wxString& label,
                 const wxBitmap& image,
@@ -1256,7 +1255,7 @@ void wxNotebook::MSWNotebookPaint()
         if ( n == 0 )
             flags |= wxCONTROL_SPECIAL;
 
-        DrawNotebookTab(this, dc, rect,
+        DrawNotebookTab(dc, rect,
                         GetPageText(n),
                         GetImageBitmapFor(this, GetPageImage(n)),
                         tabOrient,


### PR DESCRIPTION
The region of `wxNotebook` affected by `SetbackgroundColour()` is different in light mode and dark mode. In light mode, it is alongside the tabs but in dark mode, it is the selected tab. The dark mode background painting is adjusted so that it matches light mode.

The default background colour is changed to `wxSYS_COLOUR_WINDOW` rather than `wxSYS_COLOUR_BTNFACE`, which looks too light.

See #25678. Closes #25678.
