### PR TITLE
Remove implicit conversion of wxColour to GdkRGBA* in wxGTK

### DIFF
--- a/include/wx/gtk/colour.h
+++ b/include/wx/gtk/colour.h
@@ -39,7 +39,7 @@ public:
 
     // Implementation part
 #ifdef __WXGTK3__
-    operator const GdkRGBA*() const;
+    const GdkRGBA* GTKGetRGBA() const;
 #else
     void CalcPixel( GdkColormap *cmap );
     int GetPixel() const;

--- a/src/gtk/clrpicker.cpp
+++ b/src/gtk/clrpicker.cpp
@@ -80,7 +80,7 @@ bool wxColourButton::Create( wxWindow *parent, wxWindowID id,
 
     m_colour = col;
 #ifdef __WXGTK3__
-    m_widget = gtk_color_button_new_with_rgba(m_colour);
+    m_widget = gtk_color_button_new_with_rgba(m_colour.GTKGetRGBA());
 #else
     m_widget = gtk_color_button_new_with_color( m_colour.GetColor() );
 #endif
@@ -112,7 +112,7 @@ void wxColourButton::UpdateColour()
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(m_widget), m_colour);
 #elif defined(__WXGTK3__)
     wxGCC_WARNING_SUPPRESS(deprecated-declarations)
-    gtk_color_button_set_rgba(GTK_COLOR_BUTTON(m_widget), m_colour);
+    gtk_color_button_set_rgba(GTK_COLOR_BUTTON(m_widget), m_colour.GTKGetRGBA());
     wxGCC_WARNING_RESTORE()
 #else
     gtk_color_button_set_color(GTK_COLOR_BUTTON(m_widget), m_colour.GetColor());

--- a/src/gtk/colordlg.cpp
+++ b/src/gtk/colordlg.cpp
@@ -100,7 +100,7 @@ void wxColourDialog::ColourDataToDialog()
     if (color.IsOk())
     {
 #ifdef __WXGTK3__
-        gtk_color_selection_set_current_rgba(sel, color);
+        gtk_color_selection_set_current_rgba(sel, color.GTKGetRGBA());
 #else
         gtk_color_selection_set_current_color(sel, color.GetColor());
         // Convert alpha range: [0,255] -> [0,65535]

--- a/src/gtk/colour.cpp
+++ b/src/gtk/colour.cpp
@@ -245,7 +245,7 @@ const GdkColor *wxColourImpl::GetColor() const
 }
 
 #ifdef __WXGTK3__
-wxColourImpl::operator const GdkRGBA*() const
+const GdkRGBA* wxColourImpl::GTKGetRGBA() const
 {
     const GdkRGBA* c = nullptr;
     if (IsOk())

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2282,7 +2282,7 @@ void GtkApplyAttr(GtkCellRendererText *renderer, const wxDataViewItemAttr& attr)
 
 #ifdef __WXGTK3__
         wxGtkValue gvalue( GDK_TYPE_RGBA);
-        g_value_set_boxed(gvalue, static_cast<const GdkRGBA*>(attr.GetColour()));
+        g_value_set_boxed(gvalue, attr.GetColour().GTKGetRGBA());
         g_object_set_property(G_OBJECT(renderer), "foreground-rgba", gvalue);
 #else
         const GdkColor* const gcol = attr.GetColour().GetColor();
@@ -2343,7 +2343,7 @@ void GtkApplyAttr(GtkCellRendererText *renderer, const wxDataViewItemAttr& attr)
         wxColour colour = attr.GetBackgroundColour();
 #ifdef __WXGTK3__
         wxGtkValue gvalue( GDK_TYPE_RGBA);
-        g_value_set_boxed(gvalue, static_cast<const GdkRGBA*>(colour));
+        g_value_set_boxed(gvalue, colour.GTKGetRGBA());
         g_object_set_property(G_OBJECT(renderer), "cell-background-rgba", gvalue);
 #else
         const GdkColor * const gcol = colour.GetColor();
@@ -3176,7 +3176,7 @@ void wxDataViewIconTextRenderer::SetAttr(const wxDataViewItemAttr& attr)
     if (attr.HasBackgroundColour())
     {
 #ifdef __WXGTK3__
-        const GdkRGBA* rbga = attr.GetBackgroundColour();
+        const GdkRGBA* rbga = attr.GetBackgroundColour().GTKGetRGBA();
         g_object_set(G_OBJECT(m_rendererIcon), "cell-background-rgba", rbga, nullptr);
 #else
         const GdkColor* color = attr.GetBackgroundColour().GetColor();

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -172,7 +172,7 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
                 if (!tag)
                     tag = gtk_text_buffer_create_tag( text_buffer, buf,
                                                       "underline-rgba-set", TRUE,
-                                                      "underline-rgba", static_cast<const GdkRGBA*>(colour),
+                                                      "underline-rgba", colour.GTKGetRGBA(),
                                                       nullptr );
                 gtk_text_buffer_apply_tag (text_buffer, tag, start, end);
             }

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -5917,7 +5917,7 @@ void wxWindowGTK::GTKSendPaintEvents(const GdkRegion* region)
             else if (m_backgroundColour.IsOk() && gtk_check_version(3,20,0) == nullptr)
             {
                 cairo_save(cr);
-                gdk_cairo_set_source_rgba(cr, m_backgroundColour);
+                gdk_cairo_set_source_rgba(cr, m_backgroundColour.GTKGetRGBA());
                 cairo_paint(cr);
                 cairo_restore(cr);
             }
@@ -6176,12 +6176,12 @@ void wxWindowGTK::GTKApplyWidgetStyle(bool forceStyle)
         if (isFg)
         {
             g_string_append_printf(css, "color:%s;",
-                wxGtkString(gdk_rgba_to_string(fg)).c_str());
+                wxGtkString(gdk_rgba_to_string(fg.GTKGetRGBA())).c_str());
         }
         if (isBg)
         {
             g_string_append_printf(css, "background:%s;",
-                wxGtkString(gdk_rgba_to_string(bg)).c_str());
+                wxGtkString(gdk_rgba_to_string(bg.GTKGetRGBA())).c_str());
         }
         if (isFont)
         {
@@ -6278,8 +6278,8 @@ void wxWindowGTK::GTKApplyWidgetStyle(bool forceStyle)
             // controls, and seems to do no harm to apply to all.
             const wxColour fg_sel(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
             const wxColour bg_sel(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
-            wxGtkString fg_sel_string(gdk_rgba_to_string(fg_sel));
-            wxGtkString bg_sel_string(gdk_rgba_to_string(bg_sel));
+            wxGtkString fg_sel_string(gdk_rgba_to_string(fg_sel.GTKGetRGBA()));
+            wxGtkString bg_sel_string(gdk_rgba_to_string(bg_sel.GTKGetRGBA()));
             g_string_append_printf(css,
                 "selection{color:%s;background:%s}"
                 "*:selected{color:%s;background:%s}",
@@ -6289,7 +6289,7 @@ void wxWindowGTK::GTKApplyWidgetStyle(bool forceStyle)
             if (isFg && wx_is_at_least_gtk3(20))
             {
                 g_string_append_printf(css, "*{caret-color:%s}",
-                    wxGtkString(gdk_rgba_to_string(fg)).c_str());
+                    wxGtkString(gdk_rgba_to_string(fg.GTKGetRGBA())).c_str());
             }
             if (isBg)
             {


### PR DESCRIPTION
This was dangerous because it allowed the code accidentally dereferencing wxColour to silently compile -- and do a completely wrong thing.

Just add a function returning GdkRGBA explicitly and use it.