### PR TITLE
MSW: Fix wxBitmapComboBox for system color change

### DIFF
--- a/src/msw/combobox.cpp
+++ b/src/msw/combobox.cpp
@@ -522,10 +522,6 @@ void wxComboBox::MSWRecreate()
         m_backgroundColour = wxNullColour;
         SetBackgroundColour(colBg);
     }
-    else
-    {
-        SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
-    }
 
     // Revert the old string value
     if ( !HasFlag(wxCB_READONLY) )


### PR DESCRIPTION
Adding a bitmap to a wxBitmapComboBox leads to wxComboBox::MSWRecreate() where a call to SetBackgroundColour() causes the control to stop responding to system color changes. The SetBackgroundColour() is removed. The default background color is already correct.
