### PR TITLE
Improve render sample using wxGCDC in wxMSW dark mode

### DIFF
--- a/samples/render/render.cpp
+++ b/samples/render/render.cpp
@@ -208,6 +208,7 @@ private:
         if ( m_renderer )
         {
             wxGraphicsContext* ctx = m_renderer->CreateContext(pdc);
+            gdc.SetTextForeground(GetForegroundColour());
             gdc.SetBackground(GetBackgroundColour());
             gdc.SetGraphicsContext(ctx);
         }


### PR DESCRIPTION
Tested only on Windows.

Before (notice missing control labels on the left)
<img width="596" height="518" alt="render-sample-before" src="https://github.com/user-attachments/assets/6662cc83-d38b-441f-a1e1-620edb5582b5" />

After
<img width="616" height="531" alt="render-sample-after" src="https://github.com/user-attachments/assets/be85041e-8f9c-4766-ba15-9865027ebc97" />


It may be unexpected that `wxGCDC` created from  `wxGraphicsContext` created from  `wxPaintDC` does not "inherit" the default attributes such as the text color, but I guess there is a reason why it was done like this.



The render sample exposes some issues in `wxRendererNative` on MSW (e.g. the `DrawItemText()` not working with `wxGCDC` as seen in the screenshots) but I will create a separate issue for that.