### PR TITLE
Fix XRC unknown-control size hints after attach

### DIFF
--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -21,6 +21,7 @@
     #include "wx/panel.h"
     #include "wx/frame.h"
     #include "wx/dialog.h"
+    #include "wx/sizer.h"
     #include "wx/settings.h"
     #include "wx/bitmap.h"
     #include "wx/image.h"
@@ -616,6 +617,26 @@ wxXmlResource::DoLoadObject(wxObject *instance,
 }
 
 
+namespace
+{
+
+void UpdateSizeHintsForAttachedUnknownControl(wxWindow *container)
+{
+    wxWindow *window = container;
+
+    while ( window && !window->IsTopLevel() )
+        window = window->GetParent();
+
+    if ( window )
+    {
+        wxSizer * const sizer = window->GetSizer();
+        if ( sizer )
+            sizer->SetSizeHints(window);
+    }
+}
+
+} // anonymous namespace
+
 bool wxXmlResource::AttachUnknownControl(const wxString& name,
                                          wxWindow *control, wxWindow *parent)
 {
@@ -627,7 +648,12 @@ bool wxXmlResource::AttachUnknownControl(const wxString& name,
         wxLogError("Cannot find container for unknown control '%s'.", name);
         return false;
     }
-    return control->Reparent(container);
+
+    const bool attached = control->Reparent(container);
+    if ( attached )
+        UpdateSizeHintsForAttachedUnknownControl(container);
+
+    return attached;
 }
 
 // Small helper returning true if any of the tokens in the given string

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -21,6 +21,7 @@
     #include "wx/panel.h"
     #include "wx/frame.h"
     #include "wx/dialog.h"
+    #include "wx/sizer.h"
     #include "wx/settings.h"
     #include "wx/bitmap.h"
     #include "wx/image.h"
@@ -616,6 +617,29 @@ wxXmlResource::DoLoadObject(wxObject *instance,
 }
 
 
+namespace
+{
+
+void UpdateSizeHintsForAttachedUnknownControl(wxWindow *container,
+                                              wxWindow *control)
+{
+    if ( auto* const window = wxGetTopLevelParent(container) )
+    {
+        wxSizer * const sizer = window->GetSizer();
+        if ( sizer )
+        {
+            sizer->SetSizeHints(window);
+            // SetSizeHints() can resize the TLW without immediately laying out
+            // its children, as happens in wxQt, so force the attached control
+            // to take the expanded placeholder size now.
+            window->Layout();
+            control->SetSize(wxRect(container->GetClientSize()));
+        }
+    }
+}
+
+} // anonymous namespace
+
 bool wxXmlResource::AttachUnknownControl(const wxString& name,
                                          wxWindow *control, wxWindow *parent)
 {
@@ -627,7 +651,12 @@ bool wxXmlResource::AttachUnknownControl(const wxString& name,
         wxLogError("Cannot find container for unknown control '%s'.", name);
         return false;
     }
-    return control->Reparent(container);
+
+    const bool attached = control->Reparent(container);
+    if ( attached )
+        UpdateSizeHintsForAttachedUnknownControl(container, control);
+
+    return attached;
 }
 
 // Small helper returning true if any of the tokens in the given string

--- a/tests/xml/xrctest.cpp
+++ b/tests/xml/xrctest.cpp
@@ -135,6 +135,19 @@ void LoadTestXrc()
     LoadXrcFrom(wxString::FromAscii(xrcText));
 }
 
+class XrcSizeHintPanel : public wxPanel
+{
+public:
+    explicit XrcSizeHintPanel(wxWindow *parent)
+        : wxPanel(parent, wxID_ANY)
+    {
+        wxBoxSizer * const sizer = new wxBoxSizer(wxVERTICAL);
+        sizer->Add(220, 120);
+        SetSizer(sizer);
+        sizer->SetSizeHints(this);
+    }
+};
+
 } // anon namespace
 
 
@@ -210,6 +223,42 @@ TEST_CASE_METHOD(XrcTestCase, "XRC::IDRanges", "[xrc]")
         // Unload the xrc, so it can be reloaded and the tests rerun
         CHECK( wxXmlResource::Get()->Unload(TEST_XRC_FILE) );
     }
+}
+
+TEST_CASE("XRC::UnknownControlSizeHints", "[xrc]")
+{
+    wxXmlResource::Get()->InitAllHandlers();
+
+    LoadXrcFrom(R"(<?xml version="1.0" ?>
+<resource>
+  <object class="wxDialog" name="unknown_dialog">
+    <title>unknown</title>
+    <object class="wxBoxSizer">
+      <orient>wxVERTICAL</orient>
+      <object class="sizeritem">
+        <object class="unknown" name="unknown_panel">
+          <size>100,100</size>
+        </object>
+      </object>
+    </object>
+  </object>
+</resource>
+    )");
+
+    wxDialog dlg;
+    REQUIRE( wxXmlResource::Get()->LoadDialog(&dlg, nullptr, "unknown_dialog") );
+
+    const wxSize sizeBefore = dlg.GetClientSize();
+    XrcSizeHintPanel * const panel = new XrcSizeHintPanel(&dlg);
+    const wxSize panelMin = panel->GetMinSize();
+
+    REQUIRE( panelMin.x > sizeBefore.x );
+    REQUIRE( wxXmlResource::Get()->AttachUnknownControl("unknown_panel",
+                                                        panel,
+                                                        &dlg) );
+
+    CHECK( dlg.GetClientSize().x >= panelMin.x );
+    CHECK( panel->GetSize().x >= panelMin.x );
 }
 
 TEST_CASE("XRC::PathWithFragment", "[xrc][uri]")


### PR DESCRIPTION
Refresh the containing top-level window's sizer hints after an unknown control is reparented into its placeholder. This lets wxPanel-derived controls with their own size hints expand the dialog instead of staying clipped at the placeholder's original size.

Add a regression test covering a panel attached to an unknown XRC placeholder.

Fixes #2726