### PR TITLE
MSW: Make wxTextCtrl dark mode border consistent with light mode

### DIFF
--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -247,7 +247,7 @@ protected:
 
     virtual wxString DoGetValue() const override;
 
-    virtual void MSWDrawThemeBorder(HDC hdc, RECT& rcBorder, int thickness) override;
+    virtual void MSWDrawThemeBorder(WXHDC hdc, int thickness) override;
 
     virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
 

--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -247,6 +247,8 @@ protected:
 
     virtual wxString DoGetValue() const override;
 
+    virtual void MSWDrawThemeBorder(HDC hdc, RECT& rcBorder, int thickness) override;
+
     virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
 
 #if wxUSE_RICHEDIT

--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -247,7 +247,7 @@ protected:
 
     virtual wxString DoGetValue() const override;
 
-    virtual void MSWDrawThemeBorder(WXHDC hdc, int thickness) override;
+    virtual void MSWDrawThemeBorder(WXHDC hdc) override;
 
     virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -816,6 +816,8 @@ protected:
     void MSWMoveWindowToAnyPosition(WXHWND hwnd, int x, int y,
                                     int width, int height, bool bRepaint);
 
+    virtual void MSWDrawThemeBorder(HDC hdc, RECT& rect, int thickness);
+
 #if wxUSE_DEFERRED_SIZING
     // this function is called after the window was resized to its new size
     virtual void MSWEndDeferWindowPos()

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -816,7 +816,7 @@ protected:
     void MSWMoveWindowToAnyPosition(WXHWND hwnd, int x, int y,
                                     int width, int height, bool bRepaint);
 
-    virtual void MSWDrawThemeBorder(HDC hdc, RECT& rect, int thickness);
+    virtual void MSWDrawThemeBorder(WXHDC hdc, int thickness);
 
 #if wxUSE_DEFERRED_SIZING
     // this function is called after the window was resized to its new size

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -816,7 +816,7 @@ protected:
     void MSWMoveWindowToAnyPosition(WXHWND hwnd, int x, int y,
                                     int width, int height, bool bRepaint);
 
-    virtual void MSWDrawThemeBorder(WXHDC hdc, int thickness);
+    virtual void MSWDrawThemeBorder(WXHDC hdc);
 
 #if wxUSE_DEFERRED_SIZING
     // this function is called after the window was resized to its new size

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2857,12 +2857,12 @@ void wxTextCtrl::OnSetFocus(wxFocusEvent& event)
     event.Skip();
 }
 
