### PR TITLE
MSW: Fix wxTextCtrl for disabled rich edit in dark mode

### DIFF
--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -308,6 +308,7 @@ private:
     void MSWDeleteWordBack();
 
     void OnKeyDown(wxKeyEvent& event);
+    void OnPaint(wxPaintEvent& event);
 
     // Used by EN_MAXTEXT handler to increase the size limit (will do nothing
     // if the current limit is big enough). Should never be called directly.

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2402,7 +2402,7 @@ void wxTextCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
         for (long pos = start; pos < (long)text.length(); pos++)
         {
             wxPoint pt = PositionToCoords(pos);
-            if ( pt.y > rect.height )
+            if ( pt.y >= rect.height )
                 break;
             dc.DrawText(text[pos], pt);
         }

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2399,7 +2399,7 @@ void wxTextCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 
         // Draw each character one at a time. This mimics the line spacing,
         // character spacing, and word wrap layout.
-        for (long pos = start; pos < text.length(); pos++)
+        for (long pos = start; pos < (long)text.length(); pos++)
         {
             wxPoint pt = PositionToCoords(pos);
             if ( pt.y > rect.height )

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -382,6 +382,7 @@ wxBEGIN_EVENT_TABLE(wxTextCtrl, wxTextCtrlBase)
     EVT_CHAR(wxTextCtrl::OnChar)
     EVT_KEY_DOWN(wxTextCtrl::OnKeyDown)
     EVT_DROP_FILES(wxTextCtrl::OnDropFiles)
+    EVT_PAINT(wxTextCtrl::OnPaint)
 
     EVT_MENU(wxID_CUT, wxTextCtrl::OnCut)
     EVT_MENU(wxID_COPY, wxTextCtrl::OnCopy)
@@ -2376,6 +2377,36 @@ void wxTextCtrl::OnKeyDown(wxKeyEvent& event)
 
     // no, we didn't process it
     event.Skip();
+}
+
+void wxTextCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
+{
+    // In dark mode, when a rich edit control is disabled, it paints the
+    // background light instead of dark. Work around this by custom drawing
+    // the control.
+    if ( wxMSWDarkMode::IsActive() && IsRich() && !m_isEnabled )
+    {
+        wxPaintDC dc(this);
+        dc.SetBackground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+        dc.Clear();
+        dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+
+        // Set up for traversing the visible text.
+        long firstLine = ::SendMessage(m_hWnd, EM_GETFIRSTVISIBLELINE, 0, 0);
+        long start = XYToPosition(0, firstLine);
+        const wxString text = GetValue();
+        wxRect rect = GetClientRect();
+
+        // Draw each character one at a time. This mimics the line spacing,
+        // character spacing, and word wrap layout.
+        for (long pos = start; pos < text.length(); pos++)
+        {
+            wxPoint pt = PositionToCoords(pos);
+            if ( pt.y > rect.height )
+                break;
+            dc.DrawText(text[pos], pt);
+        }
+    }
 }
 
 void wxTextCtrl::Paste()


### PR DESCRIPTION
In dark mode, when a rich edit control is disabled, it paints the background light instead of dark. To work around this, custom draw the control. See #26551.

The control erases the background during painting, so overriding the background erase was not an option.