### PR TITLE
Add inline IME support to wxStyledTextCtrl

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -217,6 +217,7 @@ public :
     virtual void                cursorUpdate(WX_NSEvent event, WXWidget slf, void* _cmd);
     virtual void                keyEvent(WX_NSEvent event, WXWidget slf, void* _cmd);
     virtual void                insertText(NSString* text, WXWidget slf, void* _cmd);
+    void                        textInputEventHandled();
     // Returns true if the event was processed by a user-defined event handler.
     virtual bool                doCommandBySelector(void* sel, WXWidget slf, void* _cmd);
     virtual bool                acceptsFirstResponder(WXWidget slf, void* _cmd);

--- a/include/wx/private/textinput.h
+++ b/include/wx/private/textinput.h
@@ -1,0 +1,88 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/textinput.h
+// Purpose:     Internal interface for controls handling native text input
+// Author:      Ryan Lucia
+// Created:     2026-07-29
+// Copyright:   (c) 2026 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_TEXTINPUT_H_
+#define _WX_PRIVATE_TEXTINPUT_H_
+
+#include "wx/defs.h"
+
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+
+#include "wx/gdicmn.h"
+#include "wx/string.h"
+
+class WXDLLIMPEXP_FWD_CORE wxWindow;
+class WXDLLIMPEXP_FWD_CORE wxWindowBase;
+
+// Implemented by generic controls that handle native text input themselves.
+//
+// This interface is deliberately private: native ports use it to delegate
+// input method protocol calls without adding virtual functions to wxWindow.
+class wxTextInputClient
+{
+public:
+    // Sentinel positions used when a native text input API doesn't provide a
+    // document position or explicitly refers to a non-existent one.
+    static constexpr long NoPosition = -1;
+    static constexpr long InvalidPosition = -2;
+
+    virtual bool IsTextInputEnabled() const = 0;
+    virtual bool HasActiveComposition() const = 0;
+    virtual void CancelComposition() = 0;
+
+#ifdef __WXGTK__
+    virtual bool UpdateComposition(const wxString& text, int cursor) = 0;
+    virtual bool CommitComposition(const wxString& text) = 0;
+    virtual wxRect GetIMEContextRect() = 0;
+#endif // __WXGTK__
+
+#ifdef __WXOSX_COCOA__
+    virtual bool InsertText(const wxString& text,
+                            long replacementStart,
+                            long replacementLength) = 0;
+    virtual bool SetMarkedText(const wxString& text,
+                               long selectedStart,
+                               long selectedLength,
+                               long replacementStart,
+                               long replacementLength) = 0;
+    virtual void UnmarkText() = 0;
+    virtual bool HasMarkedText() const = 0;
+    virtual bool GetMarkedTextRange(long* start, long* length) const = 0;
+    virtual bool GetSelectedTextRange(long* start, long* length) const = 0;
+    virtual bool GetTextInRange(long start, long length, wxString* text,
+                                long* actualStart,
+                                long* actualLength) const = 0;
+    virtual bool GetTextRect(long start, long length, wxRect* rect,
+                             long* actualStart,
+                             long* actualLength) = 0;
+    virtual bool GetTextPosition(const wxPoint& point, long* position) = 0;
+#endif // __WXOSX_COCOA__
+
+protected:
+    virtual ~wxTextInputClient() = default;
+};
+
+// Associate a private text input client with a window. Passing nullptr as the
+// client removes an existing association.
+WXDLLIMPEXP_CORE
+void wxAssociateTextInputClient(wxWindowBase* window,
+                                wxTextInputClient* client);
+
+WXDLLIMPEXP_CORE
+wxTextInputClient* wxFindTextInputClient(const wxWindowBase* window);
+
+#ifdef __WXGTK__
+// Apply a changed text input mode to an already-created GTK IM context.
+WXDLLIMPEXP_CORE
+void wxUpdateTextInputClient(wxWindow* window);
+#endif // __WXGTK__
+
+#endif // __WXGTK__ || __WXOSX_COCOA__
+
+#endif // _WX_PRIVATE_TEXTINPUT_H_

--- a/interface/wx/stc/stc.h
+++ b/interface/wx/stc/stc.h
@@ -5519,7 +5519,11 @@ public:
         Choose to display the IME in a window or inline.
 
         The input should be one of the
-        @link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink constants.
+        @link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink
+        constants.
+        @remarks
+        Inline IME interaction is used by default under wxGTK and wxOSX.
+        The other ports use windowed IME interaction by default.
         @since 3.1.0
     */
     void SetIMEInteraction(int imeInteraction);

--- a/interface/wx/stc/stc.h
+++ b/interface/wx/stc/stc.h
@@ -5519,7 +5519,13 @@ public:
         Choose to display the IME in a window or inline.
 
         The input should be one of the
-        @link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink constants.
+        @link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink
+        constants.
+        @remarks
+        Inline IME interaction is used by default under wxGTK and wxOSX.
+        The other ports use windowed IME interaction by default.
+        Inline interaction also requires undo collection to be enabled,
+        windowed interaction is used while it is disabled.
         @since 3.1.0
     */
     void SetIMEInteraction(int imeInteraction);

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -74,6 +74,9 @@
 #include "wx/platinfo.h"
 #include "wx/recguard.h"
 #include "wx/private/rescale.h"
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    #include "wx/private/textinput.h"
+#endif
 #include "wx/private/window.h"
 
 #if defined(__WXOSX__)
@@ -82,6 +85,10 @@
 #endif
 
 #include <math.h>
+
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    #include <unordered_map>
+#endif
 
 // Windows List
 WXDLLIMPEXP_DATA_CORE(wxWindowList) wxTopLevelWindows;
@@ -92,6 +99,37 @@ wxMenu *wxCurrentPopupMenu = nullptr;
 #endif // wxUSE_MENUS
 
 extern WXDLLEXPORT_DATA(const char) wxPanelNameStr[] = "panel";
+
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+
+namespace
+{
+using wxTextInputClients =
+    std::unordered_map<const wxWindowBase*, wxTextInputClient*>;
+
+wxTextInputClients& wxGetTextInputClients()
+{
+    static wxTextInputClients clients;
+    return clients;
+}
+} // anonymous namespace
+
+void wxAssociateTextInputClient(wxWindowBase* window,
+                                wxTextInputClient* client)
+{
+    if ( client )
+        wxGetTextInputClients()[window] = client;
+    else
+        wxGetTextInputClients().erase(window);
+}
+
+wxTextInputClient* wxFindTextInputClient(const wxWindowBase* window)
+{
+    const auto it = wxGetTextInputClients().find(window);
+    return it == wxGetTextInputClients().end() ? nullptr : it->second;
+}
+
+#endif // __WXGTK__ || __WXOSX_COCOA__
 
 namespace wxMouseCapture
 {

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -50,6 +50,7 @@
 #include "wx/gtk/private/wayland.h"
 #include "wx/gtk/private/win_gtk.h"
 #include "wx/gtk/private/backend.h"
+#include "wx/private/textinput.h"
 #include "wx/private/textmeasure.h"
 using namespace wxGTKImpl;
 
@@ -1476,14 +1477,128 @@ int wxWindowGTK::GTKIMFilterKeypress(GdkEventKey* event) const
                        : FALSE;
 }
 
+void wxUpdateTextInputClient(wxWindow* window)
+{
+    if ( !window->m_imContext )
+        return;
+
+    wxTextInputClient* const client = wxFindTextInputClient(window);
+    const bool usePreedit = client && client->IsTextInputEnabled();
+    if ( !usePreedit )
+        gtk_im_context_reset(window->m_imContext);
+
+    gtk_im_context_set_use_preedit(window->m_imContext, usePreedit);
+}
+
 extern "C" {
 static void
 gtk_wxwindow_commit_cb (GtkIMContext * WXUNUSED(context),
                         const gchar  *str,
-                        wxWindow     *window)
+                        wxWindowGTK  *window)
 {
+    wxTextInputClient* const client = wxFindTextInputClient(window);
+    if ( client && client->IsTextInputEnabled() &&
+         client->CommitComposition(wxString::FromUTF8Unchecked(str)) )
+    {
+        return;
+    }
+
     // Ignore the return value here, it doesn't matter for the "commit" signal.
     window->GTKDoInsertTextFromIM(str);
+}
+
+static void
+gtk_wxwindow_preedit_changed_cb(GtkIMContext *context,
+                                wxWindowGTK  *window)
+{
+    gchar* text = nullptr;
+    PangoAttrList* attrs = nullptr;
+    gint cursor = 0;
+    gtk_im_context_get_preedit_string(context, &text, &attrs, &cursor);
+
+    wxTextInputClient* const clientFound = wxFindTextInputClient(window);
+    wxTextInputClient* const client =
+        clientFound && clientFound->IsTextInputEnabled()
+            ? clientFound
+            : nullptr;
+    const bool handled =
+        client && client->UpdateComposition(
+                      wxString::FromUTF8Unchecked(text ? text : ""), cursor);
+
+    if ( attrs )
+        pango_attr_list_unref(attrs);
+    g_free(text);
+
+    if ( !handled )
+    {
+        wxTextInputClient* const clientCurrent =
+            wxFindTextInputClient(window);
+        if ( clientCurrent && clientCurrent->IsTextInputEnabled() )
+            // A synchronous empty preedit notification is handled without
+            // trying to reset the context again.
+            gtk_im_context_reset(context);
+    }
+    else
+    {
+        wxTextInputClient* const clientCurrent =
+            wxFindTextInputClient(window);
+        if ( clientCurrent && clientCurrent->IsTextInputEnabled() &&
+             clientCurrent->HasActiveComposition() )
+        {
+            const wxRect rect = clientCurrent->GetIMEContextRect();
+            GdkRectangle cursorRect;
+            cursorRect.x = rect.x;
+            cursorRect.y = rect.y;
+            cursorRect.width = rect.width;
+            cursorRect.height = rect.height;
+            gtk_im_context_set_cursor_location(context, &cursorRect);
+        }
+    }
+}
+
+static void
+gtk_wxwindow_preedit_end_cb(GtkIMContext * WXUNUSED(context),
+                            wxWindowGTK  *window)
+{
+    wxTextInputClient* const client = wxFindTextInputClient(window);
+    if ( client && client->IsTextInputEnabled() )
+        client->CancelComposition();
+}
+
+static void
+gtk_wxwindow_end_preedit(wxWindowGTK* window)
+{
+    wxTextInputClient* client = wxFindTextInputClient(window);
+    if ( !window->m_imContext || !client ||
+         !client->IsTextInputEnabled() ||
+         !client->HasActiveComposition() )
+    {
+        return;
+    }
+
+    gchar* text = nullptr;
+    PangoAttrList* attrs = nullptr;
+    gint cursor = 0;
+    gtk_im_context_get_preedit_string(
+        window->m_imContext, &text, &attrs, &cursor);
+    const wxString preedit =
+        wxString::FromUTF8Unchecked(text ? text : "");
+
+    if ( attrs )
+        pango_attr_list_unref(attrs);
+    g_free(text);
+
+    // Reset the native state first and let any signals it emits decide
+    // whether the composition is committed or cancelled. Some IM modules
+    // don't emit them, so finish the client state explicitly as a fallback.
+    gtk_im_context_reset(window->m_imContext);
+    client = wxFindTextInputClient(window);
+    if ( client && client->IsTextInputEnabled() &&
+         client->HasActiveComposition() &&
+         !client->CommitComposition(preedit) )
+    {
+        client->CancelComposition();
+    }
 }
 }
 
@@ -1856,6 +1971,8 @@ wxGTKImpl::WindowButtonPressCallback(GtkWidget* WXUNUSED_IN_GTK3(widget),
     // reset the event object and id in case win changed.
     event.SetEventObject( win );
     event.SetId( win->GetId() );
+
+    gtk_wxwindow_end_preedit(win);
 
     if ( win->GTKProcessEvent( event ) )
         return TRUE;
@@ -2706,11 +2823,18 @@ void wxWindowGTK::GTKHandleRealized()
             // Create input method handler
             m_imContext = gtk_im_multicontext_new();
 
-            // Cannot handle drawing preedited text yet
-            gtk_im_context_set_use_preedit(m_imContext, false);
+            wxTextInputClient* const client = wxFindTextInputClient(this);
+            gtk_im_context_set_use_preedit(
+                m_imContext, client && client->IsTextInputEnabled());
 
             g_signal_connect(m_imContext,
                 "commit", G_CALLBACK(gtk_wxwindow_commit_cb), this);
+            g_signal_connect(m_imContext,
+                "preedit-changed",
+                G_CALLBACK(gtk_wxwindow_preedit_changed_cb), this);
+            g_signal_connect(m_imContext,
+                "preedit-end",
+                G_CALLBACK(gtk_wxwindow_preedit_end_cb), this);
         }
         gtk_im_context_set_client_window(m_imContext, window);
     }
