### PR TITLE
Fix generic wxSearchCtrl for system colour change

### DIFF
--- a/include/wx/generic/srchctlg.h
+++ b/include/wx/generic/srchctlg.h
@@ -188,6 +188,9 @@ private:
 
     void RecalcBitmaps();
 
+    void OnSysColourChanged(wxSysColourChangedEvent& event);
+    void UpdateColours();
+
     enum class BitmapType
     {
         Search,

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -153,7 +153,6 @@ public:
           m_eventType(eventType),
           m_bmp(bmp)
     {
-        SetBackgroundColour(search->GetBackgroundColour());
     }
 
     void SetBitmapLabel(const wxBitmap& label)
@@ -233,6 +232,7 @@ wxBEGIN_EVENT_TABLE(wxSearchCtrl, wxSearchCtrlBase)
     EVT_SEARCH_CANCEL(wxID_ANY, wxSearchCtrl::OnCancelButton)
     EVT_SIZE(wxSearchCtrl::OnSize)
     EVT_DPI_CHANGED(wxSearchCtrl::OnDPIChanged)
+    EVT_SYS_COLOUR_CHANGED(wxSearchCtrl::OnSysColourChanged)
 wxEND_EVENT_TABLE()
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxSearchCtrl, wxSearchCtrlBase);
@@ -302,10 +302,7 @@ bool wxSearchCtrl::Create(wxWindow *parent, wxWindowID id,
                                         wxEVT_SEARCH,
                                         m_searchBitmap);
 
-    m_text->SetBackgroundColour(wxColour());
-    SetBackgroundColour( m_text->GetBackgroundColour() );
-
-    RecalcBitmaps();
+    UpdateColours();
 
     SetInitialSize(size);
     Move(pos);
@@ -406,7 +403,7 @@ void wxSearchCtrl::ShowCancelButton( bool show )
         m_cancelButton = new wxSearchButton(this,
                                             wxEVT_SEARCH_CANCEL,
                                             m_cancelBitmap);
-        RecalcBitmaps();
+        UpdateColours();
     }
 
     m_cancelButton->Show(show);
@@ -1061,16 +1058,10 @@ void wxSearchCtrl::RecalcBitmaps()
 
     if ( !m_searchBitmapUser )
     {
-        if (
-            !m_searchBitmap.IsOk() ||
-            m_searchBitmap.GetSize() != bitmapSize
-            )
+        m_searchBitmap = RenderBitmap(bitmapSize, BitmapType::Search);
+        if ( !HasMenu() )
         {
-            m_searchBitmap = RenderBitmap(bitmapSize, BitmapType::Search);
-            if ( !HasMenu() )
-            {
-                m_searchButton->SetBitmapLabel(m_searchBitmap);
-            }
+            m_searchButton->SetBitmapLabel(m_searchBitmap);
         }
         // else this bitmap was set by user, don't alter
     }
@@ -1078,16 +1069,10 @@ void wxSearchCtrl::RecalcBitmaps()
 #if wxUSE_MENUS
     if ( !m_searchMenuBitmapUser )
     {
-        if (
-            !m_searchMenuBitmap.IsOk() ||
-            m_searchMenuBitmap.GetSize() != bitmapSize
-            )
+        m_searchMenuBitmap = RenderBitmap(bitmapSize, BitmapType::Menu);
+        if ( m_menu )
         {
-            m_searchMenuBitmap = RenderBitmap(bitmapSize, BitmapType::Menu);
-            if ( m_menu )
-            {
-                m_searchButton->SetBitmapLabel(m_searchMenuBitmap);
-            }
+            m_searchButton->SetBitmapLabel(m_searchMenuBitmap);
         }
         // else this bitmap was set by user, don't alter
     }
@@ -1108,16 +1093,30 @@ void wxSearchCtrl::RecalcBitmaps()
 
     if ( m_cancelButton && !m_cancelBitmapUser )
     {
-        if (
-            !m_cancelBitmap.IsOk() ||
-            m_cancelBitmap.GetSize() != bitmapSize
-            )
-        {
-            m_cancelBitmap = RenderBitmap(bitmapSize, BitmapType::Cancel);
-            m_cancelButton->SetBitmapLabel(m_cancelBitmap);
-        }
+        m_cancelBitmap = RenderBitmap(bitmapSize, BitmapType::Cancel);
+        m_cancelButton->SetBitmapLabel(m_cancelBitmap);
         // else this bitmap was set by user, don't alter
     }
+}
+
+void wxSearchCtrl::OnSysColourChanged(wxSysColourChangedEvent& event)
+{
+    UpdateColours();
+    event.Skip();
+}
+
+void wxSearchCtrl::UpdateColours()
+{
+    if ( !m_hasBgCol )
+    {
+        m_backgroundColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+        m_text->SetBackgroundColour(m_backgroundColour);
+        m_searchButton->SetBackgroundColour(m_backgroundColour);
+        if ( m_cancelButton )
+            m_cancelButton->SetBackgroundColour(m_backgroundColour);
+    }
+
+    RecalcBitmaps();
 }
 
 void wxSearchCtrl::OnCancelButton( wxCommandEvent& event )


### PR DESCRIPTION
Update the background colour of the generic `wxSearchCtrl` upon `wxSysColourChangedEvent`. The strategy is to move the colour setting code into a new function `UpdateColours()`, and call that during both creation and upon colour change event.

The text control background colour is set explicitly rather than relying on the text control to respond to colour change events itself. I made this decision due to 9b97d3a308d which indicates Qt requires the explicit colour. I tested with Qt but could not confirm this requirement. Nevertheless, it seems less risky to continue setting the colour explicitly.

The method of setting the `wxSearchCtrl` colour is changed from calling `SetBackgroundColour()` to assigning `m_backgroundColour` unless `m_hasBgCol` is set, to avoid overwriting a user-set colour.

In `RecalcBitmaps()`, remove the checks that avoided rendering the bitmaps if their size had not changed. The bitmaps need to be rendered when the light/dark mode changes.
