### PR TITLE
Add a function to perform internal processing of wxSysColourChangedEvent

### DIFF
--- a/include/wx/msw/frame.h
+++ b/include/wx/msw/frame.h
@@ -16,6 +16,7 @@ class WXDLLIMPEXP_FWD_CORE wxTaskBarButton;
 
 class WXDLLIMPEXP_CORE wxFrame : public wxFrameBase
 {
+    typedef wxFrameBase BaseType;
 public:
     // construction
     wxFrame() { Init(); }
@@ -46,9 +47,6 @@ public:
 
     // implementation only from now on
     // -------------------------------
-
-    // event handlers
-    void OnSysColourChanged(wxSysColourChangedEvent& event);
 
     // Toolbar
 #if wxUSE_TOOLBAR
@@ -87,6 +85,8 @@ public:
 
     // override the base class function to handle iconized/maximized frames
     virtual void SendSizeEvent(int flags = 0) override;
+
+    virtual void SendSysColourChangedEvents() override;
 
     virtual wxPoint GetClientAreaOrigin() const override;
 
@@ -186,7 +186,6 @@ private:
     wxTaskBarButton* m_taskBarButton;
 #endif
 
-    wxDECLARE_EVENT_TABLE();
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxFrame);
 };
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -544,8 +544,7 @@ public:
                            wxShowEffect effect,
                            unsigned timeout);
 
-    // Responds to colour changes: passes event on to children.
-    void OnSysColourChanged(wxSysColourChangedEvent& event);
+    virtual void SendSysColourChangedEvents() override;
 
     // initialize various fields of wxMouseEvent (common part of MSWOnMouseXXX)
     void InitMouseEvent(wxMouseEvent& event, int x, int y, WXUINT flags);
@@ -837,7 +836,6 @@ protected:
 private:
     wxDECLARE_DYNAMIC_CLASS(wxWindowMSW);
     wxDECLARE_NO_COPY_CLASS(wxWindowMSW);
-    wxDECLARE_EVENT_TABLE();
 };
 
 // window creation helper class: before creating a new HWND, instantiate an

--- a/include/wx/osx/frame.h
+++ b/include/wx/osx/frame.h
@@ -18,6 +18,7 @@ class WXDLLIMPEXP_FWD_CORE wxMacToolTip ;
 
 class WXDLLIMPEXP_CORE wxFrame: public wxFrameBase
 {
+    typedef wxFrameBase BaseType;
 public:
     // construction
     wxFrame() = default;
@@ -53,7 +54,6 @@ public:
 
     // event handlers
     void OnActivate(wxActivateEvent& event);
-    void OnSysColourChanged(wxSysColourChangedEvent& event);
 
     // Toolbar
 #if wxUSE_TOOLBAR
@@ -78,6 +78,8 @@ public:
 
     // internal response to size events
     virtual void MacOnInternalSize() override { PositionBars(); }
+
+    virtual void SendSysColourChangedEvents() override;
 
 protected:
 #if wxUSE_TOOLBAR

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -1612,7 +1612,6 @@ public:
     static inline const wxWindow* AsWindow(const wxWindowBase* win);
 
         // event handlers
-    void OnSysColourChanged( wxSysColourChangedEvent& event );
     void OnInitDialog( wxInitDialogEvent &event );
     void OnMiddleClick( wxMouseEvent& event );
 #if wxUSE_HELP
@@ -1626,6 +1625,8 @@ public:
     // Send idle event to window and all subwindows
     // Returns true if more idle time is requested.
     virtual bool SendIdleEvents(wxIdleEvent& event);
+
+    virtual void SendSysColourChangedEvents();
 
     // Send wxContextMenuEvent and return true if it was processed.
     //

--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -1005,7 +1005,6 @@ void wxPreviewCanvas::OnDPIChanged(wxDPIChangedEvent& event)
     event.Skip();
 }
 
-// Responds to colour changes, and passes event on to children.
 void wxPreviewCanvas::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
 #ifdef __WXMAC__
@@ -1020,8 +1019,7 @@ void wxPreviewCanvas::OnSysColourChanged(wxSysColourChangedEvent& event)
     SetBackgroundColour(wxSystemSettings::GetColour(colourIndex));
     Refresh();
 
-    // Propagate the event to the non-top-level children
-    wxWindow::OnSysColourChanged(event);
+    event.Skip();
 }
 
 void wxPreviewCanvas::OnChar(wxKeyEvent &event)

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -113,7 +113,6 @@ wxIMPLEMENT_ABSTRACT_CLASS(wxWindowBase, wxEvtHandler);
 // ----------------------------------------------------------------------------
 
 wxBEGIN_EVENT_TABLE(wxWindowBase, wxEvtHandler)
