### PR TITLE
MSW: Fix wxChoice dark mode scroll bar

### DIFF
--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -226,9 +226,10 @@ void wxChoice::MSWSetDarkOrLightMode(SetMode setmode)
     if ( ::GetComboBoxInfo(GetHwnd(), &info) && info.hwndList )
     {
         // The default theme does not look good on starting with Windows 11
-        // build 26300.8553. DarkMode_DarkTheme looks OK and was available
-        // starting with Windows 11 build 26200.
-        if ( wxCheckOsVersion(10, 0, 26200) )
+        // build 26300.8553. DarkMode_DarkTheme looks OK and is available
+        // starting with Windows 11 25H2 (build 26200). Do not use
+        // DarkMode_DarkTheme for light mode otherwise the scroll bar is dark.
+        if ( wxMSWDarkMode::IsActive() && wxCheckOsVersion(10, 0, 26200) )
             wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
         else
             wxMSWDarkMode::AllowForWindow(info.hwndList);


### PR DESCRIPTION
On Windows 11 25H2 and later, when switching to light mode, the `wxChoice` drop-down list scroll bar stays dark. Solved by using `DarkMode_DarkTheme` only for dark mode. Use `Explorer` for light mode.
