### PR TITLE
Description of wxMakeGuard

### DIFF
--- a/interface/wx/scopeguard.h
+++ b/interface/wx/scopeguard.h
@@ -41,34 +41,18 @@ public:
 ///@{
 /**
     Returns a scope guard object which will call the specified function with
-    the given parameters on scope exit; actually, there four defined, for zero
-    to three parameters.
+    the given parameters on scope exit; actually, there are four defined, for
+    zero to three parameters.
 
     This function is overloaded to take several parameters up to some
-    implementation-defined (but relatively low) limit.
+    implementation-defined (but relatively low) limit (actually three).
 
     The @a func should be a functor taking parameters of the types P1, ..., PN,
     i.e. the expression @c func(p1, ..., pN) should be valid.
-
-    In pseudo-code:
-
-    @code
-    template <typename F, typename P1, ..., typename PN>
-    wxScopeGuard wxMakeGuard(F func, P1 p1, ..., PN pN);
-    @endcode
  */
 
-template <typename F>
-wxScopeGuard wxMakeGuard(F fun);
-
-template <typename F, typename P1>
-wxScopeGuard wxMakeGuard(F fun, P1 p1);
-
-template <typename F, typename P1, typename P2>
-wxScopeGuard wxMakeGuard(F fun, P1 p1, P2 p2);
-
-template <typename F, typename P1, typename P2, typename P3>
-wxScopeGuard wxMakeGuard(F fun, P1 p1, P2 p2, P3 p3);
+template <typename F, typename ...P>
+wxScopeGuard wxMakeGuard(F fun, P ...p);
 
 ///@}
 

--- a/interface/wx/scopeguard.h
+++ b/interface/wx/scopeguard.h
@@ -41,16 +41,34 @@ public:
 ///@{
 /**
     Returns a scope guard object which will call the specified function with
-    the given parameters on scope exit.
+    the given parameters on scope exit; actually, there four defined, for zero
+    to three parameters.
 
     This function is overloaded to take several parameters up to some
     implementation-defined (but relatively low) limit.
 
     The @a func should be a functor taking parameters of the types P1, ..., PN,
     i.e. the expression @c func(p1, ..., pN) should be valid.
+
+    In pseudo-code:
+
+    @code
+    template <typename F, typename P1, ..., typename PN>
+    wxScopeGuard wxMakeGuard(F func, P1 p1, ..., PN pN);
+    @endcode
  */
-template <typename F, typename P1, ..., typename PN>
-wxScopeGuard wxMakeGuard(F func, P1 p1, ..., PN pN);
+
+template <typename F>
+wxScopeGuard wxMakeGuard(F fun);
+
+template <typename F, typename P1>
+wxScopeGuard wxMakeGuard(F fun, P1 p1);
+
+template <typename F, typename P1, typename P2>
+wxScopeGuard wxMakeGuard(F fun, P1 p1, P2 p2);
+
+template <typename F, typename P1, typename P2, typename P3>
+wxScopeGuard wxMakeGuard(F fun, P1 p1, P2 p2, P3 p3);
 
 ///@}
 


### PR DESCRIPTION
I’m not sure about this one.

When I first saw the description of wxMakeGuard, I bugged seeing what was looking like a variadic parameter, not at the end where it should be. To understand, I had a look at the source and saw there are multiple definitions, which explains why the comment mentions overloading.

The change exposes the implementation defined limit. I’m unsure about that, because it seems it is not to be exposed. On an other hand, there is a single implementation, this is not like an interface to various possible implementations. I still left the note about uncertainty, because it may tell their count may vary in future versions.

In the HTML, the explanation appears only for the first definition, but the three other definitions follow immediately after.

The original signature is kept in a comment presenting it as a pseudo‑code illustration, which it was.

In the interface description, the template parameters are typename, while in the source, they are class. May be it makes a difference with dynamic dispatch, I don’t know C++ well enough to tell. I kept what was in the original, typename.

For the return type, I also kept what's in the original, which should be OK, since this type is a base type for the really returned types.