-void wxTextCtrl::MSWDrawThemeBorder(HDC hdc, RECT& rect, int thickness)
+void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc, int thickness)
 {
     if ( IsRich() )
     {
         // Always draw a simple border.
-        wxTextCtrlBase::MSWDrawThemeBorder(hdc, rect, thickness);
+        wxTextCtrlBase::MSWDrawThemeBorder(hdc, thickness);
     }
     else
     {
@@ -2871,6 +2871,8 @@ void wxTextCtrl::MSWDrawThemeBorder(HDC hdc, RECT& rect, int thickness)
         // bottom otherwise a light gray line.
         wxASSERT(wxMSWDarkMode::IsActive());
         wxASSERT(thickness == 2);
+        RECT rect;
+        wxCopyRectToRECT(GetSize(), rect);
 
         // Colour for top, left, and right. Taken from WinUI 3 TextBox.
         const COLORREF colTop = 0x303030;

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -496,8 +496,8 @@ bool wxTextCtrl::Create(wxWindow *parent,
 // returns true if the platform should explicitly apply a theme border
 bool wxTextCtrl::CanApplyThemeBorder() const
 {
-    // Standard text control already handles theming
-    return ((GetWindowStyle() & (wxTE_RICH|wxTE_RICH2)) != 0);
+    // Standard text control already handles theming in light mode.
+    return IsRich() || wxMSWDarkMode::IsActive();
 }
 
 bool wxTextCtrl::MSWCreateText(const wxString& value,
@@ -2855,6 +2855,58 @@ void wxTextCtrl::OnSetFocus(wxFocusEvent& event)
     }
 
     event.Skip();
+}
+
+void wxTextCtrl::MSWDrawThemeBorder(HDC hdc, RECT& rect, int thickness)
+{
+    if ( IsRich() )
+    {
+        // Always draw a simple border.
+        wxTextCtrlBase::MSWDrawThemeBorder(hdc, rect, thickness);
+    }
+    else
+    {
+        // Draw a dark mode border similar to how the control looks in light
+        // mode. If the control has the focus, a blue line appears along the
+        // bottom otherwise a light gray line.
+        wxASSERT(wxMSWDarkMode::IsActive());
+        wxASSERT(thickness == 2);
+
+        // Colour for top, left, and right. Taken from WinUI 3 TextBox.
+        const COLORREF colTop = 0x303030;
+        // Colour for bottom when unfocused. Taken from WinUI 3 TextBox.
+        const COLORREF colBotGray = 0x9a9a9a;
+        // Colour for bottom when focused. This accent colour matches the
+        // Win32 checkbox when checked, and the radio button when selected.
+        const COLORREF colBotBlue = 0xffcd60;
+
+        // Draw outer 1 pixel thick border with a rectangle. The bottom will be
+        // drawn over later.
+        AutoHBRUSH brushBorder(colTop);
+        ::FrameRect(hdc, &rect, brushBorder);
+        // Draw inner 1 pixel thick rectangle as background colour.
+        AutoHBRUSH brushBg(GetBackgroundColour().GetPixel());
+        RECT rcInner = rect;
+        ::InflateRect(&rcInner, -1, -1);
+        ::FrameRect(hdc, &rcInner, brushBg);
+        // Draw 1 or 2 pixel thick bottom line.
+        COLORREF colBot;
+        int thicknessBot;
+        if ( HasFocus() )
+        {
+            colBot = colBotBlue;
+            thicknessBot = 2;
+        }
+        else
+        {
+            colBot = colBotGray;
+            thicknessBot = 1;
+        }
+        AutoHBRUSH brushBottom(colBot);
+        RECT rcBottom = rect;
+        rcBottom.top = rect.bottom - thicknessBot;
+        ::FillRect(hdc, &rcBottom, brushBottom);
+    }
 }
 
 // the rest of the file only deals with the rich edit controls

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2857,20 +2857,18 @@ void wxTextCtrl::OnSetFocus(wxFocusEvent& event)
     event.Skip();
 }
 
-void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc, int thickness)
+void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc)
 {
     if ( IsRich() )
     {
         // Always draw a simple border.
-        wxTextCtrlBase::MSWDrawThemeBorder(hdc, thickness);
+        wxTextCtrlBase::MSWDrawThemeBorder(hdc);
     }
     else
     {
         // Draw a dark mode border similar to how the control looks in light
         // mode. If the control has the focus, a blue line appears along the
         // bottom otherwise a light gray line.
-        wxASSERT(wxMSWDarkMode::IsActive());
-        wxASSERT(thickness == 2);
         RECT rect;
         wxCopyRectToRECT(GetSize(), rect);
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3880,11 +3880,10 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                     processed = true;
 
                     wxWindowDC dc((wxWindow *)this);
-                    RECT rcBorder;
-                    wxCopyRectToRECT(GetSize(), rcBorder);
 
                     // Exclude the client area and any scroll bars.
-                    RECT rcClient = rcBorder;
+                    RECT rcClient;
+                    wxCopyRectToRECT(GetSize(), rcClient);
                     InflateRect(&rcClient, -thickness, -thickness);
                     HDC hdc = dc.GetHDC();
                     ::ExcludeClipRect(hdc, rcClient.left, rcClient.top,
@@ -3892,12 +3891,12 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     // Draw the border.
                     if ( border == wxBORDER_THEME )
-                        MSWDrawThemeBorder(hdc, rcBorder, thickness);
+                        MSWDrawThemeBorder(hdc, thickness);
                     else
                     {
                         // In dark mode, draw a simple border for all the 3D border styles.
                         wxASSERT(wxMSWDarkMode::IsActive());
-                        wxWindowMSW::MSWDrawThemeBorder(hdc, rcBorder, thickness);
+                        wxWindowMSW::MSWDrawThemeBorder(hdc, thickness);
                     }
                 }
             }
@@ -3922,8 +3921,11 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 }
 
 // Draw a simple generic border.
