### PR TITLE
MSW: Dark mode system color values consistent with other platforms

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -352,15 +352,22 @@ void wxGridHeaderLabelsRenderer::DrawLabel(const wxGrid& grid,
     wxColour colText;
     if ( !grid.IsEnabled() )
     {
-        colText = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT);
-        dc.SetTextForeground(colText);
+        if ( wxSystemSettings::GetAppearance().IsDark() )
+        {
+            colText = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
+        }
+        else
+        {
+            colText = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT);
+            dc.SetTextForeground(colText);
 
-        wxRect rectShadow = rect;
-        rectShadow.Offset(1, 1);
-        grid.DrawTextRectangle(dc, value, rectShadow,
-                               horizAlign, vertAlign, textOrientation);
+            wxRect rectShadow = rect;
+            rectShadow.Offset(1, 1);
+            grid.DrawTextRectangle(dc, value, rectShadow,
+                horizAlign, vertAlign, textOrientation);
 
-        colText = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW);
+            colText = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW);
+        }
     }
     else
     {

--- a/src/generic/stattextg.cpp
+++ b/src/generic/stattextg.cpp
@@ -72,14 +72,22 @@ void wxGenericStaticText::OnPaint(wxPaintEvent& WXUNUSED(event))
     wxRect rect = GetClientRect();
     if ( !IsEnabled() )
     {
-        // draw shadow of the text
-        dc.SetTextForeground(
-                       wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
-        wxRect rectShadow = rect;
-        rectShadow.Offset(1, 1);
-        DoDrawLabel(dc, rectShadow);
-        dc.SetTextForeground(
-                       wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));
+        if ( wxSystemSettings::GetAppearance().IsDark() )
+        {
+            dc.SetTextForeground(
+                wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+        }
+        else
+        {
+            // draw shadow of the text
+            dc.SetTextForeground(
+                wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
+            wxRect rectShadow = rect;
+            rectShadow.Offset(1, 1);
+            DoDrawLabel(dc, rectShadow);
+            dc.SetTextForeground(
+                wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));
+        }
     }
     DoDrawLabel(dc, rect);
 }

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -434,14 +434,14 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
             // Selected text background in File Open dialog
             return wxColour(isWindows10 ? 0xd77800 : 0xd47800);
 
+        case wxSYS_COLOUR_3DLIGHT:
         case wxSYS_COLOUR_BTNHIGHLIGHT:
-            return wxColour(0x777777);
+            return wxColour(0x303030);
 
         case wxSYS_COLOUR_INACTIVECAPTIONTEXT:
             return wxColour(0xaaaaaa);
 
         case wxSYS_COLOUR_3DDKSHADOW:
-        case wxSYS_COLOUR_3DLIGHT:
         case wxSYS_COLOUR_ACTIVEBORDER:
         case wxSYS_COLOUR_DESKTOP:
         case wxSYS_COLOUR_GRADIENTACTIVECAPTION:


### PR DESCRIPTION
Make the RGB values for `wxSYS_COLOUR_3DLIGHT` and `wxSYS_COLOUR_BTNHIGHLIGHT` consistent with Linux and macOS.

These colors are currently very different than other systems. I choose the value 0x303030 for both colors based on looking at several Linux systems and macOS. I found the values for both colors were always in the range 0x2c2c2c to 0x373737. On all systems they are nearly the same or exactly the same. Of note, the Kicad project uses the value [0x2b2b2b](https://github.com/KiCad/kicad-source-mirror/blob/7fd8018b1bad9eec78050225271440e8c82eee4e/libs/kiplatform/os/windows/app.cpp#L77).
