### PR TITLE
Reject TGA images whose declared size cannot fit the input stream

### DIFF
--- a/src/common/imagtga.cpp
+++ b/src/common/imagtga.cpp
@@ -235,6 +235,8 @@ int ReadTGA(wxImage* image, wxInputStream& stream)
     // Read in the TGA header
     unsigned char hdr[HDR_SIZE];
     stream.Read(hdr, HDR_SIZE);
+    if ( stream.LastRead() != HDR_SIZE )
+        return wxTGA_INVFORMAT;
 
     short offset = hdr[HDR_OFFSET] + HDR_SIZE;
     short colorType = hdr[HDR_COLORTYPE];
@@ -249,6 +251,29 @@ int ReadTGA(wxImage* image, wxInputStream& stream)
                  (hdr[HDR_YORIGIN] + 256 * hdr[HDR_YORIGIN + 1]);
     short bpp = hdr[HDR_BPP];
     short orientation = hdr[HDR_ORIENTATION] & 0x20;
+    const short pixelSize = bpp / 8;
+
+    // Sanity-check the dimensions before allocating any buffers. The
+    // claimed image size must fit the input stream: uncompressed TGAs
+    // (image types 1-3) store exactly width*height*pixelSize payload
+    // bytes; RLE variants (types 9-11) can expand by at most ~128:1
+    // per chunk.
+    if (width <= 0 || height <= 0 || pixelSize == 0)
+        return wxTGA_INVFORMAT;
+
+    const unsigned long long imageSize64 =
+        static_cast<unsigned long long>(width) * height * pixelSize;
+
+    const wxFileOffset streamLen = stream.GetLength();
+    if (streamLen > 0)
+    {
+        const bool isRLE = imageType == 9 || imageType == 10 || imageType == 11;
+        const unsigned long long maxAllowed = isRLE
+            ? 128ULL * static_cast<unsigned long long>(streamLen)
+            : static_cast<unsigned long long>(streamLen);
+        if (imageSize64 > maxAllowed)
+            return wxTGA_INVFORMAT;
+    }
 
     image->Create(width, height);
 
@@ -257,9 +282,7 @@ int ReadTGA(wxImage* image, wxInputStream& stream)
         return wxTGA_MEMERR;
     }
 
-    const short pixelSize = bpp / 8;
-
-    const unsigned long imageSize = static_cast<unsigned long>(width) * height * pixelSize;
+    const unsigned long imageSize = static_cast<unsigned long>(imageSize64);
 
     wxScopedArray<unsigned char> imageData(imageSize);
 
@@ -374,6 +397,8 @@ int ReadTGA(wxImage* image, wxInputStream& stream)
             // No compression read the data directly to imageData.
 
             stream.Read(imageData.get(), imageSize);
+            if ( stream.LastRead() != imageSize )
+                return wxTGA_INVFORMAT;
 
             // If orientation == 0, then the image is stored upside down.
             // We need to store it right side up.
@@ -445,6 +470,8 @@ int ReadTGA(wxImage* image, wxInputStream& stream)
             // No compression read the data directly to imageData.
 
             stream.Read(imageData.get(), imageSize);
+            if ( stream.LastRead() != imageSize )
+                return wxTGA_INVFORMAT;
 
             // If orientation == 0, then the image is stored upside down.
             // We need to store it right side up.
@@ -522,6 +549,8 @@ int ReadTGA(wxImage* image, wxInputStream& stream)
             // No compression read the data directly to imageData.
 
             stream.Read(imageData.get(), imageSize);
+            if ( stream.LastRead() != imageSize )
+                return wxTGA_INVFORMAT;
 
             // If orientation == 0, then the image is stored upside down.
             // We need to store it right side up.
@@ -940,6 +969,8 @@ bool wxTGAHandler::DoCanRead(wxInputStream& stream)
     // read the fixed-size TGA headers
     unsigned char hdr[HDR_SIZE];
     stream.Read(hdr, HDR_SIZE);     // it's ok to modify the stream position here