-void wxWindowMSW::MSWDrawThemeBorder(HDC hdc, RECT& rcBorder, int thickness)
+void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc, int thickness)
 {
+    RECT rcBorder;
+    wxCopyRectToRECT(GetSize(), rcBorder);
+
     if ( wxMSWDarkMode::IsActive() )
     {
         // There does not seem to be a theme class that draws a good
@@ -3948,7 +3950,7 @@ void wxWindowMSW::MSWDrawThemeBorder(HDC hdc, RECT& rcBorder, int thickness)
         // Make sure the background is in a proper state
         if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
         {
-            ::DrawThemeParentBackground(GetHwnd(), hdc, &rcBorder);
+            ::DrawThemeParentBackground(m_hWnd, hdc, &rcBorder);
         }
         // Draw the border
         hTheme.DrawBackground(hdc, rcBorder, EP_EDITTEXT, ETS_NORMAL);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3891,12 +3891,12 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     // Draw the border.
                     if ( border == wxBORDER_THEME )
-                        MSWDrawThemeBorder(hdc, thickness);
+                        MSWDrawThemeBorder(hdc);
                     else
                     {
                         // In dark mode, draw a simple border for all the 3D border styles.
                         wxASSERT(wxMSWDarkMode::IsActive());
-                        wxWindowMSW::MSWDrawThemeBorder(hdc, thickness);
+                        wxWindowMSW::MSWDrawThemeBorder(hdc);
                     }
                 }
             }
@@ -3921,7 +3921,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 }
 
 // Draw a simple generic border.
-void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc, int thickness)
+void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc)
 {
     RECT rcBorder;
     wxCopyRectToRECT(GetSize(), rcBorder);
@@ -3937,6 +3937,7 @@ void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc, int thickness)
         // Draw the background with consecutively smaller 1-pixel thick
         // rectangles.
         AutoHBRUSH brushBg(GetBackgroundColour().GetPixel());
