### PR TITLE
[CMAKE] Avoid X11 session manager when X11 is not used (#26691)

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -811,7 +811,7 @@ if(wxUSE_GUI)
     endif()
 
     if(wxUSE_DETECT_SM)
-        if(APPLE OR WIN32)
+        if(NOT X11_FOUND)
             wx_option_force_value(wxUSE_DETECT_SM OFF)
         else()
             find_package(PkgConfig)


### PR DESCRIPTION
This PR fixes issue #26691 according to the suggestion received.