### PR TITLE
Use wxIMPLEMENT_APP_CONSOLE() in the archive sample

### DIFF
--- a/samples/archive/archive.cpp
+++ b/samples/archive/archive.cpp
@@ -351,4 +351,4 @@ int ArchiveApp::OnRun()
     return result;
 }
 
-wxIMPLEMENT_APP(ArchiveApp);
+wxIMPLEMENT_APP_CONSOLE(ArchiveApp);


### PR DESCRIPTION
Replacing wxIMPLEMENT_APP() with wxIMPLEMENT_APP_CONSOLE() allows building the sample on Windows with CMake with wxWidgets built in the monolithic configuration.

The archive sample is a console, not GUI, sample and console applications should use wxIMPLEMENT_APP_CONSOLE() instead of wxIMPLEMENT_APP(). This matters on Windows when compiling with MSVC and the linker subsystem set to console.

It can still work when wxUSE_GUI=0 is defined but this is not possible with wxWidgets monolithic build, where wxUSE_GUI=1 is defined for all the projects.