### PR TITLE
MSW: Fix dark mode title bar for Windows 10 1909 and 1903

### DIFF
--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -135,8 +135,6 @@ wxDarkModeSettings::~wxDarkModeSettings() = default;
 static const char* TRACE_DARKMODE = "msw-darkmode";
 #endif // wxUSE_LOG_TRACE
 
-#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
-
 namespace
 {
 
@@ -478,6 +476,10 @@ bool HasChanged()
 void ConfigureTLW(HWND hwnd)
 {
     BOOL useDarkMode = wxMSWImpl::ShouldUseDarkMode();
+
+    // The value of DWMWA_USE_IMMERSIVE_DARK_MODE is 20 since Windows 10 2004
+    // (build 19041). Before that it was 19.
+    auto DWMWA_USE_IMMERSIVE_DARK_MODE = wxCheckOsVersion(10, 0, 19041) ? 20 : 19;
 
     HRESULT hr = wxDarkModeModule::GetDwmSetWindowAttribute()
                  (


### PR DESCRIPTION
This change essentially reverts ffeeb61. That commit was based my reading of a comment that seemed to say the value of DWMWA_USE_IMMERSIVE_DARK_MODE changed with Windows 10 1809. In fact, the value changed in Windows 10 2004, which I verified by testing.