@@ -5081,7 +5205,10 @@ void wxWindowGTK::GTKHandleFocusOutNoDeferring()
     gs_lastFocus = this;
 
     if (m_imContext)
+    {
+        gtk_wxwindow_end_preedit(this);
         gtk_im_context_focus_out(m_imContext);
+    }
 
     if ( gs_currentFocus != this )
     {

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -50,6 +50,7 @@
 #include "wx/gtk/private/wayland.h"
 #include "wx/gtk/private/win_gtk.h"
 #include "wx/gtk/private/backend.h"
+#include "wx/private/textinput.h"
 #include "wx/private/textmeasure.h"
 using namespace wxGTKImpl;
 
@@ -1326,6 +1327,29 @@ gtk_window_key_press_callback( GtkWidget *WXUNUSED(widget),
     if (EventAlreadyProcessed(gdk_event))
         return FALSE;
 
+    bool filteredByIM = false;
+
+    // While inline composition is active the IM context must see key events
+    // before the application: keys such as Enter, Backspace and the arrows
+    // confirm or edit the pre-edit text, and handling them as normal key
+    // events would modify the tentative document contents instead.
+    wxTextInputClient* const inputClient = wxFindTextInputClient(win);
+    if ( inputClient && inputClient->IsTextInputEnabled() &&
+         inputClient->HasActiveComposition() )
+    {
+        win->m_imKeyEvent = gdk_event;
+        const int intercepted_by_IM = win->GTKIMFilterKeypress(gdk_event);
+        win->m_imKeyEvent = nullptr;
+
+        if ( intercepted_by_IM )
+        {
+            wxLogTrace(TRACE_KEYS, wxT("Key event intercepted by IM"));
+            return TRUE;
+        }
+
+        filteredByIM = true;
+    }
+
     wxKeyEvent event( wxEVT_KEY_DOWN );
     bool ret = false;
 
@@ -1369,7 +1393,9 @@ gtk_window_key_press_callback( GtkWidget *WXUNUSED(widget),
     if ( !ret )
         ret = win->HandleWindowEvent( event );
 
-    if ( !ret )
+    // Don't filter the same event again if it was already offered to the IM
+    // context above because of an active composition.
+    if ( !ret && !filteredByIM )
     {
         // Indicate that IM handling is in process by setting this pointer
         // (which will remain valid for all the code called during IM key
@@ -1477,14 +1503,128 @@ int wxWindowGTK::GTKIMFilterKeypress(GdkEventKey* event) const
                        : FALSE;
 }
 
+void wxUpdateTextInputClient(wxWindow* window)
+{
+    if ( !window->m_imContext )
+        return;
+
+    wxTextInputClient* const client = wxFindTextInputClient(window);
+    const bool usePreedit = client && client->IsTextInputEnabled();
+    if ( !usePreedit )
+        gtk_im_context_reset(window->m_imContext);
+
+    gtk_im_context_set_use_preedit(window->m_imContext, usePreedit);
+}
+
 extern "C" {
 static void
 gtk_wxwindow_commit_cb (GtkIMContext * WXUNUSED(context),
                         const gchar  *str,
-                        wxWindow     *window)
+                        wxWindowGTK  *window)
 {
+    wxTextInputClient* const client = wxFindTextInputClient(window);
+    if ( client && client->IsTextInputEnabled() &&
+         client->CommitComposition(wxString::FromUTF8Unchecked(str)) )
+    {
+        return;
+    }
+
     // Ignore the return value here, it doesn't matter for the "commit" signal.
     window->GTKDoInsertTextFromIM(str);
+}
+
+static void
+gtk_wxwindow_preedit_changed_cb(GtkIMContext *context,
+                                wxWindowGTK  *window)
+{
+    gchar* text = nullptr;
+    PangoAttrList* attrs = nullptr;
+    gint cursor = 0;
+    gtk_im_context_get_preedit_string(context, &text, &attrs, &cursor);
+
+    wxTextInputClient* const clientFound = wxFindTextInputClient(window);
+    wxTextInputClient* const client =
+        clientFound && clientFound->IsTextInputEnabled()
+            ? clientFound
+            : nullptr;
+    const bool handled =
+        client && client->UpdateComposition(
+                      wxString::FromUTF8Unchecked(text ? text : ""), cursor);
+
+    if ( attrs )
+        pango_attr_list_unref(attrs);
+    g_free(text);
+
+    if ( !handled )
+    {
+        wxTextInputClient* const clientCurrent =
+            wxFindTextInputClient(window);
+        if ( clientCurrent && clientCurrent->IsTextInputEnabled() )
+            // A synchronous empty preedit notification is handled without
+            // trying to reset the context again.
+            gtk_im_context_reset(context);
+    }
+    else
+    {
+        wxTextInputClient* const clientCurrent =
+            wxFindTextInputClient(window);
+        if ( clientCurrent && clientCurrent->IsTextInputEnabled() &&
+             clientCurrent->HasActiveComposition() )
+        {
+            const wxRect rect = clientCurrent->GetIMEContextRect();
+            GdkRectangle cursorRect;
+            cursorRect.x = rect.x;
+            cursorRect.y = rect.y;
+            cursorRect.width = rect.width;
+            cursorRect.height = rect.height;
+            gtk_im_context_set_cursor_location(context, &cursorRect);
+        }
+    }
+}
+
+static void
+gtk_wxwindow_preedit_end_cb(GtkIMContext * WXUNUSED(context),
+                            wxWindowGTK  *window)
+{
+    wxTextInputClient* const client = wxFindTextInputClient(window);
+    if ( client && client->IsTextInputEnabled() )
+        client->CancelComposition();
+}
+
+static void
+gtk_wxwindow_end_preedit(wxWindowGTK* window)
+{
+    wxTextInputClient* client = wxFindTextInputClient(window);
+    if ( !window->m_imContext || !client ||
+         !client->IsTextInputEnabled() ||
+         !client->HasActiveComposition() )
+    {
+        return;
+    }
+
+    gchar* text = nullptr;
+    PangoAttrList* attrs = nullptr;
+    gint cursor = 0;
+    gtk_im_context_get_preedit_string(
+        window->m_imContext, &text, &attrs, &cursor);
+    const wxString preedit =
+        wxString::FromUTF8Unchecked(text ? text : "");
+
+    if ( attrs )
+        pango_attr_list_unref(attrs);
+    g_free(text);
+
+    // Reset the native state first and let any signals it emits decide
+    // whether the composition is committed or cancelled. Some IM modules
+    // don't emit them, so finish the client state explicitly as a fallback.
+    gtk_im_context_reset(window->m_imContext);
+    client = wxFindTextInputClient(window);
+    if ( client && client->IsTextInputEnabled() &&
+         client->HasActiveComposition() &&
+         !client->CommitComposition(preedit) )
+    {
+        client->CancelComposition();
+    }
 }
 }
 
@@ -1857,6 +1997,8 @@ wxGTKImpl::WindowButtonPressCallback(GtkWidget* WXUNUSED_IN_GTK3(widget),
     // reset the event object and id in case win changed.
     event.SetEventObject( win );
     event.SetId( win->GetId() );
+
+    gtk_wxwindow_end_preedit(win);
 
     if ( win->GTKProcessEvent( event ) )
         return TRUE;
@@ -2707,11 +2849,18 @@ void wxWindowGTK::GTKHandleRealized()
             // Create input method handler
             m_imContext = gtk_im_multicontext_new();
 
-            // Cannot handle drawing preedited text yet
-            gtk_im_context_set_use_preedit(m_imContext, false);
+            wxTextInputClient* const client = wxFindTextInputClient(this);
+            gtk_im_context_set_use_preedit(
+                m_imContext, client && client->IsTextInputEnabled());
 
             g_signal_connect(m_imContext,
                 "commit", G_CALLBACK(gtk_wxwindow_commit_cb), this);
+            g_signal_connect(m_imContext,
+                "preedit-changed",
+                G_CALLBACK(gtk_wxwindow_preedit_changed_cb), this);
+            g_signal_connect(m_imContext,
+                "preedit-end",
+                G_CALLBACK(gtk_wxwindow_preedit_end_cb), this);
         }
         gtk_im_context_set_client_window(m_imContext, window);
     }
@@ -5134,7 +5283,10 @@ void wxWindowGTK::GTKHandleFocusOutNoDeferring()
     gs_lastFocus = this;
 
     if (m_imContext)
+    {
+        gtk_wxwindow_end_preedit(this);
         gtk_im_context_focus_out(m_imContext);
+    }
 
     if ( gs_currentFocus != this )
     {

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -26,6 +26,7 @@
 #endif
 
 #include "wx/private/bmpbndl.h"
+#include "wx/private/textinput.h"
 
 #include "wx/evtloop.h"
 
@@ -1020,24 +1021,99 @@ static void SetDrawingEnabledIfFrozenRecursive(wxWidgetCocoaImpl *impl, bool ena
 
 @end // wxNSView
 
-// We need to adopt NSTextInputClient protocol in order to interpretKeyEvents: to work.
-// Currently, only insertText:(replacementRange:) is
-// implemented here, and the rest of the methods are stubs.
-// It is hoped that someday IME-related functionality is implemented in
-// wxWidgets and the methods of this protocol are fully working.
+// We need to adopt NSTextInputClient for interpretKeyEvents: to work.
+// Custom controls can opt in to the complete protocol through the private
+// text input client interface;
+// other controls retain the existing insertText: behaviour.
 
 @implementation wxNSView(TextInput)
 
 void wxOSX_insertText(NSView* self, SEL _cmd, NSString* text);
 
+static wxTextInputClient* wxOSXGetTextInputClient(NSView* view)
+{
+    wxWidgetCocoaImpl* const impl =
+        static_cast<wxWidgetCocoaImpl*>(
+            wxWidgetImpl::FindFromWXWidget(view));
+    if ( !impl )
+        return nullptr;
+
+    wxWindowMac* const peer = impl->GetWXPeer();
+    wxTextInputClient* const client = wxFindTextInputClient(peer);
+    return client && client->IsTextInputEnabled() ? client : nullptr;
+}
+
+static void wxOSXEndTextInput(NSView* view)
+{
+    wxTextInputClient* const client = wxOSXGetTextInputClient(view);
+    if ( !client || !client->HasMarkedText() )
+        return;
+
+    // Stop the input manager from referring to the old marked range, then
+    // commit the displayed tentative text before focus or selection moves.
+    [[view inputContext] discardMarkedText];
+    client->UnmarkText();
+}
+
+static void wxOSXTextInputEventHandled(NSView* view)
+{
+    wxWidgetCocoaImpl* const impl =
+        static_cast<wxWidgetCocoaImpl*>(
+            wxWidgetImpl::FindFromWXWidget(view));
+    if ( impl )
+        impl->textInputEventHandled();
+}
+
+static NSString* wxOSXGetTextInputString(id value)
+{
+    if ( [value isKindOfClass:[NSString class]] )
+        return static_cast<NSString*>(value);
+    if ( [value isKindOfClass:[NSAttributedString class]] )
+        return [static_cast<NSAttributedString*>(value) string];
+    return @"";
+}
+
+static long wxOSXGetTextInputPosition(NSUInteger position)
+{
+    if ( position == NSNotFound )
+        return wxTextInputClient::NoPosition;
+    if ( position == NSNotFound - 1 )
+        return wxTextInputClient::InvalidPosition;
+
+    return static_cast<long>(position);
+}
+
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange
 {
-    wxUnusedVar(replacementRange);
-    wxOSX_insertText(self, @selector(insertText:), aString);
+    NSString* const text = wxOSXGetTextInputString(aString);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( client &&
+         client->InsertText(
+             wxStringWithNSString(text),
+             wxOSXGetTextInputPosition(replacementRange.location),
+             static_cast<long>(replacementRange.length)) )
+    {
+        wxOSXTextInputEventHandled(self);
+        return;
+    }
+
+    wxOSX_insertText(self, @selector(insertText:), text);
 }
 
 - (void)doCommandBySelector:(SEL)aSelector
 {
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( client && client->HasMarkedText() &&
+         aSelector == @selector(insertNewline:) )
+    {
+        // Some input methods use this command to accept the selected
+        // candidate instead of calling insertText:. Commit the marked text
+        // and consume Enter so it isn't inserted as a newline too.
+        client->UnmarkText();
+        wxOSXTextInputEventHandled(self);
+        return;
+    }
+
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
     if (impl)
         impl->doCommandBySelector(aSelector, self, _cmd);
@@ -1045,52 +1121,149 @@ void wxOSX_insertText(NSView* self, SEL _cmd, NSString* text);
 
 - (void)setMarkedText:(id)aString selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange
 {
-    wxUnusedVar(aString);
-    wxUnusedVar(selectedRange);
-    wxUnusedVar(replacementRange);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client )
+        return;
+
+    if ( client->SetMarkedText(
+            wxStringWithNSString(wxOSXGetTextInputString(aString)),
+            wxOSXGetTextInputPosition(selectedRange.location),
+            static_cast<long>(selectedRange.length),
+            wxOSXGetTextInputPosition(replacementRange.location),
+            static_cast<long>(replacementRange.length)) )
+    {
+        wxOSXTextInputEventHandled(self);
+    }
 }
 
 - (void)unmarkText
 {
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( client )
+        client->UnmarkText();
 }
 
 - (NSRange)selectedRange
 {
-    return NSMakeRange(NSNotFound, 0);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    long start, length;
+    if ( !client || !client->GetSelectedTextRange(&start, &length) )
+        return NSMakeRange(NSNotFound, 0);
+
+    if ( length == 0 )
+    {
+        NSTextInputContext* const context =
+            [NSTextInputContext currentInputContext];
+        // Cangjie crashes in malloc when an empty selection is returned with
+        // its actual position, so report no selection for this input method.
+        // Doing this for all input methods prevents the European accented
+        // character chooser from appearing.
+        if ( [[context selectedKeyboardInputSource]
+                isEqualToString:@"com.apple.inputmethod.TCIM.Cangjie"] )
+        {
+            return NSMakeRange(NSNotFound, 0);
+        }
+    }
+
+    return NSMakeRange(static_cast<NSUInteger>(start),
+                       static_cast<NSUInteger>(length));
 }
 
 - (NSRange)markedRange
 {
-    return NSMakeRange(NSNotFound, 0);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    long start, length;
+    if ( !client || !client->GetMarkedTextRange(&start, &length) )
+        return NSMakeRange(NSNotFound, 0);
+
+    return NSMakeRange(static_cast<NSUInteger>(start),
+                       static_cast<NSUInteger>(length));
 }
 
 - (BOOL)hasMarkedText
 {
-    return NO;
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    return client && client->HasMarkedText();
 }
 
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
 {
-    wxUnusedVar(aRange);
-    wxUnusedVar(actualRange);
-    return nil;
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client )
+        return nil;
+
+    wxString text;
+    long start, length;
+    if ( !client->GetTextInRange(
+            static_cast<long>(aRange.location),
+            static_cast<long>(aRange.length),
+            &text, &start, &length) )
+    {
+        return nil;
+    }
+
+    if ( actualRange )
+    {
+        *actualRange = NSMakeRange(static_cast<NSUInteger>(start),
+                                   static_cast<NSUInteger>(length));
+    }
+
+    return [[[NSAttributedString alloc]
+                initWithString:wxCFStringRef(text).AsNSString()]
+                autorelease];
 }
 
 - (NSArray*)validAttributesForMarkedText
 {
-    return nil;
+    return @[];
 }
 
 - (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
 {
-    wxUnusedVar(aRange);
-    wxUnusedVar(actualRange);
-    return NSMakeRect(0, 0, 0, 0);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client )
+        return NSZeroRect;
+
+    wxRect rect;
+    long start, length;
+    if ( !client->GetTextRect(
+            static_cast<long>(aRange.location),
+            static_cast<long>(aRange.length),
+            &rect, &start, &length) )
+    {
+        return NSZeroRect;
+    }
+
+    if ( actualRange )
+    {
+        *actualRange = NSMakeRange(static_cast<NSUInteger>(start),
+                                   static_cast<NSUInteger>(length));
+    }
+
+    const NSRect localRect = wxToNSRect(self, rect);
+    const NSRect windowRect = [self convertRect:localRect toView:nil];
+    return [[self window] convertRectToScreen:windowRect];
 }
+
 - (NSUInteger)characterIndexForPoint:(NSPoint)aPoint
 {
-    wxUnusedVar(aPoint);
-    return NSNotFound;
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client || ![self window] )
+        return NSNotFound;
+
+    const NSRect screenRect = NSMakeRect(aPoint.x, aPoint.y, 0, 0);
+    const NSRect windowRect = [[self window] convertRectFromScreen:screenRect];
+    const NSPoint localPoint =
+        [self convertPoint:windowRect.origin fromView:nil];
+
+    long position;
+    if ( !client->GetTextPosition(wxFromNSPoint(self, localPoint),
+                                  &position) )
+    {
+        return NSNotFound;
+    }
+
+    return static_cast<NSUInteger>(position);
 }
 
 @end // wxNSView(TextInput)
@@ -1146,7 +1319,17 @@ void wxOSX_mouseEvent(NSView* self, SEL _cmd, NSEvent *event)
 
     // We shouldn't let disabled windows get mouse events.
     if (impl->GetWXPeer()->IsEnabled())
+    {
+        const int type = [event type];
+        if ( type == NSLeftMouseDown ||
+             type == NSRightMouseDown ||
+             type == NSOtherMouseDown )
+        {
+            wxOSXEndTextInput(self);
+        }
+
         impl->mouseEvent(event, self, _cmd);
+    }
 }
 
 void wxOSX_cursorUpdate(NSView* self, SEL _cmd, NSEvent *event)
