### PR TITLE
Tiny improvements to drawing and menu samples

### DIFF
--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -1156,7 +1156,7 @@ void MyCanvas::DrawText(wxDC& dc)
 #ifdef __WXMSW__
                                    " (only when using Direct2D)"
 #endif
-                                   ": \U0001F60A"), dc.FromDIP(400), y);
+                                   ": \xF0\x9F\x98\x8A"), dc.FromDIP(400), y);
 }
 
 static const struct

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -638,7 +638,7 @@ MyFrame::MyFrame()
     menuMenu->AppendSeparator();
 #endif
 
-    menuMenu->Append(Menu_Menu_GetInfo, "Get menu item in&fo\tAlt-F",
+    menuMenu->Append(Menu_Menu_GetInfo, "Get menu item inf&o\tAlt-O",
                      "Show the state of the last menu item");
 #if wxUSE_TEXTDLG
     menuMenu->Append(Menu_Menu_SetLabel, "Set menu item label\tAlt-L",


### PR DESCRIPTION
### Fix drawing color emoji in the drawing sample with MSVS 2015
The old-but-still-supported MSVS 2015 has problem parsing Unicode literals outside the BMP when using the '\U' escape. Use raw octet syntax to work around this.

### Remove conflicting keyboard shortcut from the menu sample

The sample used <Alt+F> for the Get menu info command. However, this conflicted with the shortcut used to invoke the File menu.

Fix this by using a different shortcut for the Get menu info.