### PR TITLE
Fix memory leak in GTK WebKit2

### DIFF
--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -511,6 +511,7 @@ wxgtk_webview_webkit_uri_scheme_request_cb(WebKitURISchemeRequest *request,
                                                                        g_free);
             wxString mime = file->GetMimeType();
             webkit_uri_scheme_request_finish(request, stream, length, mime.utf8_str());
+            g_object_unref(stream);
         }
         else
         {


### PR DESCRIPTION
Needed to call `g_object_unref` (see https://webkitgtk.org/reference/webkit2gtk/2.38.3/method.WebContext.register_uri_scheme.html for example).