### PR TITLE
Use system colors for generic calendar header

### DIFF
--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -161,9 +161,6 @@ void wxGenericCalendarCtrl::InitColours()
 
     m_colHolidayFg = *wxRED;
     // don't set m_colHolidayBg - by default, same as our bg colour
-
-    m_colHeaderFg = *wxBLUE;
-    m_colHeaderBg = *wxLIGHT_GREY;
 }
 
 bool wxGenericCalendarCtrl::Create(wxWindow *parent,
@@ -802,14 +799,19 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
     wxCoord y = 0;
     wxCoord x0 = m_calendarWeekWidth;
 
+    const wxColour colHeaderBg = m_colHeaderBg.IsOk() ? m_colHeaderBg :
+        wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    const wxColour colHeaderFg = m_colHeaderFg.IsOk() ? m_colHeaderFg :
+        wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+
     if ( HasFlag(wxCAL_SEQUENTIAL_MONTH_SELECTION) )
     {
         // draw the sequential month-selector
 
         dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
-        dc.SetTextForeground(*wxBLACK);
-        dc.SetBrush(wxBrush(m_colHeaderBg, wxBRUSHSTYLE_SOLID));
-        dc.SetPen(wxPen(m_colHeaderBg, 1, wxPENSTYLE_SOLID));
+        dc.SetTextForeground(colHeaderFg);
+        dc.SetBrush(wxBrush(colHeaderBg));
+        dc.SetPen(wxPen(colHeaderBg));
         dc.DrawRectangle(0, y, GetClientSize().x, m_heightRow);
 
         // Get extent of month-name + year
@@ -852,8 +854,8 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
             if ( IsDateInRange(ldpm) && ( ( ldpm.GetYear() == m_date.GetYear() ) ? true : AllowYearChange() ) )
             {
                 m_leftArrowRect = wxRect(larrowx - rectx + 1, arrowy - recty, (arrowheight / 2) + 2 * rectx, (arrowheight + 2 * recty));
-                dc.SetBrush(*wxBLACK_BRUSH);
-                dc.SetPen(*wxBLACK_PEN);
+                dc.SetBrush(wxBrush(colHeaderFg));
+                dc.SetPen(wxPen(colHeaderFg));
                 dc.DrawPolygon(3, leftarrow, larrowx , arrowy, wxWINDING_RULE);
                 dc.SetBrush(*wxTRANSPARENT_BRUSH);
                 dc.DrawRectangle(m_leftArrowRect);
@@ -862,8 +864,8 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
             if ( IsDateInRange(fdnm) && ( ( fdnm.GetYear() == m_date.GetYear() ) ? true : AllowYearChange() ) )
             {
                 m_rightArrowRect = wxRect(rarrowx - rectx, arrowy - recty, (arrowheight / 2) + 2 * rectx, (arrowheight + 2 * recty));
-                dc.SetBrush(*wxBLACK_BRUSH);
-                dc.SetPen(*wxBLACK_PEN);
+                dc.SetBrush(wxBrush(colHeaderFg));
+                dc.SetPen(wxPen(colHeaderFg));
                 dc.DrawPolygon(3, rightarrow, rarrowx , arrowy, wxWINDING_RULE);
                 dc.SetBrush(*wxTRANSPARENT_BRUSH);
                 dc.DrawRectangle(m_rightArrowRect);
@@ -881,9 +883,9 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 #endif
 
         dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
-        dc.SetTextForeground(m_colHeaderFg);
-        dc.SetBrush(wxBrush(m_colHeaderBg, wxBRUSHSTYLE_SOLID));
-        dc.SetPen(wxPen(m_colHeaderBg, 1, wxPENSTYLE_SOLID));
+        dc.SetTextForeground(colHeaderFg);
+        dc.SetBrush(wxBrush(colHeaderBg));
+        dc.SetPen(wxPen(colHeaderBg));
         dc.DrawRectangle(0, y, GetClientSize().x, m_heightRow);
 
         bool startOnMonday = WeekStartsOnMonday();
@@ -906,14 +908,23 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 
     y += m_heightRow;
 
+    // Draw a horizontal line under the header.
+    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRIDLINES)));
+    dc.DrawLine(0, y, GetClientSize().x, y);
+
     // draw column with calendar week nr
     if ( HasFlag( wxCAL_SHOW_WEEK_NUMBERS ) && IsExposed( 0, y, m_calendarWeekWidth, m_heightRow * 6 ))
     {
-        dc.SetTextForeground(*wxBLACK);
+        dc.SetTextForeground(colHeaderFg);
         dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
-        dc.SetBrush(wxBrush(m_colHeaderBg, wxBRUSHSTYLE_SOLID));
-        dc.SetPen(wxPen(m_colHeaderBg, 1, wxPENSTYLE_SOLID));
+        dc.SetBrush(wxBrush(colHeaderBg));
+        dc.SetPen(wxPen(colHeaderBg));
         dc.DrawRectangle( 0, y, m_calendarWeekWidth, m_heightRow * 6 );
+
+        // Draw a vertical line to the right of week numbers.
+        dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRIDLINES)));
+        dc.DrawLine(m_calendarWeekWidth, y, m_calendarWeekWidth, m_heightRow * 6);
+
         wxDateTime date = GetStartDate();
         for ( size_t i = 0; i < 6; ++i )
         {


### PR DESCRIPTION
Use system colors for the generic calendar header instead of blue and gray. A separator line is drawn below the header. This makes the control look consistent with the Win32 and WinUI 3 controls. Custom header colors are not overwritten by system color change event. See #25552.