### PR TITLE
wxStaticBitmap::DoUpdateImage() using wrong coordinates when invalidating the bitmap's rectangle.  

### DIFF
--- a/src/msw/statbmp.cpp
+++ b/src/msw/statbmp.cpp
@@ -320,7 +320,8 @@ void wxStaticBitmap::DoUpdateImage(const wxSize& sizeOld, bool wasIcon)
         SetSize(GetBestSize());
     }
 
-    RECT rect = wxGetWindowRect(GetHwnd());
+    RECT rect;
+    wxCopyRectToRECT(GetRect(), rect);
     ::InvalidateRect(GetHwndOf(GetParent()), &rect, TRUE);
 }
 


### PR DESCRIPTION
::InvalidateRect() interprets the rect in the parent's *client* coordinates, but wxGetWindowRect() returns *screen* coordinates.  With a large parent the unconverted rect invalidated a phantom control-sized band displaced by the frame's screen origin on every SetBitmap().