### PR TITLE
Attempt to fix scrollbar corner colour in wxMSW dark mode for all windows

### DIFF
--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -89,10 +89,6 @@ namespace wxMSWImpl
 // so it's implemented there as well.
 void EnableRoundCorners(HWND hwnd);
 
-// This function draws over the section where the scroll bars meet
-// to maintain a consistent theme
-void PaintScrollBarCorner(HWND hwnd);
-
 } // namespace wxMSWImpl
 
 #endif // _WX_MSW_PRIVATE_DARKMODE_H_

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -795,6 +795,9 @@ private:
 
     int MSWGetBorderThickness() const;
 
+
+    void MSWDarkPaintScrollBarCorner();
+
     static inline bool MSWIsPositionDirectlySupported(int x, int y)
     {
         // The supported coordinate intervals for various functions are:

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -851,33 +851,6 @@ void NotifySysColorChange()
 
 } // namespace wxMSWDarkMode
 
-void wxMSWImpl::PaintScrollBarCorner(HWND hwnd)
-{
-    WinStruct<SCROLLBARINFO> sbiV, sbiH;
-
-    if ( !::GetScrollBarInfo(hwnd, OBJID_VSCROLL, &sbiV) ||
-         !::GetScrollBarInfo(hwnd, OBJID_HSCROLL, &sbiH) ||
-            (sbiV.rgstate[0] & STATE_SYSTEM_INVISIBLE) ||
-            (sbiH.rgstate[0] & STATE_SYSTEM_INVISIBLE))
-    {
-        return;
-    }
-
-    const RECT windowRect = wxGetWindowRect(hwnd);
-
-    RECT rectToPaint;
-    rectToPaint.left = sbiV.rcScrollBar.left - windowRect.left;
-    rectToPaint.top = sbiH.rcScrollBar.top - windowRect.top;
-
-    // Constrain outer limits by exactly -1 to snap cleanly to the visual frame edge
-    rectToPaint.right = (windowRect.right - windowRect.left) - 1;
-    rectToPaint.bottom = (windowRect.bottom - windowRect.top) - 1;
-
-    WindowHDC hdcWin(hwnd);
-    AutoHBRUSH hBrush(RGB(0x17, 0x17, 0x17));
-    ::FillRect(hdcWin, &rectToPaint, hBrush);
-}
-
 #else // !wxUSE_DARK_MODE
 
 bool
@@ -968,10 +941,6 @@ void NotifySysColorChange()
 }
 
 } // namespace wxMSWDarkMode
