### PR TITLE
Fix GTK-CRITICAL when SetBitmap() is called after Append() on a wxMenuItem

### DIFF
--- a/src/gtk/menu.cpp
+++ b/src/gtk/menu.cpp
@@ -1009,7 +1009,17 @@ void wxMenu::GtkAppend(wxMenuItem* mitem, int pos)
                     // that it never hurts to follow GTK+ conventions more closely
                     menuItem = gtk_image_menu_item_new_from_stock(stockid, nullptr);
                 else
-                    menuItem = gtk_menu_item_new_with_label("");
+                    // Even though no bitmap is set yet, still create an
+                    // image-capable item: SetBitmap() is commonly called
+                    // after Append() returns (Append() returns the new
+                    // wxMenuItem* precisely to support this), and
+                    // SetupBitmaps() later calls
+                    // gtk_image_menu_item_set_image(), which requires the
+                    // underlying widget to already be a GtkImageMenuItem.
+                    // A GtkImageMenuItem with no image behaves the same as
+                    // a plain GtkMenuItem, so this is harmless when no
+                    // bitmap is ever set.
+                    menuItem = gtk_image_menu_item_new_with_label("");
             }
             wxGCC_WARNING_RESTORE()
 #endif


### PR DESCRIPTION
## Bug

`wxMenu::GtkAppend()` (`src/gtk/menu.cpp`) decides whether to build a
`GtkImageMenuItem` or a plain `GtkMenuItem` based on
`mitem->GetBitmap().IsOk()` **at `Append()` time**:

```cpp
case wxITEM_NORMAL:
    if (mitem->GetBitmap().IsOk())
        menuItem = gtk_image_menu_item_new_with_label("");
    else
    {
        const char* stockid = wxGetStockGtkID(mitem->GetId());
        if (stockid)
            menuItem = gtk_image_menu_item_new_from_stock(stockid, nullptr);
        else
            menuItem = gtk_menu_item_new_with_label(""); // <-- plain item
    }
```

But `wxMenu::Append()` returns the new `wxMenuItem*` precisely to
support the common idiom:

```cpp
menu->Append(id, label)->SetBitmap(bmp);
```

Here `SetBitmap()` runs *after* `Append()` already built the
underlying GTK widget. For any non-stock `id`, that widget ends up
being a plain `GtkMenuItem`. Later, whenever the menu is actually
shown (`wxWindowGTK::DoPopupMenu()` → `wxMenu::SetupBitmaps()` →
`wxMenuItem::SetupBitmaps()`), wx calls:

```cpp
gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(m_menuItem), image);
```

on that plain `GtkMenuItem`, which trips the `GTK_IS_IMAGE_MENU_ITEM`
assertion:

```
Gtk-CRITICAL **: gtk_image_menu_item_set_image: assertion 'GTK_IS_IMAGE_MENU_ITEM (image_menu_item)' failed
```

and the bitmap is silently never attached.

## Repro

Minimal standalone repro (not included in this PR, happy to attach if
useful):

```cpp
wxMenu menu;
menu.Append(wxID_HIGHEST + 1000, "Test Item")->SetBitmap(wxBitmap(16, 16));
PopupMenu(&menu, wxPoint(20, 20));
```

Confirmed present on both the `3.2` branch and `master`, built from
source (not just the Fedora-packaged wx), with `--with-gtk=3` and
system third-party libs.

## Fix

Always build a `GtkImageMenuItem` for `wxITEM_NORMAL` (unless a stock
GTK id already provides one via `gtk_image_menu_item_new_from_stock`).
An empty `GtkImageMenuItem` behaves identically to a plain
`GtkMenuItem`, so this is a no-op for items that never get a bitmap,
and fixes the assertion (and the missing icon) for items that get
`SetBitmap()` called after `Append()`.

Verified: rebuilt both `3.2` and `master` from source with the fix
applied, reran the repro above — no assertion, clean stderr.

A separate PR with the same fix against the `3.2` branch will follow
if useful; let me know your preference on which branch should take
this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)