### PR TITLE
Do not build the MFC sample with CMake when linking CRT statically

### DIFF
--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -286,7 +286,8 @@ if(WIN32)
         wx_add_sample(taskbarbutton DEPENDS wxUSE_TASKBARBUTTON)
 
         # only check if MFC is available when the mfc sample is enabled
-        if(wxBUILD_SAMPLES STREQUAL "ALL")
+        # MFC sample links MFC dynamically, which cannot be done when linking the CRT statically
+        if(wxBUILD_SAMPLES STREQUAL "ALL" AND NOT wxBUILD_USE_STATIC_RUNTIME)
             find_package(MFC QUIET)
             if(MFC_FOUND)
                 wx_add_sample(mfc mfctest.cpp mfctest.h resource.h stdafx.h RES mfctest.rc)


### PR DESCRIPTION
I have originally tried to make the sample work even when linking the CRT statically with
```diff
diff --git a/samples/mfc/stdafx.h b/samples/mfc/stdafx.h
index a814f87e7f..86a22b0afc 100644
--- a/samples/mfc/stdafx.h
+++ b/samples/mfc/stdafx.h
@@ -1,7 +1,7 @@
 // normally this is defined by the IDE by "Using MFC" option but if it isn't
 // (e.g. because we use bakefile-generated projects), do it ourselves to ensure
 // that MFC libraries are linked in
-#ifndef _AFXDLL
+#if !defined(_AFXDLL) && defined(_DLL)
     #define _AFXDLL
 #endif
 #include <afxwin.h>
```
The sample worked great but when shutting it down I got an exception
 >	[Exception thrown at 0x00007FFED9A476BD (ntdll.dll) in mfc.exe: 0xC0000005: Access violation reading location 0x0000000000000012.]		Annotated Frame
 	ntdll.dll!00007ffed9a476bd()	Unknown	No symbols loaded.
>	mfc.exe!__vcrt_uninitialize_locks() Line 45	C++	Symbols loaded.
 	ntdll.dll!00007ffed9acad6c()	Unknown	No symbols loaded.

I probably could not figure what is wrong, this is a rather niche sample and edge case, so I opted for the simplest solution: Do not attempt to build the sample when it is doomed to fail.