### PR TITLE
MSW: Defer dark mode system colour change event

### DIFF
--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -184,12 +184,20 @@ namespace wxMSWImpl
 // don't appear in the SDK headers at all.
 //
 // Note that, not being public, they use C++ bool type and not Win32 BOOL.
+void (WINAPI *gs_RefreshImmersiveColorPolicyState)() = nullptr;
 bool (WINAPI *gs_ShouldAppsUseDarkMode)() = nullptr;
 bool (WINAPI *gs_AllowDarkModeForWindow)(HWND hwnd, bool allow) = nullptr;
 PreferredAppMode (WINAPI *gs_SetPreferredAppMode)(PreferredAppMode appMode) = nullptr;
 
 // Wrappers for the undocumented functions, to make sure we never dereference
 // a null function pointer.
+
+void RefreshImmersiveColorPolicyState()
+{
+    if ( gs_RefreshImmersiveColorPolicyState == nullptr )
+        return;
+    gs_RefreshImmersiveColorPolicyState();
+}
 
 bool ShouldAppsUseDarkMode()
 {
@@ -229,7 +237,8 @@ bool InitDarkMode()
 
     // These functions are not only undocumented but are not even exported by
     // name, and have to be resolved using their ordinals.
-    return TryLoadByOrd(gs_ShouldAppsUseDarkMode, dllUxTheme, 132) &&
+    return TryLoadByOrd(gs_RefreshImmersiveColorPolicyState, dllUxTheme, 104) &&
+           TryLoadByOrd(gs_ShouldAppsUseDarkMode, dllUxTheme, 132) &&
            TryLoadByOrd(gs_AllowDarkModeForWindow, dllUxTheme, 133) &&
            TryLoadByOrd(gs_SetPreferredAppMode, dllUxTheme, 135);
 }
@@ -283,6 +292,10 @@ bool wxApp::MSWEnableDarkMode(int flags, wxDarkModeSettings* settings)
                    "SetPreferredAppMode(%d) unexpectedly returned %d",
                    mode, rc);
     }
+
+    // Force recalculation of the active theme state so that
+    // ShouldAppsUseDarkMode() returns the correct value immediately.
+    wxMSWImpl::RefreshImmersiveColorPolicyState();
 
     gs_appMode = mode;
     gs_wasActiveOnStartup = wxMSWDarkMode::IsActive();

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3556,7 +3556,16 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             // Check for the special case of the message which notifies about
             // the colours change.
             if ( wxIsSystemColourChange(lParam) )
-                processed = HandleSysColorChange();
+            {
+                // When switching between light and dark modes, Windows normally
+                // sends two WM_SETTINGCHANGE messages with "ImmersiveColorSet",
+                // one before and one after. Sometimes the second message does not
+                // appear. To guarantee we process at least one system colour
+                // change event after the switch, defer processing this message
+                // until after the switch.
+                PostMessage(m_hWnd, WM_SYSCOLORCHANGE, 0, 0);
+                processed = true;
+            }
             else
                 processed = HandleSettingChange(wParam, lParam);
             break;


### PR DESCRIPTION
These changes address an issue with unreliable `WM_SETTINGCHANGE "ImmersiveColorSet"` messages upon switching between dark and light mode. See #26692.

Normally when the system switches between modes, Windows sends two WM_SETTINGCHANGE messages - one before the switch and one after. The problem addressed is that the second message never appears. The reason is unknown. It may be due to a timeout, since this message is broadcast using `SendMessageTimeout()`.

The fix has two parts.

1. When the `WM_SETTINGCHANGE` is received, instead of immediately issuing a `wxSysColourChangedEvent`, we instead post `WM_SYSCOLORCHANGE` to defer that action until after the mode switch is finished. This guarantees we issue at least one `wxSysColourChangedEvent` after the mode switch.

2. The change above exposed a latent bug in the dark mode initialization. The variable `gs_wasActiveOnStartup` was not initialized correctly because `ShouldAppsUseDarkMode()` did not return an accurate value until a window was created. This problem was masked by having two `WM_SETTINGCHANGE` messages, one with `IsActive()` true and one false. This caused the comparison `IsActive() != gs_wasActiveOnStartup` to be true one time despite `gs_wasActiveOnStartup` begin wrong. The solution is to call the undocumented API `RefreshImmersiveColorPolicyState()` so that `ShouldAppsUseDarkMode()` returns the correct value.