-    EVT_SYS_COLOUR_CHANGED(wxWindowBase::OnSysColourChanged)
     EVT_INIT_DIALOG(wxWindowBase::OnInitDialog)
     EVT_MIDDLE_DOWN(wxWindowBase::OnMiddleClick)
 
@@ -3019,8 +3018,12 @@ wxPoint wxWindowBase::ConvertDialogToPixels(const wxPoint& pt) const
 // ----------------------------------------------------------------------------
 
 // propagate the colour change event to the subwindows
-void wxWindowBase::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
+void wxWindowBase::SendSysColourChangedEvents()
 {
+    wxSysColourChangedEvent event;
+    event.SetEventObject(this);
+    HandleWindowEvent(event);
+
     wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
     while ( node )
     {
@@ -3028,9 +3031,7 @@ void wxWindowBase::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
         wxWindow *win = node->GetData();
         if ( !win->IsTopLevel() )
         {
-            wxSysColourChangedEvent event2;
-            event2.SetEventObject(win);
-            win->GetEventHandler()->ProcessEvent(event2);
+            win->SendSysColourChangedEvents();
         }
 
         node = node->GetNext();

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -1612,14 +1612,12 @@ void wxGenericCalendarCtrl::OnYearTextChange(wxCommandEvent& event)
     HandleYearChange(event);
 }
 
-// Responds to colour changes, and passes event on to children.
 void wxGenericCalendarCtrl::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
     // reinit colours
     InitColours();
 
-    // Propagate the event to the children
-    wxControl::OnSysColourChanged(event);
+    event.Skip();
 
     // Redraw control area
     SetBackgroundColour(m_colBackground);

--- a/src/generic/statusbr.cpp
+++ b/src/generic/statusbr.cpp
@@ -460,8 +460,7 @@ void wxStatusBarGeneric::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
     InitColours();
 
-    // Propagate the event to the non-top-level children
-    wxWindow::OnSysColourChanged(event);
+    event.Skip();
 }
 
 #ifdef __WXGTK__

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -328,9 +328,7 @@ void DoUpdateColorScheme(wxGTKImpl::ColorScheme colorScheme)
 
     for (auto* win: wxTopLevelWindows)
     {
-        wxSysColourChangedEvent event;
-        event.SetEventObject(win);
-        win->HandleWindowEvent(event);
+        win->SendSysColourChangedEvents();
     }
 }
 

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -564,9 +564,7 @@ gtk_frame_window_state_callback( GtkWidget* WXUNUSED(widget),
 extern "C" {
 static void notify_gtk_theme_name(GObject*, GParamSpec*, wxTopLevelWindowGTK* win)
 {
-    wxSysColourChangedEvent event;
-    event.SetEventObject(win);
-    win->HandleWindowEvent(event);
+    win->SendSysColourChangedEvents();
 }
 }
 

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -66,14 +66,6 @@
     extern wxMenu *wxCurrentPopupMenu;
 #endif // wxUSE_MENUS || wxUSE_MENUS_NATIVE
 
-// ----------------------------------------------------------------------------
-// event tables
-// ----------------------------------------------------------------------------
-
-wxBEGIN_EVENT_TABLE(wxFrame, wxFrameBase)
-    EVT_SYS_COLOUR_CHANGED(wxFrame::OnSysColourChanged)
-wxEND_EVENT_TABLE()
-
 // ============================================================================
 // implementation
 // ============================================================================
@@ -470,7 +462,7 @@ wxTaskBarButton* wxFrame::MSWGetTaskBarButton()
 }
 #endif // wxUSE_TASKBARBUTTON
 
-void wxFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
+void wxFrame::SendSysColourChangedEvents()
 {
 #if wxUSE_MENUS && wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__)
     if ( wxMenuBar* const menuBar = GetMenuBar() )
@@ -479,8 +471,7 @@ void wxFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
     }
 #endif // wxUSE_MENUS && wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__)
 
-    // Let children react to this event too.
-    event.Skip();
+    BaseType::SendSysColourChangedEvents();
 }
 
 // Pass true to show full screen, false to restore.

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -299,19 +299,11 @@ static bool wxIsTouchEventMSW()
     return (::GetMessageExtraInfo() & SIGNATURE_MASK) == MI_WP_SIGNATURE;
 }
 
-// ---------------------------------------------------------------------------
-// event tables
-// ---------------------------------------------------------------------------
-
 // in wxUniv/MSW this class is abstract because it doesn't have DoPopupMenu()
 // method
 #ifdef __WXUNIVERSAL__
     wxIMPLEMENT_ABSTRACT_CLASS(wxWindowMSW, wxWindowBase);
 #endif // __WXUNIVERSAL__
-
-wxBEGIN_EVENT_TABLE(wxWindowMSW, wxWindowBase)
-    EVT_SYS_COLOUR_CHANGED(wxWindowMSW::OnSysColourChanged)
-wxEND_EVENT_TABLE()
 
 // ===========================================================================
 // implementation