-
-void wxMSWImpl::PaintScrollBarCorner(HWND WXUNUSED(hwnd))
-{
-}
 
 #endif // wxUSE_DARK_MODE/!wxUSE_DARK_MODE
 

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -737,7 +737,7 @@ HandleMenuMessage(WXLRESULT* result,
             // which is one pixel too small), so we have to draw over it here
             // to get rid of it.
             {
-                *result = w->MSWDefWindowProc(nMsg, wParam, lParam);
+                *result = w->wxWindow::MSWWindowProc(nMsg, wParam, lParam);
 
                 HWND hwnd = GetHwndOf(w);
                 WindowHDC hdc(hwnd);

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3742,20 +3742,6 @@ wxListCtrl::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
             // PRF_CHILDREN flag, so leave it to the native control itself
             return MSWDefWindowProc(nMsg, wParam, lParam);
 
-        case WM_NCPAINT:
-            // In dark mode the corner between the 2 scrollbars is not drawn in
-            // the correct colour by default, so paint it over if necessary.
-            if ( wxMSWDarkMode::IsActive() )
-            {
-                // Let the control paint itself first.
-                auto const rc =
-                    wxListCtrlBase::MSWWindowProc(nMsg, wParam, lParam);
-
-                wxMSWImpl::PaintScrollBarCorner(GetHwnd());
-                return rc;
-            }
-            break;
-
         case WM_CONTEXTMENU:
             // because this message is propagated upwards the child-parent
             // chain, we get it for the right clicks on the header window but

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -36,7 +36,6 @@
 #include <windowsx.h> // needed by GET_X_LPARAM and GET_Y_LPARAM macros
 
 #include "wx/msw/private.h"
-#include "wx/msw/private/darkmode.h"
 #include "wx/msw/winundef.h"
 #include "wx/msw/private/winstyle.h"
 
@@ -2787,15 +2786,6 @@ wxTreeCtrl::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
     bool processed = false;
     WXLRESULT rc = 0;
     bool isMultiple = HasFlag(wxTR_MULTIPLE);
-
-    if ( nMsg == WM_NCPAINT && wxMSWDarkMode::IsActive() )
-    {
-        // As with wxListCtrl, we need to draw the corner between two
-        // scrollbars ourselves in dark mode to give it correct colour.
-        rc = wxTreeCtrlBase::MSWWindowProc(nMsg, wParam, lParam);
-        wxMSWImpl::PaintScrollBarCorner(GetHwnd());
-        return rc;
-    }
 
     if ( nMsg == WM_CONTEXTMENU )
     {

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3892,6 +3892,23 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         wxWindowMSW::MSWDrawThemeBorder(hdc);
                     }
                 }
+
+                if ( wxMSWDarkMode::IsActive() )
+                {
+                    const long style = ::GetWindowLong(GetHwnd(), GWL_STYLE);
+
+                    // In dark mode the corner between the two scrollbars is not drawn in
+                    // the correct colour by Windows, so we need to paint it ourselves.
+                    if ( (style & WS_HSCROLL) && (style & WS_VSCROLL) )
+                    {
+                        if ( !processed )
+                        {
+                            rc.result = MSWDefWindowProc(message, wParam, lParam);
+                            processed = true;
+                        }
+                        MSWDarkPaintScrollBarCorner();
+                    }
+                }
             }
             break;
 
@@ -3949,6 +3966,34 @@ void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc)
         // Draw the border
         hTheme.DrawBackground(hdc, rcBorder, EP_EDITTEXT, ETS_NORMAL);
     }
+}
+
+// This function draws over the section where the scroll bars meet
+// to maintain a consistent theme in dark mode.
+void wxWindowMSW::MSWDarkPaintScrollBarCorner()
+{
+    const HWND hwnd = GetHwnd();
+    WinStruct<SCROLLBARINFO> sbiV, sbiH;
+
+    if ( !::GetScrollBarInfo(hwnd, OBJID_VSCROLL, &sbiV) ||
+         !::GetScrollBarInfo(hwnd, OBJID_HSCROLL, &sbiH) ||
+            (sbiV.rgstate[0] & STATE_SYSTEM_INVISIBLE) ||
+            (sbiH.rgstate[0] & STATE_SYSTEM_INVISIBLE))
+    {
+        return;
+    }
+
+    const RECT windowRect = wxGetWindowRect(hwnd);
+    RECT rectToPaint;
+
+    rectToPaint.left = sbiV.rcScrollBar.left - windowRect.left;
+    rectToPaint.top = sbiH.rcScrollBar.top - windowRect.top;
+    rectToPaint.right = rectToPaint.left + wxGetSystemMetrics(SM_CXVSCROLL, this);
+    rectToPaint.bottom = rectToPaint.top + wxGetSystemMetrics(SM_CYHSCROLL, this);
+
+    WindowHDC hdcWin(hwnd);
+    AutoHBRUSH hBrush(RGB(0x17, 0x17, 0x17));
+    ::FillRect(hdcWin, &rectToPaint, hBrush);
 }
 
 WXLRESULT wxWindowMSW::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lParam)

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3892,7 +3892,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         wxWindowMSW::MSWDrawThemeBorder(hdc);
                     }
                 }
-
+#ifndef __WXUNIVERSAL__ // wxUniversal doesn't support wxMSW dark mode and MSWDarkPaintScrollBarCorner() would not build there
                 if ( wxMSWDarkMode::IsActive() )
                 {
                     const long style = ::GetWindowLong(GetHwnd(), GWL_STYLE);
@@ -3909,6 +3909,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         MSWDarkPaintScrollBarCorner();
                     }
                 }
