### PR TITLE
Respect swapped mouse buttons in GUI tests

### DIFF
--- a/docs/contributing/how-to-write-unit-tests.md
+++ b/docs/contributing/how-to-write-unit-tests.md
@@ -96,6 +96,11 @@ clicking buttons or typing text. A simple example of this can be found in
 `tests/controls/buttontest.cpp`. After simulating some user input always
 call `wxYield()` to allow event processing. When writing a test using
 `wxUIActionSimulator` wrap it in `#if wxUSE_UIACTIONSIMULATOR` block.
+Use `GetMouseButtonPrimary()` for normal mouse-button actions and
+`GetMouseButtonSecondary()` for context-menu actions instead of relying on
+the default mouse button or passing `wxMOUSE_BTN_LEFT` or
+`wxMOUSE_BTN_RIGHT` directly. This keeps the tests working when primary and
+secondary mouse buttons are swapped.
 
 There are a number of classes that are available to help with testing GUI
 elements. Firstly throughout the test run there is a frame of type

--- a/include/wx/uiaction.h
+++ b/include/wx/uiaction.h
@@ -32,17 +32,25 @@ public:
     bool MouseMove(long x, long y);
     bool MouseMove(const wxPoint& point) { return MouseMove(point.x, point.y); }
 
-    bool MouseDown(int button = wxMOUSE_BTN_LEFT);
-    bool MouseUp(int button = wxMOUSE_BTN_LEFT);
+    bool MouseDown(int button = PrimaryMouseButton());
+    bool MouseUp(int button = PrimaryMouseButton());
 
     // Higher level interface, use it if possible instead
-    bool MouseClick(int button = wxMOUSE_BTN_LEFT);
-    bool MouseDblClick(int button = wxMOUSE_BTN_LEFT);
+    bool MouseClick(int button = PrimaryMouseButton());
+    bool SecondaryMouseClick()
+        { return MouseClick(SecondaryMouseButton()); }
+    bool MouseDblClick(int button = PrimaryMouseButton());
+    bool SecondaryMouseDblClick()
+        { return MouseDblClick(SecondaryMouseButton()); }
     bool MouseDragDrop(long x1, long y1, long x2, long y2,
-                       int button = wxMOUSE_BTN_LEFT);
+                       int button = PrimaryMouseButton());
+    bool SecondaryDragDrop(long x1, long y1, long x2, long y2)
+        { return MouseDragDrop(x1, y1, x2, y2, SecondaryMouseButton()); }
     bool MouseDragDrop(const wxPoint& p1, const wxPoint& p2,
-                       int button = wxMOUSE_BTN_LEFT)
-    { return MouseDragDrop(p1.x, p1.y, p2.x, p2.y, button); }
+                       int button = PrimaryMouseButton())
+        { return MouseDragDrop(p1.x, p1.y, p2.x, p2.y, button); }
+    bool SecondaryMouseDragDrop(const wxPoint& p1, const wxPoint& p2)
+        { return MouseDragDrop(p1, p2, SecondaryMouseButton()); }
 
     // Keyboard simulation
     // -------------------
@@ -64,7 +72,17 @@ public:
     // Select the item with the given text in the currently focused control.
     bool Select(const wxString& text);
 
+    // Use these helpers for mouse input to respect primary/secondary button
+    // assignment on systems configured with swapped mouse buttons.
+    static int PrimaryMouseButton()
+        { return MouseButtonsSwapped() ? wxMOUSE_BTN_RIGHT : wxMOUSE_BTN_LEFT; }
+    static int SecondaryMouseButton()
+        { return MouseButtonsSwapped() ? wxMOUSE_BTN_LEFT : wxMOUSE_BTN_RIGHT; }
+
 private:
+    static bool MouseButtonsSwapped()
+        { return wxSystemSettings::GetMetric(wxSYS_SWAP_BUTTONS) != 0; }
+
     // This is the common part of Key{Down,Up}() methods: while we keep them
     // separate at public API level for consistency with Mouse{Down,Up}(), at
     // implementation level it makes more sense to have them in a single

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -495,7 +495,7 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellClick", "[grid]")
     CHECK(lclick.GetCount() == 1);
     CHECK(ldclick.GetCount() == 1);
 
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
     if ( !WaitForEventAt(point, "right click to be processed", [&]() {
             return rclick.GetCount() != 0;
         }) )
@@ -503,7 +503,7 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellClick", "[grid]")
     CHECK(rclick.GetCount() == 1);
     rclick.Clear();
 
-    sim.MouseDblClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseDblClick();
     if ( !WaitForEventAt(point, "right double click to be processed", [&]() {
             return rclick.GetCount() != 0 || rdclick.GetCount() != 0;
         }) )