+        const auto thickness = MSWGetBorderThickness();
         for (int count = 1; count < thickness; count++)
         {
             ::InflateRect(&rcBorder, -1, -1);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3844,7 +3844,8 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             {
                 // Determine whether we should draw a border.
                 bool drawBorder = false;
-                switch ( DoTranslateBorder(GetBorder()) )
+                wxBorder border = DoTranslateBorder(GetBorder());
+                switch ( border )
                 {
                     case wxBORDER_THEME:
                         drawBorder = true;
@@ -3879,45 +3880,24 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                     processed = true;
 
                     wxWindowDC dc((wxWindow *)this);
-                    wxMSWDCImpl *impl = (wxMSWDCImpl*) dc.GetImpl();
                     RECT rcBorder;
                     wxCopyRectToRECT(GetSize(), rcBorder);
 
                     // Exclude the client area and any scroll bars.
                     RECT rcClient = rcBorder;
                     InflateRect(&rcClient, -thickness, -thickness);
-                    ::ExcludeClipRect(GetHdcOf(*impl), rcClient.left, rcClient.top,
+                    HDC hdc = dc.GetHDC();
+                    ::ExcludeClipRect(hdc, rcClient.left, rcClient.top,
                                       rcClient.right, rcClient.bottom);
 
-                    // Draw the theme border and background.
-                    if ( wxMSWDarkMode::IsActive() )
-                    {
-                        // There does not seem to be a theme class that draws a good
-                        // border on all supported versions of Windows. Manually draw a
-                        // 1-pixel thick border. Use the observed colour of the simple
-                        // border, WS_BORDER.
-                        AutoHBRUSH brushBorder(0x646464);
-                        ::FrameRect(GetHdcOf(*impl), &rcBorder, brushBorder);
-                        // Draw the background with consecutively smaller 1-pixel thick
-                        // rectangles.
-                        AutoHBRUSH brushBg(GetBackgroundColour().GetPixel());
-                        for (int count = 1; count < thickness; count++)
-                        {
-                            ::InflateRect(&rcBorder, -1, -1);
-                            ::FrameRect(GetHdcOf(*impl), &rcBorder, brushBg);
-                        }
-                    }
+                    // Draw the border.
+                    if ( border == wxBORDER_THEME )
+                        MSWDrawThemeBorder(hdc, rcBorder, thickness);
                     else
                     {
-                        // The EDIT class gives a good general purpose border in light mode.
-                        wxUxThemeHandle hTheme(this, L"EDIT");
-                        // Make sure the background is in a proper state
-                        if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
-                        {
-                            ::DrawThemeParentBackground(GetHwnd(), GetHdcOf(*impl), &rcBorder);
-                        }
-                        // Draw the border
-                        hTheme.DrawBackground(GetHdcOf(*impl), rcBorder, EP_EDITTEXT, ETS_NORMAL);
+                        // In dark mode, draw a simple border for all the 3D border styles.
+                        wxASSERT(wxMSWDarkMode::IsActive());
+                        wxWindowMSW::MSWDrawThemeBorder(hdc, rcBorder, thickness);
                     }
                 }
             }
@@ -3939,6 +3919,40 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
     *result = rc.result;
 
     return true;
+}
+
+// Draw a simple generic border.
+void wxWindowMSW::MSWDrawThemeBorder(HDC hdc, RECT& rcBorder, int thickness)
+{
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        // There does not seem to be a theme class that draws a good
+        // border on all supported versions of Windows. Manually draw a
+        // 1-pixel thick border. Use the observed colour of the simple
+        // border, WS_BORDER.
+        AutoHBRUSH brushBorder(0x646464);
+        ::FrameRect(hdc, &rcBorder, brushBorder);
+        // Draw the background with consecutively smaller 1-pixel thick
+        // rectangles.
+        AutoHBRUSH brushBg(GetBackgroundColour().GetPixel());
+        for (int count = 1; count < thickness; count++)
+        {
+            ::InflateRect(&rcBorder, -1, -1);
+            ::FrameRect(hdc, &rcBorder, brushBg);
+        }
+    }
+    else
+    {
+        // The EDIT class gives a good general purpose border in light mode.
+        wxUxThemeHandle hTheme(this, L"EDIT");
+        // Make sure the background is in a proper state
+        if (::IsThemeBackgroundPartiallyTransparent(hTheme, EP_EDITTEXT, ETS_NORMAL))
+        {
+            ::DrawThemeParentBackground(GetHwnd(), hdc, &rcBorder);
+        }
+        // Draw the border
+        hTheme.DrawBackground(hdc, rcBorder, EP_EDITTEXT, ETS_NORMAL);
+    }
 }
 
 WXLRESULT wxWindowMSW::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lParam)


### PR DESCRIPTION
For `wxTextCtrl`, draw a themed border consistent with how the control looks in light mode, and consistent with the WinUI 3 `TextBox` control in dark mode. A blue line appears at the bottom when the control has the focus. The image below shows how the new border compares with light mode and with WinUI 3. The red box indicates the new border drawing.

<img width="424" height="482" alt="image" src="https://github.com/user-attachments/assets/bfb93644-c35f-4c8e-87bc-9a8da5470d6b" />

A new virtual function `MSWDrawThemeBorder()` draws the border when needed. This function could be implemented for other controls as well. For example, in light mode, `wxComboBox` has a blue border when focused.

