### PR TITLE
Fix wxGrid for system color change, Init() colors

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1933,10 +1933,10 @@ public:
     wxString GetColLabelValue( int col ) const;
     wxString GetCornerLabelValue() const;
 
-    wxColour GetCellHighlightColour() const { return m_cellHighlightColour; }
+    wxColour GetCellHighlightColour() const;
     int      GetCellHighlightPenWidth() const { return m_cellHighlightPenWidth; }
     int      GetCellHighlightROPenWidth() const { return m_cellHighlightROPenWidth; }
-    wxColor  GetGridFrozenBorderColour() const { return m_gridFrozenBorderColour; }
+    wxColor  GetGridFrozenBorderColour() const;
     int      GetGridFrozenBorderPenWidth() const { return m_gridFrozenBorderPenWidth; }
 
     // this one will use wxHeaderCtrl for the column labels
@@ -2073,7 +2073,7 @@ public:
 
     // this can be used to change the global grid lines colour
     void SetGridLineColour(const wxColour& col);
-    wxColour GetGridLineColour() const { return m_gridLineColour; }
+    wxColour GetGridLineColour() const;
 
     // these methods may be overridden to customize individual grid lines
     // appearance
@@ -2421,10 +2421,8 @@ public:
                            const wxRect& renderExtent) const;
 
     // Access or update the selection fore/back colours
-    wxColour GetSelectionBackground() const
-        { return m_selectionBackground; }
-    wxColour GetSelectionForeground() const
-        { return m_selectionForeground; }
+    wxColour GetSelectionBackground() const;
+    wxColour GetSelectionForeground() const;
 
     void SetSelectionBackground(const wxColour& c) { m_selectionBackground = c; }
     void SetSelectionForeground(const wxColour& c) { m_selectionForeground = c; }

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -340,6 +340,10 @@ wxBEGIN_EVENT_TABLE( GridFrame, wxFrame )
 
     EVT_MENU( ID_SET_CELL_FG_COLOUR, GridFrame::SetCellFgColour )
     EVT_MENU( ID_SET_CELL_BG_COLOUR, GridFrame::SetCellBgColour )
+    EVT_MENU( ID_SET_CELL_HL_COLOUR, GridFrame::SetCellHighlightColour)
+    EVT_MENU( ID_SET_SELECTION_FG_COLOUR, GridFrame::SetSelectionFgColour)
+    EVT_MENU( ID_SET_SELECTION_BG_COLOUR, GridFrame::SetSelectionBgColour)
+    EVT_MENU( ID_SET_FROZEN_BORDER, GridFrame::SetFrozenBorderColour)
 
     EVT_MENU( wxID_ABOUT, GridFrame::OnAbout )
     EVT_MENU( wxID_CLEAR, GridFrame::OnClear )
@@ -531,6 +535,10 @@ GridFrame::GridFrame()
     colMenu->Append( ID_GRIDLINECOLOUR, "&Grid line colour..." );
     colMenu->Append( ID_SET_CELL_FG_COLOUR, "Set cell &foreground colour..." );
     colMenu->Append( ID_SET_CELL_BG_COLOUR, "Set cell &background colour..." );
+    colMenu->Append( ID_SET_CELL_HL_COLOUR, "Set cell &highlight colour..." );
+    colMenu->Append( ID_SET_SELECTION_FG_COLOUR, "Set selection f&oreground colour..." );
+    colMenu->Append( ID_SET_SELECTION_BG_COLOUR, "Set selection b&ackground colour..." );
+    colMenu->Append( ID_SET_FROZEN_BORDER, "Set f&rozen border colour..." );
 
     wxMenu *editMenu = new wxMenu;
     editMenu->Append( ID_INSERTROW, "Insert &rows\tCtrl+I" );
@@ -1628,6 +1636,46 @@ void GridFrame::SetCellBgColour( wxCommandEvent& WXUNUSED(ev) )
         wxRect r(pt, grid->GetSize());
         grid->SetDefaultCellBackgroundColour(col);
         grid->Refresh(true, &r);