@@ -634,7 +634,7 @@ TEST_CASE_METHOD(GridTestCase, "Grid::LabelClick", "[grid]")
         return;
     CHECK(ldclick.GetCount() == 1);
 
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
     if ( !WaitForEventAt(pos, "mouse right click to be processed", [&]() {
             return rclick.GetCount() != 0;
         }) )
@@ -642,7 +642,7 @@ TEST_CASE_METHOD(GridTestCase, "Grid::LabelClick", "[grid]")
     CHECK(rclick.GetCount() == 1);
     rclick.Clear();
 
-    sim.MouseDblClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseDblClick();
     if ( !WaitForEventAt(pos, "mouse right double click to be processed", [&]() {
             return rclick.GetCount() != 0;
         }) )

--- a/tests/controls/listbasetest.cpp
+++ b/tests/controls/listbasetest.cpp
@@ -356,7 +356,7 @@ void ListBaseTestCase::ItemClick()
     sim.MouseDblClick();
     wxYield();
 
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
     wxYield();
 
     // We want a point within the listctrl but below any items

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -210,7 +210,7 @@ TEST_CASE_METHOD(ListCtrlTestCase, "ListCtrl::ColumnClick", "[listctrl]")
     wxYield();
 
     sim.MouseClick();
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
     wxYield();
 
     CHECK( colclick.GetCount() == 1 );

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -225,7 +225,7 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::ItemClick", "[treectrl]")
     sim.MouseDblClick();
     wxYield();
 
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
     wxYield();
 
     CHECK(activated.GetCount() == 1);
@@ -491,7 +491,7 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::Menu", "[treectrl]")
     sim.MouseMove(point);
     wxYield();
 
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
     wxYield();
 
     CHECK(menu.GetCount() == 1);

--- a/tests/events/propagation.cpp
+++ b/tests/events/propagation.cpp
@@ -763,7 +763,7 @@ void EventPropagationTestCase::ContextMenuEvent()
     // parent.
     g_str.clear();
     sim.MouseMove(origin + wxPoint(10, 10));
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
 
     // At least with MSW, for WM_CONTEXTMENU to be synthesized by the system
     // from the right mouse click event, we must dispatch the mouse messages.
@@ -782,7 +782,7 @@ void EventPropagationTestCase::ContextMenuEvent()
     // parent.
     g_str.clear();
     sim.MouseMove(origin + wxPoint(60, 60));
-    sim.MouseClick(wxMOUSE_BTN_RIGHT);
+    sim.SecondaryMouseClick();
     wxYield();
     CPPUNIT_ASSERT_EQUAL( "p", g_str );
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3,6 +3,7 @@
 // Purpose:     Test program for wxWidgets
 // Author:      Mike Wetherell
 // Copyright:   (c) 2004 Mike Wetherell
+// Copyright:   (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -33,11 +34,16 @@ std::string wxTheCurrentTestClass, wxTheCurrentTestMethod;
 
 #include "wx/apptrait.h"
 #include "wx/cmdline.h"
+#include "wx/mousestate.h"
 #include <exception>
 #include <iostream>
 
 #ifdef __WINDOWS__
     #include "wx/msw/msvcrt.h"
+#endif
+
+#ifdef __WXMSW__
+    #include "wx/msw/wrapwin.h"
 #endif
 
 #ifdef __WXOSX__
@@ -238,6 +244,30 @@ TestLogEnabler::~TestLogEnabler()
 }
 
 #endif // wxUSE_LOG
+
+#if wxUSE_GUI && wxUSE_UIACTIONSIMULATOR
+
+int GetMouseButtonPrimary()
+{
+#ifdef __WXMSW__
+    if ( ::GetSystemMetrics(SM_SWAPBUTTON) )
+        return wxMOUSE_BTN_RIGHT;
+#endif
+
+    return wxMOUSE_BTN_LEFT;
+}
+
+int GetMouseButtonSecondary()
+{
+#ifdef __WXMSW__
+    if ( ::GetSystemMetrics(SM_SWAPBUTTON) )
+        return wxMOUSE_BTN_LEFT;
+#endif
+
+    return wxMOUSE_BTN_RIGHT;
+}
+
+#endif // wxUSE_GUI && wxUSE_UIACTIONSIMULATOR
 
 #if wxUSE_GUI
     typedef wxApp TestAppBase;


### PR DESCRIPTION
Add primary and secondary mouse-button helpers to the test harness and use them in wxUIActionSimulator-based GUI tests instead of relying on physical left and right buttons.

Document the convention for new GUI tests.