### PR TITLE
Fix wxApp::DarkMode interface doc

### DIFF
--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1415,6 +1415,8 @@ public:
     /**
         Possible flags for MSWEnableDarkMode().
 
+        @onlyfor{wxmsw}
+
         @since 3.3.4
     */
     enum DarkMode


### PR DESCRIPTION
wxApp::DarkMode interface doc misses @onlyfor{wxmsw}