+    if ( stream.LastRead() != HDR_SIZE )
+        return false;               // too short to be a TGA, hdr is not filled in
 
     // Check whether we can read the file or not.
 

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1271,6 +1271,88 @@ TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadBMPPaletteIndex", "[image][bmp]
     REQUIRE( !img.LoadFile(mis, wxBITMAP_TYPE_BMP) );
 }
 
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::BadTGADimensions", "[image][tga][error]")
+{
+    /*
+    A 22 byte file whose header claims a 31232x16382 image at 24bpp.
+    width*height*pixelSize is ~1.5 GB, which the loader used to allocate
+    twice over, for the image and for the scratch buffer, before reading
+    any pixels. It then decoded the whole uninitialised scratch buffer
+    into the image and reported success.
+    */
+    static const unsigned char tooBigTGA[] =
+    {
+        0,          // ID length
+        0,          // Color map type
+        2,          // Image type = uncompressed RGB
+
+        0, 0,       // Color map origin
+        0, 0,       // Color map length
+        0,          // Color map entry size
+
+        0, 0,       // X-origin
+        2, 0,       // Y-origin
+
+        0x00, 0x7a, // Width = 31232
+        0x00, 0x40, // Height = 16384, minus the Y-origin gives 16382
+
+        24,         // Bits per pixel
+        0x20,       // Image descriptor
+
+        // Four bytes of "payload", against the ~1.5 GB claimed above
+        0x00, 0x00, 0xff, 0xff
+    };
+
+    wxMemoryInputStream tooBigStream(tooBigTGA, WXSIZEOF(tooBigTGA));
+
+    REQUIRE( tooBigStream.IsOk() );
+
+    wxImage tgaImage;
+
+    REQUIRE( !tgaImage.LoadFile(tooBigStream, wxBITMAP_TYPE_TGA) );
+}
+
+TEST_CASE_METHOD(ImageHandlersInit, "wxImage::TruncatedTGA", "[image][tga][error]")
+{
+    /*
+    A 2x2 24bpp image needs 12 bytes of pixel data but only 6 follow the
+    header. The declared size is small enough to look plausible next to
+    the stream length, so only checking the amount actually read catches
+    this: the loader used to decode the 6 bytes it never received out of
+    the uninitialised scratch buffer and report success.
+    */
+    static const unsigned char truncatedTGA[] =
+    {
+        0,          // ID length
+        0,          // Color map type
+        2,          // Image type = uncompressed RGB
+
+        0, 0,       // Color map origin
+        0, 0,       // Color map length
+        0,          // Color map entry size
+
+        0, 0,       // X-origin
+        0, 0,       // Y-origin
+
+        2, 0,       // Width = 2
+        2, 0,       // Height = 2
+
+        24,         // Bits per pixel
+        0x20,       // Image descriptor
+
+        // Half of the 12 bytes of pixel data the header promises
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66
+    };
+
+    wxMemoryInputStream truncatedStream(truncatedTGA, WXSIZEOF(truncatedTGA));
+
+    REQUIRE( truncatedStream.IsOk() );
+
+    wxImage tgaImage;
+
+    REQUIRE( !tgaImage.LoadFile(truncatedStream, wxBITMAP_TYPE_TGA) );
+}
+
 #if wxUSE_GIF
 
 TEST_CASE_METHOD(ImageHandlersInit, "wxImage::SaveAnimatedGIF", "[image]")


### PR DESCRIPTION
Closes #26760.

Two changes to `src/common/imagtga.cpp`:

1. Reject a header whose declared image size cannot fit the stream, before either allocation. Uncompressed types have to fit exactly. The RLE types are allowed 128:1, since a packet costs `1 + pixelSize` input bytes and yields at most `128 * pixelSize` output bytes. The check is skipped when `GetLength()` returns no usable value, so non-seekable streams are unaffected.

2. Check `LastRead()` after the header read and after the three uncompressed bulk reads, so a truncated file fails instead of loading. `imagpcx.cpp` has done this since #26624. `DecodeRLE()` already validated its own reads, which is why the RLE paths were already rejecting these files.

`wxTGAHandler::DoCanRead()` gets the same header check, since it was reading an unfilled `hdr` for streams shorter than 18 bytes.

Two regression tests in `tests/image/image.cpp`: Both fail on `d5aacc4712` and pass with this commit. Also verified against the 3.3.3 release, where `src/common/imagtga.cpp` is byte-identical to master.