@@ -2360,10 +2543,15 @@ void wxWidgetCocoaImpl::insertText(NSString* text, WXWidget slf, void *_cmd)
     bool result = false;
     if ( HasUserKeyHandling() && !m_hasEditor && [text length] > 0)
     {
-        if ( IsInNativeKeyDown() && [text isEqualToString:[GetLastNativeKeyDownEvent() characters]])
+        if ( IsInNativeKeyDown() &&
+             [text isEqualToString:[GetLastNativeKeyDownEvent() characters]])
         {
             // If we have a corresponding key event, send wxEVT_KEY_DOWN now.
             // (see also: wxWidgetCocoaImpl::DoHandleKeyEvent)
+            // An IME can commit marked text and then insert this character
+            // during the same native key event, in which case the event was
+            // already consumed by the text input client.
+            if ( !WasKeyDownSent() )
             {
                 wxKeyEvent wxevent(wxEVT_KEY_DOWN);
                 SetupKeyEvent( wxevent, GetLastNativeKeyDownEvent() );
@@ -2386,6 +2574,12 @@ void wxWidgetCocoaImpl::insertText(NSString* text, WXWidget slf, void *_cmd)
         wxOSX_TextEventHandlerPtr superimpl = (wxOSX_TextEventHandlerPtr) [[slf superclass] instanceMethodForSelector:(SEL)_cmd];
         superimpl(slf, (SEL)_cmd, text);
     }
+}
+
+void wxWidgetCocoaImpl::textInputEventHandled()
+{
+    if ( IsInNativeKeyDown() && !WasKeyDownSent() )
+        SetKeyDownSent();
 }
 
 bool wxWidgetCocoaImpl::doCommandBySelector(void* sel, WXWidget slf, void* WXUNUSED(_cmd))
@@ -2451,6 +2645,8 @@ bool wxWidgetCocoaImpl::becomeFirstResponder(WXWidget slf, void *_cmd)
 
 bool wxWidgetCocoaImpl::resignFirstResponder(WXWidget slf, void *_cmd)
 {
+    wxOSXEndTextInput(static_cast<NSView*>(slf));
+
     wxOSX_FocusHandlerPtr superimpl = (wxOSX_FocusHandlerPtr) [[slf superclass] instanceMethodForSelector:(SEL)_cmd];
     BOOL r = superimpl(slf, (SEL)_cmd);
 

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -26,6 +26,7 @@
 #endif
 
 #include "wx/private/bmpbndl.h"
+#include "wx/private/textinput.h"
 
 #include "wx/evtloop.h"
 
@@ -982,24 +983,99 @@ static void SetDrawingEnabledIfFrozenRecursive(wxWidgetCocoaImpl *impl, bool ena
 
 @end // wxNSView
 
-// We need to adopt NSTextInputClient protocol in order to interpretKeyEvents: to work.
-// Currently, only insertText:(replacementRange:) is
-// implemented here, and the rest of the methods are stubs.
-// It is hoped that someday IME-related functionality is implemented in
-// wxWidgets and the methods of this protocol are fully working.
+// We need to adopt NSTextInputClient for interpretKeyEvents: to work.
+// Custom controls can opt in to the complete protocol through the private
+// text input client interface;
+// other controls retain the existing insertText: behaviour.
 
 @implementation wxNSView(TextInput)
 
 void wxOSX_insertText(NSView* self, SEL _cmd, NSString* text);
 
+static wxTextInputClient* wxOSXGetTextInputClient(NSView* view)
+{
+    wxWidgetCocoaImpl* const impl =
+        static_cast<wxWidgetCocoaImpl*>(
+            wxWidgetImpl::FindFromWXWidget(view));
+    if ( !impl )
+        return nullptr;
+
+    wxWindowMac* const peer = impl->GetWXPeer();
+    wxTextInputClient* const client = wxFindTextInputClient(peer);
+    return client && client->IsTextInputEnabled() ? client : nullptr;
+}
+
+static void wxOSXEndTextInput(NSView* view)
+{
+    wxTextInputClient* const client = wxOSXGetTextInputClient(view);
+    if ( !client || !client->HasMarkedText() )
+        return;
+
+    // Stop the input manager from referring to the old marked range, then
+    // commit the displayed tentative text before focus or selection moves.
+    [[view inputContext] discardMarkedText];
+    client->UnmarkText();
+}
+
+static void wxOSXTextInputEventHandled(NSView* view)
+{
+    wxWidgetCocoaImpl* const impl =
+        static_cast<wxWidgetCocoaImpl*>(
+            wxWidgetImpl::FindFromWXWidget(view));
+    if ( impl )
+        impl->textInputEventHandled();
+}
+
+static NSString* wxOSXGetTextInputString(id value)
+{
+    if ( [value isKindOfClass:[NSString class]] )
+        return static_cast<NSString*>(value);
+    if ( [value isKindOfClass:[NSAttributedString class]] )
+        return [static_cast<NSAttributedString*>(value) string];
+    return @"";
+}
+
+static long wxOSXGetTextInputPosition(NSUInteger position)
+{
+    if ( position == NSNotFound )
+        return wxTextInputClient::NoPosition;
+    if ( position == NSNotFound - 1 )
+        return wxTextInputClient::InvalidPosition;
+
+    return static_cast<long>(position);
+}
+
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange
 {
-    wxUnusedVar(replacementRange);
-    wxOSX_insertText(self, @selector(insertText:), aString);
+    NSString* const text = wxOSXGetTextInputString(aString);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( client &&
+         client->InsertText(
+             wxStringWithNSString(text),
+             wxOSXGetTextInputPosition(replacementRange.location),
+             static_cast<long>(replacementRange.length)) )
+    {
+        wxOSXTextInputEventHandled(self);
+        return;
+    }
+
+    wxOSX_insertText(self, @selector(insertText:), text);
 }
 
 - (void)doCommandBySelector:(SEL)aSelector
 {
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( client && client->HasMarkedText() &&
+         aSelector == @selector(insertNewline:) )
+    {
+        // Some input methods use this command to accept the selected
+        // candidate instead of calling insertText:. Commit the marked text
+        // and consume Enter so it isn't inserted as a newline too.
+        client->UnmarkText();
+        wxOSXTextInputEventHandled(self);
+        return;
+    }
+
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
     if (impl)
         impl->doCommandBySelector(aSelector, self, _cmd);
@@ -1007,52 +1083,149 @@ void wxOSX_insertText(NSView* self, SEL _cmd, NSString* text);
 
 - (void)setMarkedText:(id)aString selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange
 {
-    wxUnusedVar(aString);
-    wxUnusedVar(selectedRange);
-    wxUnusedVar(replacementRange);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client )
+        return;
+
+    if ( client->SetMarkedText(
+            wxStringWithNSString(wxOSXGetTextInputString(aString)),
+            wxOSXGetTextInputPosition(selectedRange.location),
+            static_cast<long>(selectedRange.length),
+            wxOSXGetTextInputPosition(replacementRange.location),
+            static_cast<long>(replacementRange.length)) )
+    {
+        wxOSXTextInputEventHandled(self);
+    }
 }
 
 - (void)unmarkText
 {
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( client )
+        client->UnmarkText();
 }
 
 - (NSRange)selectedRange
 {
-    return NSMakeRange(NSNotFound, 0);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    long start, length;
+    if ( !client || !client->GetSelectedTextRange(&start, &length) )
+        return NSMakeRange(NSNotFound, 0);
+
+    if ( length == 0 )
+    {
+        NSTextInputContext* const context =
+            [NSTextInputContext currentInputContext];
+        // Cangjie crashes in malloc when an empty selection is returned with
+        // its actual position, so report no selection for this input method.
+        // Doing this for all input methods prevents the European accented
+        // character chooser from appearing.
+        if ( [[context selectedKeyboardInputSource]
+                isEqualToString:@"com.apple.inputmethod.TCIM.Cangjie"] )
+        {
+            return NSMakeRange(NSNotFound, 0);
+        }
+    }
+
+    return NSMakeRange(static_cast<NSUInteger>(start),
+                       static_cast<NSUInteger>(length));
 }
 
 - (NSRange)markedRange
 {
-    return NSMakeRange(NSNotFound, 0);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    long start, length;
+    if ( !client || !client->GetMarkedTextRange(&start, &length) )
+        return NSMakeRange(NSNotFound, 0);
+
+    return NSMakeRange(static_cast<NSUInteger>(start),
+                       static_cast<NSUInteger>(length));
 }
 
 - (BOOL)hasMarkedText
 {
-    return NO;
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    return client && client->HasMarkedText();
 }
 
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
 {
-    wxUnusedVar(aRange);
-    wxUnusedVar(actualRange);
-    return nil;
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client )
+        return nil;
+
+    wxString text;
+    long start, length;
+    if ( !client->GetTextInRange(
+            static_cast<long>(aRange.location),
+            static_cast<long>(aRange.length),
+            &text, &start, &length) )
+    {
+        return nil;
+    }
+
+    if ( actualRange )
+    {
+        *actualRange = NSMakeRange(static_cast<NSUInteger>(start),
+                                   static_cast<NSUInteger>(length));
+    }
+
+    return [[[NSAttributedString alloc]
+                initWithString:wxCFStringRef(text).AsNSString()]
+                autorelease];
 }
 
 - (NSArray*)validAttributesForMarkedText
 {
-    return nil;
+    return @[];
 }
 
 - (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
 {
-    wxUnusedVar(aRange);
-    wxUnusedVar(actualRange);
-    return NSMakeRect(0, 0, 0, 0);
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client )
+        return NSZeroRect;
+
+    wxRect rect;
+    long start, length;
+    if ( !client->GetTextRect(
+            static_cast<long>(aRange.location),
+            static_cast<long>(aRange.length),
+            &rect, &start, &length) )
+    {
+        return NSZeroRect;
+    }
+
+    if ( actualRange )
+    {
+        *actualRange = NSMakeRange(static_cast<NSUInteger>(start),
+                                   static_cast<NSUInteger>(length));
+    }
+
+    const NSRect localRect = wxToNSRect(self, rect);
+    const NSRect windowRect = [self convertRect:localRect toView:nil];
+    return [[self window] convertRectToScreen:windowRect];
 }
+
 - (NSUInteger)characterIndexForPoint:(NSPoint)aPoint
 {
-    wxUnusedVar(aPoint);
-    return NSNotFound;
+    wxTextInputClient* const client = wxOSXGetTextInputClient(self);
+    if ( !client || ![self window] )
+        return NSNotFound;
+
+    const NSRect screenRect = NSMakeRect(aPoint.x, aPoint.y, 0, 0);
+    const NSRect windowRect = [[self window] convertRectFromScreen:screenRect];
+    const NSPoint localPoint =
+        [self convertPoint:windowRect.origin fromView:nil];
+
+    long position;
+    if ( !client->GetTextPosition(wxFromNSPoint(self, localPoint),
+                                  &position) )
+    {
+        return NSNotFound;
+    }
+
+    return static_cast<NSUInteger>(position);
 }
 
 @end // wxNSView(TextInput)
@@ -1108,7 +1281,17 @@ void wxOSX_mouseEvent(NSView* self, SEL _cmd, NSEvent *event)
 
     // We shouldn't let disabled windows get mouse events.
     if (impl->GetWXPeer()->IsEnabled())
+    {
+        const int type = [event type];
+        if ( type == NSLeftMouseDown ||
+             type == NSRightMouseDown ||
+             type == NSOtherMouseDown )
+        {
+            wxOSXEndTextInput(self);
+        }
+
         impl->mouseEvent(event, self, _cmd);
+    }
 }
 
 void wxOSX_cursorUpdate(NSView* self, SEL _cmd, NSEvent *event)
@@ -2322,10 +2505,15 @@ void wxWidgetCocoaImpl::insertText(NSString* text, WXWidget slf, void *_cmd)
     bool result = false;
     if ( HasUserKeyHandling() && !m_hasEditor && [text length] > 0)
     {
-        if ( IsInNativeKeyDown() && [text isEqualToString:[GetLastNativeKeyDownEvent() characters]])
+        if ( IsInNativeKeyDown() &&
+             [text isEqualToString:[GetLastNativeKeyDownEvent() characters]])
         {
             // If we have a corresponding key event, send wxEVT_KEY_DOWN now.
             // (see also: wxWidgetCocoaImpl::DoHandleKeyEvent)
+            // An IME can commit marked text and then insert this character
+            // during the same native key event, in which case the event was
+            // already consumed by the text input client.
+            if ( !WasKeyDownSent() )
             {
                 wxKeyEvent wxevent(wxEVT_KEY_DOWN);
                 SetupKeyEvent( wxevent, GetLastNativeKeyDownEvent() );
@@ -2348,6 +2536,12 @@ void wxWidgetCocoaImpl::insertText(NSString* text, WXWidget slf, void *_cmd)
         wxOSX_TextEventHandlerPtr superimpl = (wxOSX_TextEventHandlerPtr) [[slf superclass] instanceMethodForSelector:(SEL)_cmd];
         superimpl(slf, (SEL)_cmd, text);
     }
+}
+
+void wxWidgetCocoaImpl::textInputEventHandled()
+{
+    if ( IsInNativeKeyDown() && !WasKeyDownSent() )
+        SetKeyDownSent();
 }
 
 bool wxWidgetCocoaImpl::doCommandBySelector(void* sel, WXWidget slf, void* WXUNUSED(_cmd))
@@ -2413,6 +2607,8 @@ bool wxWidgetCocoaImpl::becomeFirstResponder(WXWidget slf, void *_cmd)
 
 bool wxWidgetCocoaImpl::resignFirstResponder(WXWidget slf, void *_cmd)
 {
+    wxOSXEndTextInput(static_cast<NSView*>(slf));
+
     wxOSX_FocusHandlerPtr superimpl = (wxOSX_FocusHandlerPtr) [[slf superclass] instanceMethodForSelector:(SEL)_cmd];
     BOOL r = superimpl(slf, (SEL)_cmd);
 

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -213,7 +213,15 @@ ScintillaWX::ScintillaWX(wxStyledTextCtrl* win) {
     stc   = win;
     wheelVRotation = 0;
     wheelHRotation = 0;
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    m_compositionActive = false;
+    m_compositionStart = 0;
+    m_compositionLength = 0;
+#endif
     Initialise();
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    wxAssociateTextInputClient(stc, this);
+#endif
 #ifdef __WXMSW__
     sysCaretBitmap = 0;
     sysCaretWidth = 0;
@@ -241,6 +249,11 @@ ScintillaWX::ScintillaWX(wxStyledTextCtrl* win) {
 
 
 ScintillaWX::~ScintillaWX() {
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    wxAssociateTextInputClient(stc, nullptr);
+    CancelComposition();
+#endif
+
     for ( auto& entry : timers ) {
         delete entry.second;
     }
@@ -793,6 +806,14 @@ sptr_t ScintillaWX::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam)
         case SCI_GETDIRECTPOINTER:
             return reinterpret_cast<sptr_t>(this);
 
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+        case SCI_SETDOCPOINTER:
+            // Tentative input belongs to the current document and must not
+            // leak into a newly attached one.
+            CancelComposition();
+            break;
+#endif
+
 #ifdef __WXMSW__
         // ScintillaWin
         case WM_IME_STARTCOMPOSITION:
@@ -1079,6 +1100,386 @@ void ScintillaWX::DoAddChar(wxChar key) {
     InsertCharacter(buf, buf.length(), CharacterSource::directInput);
 }
 
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+
+Sci::Position ScintillaWX::PositionFromUTF16(long position) const
+{
+    if ( position < 0 )
+        return Sci::invalidPosition;
+
+    const Sci::Position pos = pdoc->GetRelativePositionUTF16(0, position);
+    return pos == Sci::invalidPosition ? pdoc->Length() : pos;
+}
+
+long ScintillaWX::PositionToUTF16(Sci::Position position) const
+{
+    position = std::max<Sci::Position>(0,
+                std::min<Sci::Position>(position, pdoc->Length()));
+    return static_cast<long>(pdoc->CountUTF16(0, position));
+}
+
+Sci::Position ScintillaWX::InsertCompositionText(const wxString& text,
+                                                 CharacterSource source)
+{
+    const wxScopedCharBuffer utf8 = text.utf8_str();
+    const char* const bytes = utf8.data();
+    const size_t length = utf8.length();
+    const Sci::Position start = CurrentPosition();
+
+    for ( size_t offset = 0; offset < length; )
+    {
+        const unsigned char lead = static_cast<unsigned char>(bytes[offset]);
+        size_t charLength = UTF8BytesOfLead[lead];
+        if ( charLength == 0 || offset + charLength > length )
+            charLength = 1;
+
+        InsertCharacter(bytes + offset, static_cast<unsigned int>(charLength),
+                        source);
+        offset += charLength;
+    }
+
+    return CurrentPosition() - start;
+}
+
+void ScintillaWX::ClearCompositionIndicator()
+{
+    pdoc->DecorationSetCurrentIndicator(INDICATOR_IME);
+    pdoc->DecorationFillRange(0, 0, pdoc->Length());
+}
+
+void ScintillaWX::UndoCompositionText()
+{
+    if ( pdoc->TentativeActive() )
+        pdoc->TentativeUndo();
+
+    ClearCompositionIndicator();
+    SetEmptySelection(m_compositionStart);
+    m_compositionLength = 0;
+}
+
+bool ScintillaWX::StartComposition(long replacementStart,
+                                   long replacementLength)
+{
+    if ( pdoc->IsReadOnly() )
+        return false;
+
+    if ( m_compositionActive )
+    {
+        UndoCompositionText();
+        return true;
+    }
+
+    // Cocoa text input only supports a single selection. GTK composition is
+    // also kept to the main selection to make the marked range unambiguous.
+    sel.SetSelection(sel.RangeMain());
+
+    if ( replacementStart >= 0 )
+    {
+        const Sci::Position start = PositionFromUTF16(replacementStart);
+        Sci::Position end = pdoc->GetRelativePositionUTF16(
+                                start, std::max<long>(0, replacementLength));
+        if ( end == Sci::invalidPosition )
+            end = pdoc->Length();
+
+        if ( RangeContainsProtected(start, end) )
+            return false;
+
+        SetSelection(end, start);
+    }
+    else if ( SelectionContainsProtected() )
+    {
+        return false;
+    }
+
+    const Sci::Position insertionPosition = sel.RangeMain().Start().Position();
+
+    // Selection deletion and virtual-space realization must precede the
+    // tentative transaction so undo restores the original text correctly.
+    // Explicitly collapse at the original start: document modification
+    // tracking can otherwise move an endpoint to the end of the document
+    // when all selected text is deleted.
+    ClearBeforeTentativeStart();
+    if ( !sel.Empty() )
+        return false;
+
+    SetEmptySelection(insertionPosition);
+    m_compositionStart = insertionPosition;
+    m_compositionLength = 0;
+    m_compositionActive = true;
+    return true;
+}
+
+#ifdef __WXGTK__
+
+bool ScintillaWX::UpdateComposition(const wxString& text,
+                                    int cursorCharacters)
+{
+    // GTK emits a final preedit-changed signal with an empty string when
+    // composition ends. Don't start a new composition for this notification,
+    // as doing so would leave a stale start position and could alter the
+    // current selection.
+    if ( text.empty() )
+    {
+        CancelComposition();
+        return true;
+    }
+
+    if ( !StartComposition(wxTextInputClient::NoPosition, 0) )
+        return false;
+
+    pdoc->TentativeStart();
+    m_compositionLength =
+        InsertCompositionText(text, CharacterSource::tentativeInput);
+
+    pdoc->DecorationSetCurrentIndicator(INDICATOR_IME);
+    pdoc->DecorationFillRange(m_compositionStart, 1, m_compositionLength);
+
+    Sci::Position caret = pdoc->GetRelativePosition(
+                              m_compositionStart,
+                              std::max(0, cursorCharacters));
+    if ( caret == Sci::invalidPosition ||
+         caret > m_compositionStart + m_compositionLength )
+    {
+        caret = m_compositionStart + m_compositionLength;
+    }
+    SetEmptySelection(caret);
+
+    EnsureCaretVisible();
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+bool ScintillaWX::CommitComposition(const wxString& text)
+{
+    if ( !m_compositionActive )
+        return false;
+
+    UndoCompositionText();
+    m_compositionActive = false;
+    m_compositionLength = 0;
+    InsertCompositionText(text, CharacterSource::imeResult);
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+#endif // __WXGTK__
+
+void ScintillaWX::CancelComposition()
+{
+    if ( !m_compositionActive )
+        return;
+
+    UndoCompositionText();
+    m_compositionActive = false;
+    m_compositionLength = 0;
+    ShowCaretAtCurrentPosition();
+}
+
+#ifdef __WXGTK__
+
+wxRect ScintillaWX::GetIMEContextRect()
+{
+    const Point pt = PointMainCaret();
+    // Keep the candidate window from overlapping the current line.
+    return wxRect(static_cast<int>(pt.x),
+                  static_cast<int>(pt.y + std::max(4, vs.lineHeight / 4)),
+                  0, vs.lineHeight);
+}
+
+#endif // __WXGTK__
+
+#ifdef __WXOSX_COCOA__
+
+bool ScintillaWX::InsertText(const wxString& text,
+                            long replacementStart,
+                            long replacementLength)
+{
+    // The accent chooser can pass NSNotFound-1 to describe a range which
+    // doesn't exist and must not be replaced.
+    if ( replacementStart == wxTextInputClient::InvalidPosition )
+    {
+        CancelComposition();
+        return true;
+    }
+
+    const bool wasComposing = m_compositionActive;
+
+    // Let the normal wx key event path handle ordinary, non-composed input.
+    if ( !wasComposing && replacementStart < 0 )
+        return false;
+
+    if ( wasComposing )
+    {
+        // AppKit normally passes either the marked range or NSNotFound here.
+        // The stored composition range is authoritative and applying the
+        // replacement range as well would replace it twice.
+        UndoCompositionText();
+    }
+    else if ( !StartComposition(replacementStart, replacementLength) )
+    {
+        return true;
+    }
+
+    m_compositionActive = false;
+    m_compositionLength = 0;
+    InsertCompositionText(text, wasComposing
+                                ? CharacterSource::imeResult
+                                : CharacterSource::directInput);
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+bool ScintillaWX::SetMarkedText(const wxString& text,
+                               long selectedStart,
+                               long selectedLength,
+                               long replacementStart,
+                               long replacementLength)
+{
+    // Once composition has started, the existing marked range is replaced.
+    if ( m_compositionActive )
+        replacementStart = wxTextInputClient::NoPosition;
+
+    if ( !StartComposition(replacementStart, replacementLength) )
+        return false;
+
+    if ( text.empty() )
+    {
+        UnmarkText();
+        return true;
+    }
+
+    pdoc->TentativeStart();
+    m_compositionLength =
+        InsertCompositionText(text, CharacterSource::tentativeInput);
+
+    pdoc->DecorationSetCurrentIndicator(INDICATOR_IME);
+    pdoc->DecorationFillRange(m_compositionStart, 1, m_compositionLength);
+
+    selectedStart = std::max<long>(0, selectedStart);
+    selectedLength = std::max<long>(0, selectedLength);
+    Sci::Position selectionStart =
+        pdoc->GetRelativePositionUTF16(m_compositionStart, selectedStart);
+    if ( selectionStart == Sci::invalidPosition ||
+         selectionStart > m_compositionStart + m_compositionLength )
+    {
+        selectionStart = m_compositionStart + m_compositionLength;
+    }
+
+    Sci::Position selectionEnd =
+        pdoc->GetRelativePositionUTF16(selectionStart, selectedLength);
+    if ( selectionEnd == Sci::invalidPosition ||
+         selectionEnd > m_compositionStart + m_compositionLength )
+    {
+        selectionEnd = m_compositionStart + m_compositionLength;
+    }
+
+    SetSelection(selectionEnd, selectionStart);
+    EnsureCaretVisible();
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+void ScintillaWX::UnmarkText()
+{
+    if ( !m_compositionActive )
+        return;
+
+    if ( pdoc->TentativeActive() )
+        pdoc->TentativeCommit();
+
+    ClearCompositionIndicator();
+    m_compositionActive = false;
+    m_compositionLength = 0;
+}
+
+bool ScintillaWX::GetMarkedTextRange(long* start, long* length) const
+{
+    if ( !m_compositionActive || m_compositionLength == 0 )
+        return false;
+
+    *start = PositionToUTF16(m_compositionStart);
+    *length = static_cast<long>(
+        pdoc->CountUTF16(m_compositionStart,
+                         m_compositionStart + m_compositionLength));
+    return true;
+}
+
+bool ScintillaWX::GetSelectedTextRange(long* start, long* length) const
+{
+    const Sci::Position positionStart = sel.RangeMain().Start().Position();
+    const Sci::Position positionEnd = sel.RangeMain().End().Position();
+    *start = PositionToUTF16(positionStart);
+    *length = static_cast<long>(pdoc->CountUTF16(positionStart, positionEnd));
+    return true;
+}
+
+bool ScintillaWX::GetTextInRange(long start, long length,
+                                wxString* text,
+                                long* actualStart,
+                                long* actualLength) const
+{
+    const long documentLength = PositionToUTF16(pdoc->Length());
+    if ( start < 0 || start > documentLength )
+        return false;
+
+    length = std::max<long>(0, std::min(length, documentLength - start));
+    const Sci::Position positionStart = PositionFromUTF16(start);
+    Sci::Position positionEnd =
+        pdoc->GetRelativePositionUTF16(positionStart, length);
+    if ( positionEnd == Sci::invalidPosition )
+        positionEnd = pdoc->Length();
+
+    const std::string range = RangeText(positionStart, positionEnd);
+    *text = wxString::FromUTF8(range.data(), range.length());
+    *actualStart = start;
+    *actualLength = static_cast<long>(
+        pdoc->CountUTF16(positionStart, positionEnd));
+    return true;
+}
+
+bool ScintillaWX::GetTextRect(long start, long length,
+                             wxRect* rect,
+                             long* actualStart,
+                             long* actualLength)
+{
+    wxString unused;
+    if ( !GetTextInRange(start, length, &unused,
+                         actualStart, actualLength) )
+    {
+        return false;
+    }
+
+    const Sci::Position positionStart = PositionFromUTF16(*actualStart);
+    Sci::Position positionEnd =
+        pdoc->GetRelativePositionUTF16(positionStart, *actualLength);
+    if ( positionEnd == Sci::invalidPosition )
+        positionEnd = pdoc->Length();
+
+    const Point pointStart = LocationFromPosition(positionStart);
+    const Point pointEnd = LocationFromPosition(positionEnd);
+    const int width = pointStart.y == pointEnd.y
+                    ? std::max(0, static_cast<int>(pointEnd.x - pointStart.x))
+                    : 0;
+    *rect = wxRect(static_cast<int>(pointStart.x),
+                   static_cast<int>(pointStart.y),
+                   width, vs.lineHeight);
+    return true;
+}
+
+bool ScintillaWX::GetTextPosition(const wxPoint& point, long* position)
+{
+    const Sci::Position documentPosition =
+        PositionFromLocation(Point::FromInts(point.x, point.y), true, true);
+    if ( documentPosition == Sci::invalidPosition )
+        return false;
+
+    *position = PositionToUTF16(documentPosition);
+    return true;
+}
+
+#endif // __WXOSX_COCOA__
+
+#endif // __WXGTK__ || __WXOSX_COCOA__
 
 int  ScintillaWX::DoKeyDown(const wxKeyEvent& evt, bool* consumed)
 {

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -213,7 +213,15 @@ ScintillaWX::ScintillaWX(wxStyledTextCtrl* win) {
     stc   = win;
     wheelVRotation = 0;
     wheelHRotation = 0;
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    m_compositionActive = false;
+    m_compositionStart = 0;
+    m_compositionLength = 0;
+#endif
     Initialise();
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    wxAssociateTextInputClient(stc, this);
+#endif
 #ifdef __WXMSW__
     sysCaretBitmap = 0;
     sysCaretWidth = 0;
@@ -241,6 +249,11 @@ ScintillaWX::ScintillaWX(wxStyledTextCtrl* win) {
 
 
 ScintillaWX::~ScintillaWX() {
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    wxAssociateTextInputClient(stc, nullptr);
+    CancelComposition();
+#endif
+
     for ( auto& entry : timers ) {
         delete entry.second;
     }
@@ -793,6 +806,21 @@ sptr_t ScintillaWX::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam)
         case SCI_GETDIRECTPOINTER:
             return reinterpret_cast<sptr_t>(this);
 
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+        case SCI_SETDOCPOINTER:
+            // Tentative input belongs to the current document and must not
+            // leak into a newly attached one.
+            CancelComposition();
+            break;
+
+        case SCI_SETUNDOCOLLECTION:
+            // Composition rollback needs the tentative undo actions, so roll
+            // back while they are still recorded.
+            if ( !wParam )
+                CancelComposition();
+            break;
+#endif
+
 #ifdef __WXMSW__
         // ScintillaWin
         case WM_IME_STARTCOMPOSITION:
@@ -1079,6 +1107,411 @@ void ScintillaWX::DoAddChar(wxChar key) {
     InsertCharacter(buf, buf.length(), CharacterSource::directInput);
 }
 
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+
+Sci::Position ScintillaWX::PositionFromUTF16(long position) const
+{
+    if ( position < 0 )
+        return Sci::invalidPosition;
+
+    return RelativePositionUTF16Clamped(0, position);
+}
+
+long ScintillaWX::PositionToUTF16(Sci::Position position) const
+{
+    position = std::max<Sci::Position>(0,
+                std::min<Sci::Position>(position, pdoc->Length()));
+    return static_cast<long>(pdoc->CountUTF16(0, position));
+}
+
+// Unlike Document::GetRelativePositionUTF16(), never fails: an offset falling
+// inside a surrogate pair is extended to the end of that character and
+// walking off the document end stops there. Native text input APIs may
+// propose ranges with either problem and expect them to be adjusted to the
+// nearest valid ones rather than rejected.
+Sci::Position
+ScintillaWX::RelativePositionUTF16Clamped(Sci::Position position,
+                                          long lengthUTF16) const
+{
+    for ( long remaining = lengthUTF16; remaining > 0; )
+    {
+        const Sci::Position next = pdoc->NextPosition(position, 1);
+        if ( next == position )
+            break;
+
+        // Character of 4 UTF-8 bytes = 2 UTF-16 code units.
+        remaining -= next - position > 3 ? 2 : 1;
+        position = next;
+    }
+
+    return position;
+}
+
+Sci::Position ScintillaWX::InsertCompositionText(const wxString& text,
+                                                 CharacterSource source)
+{
+    const wxScopedCharBuffer utf8 = text.utf8_str();
+    const char* const bytes = utf8.data();
+    const size_t length = utf8.length();
+    const Sci::Position start = CurrentPosition();
+
+    for ( size_t offset = 0; offset < length; )
+    {
+        const unsigned char lead = static_cast<unsigned char>(bytes[offset]);
+        size_t charLength = UTF8BytesOfLead[lead];
+        if ( charLength == 0 || offset + charLength > length )
+            charLength = 1;
+
+        InsertCharacter(bytes + offset, static_cast<unsigned int>(charLength),
+                        source);
+        offset += charLength;
+    }
+
+    return CurrentPosition() - start;
+}
+
+void ScintillaWX::ClearCompositionIndicator()
+{
+    pdoc->DecorationSetCurrentIndicator(INDICATOR_IME);
+    pdoc->DecorationFillRange(0, 0, pdoc->Length());
+}
+
+void ScintillaWX::UndoCompositionText()
+{
+    if ( pdoc->TentativeActive() )
+        pdoc->TentativeUndo();
+
+    ClearCompositionIndicator();
+    SetEmptySelection(m_compositionStart);
+    m_compositionLength = 0;
+}
+
+bool ScintillaWX::StartComposition(long replacementStart,
+                                   long replacementLength)
+{
+    if ( pdoc->IsReadOnly() )
+        return false;
+
+    if ( m_compositionActive )
+    {
+        UndoCompositionText();
+        return true;
+    }
+
+    // Rolling the pre-edit text back relies on tentative undo actions being
+    // recorded, so composition can't start while undo collection is disabled.
+    if ( !pdoc->IsCollectingUndo() )
+        return false;
+
+    // Cocoa text input only supports a single selection. GTK composition is
+    // also kept to the main selection to make the marked range unambiguous.
+    sel.SetSelection(sel.RangeMain());
+
+    if ( replacementStart >= 0 )
+    {
+        const Sci::Position start = PositionFromUTF16(replacementStart);
+        const Sci::Position end = RelativePositionUTF16Clamped(
+                                start, std::max<long>(0, replacementLength));
+
+        if ( RangeContainsProtected(start, end) )
+            return false;
+
+        SetSelection(end, start);
+    }
+    else if ( SelectionContainsProtected() )
+    {
+        return false;
+    }
+
+    // Selection deletion and virtual-space realization must precede the
+    // tentative transaction so undo restores the original text correctly.
+    //
+    // When the selection contains text, collapse explicitly at its original
+    // start: document modification tracking can otherwise move an endpoint
+    // to the end of the document when all selected text is deleted. An empty
+    // selection may however still be in virtual space, which
+    // ClearBeforeTentativeStart() realizes by inserting actual whitespace,
+    // and its final position is only known from the tracked selection
+    // afterwards.
+    const bool selectionDeletesText = sel.RangeMain().Length() != 0;
+    Sci::Position insertionPosition = sel.RangeMain().Start().Position();
+
+    ClearBeforeTentativeStart();
+    if ( !sel.Empty() )
+        return false;
+
+    if ( !selectionDeletesText )
+        insertionPosition = sel.RangeMain().Start().Position();
+
+    SetEmptySelection(insertionPosition);
+    m_compositionStart = insertionPosition;
+    m_compositionLength = 0;
+    m_compositionActive = true;
+    return true;
+}
+
+#ifdef __WXGTK__
+
+bool ScintillaWX::UpdateComposition(const wxString& text,
+                                    int cursorCharacters)
+{
+    // GTK emits a final preedit-changed signal with an empty string when
+    // composition ends. Don't start a new composition for this notification,
+    // as doing so would leave a stale start position and could alter the
+    // current selection.
+    if ( text.empty() )
+    {
+        CancelComposition();
+        return true;
+    }
+
+    if ( !StartComposition(wxTextInputClient::NoPosition, 0) )
+        return false;
+
+    pdoc->TentativeStart();
+    m_compositionLength =
+        InsertCompositionText(text, CharacterSource::tentativeInput);
+
+    pdoc->DecorationSetCurrentIndicator(INDICATOR_IME);
+    pdoc->DecorationFillRange(m_compositionStart, 1, m_compositionLength);
+
+    Sci::Position caret = pdoc->GetRelativePosition(
+                              m_compositionStart,
+                              std::max(0, cursorCharacters));
+    if ( caret == Sci::invalidPosition ||
+         caret > m_compositionStart + m_compositionLength )
+    {
+        caret = m_compositionStart + m_compositionLength;
+    }
+    SetEmptySelection(caret);
+
+    EnsureCaretVisible();
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+bool ScintillaWX::CommitComposition(const wxString& text)
+{
+    if ( !m_compositionActive )
+        return false;
+
+    UndoCompositionText();
+    m_compositionActive = false;
+    m_compositionLength = 0;
+    InsertCompositionText(text, CharacterSource::imeResult);
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+#endif // __WXGTK__
+
+void ScintillaWX::CancelComposition()
+{
+    if ( !m_compositionActive )
+        return;
+
+    UndoCompositionText();
+    m_compositionActive = false;
+    m_compositionLength = 0;
+    ShowCaretAtCurrentPosition();
+}
+
+#ifdef __WXGTK__
+
+wxRect ScintillaWX::GetIMEContextRect()
+{
+    const Point pt = PointMainCaret();
+    // Keep the candidate window from overlapping the current line.
+    return wxRect(static_cast<int>(pt.x),
+                  static_cast<int>(pt.y + std::max(4, vs.lineHeight / 4)),
+                  0, vs.lineHeight);
+}
+
+#endif // __WXGTK__
+
+#ifdef __WXOSX_COCOA__
+
+bool ScintillaWX::InsertText(const wxString& text,
+                            long replacementStart,
+                            long replacementLength)
+{
+    // The accent chooser can pass NSNotFound-1 to describe a range which
+    // doesn't exist and must not be replaced.
+    if ( replacementStart == wxTextInputClient::InvalidPosition )
+    {
+        CancelComposition();
+        return true;
+    }
+
+    const bool wasComposing = m_compositionActive;
+
+    // Let the normal wx key event path handle ordinary, non-composed input.
+    if ( !wasComposing && replacementStart < 0 )
+        return false;
+
+    if ( wasComposing )
+    {
+        // AppKit normally passes either the marked range or NSNotFound here.
+        // The stored composition range is authoritative and applying the
+        // replacement range as well would replace it twice.
+        UndoCompositionText();
+    }
+    else if ( !StartComposition(replacementStart, replacementLength) )
+    {
+        return true;
+    }
+
+    m_compositionActive = false;
+    m_compositionLength = 0;
+    InsertCompositionText(text, wasComposing
+                                ? CharacterSource::imeResult
+                                : CharacterSource::directInput);
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+bool ScintillaWX::SetMarkedText(const wxString& text,
+                               long selectedStart,
+                               long selectedLength,
+                               long replacementStart,
+                               long replacementLength)
+{
+    // Once composition has started, the existing marked range is replaced.
+    if ( m_compositionActive )
+        replacementStart = wxTextInputClient::NoPosition;
+
+    if ( !StartComposition(replacementStart, replacementLength) )
+        return false;
+
+    if ( text.empty() )
+    {
+        UnmarkText();
+        return true;
+    }
+
+    pdoc->TentativeStart();
+    m_compositionLength =
+        InsertCompositionText(text, CharacterSource::tentativeInput);
+
+    pdoc->DecorationSetCurrentIndicator(INDICATOR_IME);
+    pdoc->DecorationFillRange(m_compositionStart, 1, m_compositionLength);
+
+    const Sci::Position compositionEnd =
+        m_compositionStart + m_compositionLength;
+    const Sci::Position selectionStart = std::min(
+        RelativePositionUTF16Clamped(m_compositionStart,
+                                     std::max<long>(0, selectedStart)),
+        compositionEnd);
+    const Sci::Position selectionEnd = std::min(
+        RelativePositionUTF16Clamped(selectionStart,
+                                     std::max<long>(0, selectedLength)),
+        compositionEnd);
+
+    SetSelection(selectionEnd, selectionStart);
+    EnsureCaretVisible();
+    ShowCaretAtCurrentPosition();
+    return true;
+}
+
+void ScintillaWX::UnmarkText()
+{
+    if ( !m_compositionActive )
+        return;
+
+    if ( pdoc->TentativeActive() )
+        pdoc->TentativeCommit();
+
+    ClearCompositionIndicator();
+    m_compositionActive = false;
+    m_compositionLength = 0;
+}
+
+bool ScintillaWX::GetMarkedTextRange(long* start, long* length) const
+{
+    if ( !m_compositionActive || m_compositionLength == 0 )
+        return false;
+
+    *start = PositionToUTF16(m_compositionStart);
+    *length = static_cast<long>(
+        pdoc->CountUTF16(m_compositionStart,
+                         m_compositionStart + m_compositionLength));
+    return true;
+}
+
+bool ScintillaWX::GetSelectedTextRange(long* start, long* length) const
+{
+    const Sci::Position positionStart = sel.RangeMain().Start().Position();
+    const Sci::Position positionEnd = sel.RangeMain().End().Position();
+    *start = PositionToUTF16(positionStart);
+    *length = static_cast<long>(pdoc->CountUTF16(positionStart, positionEnd));
+    return true;
+}
+
+bool ScintillaWX::GetTextInRange(long start, long length,
+                                wxString* text,
+                                long* actualStart,
+                                long* actualLength) const
+{
+    const long documentLength = PositionToUTF16(pdoc->Length());
+    if ( start < 0 || start > documentLength )
+        return false;
+
+    length = std::max<long>(0, std::min(length, documentLength - start));
+    const Sci::Position positionStart = PositionFromUTF16(start);
+    const Sci::Position positionEnd =
+        RelativePositionUTF16Clamped(positionStart, length);
+
+    const std::string range = RangeText(positionStart, positionEnd);
+    *text = wxString::FromUTF8(range.data(), range.length());
+    // Report the range adjusted to character boundaries, which may differ
+    // from the requested one if it split a surrogate pair.
+    *actualStart = PositionToUTF16(positionStart);
+    *actualLength = static_cast<long>(
+        pdoc->CountUTF16(positionStart, positionEnd));
+    return true;
+}
+
+bool ScintillaWX::GetTextRect(long start, long length,
+                             wxRect* rect,
+                             long* actualStart,
+                             long* actualLength)
+{
+    wxString unused;
+    if ( !GetTextInRange(start, length, &unused,
+                         actualStart, actualLength) )
+    {
+        return false;
+    }
+
+    const Sci::Position positionStart = PositionFromUTF16(*actualStart);
+    const Sci::Position positionEnd =
+        RelativePositionUTF16Clamped(positionStart, *actualLength);
+
+    const Point pointStart = LocationFromPosition(positionStart);
+    const Point pointEnd = LocationFromPosition(positionEnd);
+    const int width = pointStart.y == pointEnd.y
+                    ? std::max(0, static_cast<int>(pointEnd.x - pointStart.x))
+                    : 0;
+    *rect = wxRect(static_cast<int>(pointStart.x),
+                   static_cast<int>(pointStart.y),
+                   width, vs.lineHeight);
+    return true;
+}
+
+bool ScintillaWX::GetTextPosition(const wxPoint& point, long* position)
+{
+    const Sci::Position documentPosition =
+        PositionFromLocation(Point::FromInts(point.x, point.y), true, true);
+    if ( documentPosition == Sci::invalidPosition )
+        return false;
+
+    *position = PositionToUTF16(documentPosition);
+    return true;
+}
+
+#endif // __WXOSX_COCOA__
+
+#endif // __WXGTK__ || __WXOSX_COCOA__
 
 int  ScintillaWX::DoKeyDown(const wxKeyEvent& evt, bool* consumed)
 {

--- a/src/stc/ScintillaWX.h
+++ b/src/stc/ScintillaWX.h
@@ -67,6 +67,9 @@
 
 #include "wx/dnd.h"
 #include "wx/event.h"
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+#include "wx/private/textinput.h"
+#endif
 #ifdef __WXMSW__
 #include "wx/msw/wrapwin.h"                     // HBITMAP
 #endif
@@ -110,7 +113,11 @@ private:
 
 //----------------------------------------------------------------------
 
-class ScintillaWX : public ScintillaBase {
+class ScintillaWX : public ScintillaBase
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+                  , public wxTextInputClient
+#endif
+{
 public:
 
     ScintillaWX(wxStyledTextCtrl* win);
@@ -184,6 +191,45 @@ public:
     void DoOnListBox();
     void DoMouseCaptureLost();
 
+    // Native text input composition.
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    bool IsTextInputEnabled() const override
+        { return imeInteraction == imeInline; }
+    bool HasActiveComposition() const override
+        { return m_compositionActive; }
+    void CancelComposition() override;
+#endif
+
+#ifdef __WXGTK__
+    bool UpdateComposition(const wxString& text,
+                           int cursorCharacters) override;
+    bool CommitComposition(const wxString& text) override;
+    wxRect GetIMEContextRect() override;
+#endif // __WXGTK__
+
+#ifdef __WXOSX_COCOA__
+    bool InsertText(const wxString& text,
+                    long replacementStart,
+                    long replacementLength) override;
+    bool SetMarkedText(const wxString& text,
+                       long selectedStart,
+                       long selectedLength,
+                       long replacementStart,
+                       long replacementLength) override;
+    void UnmarkText() override;
+    bool HasMarkedText() const override
+        { return HasActiveComposition() && m_compositionLength != 0; }
+    bool GetMarkedTextRange(long* start, long* length) const override;
+    bool GetSelectedTextRange(long* start, long* length) const override;
+    bool GetTextInRange(long start, long length, wxString* text,
+                        long* actualStart,
+                        long* actualLength) const override;
+    bool GetTextRect(long start, long length, wxRect* rect,
+                     long* actualStart,
+                     long* actualLength) override;
+    bool GetTextPosition(const wxPoint& point, long* position) override;
+#endif // __WXOSX_COCOA__
+
 
     // helpers
     void FullPaint();
@@ -214,6 +260,20 @@ private:
     int                 wheelVRotation;
     int                 wheelHRotation;
     SurfaceData*        m_surfaceData;
+
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    bool                m_compositionActive;
+    Sci::Position       m_compositionStart;
+    Sci::Position       m_compositionLength;
+
+    bool StartComposition(long replacementStart, long replacementLength);
+    void UndoCompositionText();
+    void ClearCompositionIndicator();
+    Sci::Position InsertCompositionText(const wxString& text,
+                                        CharacterSource source);
+    Sci::Position PositionFromUTF16(long position) const;
+    long PositionToUTF16(Sci::Position position) const;
+#endif
 
     // For use in creating a system caret
     bool HasCaretSizeChanged();

--- a/src/stc/ScintillaWX.h
+++ b/src/stc/ScintillaWX.h
@@ -69,6 +69,9 @@ wxGCC_WARNING_RESTORE(double-promotion)
 
 #include "wx/dnd.h"
 #include "wx/event.h"
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+#include "wx/private/textinput.h"
+#endif
 #ifdef __WXMSW__
 #include "wx/msw/wrapwin.h"                     // HBITMAP
 #endif
@@ -112,7 +115,11 @@ private:
 
 //----------------------------------------------------------------------
 
-class ScintillaWX : public ScintillaBase {
+class ScintillaWX : public ScintillaBase
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+                  , public wxTextInputClient
+#endif
+{
 public:
 
     ScintillaWX(wxStyledTextCtrl* win);
@@ -186,6 +193,47 @@ public:
     void DoOnListBox();
     void DoMouseCaptureLost();
 
+    // Native text input composition.
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    // Rolling the pre-edit text back relies on tentative undo actions being
+    // recorded, so inline composition also requires undo collection.
+    bool IsTextInputEnabled() const override
+        { return imeInteraction == imeInline && pdoc->IsCollectingUndo(); }
+    bool HasActiveComposition() const override
+        { return m_compositionActive; }
+    void CancelComposition() override;
+#endif
+
+#ifdef __WXGTK__
+    bool UpdateComposition(const wxString& text,
+                           int cursorCharacters) override;
+    bool CommitComposition(const wxString& text) override;
+    wxRect GetIMEContextRect() override;
+#endif // __WXGTK__
+
+#ifdef __WXOSX_COCOA__
+    bool InsertText(const wxString& text,
+                    long replacementStart,
+                    long replacementLength) override;
+    bool SetMarkedText(const wxString& text,
+                       long selectedStart,
+                       long selectedLength,
+                       long replacementStart,
+                       long replacementLength) override;
+    void UnmarkText() override;
+    bool HasMarkedText() const override
+        { return HasActiveComposition() && m_compositionLength != 0; }
+    bool GetMarkedTextRange(long* start, long* length) const override;
+    bool GetSelectedTextRange(long* start, long* length) const override;
+    bool GetTextInRange(long start, long length, wxString* text,
+                        long* actualStart,
+                        long* actualLength) const override;
+    bool GetTextRect(long start, long length, wxRect* rect,
+                     long* actualStart,
+                     long* actualLength) override;
+    bool GetTextPosition(const wxPoint& point, long* position) override;
+#endif // __WXOSX_COCOA__
+
 
     // helpers
     void FullPaint();
@@ -216,6 +264,22 @@ private:
     int                 wheelVRotation;
     int                 wheelHRotation;
     SurfaceData*        m_surfaceData;
+
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    bool                m_compositionActive;
+    Sci::Position       m_compositionStart;
+    Sci::Position       m_compositionLength;
+
+    bool StartComposition(long replacementStart, long replacementLength);
+    void UndoCompositionText();
+    void ClearCompositionIndicator();
+    Sci::Position InsertCompositionText(const wxString& text,
+                                        CharacterSource source);
+    Sci::Position PositionFromUTF16(long position) const;
+    long PositionToUTF16(Sci::Position position) const;
+    Sci::Position RelativePositionUTF16Clamped(Sci::Position position,
+                                               long lengthUTF16) const;
+#endif
 
     // For use in creating a system caret
     bool HasCaretSizeChanged();

--- a/src/stc/gen_docs.py
+++ b/src/stc/gen_docs.py
@@ -1071,7 +1071,11 @@ extendedDocs = {
 
     'SetIMEInteraction':
         ('The input should be one of the',
-        '@link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink constants.',),
+        '@link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink',
+        'constants.',
+        '@remarks',
+        'Inline IME interaction is used by default under wxGTK and wxOSX.',
+        'The other ports use windowed IME interaction by default.',),
 
     'GetIndentationGuides':
         ('The return value will be one of the',

--- a/src/stc/gen_docs.py
+++ b/src/stc/gen_docs.py
@@ -1071,7 +1071,13 @@ extendedDocs = {
 
     'SetIMEInteraction':
         ('The input should be one of the',
-        '@link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink constants.',),
+        '@link wxStyledTextCtrl::wxSTC_IME_WINDOWED wxSTC_IME_* @endlink',
+        'constants.',
+        '@remarks',
+        'Inline IME interaction is used by default under wxGTK and wxOSX.',
+        'The other ports use windowed IME interaction by default.',
+        'Inline interaction also requires undo collection to be enabled,',
+        'windowed interaction is used while it is disabled.',),
 
     'GetIndentationGuides':
         ('The return value will be one of the',

--- a/src/stc/gen_iface.py
+++ b/src/stc/gen_iface.py
@@ -913,6 +913,19 @@ methodOverrideMap = {
     SendMsg(%s, codePage);'''
     ),
 
+    'SetIMEInteraction' :
+    (0,
+     0,
+     '''void %s(int imeInteraction) {
+    SendMsg(%s, imeInteraction);
+#ifdef __WXGTK__
+    wxUpdateTextInputClient(this);
+#endif
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    if ( imeInteraction != wxSTC_IME_INLINE && m_swx )
+        m_swx->CancelComposition();
+#endif'''
+    ),
 
     'GrabFocus' : (None, 0, 0),
 

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -212,6 +212,13 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
     // Put Scintilla into unicode (UTF-8) mode
     SetCodePage(wxSTC_CP_UTF8);
 
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    // The generic wxSTC backend can display composition itself on these
+    // platforms, so prefer inline input instead of relying on an IM module to
+    // provide a separate pre-edit window.
+    SetIMEInteraction(wxSTC_IME_INLINE);
+#endif
+
     SetInitialSize(size);
 
     // Reduces flicker on GTK+/X11
@@ -616,9 +623,15 @@ int wxStyledTextCtrl::GetIMEInteraction() const
 }
 
 // Choose to display the IME in a window or inline.
-void wxStyledTextCtrl::SetIMEInteraction(int imeInteraction)
-{
-    SendMsg(SCI_SETIMEINTERACTION, imeInteraction, 0);
+void wxStyledTextCtrl::SetIMEInteraction(int imeInteraction) {
+    SendMsg(SCI_SETIMEINTERACTION, imeInteraction);
+#ifdef __WXGTK__
+    wxUpdateTextInputClient(this);
+#endif
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    if ( imeInteraction != wxSTC_IME_INLINE && m_swx )
+        m_swx->CancelComposition();
+#endif
 }
 
 // Set the symbol used for a particular marker number,

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -212,6 +212,13 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
     // Put Scintilla into unicode (UTF-8) mode
     SetCodePage(wxSTC_CP_UTF8);
 
+#if defined(__WXGTK__) || defined(__WXOSX_COCOA__)
+    // The generic wxSTC backend can display composition itself on these
+    // platforms, so prefer inline input instead of relying on an IM module to
+    // provide a separate pre-edit window.
+    SetIMEInteraction(wxSTC_IME_INLINE);
+#endif
+
     SetInitialSize(size);
 
     // Reduces flicker on GTK+/X11

--- a/tests/controls/styledtextctrltest.cpp
+++ b/tests/controls/styledtextctrltest.cpp
@@ -18,6 +18,15 @@
 #include "wx/stc/stc.h"
 #include "wx/uiaction.h"
 
+#if defined(__WXOSX_COCOA__) || defined(__WXGTK__)
+    #include "wx/private/textinput.h"
+#endif
+
+#ifdef __WXOSX_COCOA__
+    #include <objc/message.h>
+    #include <objc/runtime.h>
+#endif
+
 #include "testwindow.h"
 
 #if defined(__WXOSX_COCOA__) || defined(__WXMSW__) || defined(__WXGTK__)
@@ -158,6 +167,179 @@ TEST_CASE_METHOD(StcPopupWindowsTestCase,
 }
 
 #endif // !defined(__WXOSX_COCOA__)
+
+#if defined(__WXOSX_COCOA__) || defined(__WXGTK__)
+
+class StcTextInputTestCase
+{
+public:
+    StcTextInputTestCase()
+        : m_stc(new wxStyledTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY))
+    {
+    }
+
+    ~StcTextInputTestCase()
+    {
+        delete m_stc;
+    }
+
+protected:
+    wxTextInputClient* GetTextInputClient() const
+    {
+        return wxFindTextInputClient(m_stc);
+    }
+
+    wxStyledTextCtrl* const m_stc;
+};
+
+#ifdef __WXGTK__
+
+TEST_CASE_METHOD(StcTextInputTestCase,
+                 "wxStyledTextCtrl::GTKTextInput",
+                 "[wxStyledTextCtrl][ime]")
+{
+    wxTextInputClient* const client = GetTextInputClient();
+    REQUIRE( client );
+    CHECK( client->IsTextInputEnabled() );
+
+    const wxString hiragana =
+        wxString::FromUTF8("\xe3\x81\xab");
+    const wxString kanji =
+        wxString::FromUTF8("\xe6\x97\xa5\xe6\x9c\xac");
+
+    m_stc->SetText("AB");
+    m_stc->EmptyUndoBuffer();
+
+    m_stc->SetSelection(0, 2);
+    REQUIRE( client->UpdateComposition("", 0) );
+    CHECK( m_stc->GetText() == "AB" );
+    CHECK( m_stc->GetSelectionStart() == 0 );
+    CHECK( m_stc->GetSelectionEnd() == 2 );
+    CHECK_FALSE( client->HasActiveComposition() );
+    CHECK_FALSE( client->CommitComposition(kanji) );
+
+    m_stc->SetEmptySelection(1);
+
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    CHECK( m_stc->GetText() == "A" + hiragana + "B" );
+
+    client->CancelComposition();
+    CHECK( m_stc->GetText() == "AB" );
+
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    REQUIRE( client->CommitComposition(kanji) );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+    CHECK_FALSE( client->CommitComposition(kanji) );
+
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == "AB" );
+
+    m_stc->SetEmptySelection(1);
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    m_stc->SetIMEInteraction(wxSTC_IME_WINDOWED);
+    CHECK( m_stc->GetText() == "AB" );
+    CHECK_FALSE( client->IsTextInputEnabled() );
+    m_stc->SetIMEInteraction(wxSTC_IME_INLINE);
+    CHECK( client->IsTextInputEnabled() );
+}
+
+#endif // __WXGTK__
+
+#ifdef __WXOSX_COCOA__
+
+TEST_CASE_METHOD(StcTextInputTestCase,
+                 "wxStyledTextCtrl::CocoaTextInput",
+                 "[wxStyledTextCtrl][ime]")
+{
+    wxTextInputClient* const client = GetTextInputClient();
+    REQUIRE( client );
+    CHECK( client->IsTextInputEnabled() );
+
+    const wxString hiragana =
+        wxString::FromUTF8("\xe3\x81\xab");
+    const wxString kanji =
+        wxString::FromUTF8("\xe6\x97\xa5\xe6\x9c\xac");
+    const wxString original =
+        wxString::FromUTF8("A\xf0\x9f\x98\x80" "B");
+
+    m_stc->SetText(original);
+    m_stc->EmptyUndoBuffer();
+    m_stc->SetSelection(1, 5);
+
+    REQUIRE( client->SetMarkedText(
+        hiragana, 1, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( m_stc->GetText() == "A" + hiragana + "B" );
+    CHECK( client->HasMarkedText() );
+
+    long start, length;
+    REQUIRE( client->GetMarkedTextRange(&start, &length) );
+    CHECK( start == 1 );
+    CHECK( length == 1 );
+    REQUIRE( client->GetSelectedTextRange(&start, &length) );
+    CHECK( start == 2 );
+    CHECK( length == 0 );
+
+    REQUIRE( client->SetMarkedText(
+        kanji, 2, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+    REQUIRE( client->InsertText(
+        kanji, wxTextInputClient::NoPosition, 0) );
+    CHECK_FALSE( client->HasMarkedText() );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == "AB" );
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == original );
+
+    // After choosing a candidate, some input methods send insertNewline: to
+    // accept it instead of calling insertText:. It must commit the marked
+    // text without inserting a newline.
+    m_stc->SetSelection(1, 5);
+    REQUIRE( client->SetMarkedText(
+        kanji, 2, 0, wxTextInputClient::NoPosition, 0) );
+    using SendSelector = void (*)(void*, SEL, SEL);
+    reinterpret_cast<SendSelector>(objc_msgSend)(
+        m_stc->GetHandle(),
+        sel_registerName("doCommandBySelector:"),
+        sel_registerName("insertNewline:"));
+    CHECK_FALSE( client->HasMarkedText() );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == "AB" );
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == original );
+
+    wxString text;
+    long actualStart, actualLength;
+    REQUIRE( client->GetTextInRange(0, 4, &text,
+                                    &actualStart, &actualLength) );
+    CHECK( text == original );
+    CHECK( actualStart == 0 );
+    CHECK( actualLength == 4 );
+
+    REQUIRE( client->InsertText("X", 1, 2) );
+    CHECK( m_stc->GetText() == "AXB" );
+    REQUIRE( client->InsertText(
+        "ignored", wxTextInputClient::InvalidPosition, 0) );
+    CHECK( m_stc->GetText() == "AXB" );
+
+    m_stc->SetEmptySelection(m_stc->GetTextLength());
+    REQUIRE( client->SetMarkedText(
+        hiragana, 1, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( client->HasMarkedText() );
+    m_stc->SetIMEInteraction(wxSTC_IME_WINDOWED);
+    CHECK( m_stc->GetText() == "AXB" );
+    CHECK_FALSE( client->HasMarkedText() );
+    CHECK_FALSE( client->IsTextInputEnabled() );
+    m_stc->SetIMEInteraction(wxSTC_IME_INLINE);
+    CHECK( client->IsTextInputEnabled() );
+}
+
+#endif // __WXOSX_COCOA__
+
+#endif // __WXOSX_COCOA__ || __WXGTK__
 
 #endif // defined(__WXOSX_COCOA__) || defined(__WXMSW__) || defined(__WXGTK__)
 

--- a/tests/controls/styledtextctrltest.cpp
+++ b/tests/controls/styledtextctrltest.cpp
@@ -20,6 +20,15 @@
 #include "wx/stc/stc.h"
 #include "wx/uiaction.h"
 
+#if defined(__WXOSX_COCOA__) || defined(__WXGTK__)
+    #include "wx/private/textinput.h"
+#endif
+
+#ifdef __WXOSX_COCOA__
+    #include <objc/message.h>
+    #include <objc/runtime.h>
+#endif
+
 #include "testwindow.h"
 
 #if defined(__WXOSX_COCOA__) || defined(__WXMSW__) || defined(__WXGTK__)
@@ -162,6 +171,263 @@ TEST_CASE_METHOD(StcPopupWindowsTestCase,
 }
 
 #endif // !defined(__WXOSX_COCOA__)
+
+#if defined(__WXOSX_COCOA__) || defined(__WXGTK__)
+
+class StcTextInputTestCase
+{
+public:
+    StcTextInputTestCase()
+        : m_stc(new wxStyledTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY))
+    {
+    }
+
+    ~StcTextInputTestCase()
+    {
+        delete m_stc;
+    }
+
+protected:
+    wxTextInputClient* GetTextInputClient() const
+    {
+        return wxFindTextInputClient(m_stc);
+    }
+
+    wxStyledTextCtrl* const m_stc;
+};
+
+#ifdef __WXGTK__
+
+TEST_CASE_METHOD(StcTextInputTestCase,
+                 "wxStyledTextCtrl::GTKTextInput",
+                 "[wxStyledTextCtrl][ime]")
+{
+    wxTextInputClient* const client = GetTextInputClient();
+    REQUIRE( client );
+    CHECK( client->IsTextInputEnabled() );
+
+    const wxString hiragana =
+        wxString::FromUTF8("\xe3\x81\xab");
+    const wxString kanji =
+        wxString::FromUTF8("\xe6\x97\xa5\xe6\x9c\xac");
+
+    m_stc->SetText("AB");
+    m_stc->EmptyUndoBuffer();
+
+    m_stc->SetSelection(0, 2);
+    REQUIRE( client->UpdateComposition("", 0) );
+    CHECK( m_stc->GetText() == "AB" );
+    CHECK( m_stc->GetSelectionStart() == 0 );
+    CHECK( m_stc->GetSelectionEnd() == 2 );
+    CHECK_FALSE( client->HasActiveComposition() );
+    CHECK_FALSE( client->CommitComposition(kanji) );
+
+    m_stc->SetEmptySelection(1);
+
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    CHECK( m_stc->GetText() == "A" + hiragana + "B" );
+
+    client->CancelComposition();
+    CHECK( m_stc->GetText() == "AB" );
+
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    REQUIRE( client->CommitComposition(kanji) );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+    CHECK_FALSE( client->CommitComposition(kanji) );
+
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == "AB" );
+
+    m_stc->SetEmptySelection(1);
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    m_stc->SetIMEInteraction(wxSTC_IME_WINDOWED);
+    CHECK( m_stc->GetText() == "AB" );
+    CHECK_FALSE( client->IsTextInputEnabled() );
+    m_stc->SetIMEInteraction(wxSTC_IME_INLINE);
+    CHECK( client->IsTextInputEnabled() );
+
+    // Rolling the pre-edit text back relies on undo collection.
+    m_stc->SetUndoCollection(false);
+    CHECK_FALSE( client->IsTextInputEnabled() );
+    CHECK_FALSE( client->UpdateComposition(hiragana, 1) );
+    CHECK( m_stc->GetText() == "AB" );
+    m_stc->SetUndoCollection(true);
+    CHECK( client->IsTextInputEnabled() );
+
+    // Disabling it mid-composition must roll the pre-edit text back while
+    // its undo actions are still available.
+    m_stc->SetEmptySelection(1);
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    m_stc->SetUndoCollection(false);
+    CHECK_FALSE( client->HasActiveComposition() );
+    CHECK( m_stc->GetText() == "AB" );
+    m_stc->SetUndoCollection(true);
+
+    // Composing in virtual space first realizes it as actual whitespace and
+    // the composition starts after it.
+    m_stc->SetText("A");
+    m_stc->EmptyUndoBuffer();
+    m_stc->SetVirtualSpaceOptions(wxSTC_VS_USERACCESSIBLE);
+    m_stc->SetEmptySelection(1);
+    m_stc->SetSelectionNCaretVirtualSpace(0, 3);
+    m_stc->SetSelectionNAnchorVirtualSpace(0, 3);
+    REQUIRE( client->UpdateComposition(hiragana, 1) );
+    CHECK( m_stc->GetText() == "A   " + hiragana );
+    REQUIRE( client->CommitComposition(kanji) );
+    CHECK( m_stc->GetText() == "A   " + kanji );
+}
+
+#endif // __WXGTK__
+
+#ifdef __WXOSX_COCOA__
+
+TEST_CASE_METHOD(StcTextInputTestCase,
+                 "wxStyledTextCtrl::CocoaTextInput",
+                 "[wxStyledTextCtrl][ime]")
+{
+    wxTextInputClient* const client = GetTextInputClient();
+    REQUIRE( client );
+    CHECK( client->IsTextInputEnabled() );
+
+    const wxString hiragana =
+        wxString::FromUTF8("\xe3\x81\xab");
+    const wxString kanji =
+        wxString::FromUTF8("\xe6\x97\xa5\xe6\x9c\xac");
+    const wxString original =
+        wxString::FromUTF8("A\xf0\x9f\x98\x80" "B");
+
+    m_stc->SetText(original);
+    m_stc->EmptyUndoBuffer();
+    m_stc->SetSelection(1, 5);
+
+    REQUIRE( client->SetMarkedText(
+        hiragana, 1, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( m_stc->GetText() == "A" + hiragana + "B" );
+    CHECK( client->HasMarkedText() );
+
+    long start, length;
+    REQUIRE( client->GetMarkedTextRange(&start, &length) );
+    CHECK( start == 1 );
+    CHECK( length == 1 );
+    REQUIRE( client->GetSelectedTextRange(&start, &length) );
+    CHECK( start == 2 );
+    CHECK( length == 0 );
+
+    REQUIRE( client->SetMarkedText(
+        kanji, 2, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+    REQUIRE( client->InsertText(
+        kanji, wxTextInputClient::NoPosition, 0) );
+    CHECK_FALSE( client->HasMarkedText() );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == "AB" );
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == original );
+
+    // After choosing a candidate, some input methods send insertNewline: to
+    // accept it instead of calling insertText:. It must commit the marked
+    // text without inserting a newline.
+    m_stc->SetSelection(1, 5);
+    REQUIRE( client->SetMarkedText(
+        kanji, 2, 0, wxTextInputClient::NoPosition, 0) );
+    using SendSelector = void (*)(void*, SEL, SEL);
+    reinterpret_cast<SendSelector>(objc_msgSend)(
+        m_stc->GetHandle(),
+        sel_registerName("doCommandBySelector:"),
+        sel_registerName("insertNewline:"));
+    CHECK_FALSE( client->HasMarkedText() );
+    CHECK( m_stc->GetText() == "A" + kanji + "B" );
+
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == "AB" );
+    m_stc->Undo();
+    CHECK( m_stc->GetText() == original );
+
+    wxString text;
+    long actualStart, actualLength;
+    REQUIRE( client->GetTextInRange(0, 4, &text,
+                                    &actualStart, &actualLength) );
+    CHECK( text == original );
+    CHECK( actualStart == 0 );
+    CHECK( actualLength == 4 );
+
+    REQUIRE( client->InsertText("X", 1, 2) );
+    CHECK( m_stc->GetText() == "AXB" );
+    REQUIRE( client->InsertText(
+        "ignored", wxTextInputClient::InvalidPosition, 0) );
+    CHECK( m_stc->GetText() == "AXB" );
+
+    m_stc->SetEmptySelection(m_stc->GetTextLength());
+    REQUIRE( client->SetMarkedText(
+        hiragana, 1, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( client->HasMarkedText() );
+    m_stc->SetIMEInteraction(wxSTC_IME_WINDOWED);
+    CHECK( m_stc->GetText() == "AXB" );
+    CHECK_FALSE( client->HasMarkedText() );
+    CHECK_FALSE( client->IsTextInputEnabled() );
+    m_stc->SetIMEInteraction(wxSTC_IME_INLINE);
+    CHECK( client->IsTextInputEnabled() );
+
+    // Rolling the pre-edit text back relies on undo collection.
+    m_stc->SetUndoCollection(false);
+    CHECK_FALSE( client->IsTextInputEnabled() );
+    CHECK_FALSE( client->SetMarkedText(
+        hiragana, 1, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( m_stc->GetText() == "AXB" );
+    m_stc->SetUndoCollection(true);
+    CHECK( client->IsTextInputEnabled() );
+
+    // Disabling it mid-composition must roll the pre-edit text back while
+    // its undo actions are still available.
+    m_stc->SetEmptySelection(1);
+    REQUIRE( client->SetMarkedText(
+        hiragana, 1, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( client->HasMarkedText() );
+    m_stc->SetUndoCollection(false);
+    CHECK_FALSE( client->HasMarkedText() );
+    CHECK( m_stc->GetText() == "AXB" );
+    m_stc->SetUndoCollection(true);
+
+    // Ranges splitting a surrogate pair are extended to the boundaries of
+    // the character containing them.
+    m_stc->SetText(original);
+    m_stc->EmptyUndoBuffer();
+    REQUIRE( client->GetTextInRange(1, 1, &text,
+                                    &actualStart, &actualLength) );
+    CHECK( text == wxString::FromUTF8("\xf0\x9f\x98\x80") );
+    CHECK( actualStart == 1 );
+    CHECK( actualLength == 2 );
+
+    REQUIRE( client->GetTextInRange(2, 1, &text,
+                                    &actualStart, &actualLength) );
+    CHECK( text == "B" );
+    CHECK( actualStart == 3 );
+    CHECK( actualLength == 1 );
+
+    REQUIRE( client->InsertText("X", 1, 1) );
+    CHECK( m_stc->GetText() == "AXB" );
+
+    // Composing in virtual space first realizes it as actual whitespace and
+    // the composition starts after it.
+    m_stc->SetText("A");
+    m_stc->EmptyUndoBuffer();
+    m_stc->SetVirtualSpaceOptions(wxSTC_VS_USERACCESSIBLE);
+    m_stc->SetEmptySelection(1);
+    m_stc->SetSelectionNCaretVirtualSpace(0, 3);
+    m_stc->SetSelectionNAnchorVirtualSpace(0, 3);
+    REQUIRE( client->SetMarkedText(
+        hiragana, 1, 0, wxTextInputClient::NoPosition, 0) );
+    CHECK( m_stc->GetText() == "A   " + hiragana );
+    REQUIRE( client->InsertText(
+        kanji, wxTextInputClient::NoPosition, 0) );
+    CHECK( m_stc->GetText() == "A   " + kanji );
+}
+
+#endif // __WXOSX_COCOA__
+
+#endif // __WXOSX_COCOA__ || __WXGTK__
 
 #endif // defined(__WXOSX_COCOA__) || defined(__WXMSW__) || defined(__WXGTK__)
 


### PR DESCRIPTION
Implement native pre-edit handling for wxGTK and Cocoa using Scintilla's tentative input support.

Use a private text input client bridge to complete Cocoa NSTextInputClient and support GTK pre-edit callbacks without changing the public API or existing class ABI.

Inline composition is now the default on GTK and Cocoa. Committed IME text generates wxEVT_STC_CHARADDED instead of wxEVT_CHAR; wxSTC_IME_WINDOWED retains the previous event path.

Document platform defaults and add regression tests for composition, UTF-16 ranges, replacement ranges, undo, and mode switching.

Closes #26228.