+    }
+}
+
+void GridFrame::SetCellHighlightColour(wxCommandEvent& WXUNUSED(event))
+{
+    wxColour col = wxGetColourFromUser(this);
+    if ( col.IsOk() )
+    {
+        grid->SetCellHighlightColour(col);
+        grid->Refresh();
+    }
+}
+
+void GridFrame::SetSelectionBgColour(wxCommandEvent& WXUNUSED(event))
+{
+    wxColour col = wxGetColourFromUser(this);
+    if ( col.IsOk() )
+    {
+        grid->SetSelectionBackground(col);
+        grid->Refresh();
+    }
+}
+
+void GridFrame::SetSelectionFgColour(wxCommandEvent& WXUNUSED(event))
+{
+    wxColour col = wxGetColourFromUser(this);
+    if ( col.IsOk() )
+    {
+        grid->SetSelectionForeground(col);
+        grid->Refresh();
+    }
+}
+
+void GridFrame::SetFrozenBorderColour(wxCommandEvent& WXUNUSED(event))
+{
+    wxColour col = wxGetColourFromUser(this);
+    if ( col.IsOk() )
+    {
+        grid->SetGridFrozenBorderColour(col);
+        grid->Refresh();
     }
 }
 

--- a/samples/grid/griddemo.h
+++ b/samples/grid/griddemo.h
@@ -67,6 +67,10 @@ class GridFrame : public wxFrame
 
     void SetCellFgColour(wxCommandEvent &);
     void SetCellBgColour(wxCommandEvent &);
+    void SetCellHighlightColour(wxCommandEvent& event);
+    void SetSelectionBgColour(wxCommandEvent& event);
+    void SetSelectionFgColour(wxCommandEvent& event);
+    void SetFrozenBorderColour(wxCommandEvent& event);
 
     void InsertRow( wxCommandEvent& );
     void InsertCol( wxCommandEvent& );
@@ -210,6 +214,10 @@ public:
         ID_SELNONE,
         ID_SET_CELL_FG_COLOUR,
         ID_SET_CELL_BG_COLOUR,
+        ID_SET_CELL_HL_COLOUR,
+        ID_SET_SELECTION_FG_COLOUR,
+        ID_SET_SELECTION_BG_COLOUR,
+        ID_SET_FROZEN_BORDER,
         ID_VTABLE,
         ID_BUGS_TABLE,
         ID_TABULAR_TABLE,

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3181,14 +3181,11 @@ void wxGrid::Init()
     m_minAcceptableColWidth  =
     m_minAcceptableRowHeight = 0;
 
-    m_gridLineColour = wxSystemSettings::GetColour(wxSYS_COLOUR_GRIDLINES);
     m_gridLinesEnabled = true;
     m_gridLinesClipHorz =
     m_gridLinesClipVert = true;
-    m_cellHighlightColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
     m_cellHighlightPenWidth = 2;
     m_cellHighlightROPenWidth = 1;
-    m_gridFrozenBorderColour = wxSystemSettings::SelectLightDark(*wxBLACK, *wxWHITE);
     m_gridFrozenBorderPenWidth = 2;
 
     m_canDragRowMove = false;
@@ -3227,9 +3224,6 @@ void wxGrid::Init()
     m_colResizeCursor = wxCursor( wxCURSOR_SIZEWE );
 
     m_currentCellCoords = wxGridNoCellCoords;
-
-    m_selectionBackground = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
-    m_selectionForeground = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
 
     m_editable = true;  // default for whole grid
 
@@ -6942,7 +6936,7 @@ void wxGrid::DrawCellHighlight( wxDC& dc, const wxGridCellAttr *attr )
         // use the cellHighlightColour if the cell is inside a selection, this
         // will ensure the cell is always visible.
         const auto penCol = (UsesOverlaySelection() || !IsInSelection(row, col))
