### PR TITLE
filesys:  fix erroneous delete

### DIFF
--- a/src/common/filesys.cpp
+++ b/src/common/filesys.cpp
@@ -295,7 +295,7 @@ wxFSFile* wxLocalFSHandler::OpenFile(wxFileSystem& WXUNUSED(fs), const wxString&
     if ( !is->IsOk() )
         return nullptr;
 
-    return new wxFSFile(is.get(),
+    return new wxFSFile(is.release(),
                         location,
                         wxEmptyString,
                         GetAnchor(location)


### PR DESCRIPTION
The recent commit b03850e3674c5bb92d98e7ec2adc00882d8920cf to use std::unique_ptr<> in wxFileSystemHandler caused an unintended delete to occur.  This causes the xrcdemo sample to crash on startup.  This PR avoids the crash, but has a potential to leak if some other parameter throws an exception.  However, it's no worse than the code before the erroneous commit.