### PR TITLE
Validate string lengths and item counts in cached help books

### DIFF
--- a/src/html/helpdata.cpp
+++ b/src/html/helpdata.cpp
@@ -321,9 +321,26 @@ inline static void CacheWriteInt32(wxOutputStream *f, wxInt32 value)
 
 inline static wxInt32 CacheReadInt32(wxInputStream *f)
 {
-    wxInt32 x;
+    wxInt32 x = 0;
     f->Read(&x, sizeof(x));
     return wxINT32_SWAP_ON_BE(x);
+}
+
+// Check a count read from the file before it is used to reserve memory: every
+// item takes at least one byte, so a count larger than the file itself can
+// only come from a corrupted or hostile .cached file.
+inline static bool CacheReadCount(wxInputStream *f, int& count)
+{
+    const wxInt32 stored = CacheReadInt32(f);
+    if ( stored < 0 )
+        return false;
+
+    const wxFileOffset available = f->GetLength();
+    if ( available != wxInvalidOffset && (wxFileOffset)stored > available )
+        return false;
+
+    count = stored;
+    return true;
 }
 
 inline static void CacheWriteString(wxOutputStream *f, const wxString& str)
@@ -334,12 +351,41 @@ inline static void CacheWriteString(wxOutputStream *f, const wxString& str)
     f->Write((const char*)mbstr, len);
 }
 
-inline static wxString CacheReadString(wxInputStream *f)
+// Read a string written by CacheWriteString(), i.e. a byte count including the
+// trailing NUL followed by that many bytes. Returns false for a length that
+// can't have been produced by CacheWriteString(), leaving the file to be
+// treated as unusable by the caller.
+inline static bool CacheReadString(wxInputStream *f, wxString& str)
 {
-    size_t len = (size_t)CacheReadInt32(f);
-    wxCharBuffer str(len-1);
-    f->Read(str.data(), len);
-    return wxString(str, wxConvUTF8);
+    const wxInt32 stored = CacheReadInt32(f);
+
+    // CacheWriteString() always counts the trailing NUL, so the shortest
+    // string it can write has a length of 1. Anything less would underflow
+    // when computing the size of the buffer below.
+    if ( stored < 1 )
+        return false;
+
+    const size_t len = (size_t)stored;
+
+    // A single string can't be longer than the file containing it.
+    const wxFileOffset available = f->GetLength();
+    if ( available != wxInvalidOffset && (wxFileOffset)len > available )
+        return false;
+
+    // wxCharBuffer allocates len + 1 bytes and puts a NUL in the last one, so
+    // reading len bytes into it leaves that terminator intact.
+    wxCharBuffer buf(len);
+    if ( f->Read(buf.data(), len).LastRead() != len )
+        return false;
+
+    // CacheWriteString() always writes the terminator, so a file lacking it is
+    // malformed. Checking for it also means the conversion below never has to
+    // go looking for one.
+    if ( buf.data()[len - 1] != '\0' )
+        return false;
+
+    str = wxString(buf.data(), wxConvUTF8, len - 1);
+    return true;
 }
 
 #define CURRENT_CACHED_BOOK_VERSION     5
@@ -369,29 +415,34 @@ bool wxHtmlHelpData::LoadCachedBook(wxHtmlBookRecord *book, wxInputStream *f)
         return false;
 
     /* load contents : */
+    int count;
+    if (!CacheReadCount(f, count))
+        return false;
     st = m_contents.size();
-    newsize = st + CacheReadInt32(f);
+    newsize = st + count;
     m_contents.Alloc(newsize);
     for (i = st; i < newsize; i++)
     {
-        wxHtmlHelpDataItem *item = new wxHtmlHelpDataItem;
+        auto item = std::make_unique<wxHtmlHelpDataItem>();
         item->level = CacheReadInt32(f);
         item->id = CacheReadInt32(f);
-        item->name = CacheReadString(f);
-        item->page = CacheReadString(f);
+        if (!CacheReadString(f, item->name) || !CacheReadString(f, item->page))
+            return false;
         item->book = book;
-        m_contents.Add(item);
+        m_contents.Add(item.release());
     }
 
     /* load index : */
+    if (!CacheReadCount(f, count))
+        return false;
     st = m_index.size();
-    newsize = st + CacheReadInt32(f);
+    newsize = st + count;
     m_index.Alloc(newsize);
     for (i = st; i < newsize; i++)
     {
         auto item = std::make_unique<wxHtmlHelpDataItem>();
-        item->name = CacheReadString(f);
-        item->page = CacheReadString(f);
+        if (!CacheReadString(f, item->name) || !CacheReadString(f, item->page))
+            return false;
         item->level = CacheReadInt32(f);
         item->book = book;
         int parentShift = CacheReadInt32(f);

--- a/tests/html/helpdata.cpp
+++ b/tests/html/helpdata.cpp
@@ -78,4 +78,91 @@ TEST_CASE("wxHtmlHelpData::BadCachedParent", "[html][help][error]")
     CHECK( !data.DoLoadCachedBook(&book, is) );
 }
 