-                          ? m_cellHighlightColour : m_selectionForeground;
+                          ? GetCellHighlightColour() : GetSelectionForeground();
 
         dc.SetPen(wxPen(penCol, penWidth));
         dc.SetBrush(*wxTRANSPARENT_BRUSH);
@@ -7072,7 +7066,7 @@ void wxGrid::DrawFrozenBorder(wxDC& dc, wxGridWindow *gridWindow, const wxRect& 
         {
             right = wxMin(right, GetColRight(m_numCols - 1));
 
-            dc.SetPen(wxPen(m_gridFrozenBorderColour,
+            dc.SetPen(wxPen(GetGridFrozenBorderColour(),
                             gridFrozenBorderPenWidth));
             dc.DrawLine(left, bottom, right, bottom);
         }
@@ -7081,7 +7075,7 @@ void wxGrid::DrawFrozenBorder(wxDC& dc, wxGridWindow *gridWindow, const wxRect& 
         {
             bottom = wxMin(bottom, GetRowBottom(m_numRows - 1));
 
-            dc.SetPen(wxPen(m_gridFrozenBorderColour,
+            dc.SetPen(wxPen(GetGridFrozenBorderColour(),
                             gridFrozenBorderPenWidth));
             dc.DrawLine(right, top, right, bottom);
         }
@@ -7095,7 +7089,7 @@ void wxGrid::DrawLabelFrozenBorder(wxDC& dc, wxWindow *window, bool isRow)
         int cw, ch;
         window->GetClientSize(&cw, &ch);
 
-        dc.SetPen(wxPen(m_gridFrozenBorderColour,
+        dc.SetPen(wxPen(GetGridFrozenBorderColour(),
                         m_gridFrozenBorderPenWidth));
 
         if ( isRow )
@@ -9596,6 +9590,12 @@ void wxGrid::SetCornerLabelValue( const wxString& s )
     }
 }
 
+wxColour wxGrid::GetGridLineColour() const
+{
+    return m_gridLineColour.IsOk() ? m_gridLineColour :
+        wxSystemSettings::GetColour(wxSYS_COLOUR_GRIDLINES);
+}
+
 void wxGrid::SetGridLineColour( const wxColour& colour )
 {
     if ( m_gridLineColour != colour )
@@ -9605,6 +9605,12 @@ void wxGrid::SetGridLineColour( const wxColour& colour )
         if ( GridLinesEnabled() )
             RedrawGridLines();
     }
+}
+
+wxColour wxGrid::GetCellHighlightColour() const
+{
+    return m_cellHighlightColour.IsOk() ? m_cellHighlightColour :
+        wxSystemSettings::SelectLightDark(*wxBLACK, *wxWHITE);
 }
 
 void wxGrid::SetCellHighlightColour( const wxColour& colour )
@@ -9656,6 +9662,12 @@ void wxGrid::SetCellHighlightROPenWidth(int width)
     }
 }
 
+wxColor wxGrid::GetGridFrozenBorderColour() const
+{
+    return m_gridFrozenBorderColour.IsOk() ? m_gridFrozenBorderColour :
+        wxSystemSettings::SelectLightDark(*wxBLACK, *wxWHITE);
+}
+
 void wxGrid::SetGridFrozenBorderColour(const wxColour &colour)
 {
     if ( m_gridFrozenBorderColour != colour )
@@ -9686,6 +9698,18 @@ void wxGrid::SetGridFrozenBorderPenWidth(int width)
                 m_frozenColGridWin->Refresh();
         }
     }
+}
+
+wxColour wxGrid::GetSelectionBackground() const
+{
+    return m_selectionBackground.IsOk() ? m_selectionBackground :
+        wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+}
+
+wxColour wxGrid::GetSelectionForeground() const
+{
+    return m_selectionForeground.IsOk() ? m_selectionForeground :
+        wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
 }
 
 void wxGrid::RedrawGridLines()


### PR DESCRIPTION
Fix `wxGrid` for system color change for colors that were assigned defaults in `Init()`, and therefore did not update. These colors are figured as needed during drawing.

The grid sample `Colours` menu gets additional commands so you can set all these colors.