+#endif //#ifndef __WXUNIVERSAL__
             }
             break;
 
@@ -3972,6 +3973,9 @@ void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc)
 // to maintain a consistent theme in dark mode.
 void wxWindowMSW::MSWDarkPaintScrollBarCorner()
 {
+// wxUniversal doesn't support wxMSW dark mode
+// the code would not even build there due to wxWindow* argument type mismatch in wxGetSystemMetrics() calls
+#ifndef __WXUNIVERSAL__
     const HWND hwnd = GetHwnd();
     WinStruct<SCROLLBARINFO> sbiV, sbiH;
 
@@ -3994,6 +3998,7 @@ void wxWindowMSW::MSWDarkPaintScrollBarCorner()
     WindowHDC hdcWin(hwnd);
     AutoHBRUSH hBrush(RGB(0x17, 0x17, 0x17));
     ::FillRect(hdcWin, &rectToPaint, hBrush);
+#endif // ifndef __WXUNIVERSAL__
 }
 
 WXLRESULT wxWindowMSW::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lParam)

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3991,6 +3991,10 @@ void wxWindowMSW::MSWDarkPaintScrollBarCorner()
     RECT rectToPaint;
 
     rectToPaint.left = sbiV.rcScrollBar.left - windowRect.left;
+    if ( ::GetWindowLong(hwnd, GWL_EXSTYLE) & WS_EX_LAYOUTRTL )
+        rectToPaint.left = windowRect.right - sbiV.rcScrollBar.right;
+    else
+        rectToPaint.left = sbiV.rcScrollBar.left - windowRect.left;
     rectToPaint.top = sbiH.rcScrollBar.top - windowRect.top;
     rectToPaint.right = rectToPaint.left + wxGetSystemMetrics(SM_CXVSCROLL, this);
     rectToPaint.bottom = rectToPaint.top + wxGetSystemMetrics(SM_CYHSCROLL, this);


### PR DESCRIPTION
This is an attempt ~~(not working perfectly)~~ to  generalize 0f8a8d2, where I tried to handling the scrollbar corner painting for all windows where needed.

I opted for maybe not the prettiest but the simplest possible solution by adding the following code to `WM_NCPAINT` handler in `wxWindow` :
```diff
diff --git a/src/msw/window.cpp b/src/msw/window.cpp
index 900a632f1b..04b0a1baa8 100644
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3891,6 +3891,20 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                         wxWindowMSW::MSWDrawThemeBorder(hdc);
                     }
                 }
+                if ( wxMSWDarkMode::IsActive() )
+                {
+                    const long style = GetWindowLong(GetHwnd(), GWL_STYLE);
+
+                    if ( (style & WS_HSCROLL) && (style & WS_VSCROLL) )
+                    {
+                        if ( !processed )
+                        {
+                            rc.result = MSWDefWindowProc(message, wParam, lParam);
+                            processed = true;
+                        }
+                        wxMSWImpl::PaintScrollBarCorner(GetHwnd());
+                    }
+                }
             }
             break;
```

I then started testing with samples. It seems to work great with controls in many samples (e.g,. _treectrl_, _listctrl_, _text_, or _stc_);  but some samples have visual glitches where drawing the corner seems to collide with the control border.

For example, _grid_ (also e.g. in _htmltest_ or _drawing_ samples) seems to have an extra horizontal line:
<img width="800" height="508" alt="wx-corner-grid" src="https://github.com/user-attachments/assets/7a47ecf5-4cff-44ad-8b61-1b7f5e915af6" />

and the `wxScrolled` in _widgets_ sample seems to draw an extra corner, where should be none:
<img width="922" height="458" alt="wx-corner-widgets" src="https://github.com/user-attachments/assets/18b7a836-61f8-4049-9568-713fd0bbf4ad" />

Perhaps this depends on a border style...