### PR TITLE
Don't hang forever inside wxContextHelp::EventLoop() under wxQt

### DIFF
--- a/src/common/cshelp.cpp
+++ b/src/common/cshelp.cpp
@@ -153,6 +153,7 @@ bool wxContextHelp::EventLoop()
 
     while ( m_inHelp )
     {
+#ifndef __WXQT__
         if (wxTheApp->Pending())
         {
             wxTheApp->Dispatch();
@@ -161,6 +162,9 @@ bool wxContextHelp::EventLoop()
         {
             wxTheApp->ProcessIdle();
         }
+#else
+        wxTheApp->Dispatch();
+#endif
     }
 
     return true;


### PR DESCRIPTION
Test for Pending() events is unreliable under wxQt, and the function has been changed to return false unconditionally in this commit 1284b2c427 (2025-03-12)