+namespace
+{
+
+// Write a string field whose declared length is decided by the caller instead
+// of being derived from the payload, which is what CacheWriteString() does and
+// so what a hostile file can do.
+void CacheWriteRawString(wxMemoryOutputStream& s, wxInt32 declaredLen,
+                         const char* payload, size_t payloadLen)
+{
+    CacheWriteInt32(s, declaredLen);
+    if ( payloadLen )
+        s.Write(payload, payloadLen);
+}
+
+// A .cached file carrying a single contents item, whose name field is written
+// by the caller.
+bool LoadWithContentsName(wxInt32 declaredLen,
+                          const char* payload, size_t payloadLen)
+{
+    wxMemoryOutputStream os;
+    CacheWriteInt32(os, 5); // CURRENT_CACHED_BOOK_VERSION
+    CacheWriteInt32(os, 1); // CACHED_BOOK_FORMAT_FLAGS
+
+    CacheWriteInt32(os, 1); // contents count
+    CacheWriteInt32(os, 0); // level
+    CacheWriteInt32(os, 0); // id
+    CacheWriteRawString(os, declaredLen, payload, payloadLen);
+    CacheWriteString(os, "page.htm");
+
+    CacheWriteInt32(os, 0); // index count
+
+    wxStreamBuffer* buf = os.GetOutputStreamBuffer();
+    wxMemoryInputStream is(buf->GetBufferStart(), buf->GetIntPosition());
+
+    wxHtmlBookRecord book("test.hhp", "", "Test", "page.htm");
+    TestHelpData data;
+    return data.DoLoadCachedBook(&book, is);
+}
+
+} // anonymous namespace
+
+// CacheWriteString() counts the trailing NUL, so a length of 0 cannot occur in
+// a file it produced. Reading one used to compute a buffer size of len - 1,
+// which underflows to SIZE_MAX, and wxCharBuffer then allocated (SIZE_MAX + 1)
+// bytes, i.e. none, before writing a NUL one byte in front of the block.
+TEST_CASE("wxHtmlHelpData::CachedStringZeroLength", "[html][help][error]")
+{
+    CHECK( !LoadWithContentsName(0, nullptr, 0) );
+}
+
+// A length that is not followed by a terminator used to leave the wxString
+// constructor scanning past the end of the buffer.
+TEST_CASE("wxHtmlHelpData::CachedStringUnterminated", "[html][help][error]")
+{
+    CHECK( !LoadWithContentsName(8, "AAAAAAAA", 8) );
+}
+
+// A string cannot be longer than the file holding it.
+TEST_CASE("wxHtmlHelpData::CachedStringTooLong", "[html][help][error]")
+{
+    CHECK( !LoadWithContentsName(0x7FFFFFFF, nullptr, 0) );
+}
+
+// Nor can a negative length, which used to be cast to a huge size_t.
+TEST_CASE("wxHtmlHelpData::CachedStringNegativeLength", "[html][help][error]")
+{
+    CHECK( !LoadWithContentsName(-1, nullptr, 0) );
+}
+
+// The item counts are used to reserve memory before anything is read, so they
+// have to be bounded by the file as well.
+TEST_CASE("wxHtmlHelpData::CachedCountTooLarge", "[html][help][error]")
+{
+    wxMemoryOutputStream os;
+    CacheWriteInt32(os, 5);
+    CacheWriteInt32(os, 1);
+    CacheWriteInt32(os, 0x7FFFFFF0); // contents count, far beyond the file
+
+    wxStreamBuffer* buf = os.GetOutputStreamBuffer();
+    wxMemoryInputStream is(buf->GetBufferStart(), buf->GetIntPosition());
+
+    wxHtmlBookRecord book("test.hhp", "", "Test", "page.htm");
+    TestHelpData data;
+
+    CHECK( !data.DoLoadCachedBook(&book, is) );
+}
+
 #endif // wxUSE_HTML


### PR DESCRIPTION
Closes https://github.com/wxWidgets/wxWidgets/issues/26765: 

`CacheReadString()` now returns a bool and takes the string by reference, so a `.cached` file that `CacheWriteString()` could not have produced is rejected instead of being acted on:

- a stored length below 1 is refused, which is what made `len - 1` underflow to  `SIZE_MAX` and `wxCharBuffer` write its terminator one byte in front of a  zero-sized block
- a length larger than the file is refused
- the buffer is sized as `len` rather than `len - 1`, so reading `len` bytes leaves the terminator intact. `ReadString()` in `src/common/zipstrm.cpp:88`  already does it this way
- the read has to deliver the bytes it asked for
- the last byte has to be the NUL that `CacheWriteString()` always writes, and  the string is then built from the known length rather than by scanning

A new `CacheReadCount()` bounds the contents and index counts against the file before `Alloc()` sees them, since a count larger than the file cannot be real. `CacheReadInt32()` initialises its temporary. The contents loop moves to
`std::make_unique` so the new early returns cannot leak, which is what the index loop already does since `ebd86dee67`.

Five tests in `tests/html/helpdata.cpp`, next to the existing `BadCachedParent`.
Checked under ASAN as well: the five `.htb` files from the issue report a heap-buffer-overflow write, an allocator abort or a hang before the change, and are clean after it.
