### PR TITLE
OSX guard toolbar toggle button when no bitmap present

### DIFF
--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -584,7 +584,7 @@ void wxToolBarTool::UpdateImages()
 {
     [(NSButton*) m_controlHandle setImage:wxOSXGetImageFromBundle(m_bmpNormal)];
 
-    if ( CanBeToggled() )
+    if ( CanBeToggled() && m_bmpNormal.IsOk() )
     {
         // TODO CS this should use the best current representation, or optionally iterate through all
         wxSize sz = m_bmpNormal.GetDefaultSize();


### PR DESCRIPTION
see bug #26763 and related fix PR by its author 