@@ -4829,7 +4821,6 @@ wxWindowMSW::MSWOnDrawItem(int WXUNUSED_UNLESS_ODRAWN(id),
     {
         return item->MSWOnDraw(itemStruct);
     }
-
 #endif // wxUSE_CONTROLS
 
     return false;
@@ -5090,10 +5081,7 @@ bool wxWindowMSW::HandleSysColorChange()
     // that information.
     wxMSWDarkMode::NotifySysColorChange();
 
-    wxSysColourChangedEvent event;
-    event.SetEventObject(this);
-
-    (void)HandleWindowEvent(event);
+    SendSysColourChangedEvents();
 
     if ( IsTopLevel() )
         Refresh();
@@ -5271,8 +5259,7 @@ bool wxWindowMSW::HandleQueryNewPalette()
     return HandleWindowEvent(event) && event.GetPaletteRealized();
 }
 
-// Responds to colour changes: passes event on to children.
-void wxWindowMSW::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
+void wxWindowMSW::SendSysColourChangedEvents()
 {
     // the top level window also reset the standard colour map as it might have
     // changed (there is no need to do it for the non top level windows as we
@@ -5290,6 +5277,10 @@ void wxWindowMSW::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
         MSWSetDarkOrLightMode(SetMode::Change);
     }
 
+    wxSysColourChangedEvent event;
+    event.SetEventObject(this);
+    ProcessWindowEvent(event);
+
     wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
     while ( node )
     {
@@ -5306,6 +5297,8 @@ void wxWindowMSW::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
 
         node = node->GetNext();
     }
+
+    // Base class functionality is duplicated here, so don't chain up
 }
 
 extern wxCOLORMAP *wxGetStdColourMap()

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -43,7 +43,6 @@ int GetMacStatusbarHeight()
 
 wxBEGIN_EVENT_TABLE(wxFrame, wxFrameBase)
   EVT_ACTIVATE(wxFrame::OnActivate)
-  EVT_SYS_COLOUR_CHANGED(wxFrame::OnSysColourChanged)
 wxEND_EVENT_TABLE()
 
 // ----------------------------------------------------------------------------
@@ -179,23 +178,18 @@ void wxFrame::PositionStatusBar()
 }
 #endif // wxUSE_STATUSBAR
 
-// Responds to colour changes, and passes event on to children.
-void wxFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
+void wxFrame::SendSysColourChangedEvents()
 {
     Refresh();
 
 #if wxUSE_STATUSBAR
     if ( m_frameStatusBar )
     {
-        wxSysColourChangedEvent event2;
-
-        event2.SetEventObject( m_frameStatusBar );
-        m_frameStatusBar->GetEventHandler()->ProcessEvent(event2);
+        m_frameStatusBar->SendSysColourChangedEvents();
     }
 #endif // wxUSE_STATUSBAR
 
-    // Propagate the event to the non-top-level children
-    wxWindow::OnSysColourChanged(event);
+    BaseType::SendSysColourChangedEvents();
 }
 
 // Default activation behaviour - set the focus for the first child

--- a/src/osx/carbon/mdi.cpp
+++ b/src/osx/carbon/mdi.cpp
@@ -238,13 +238,11 @@ void wxMDIParentFrame::OnActivate(wxActivateEvent& event)
     event.Skip();
 }
 
-// Responds to colour changes, and passes event on to children.
 void wxMDIParentFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
     // TODO
 
-    // Propagate the event to the non-top-level children
-    wxFrame::OnSysColourChanged(event);
+    event.Skip();
 }
 
 bool wxMDIParentFrame::ShouldBeVisible() const

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -702,9 +702,7 @@ static void SendFullScreenWindowEvent(NSNotification* notification, bool fullscr
                                        objectForKey:@"NSBackingPropertyOldColorSpaceKey"];
         if (![newColorSpace isEqual:oldColorSpace])
         {
-            wxSysColourChangedEvent event;
-            event.SetEventObject(wxpeer);
-            wxpeer->HandleWindowEvent(event);
+            wxpeer->SendSysColourChangedEvents();
         }
     }
 }
@@ -731,9 +729,7 @@ static void SendFullScreenWindowEvent(NSNotification* notification, bool fullscr
         wxNonOwnedWindow* wxpeer = windowimpl ? windowimpl->GetWXPeer() : nullptr;
         if (wxpeer)
         {
-            wxSysColourChangedEvent event;
-            event.SetEventObject(wxpeer);
-            wxpeer->HandleWindowEvent(event);
+            wxpeer->SendSysColourChangedEvents();
         }
     }
 }


### PR DESCRIPTION
This avoids the chronic problem of wxSysColourChangedEvent handlers inadvertently failing to call Skip() and thus blocking important internal processing, including propagating to child windows.