### PR TITLE
MSW: Fix wxTextCtrl border switching from dark mode

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -496,8 +496,8 @@ bool wxTextCtrl::Create(wxWindow *parent,
 // returns true if the platform should explicitly apply a theme border
 bool wxTextCtrl::CanApplyThemeBorder() const
 {
-    // Standard text control already handles theming in light mode.
-    return IsRich() || wxMSWDarkMode::IsActive();
+    // Standard text control already handles theming.
+    return IsRich();
 }
 
 bool wxTextCtrl::MSWCreateText(const wxString& value,

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3836,7 +3836,8 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             {
                 // Determine whether we should draw a border.
                 bool drawBorder = false;
-                wxBorder border = DoTranslateBorder(GetBorder());
+                wxBorder rawBorder = GetBorder();
+                wxBorder border = DoTranslateBorder(rawBorder);
                 switch ( border )
                 {
                     case wxBORDER_THEME:
@@ -3882,7 +3883,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                                       rcClient.right, rcClient.bottom);
 
                     // Draw the border.
-                    if ( border == wxBORDER_THEME )
+                    if ( rawBorder == wxBORDER_THEME )
                         MSWDrawThemeBorder(hdc);
                     else
                     {


### PR DESCRIPTION
The problem fixed is that when creating a `wxTextCtrl` with default themed border in dark mode and then switching to light mode, the border remains dark. To repro, run the widgets sample, set the page to Text, restart in dark mode, and switch to light mode.

<img width="117" height="43" alt="image" src="https://github.com/user-attachments/assets/7d8b5ecb-b549-4717-aa4a-2c9973df0e58" />

This problem was introduced in  d5aacc4. The problem is caused by `wxTextCtrl::CanApplyThemeBorder()` returning true in dark mode. This causes the control to be created without any border style flags. This is not a problem in dark mode because in that case we draw a custom border. But upon switching to light mode, the control does not redraw a border, apparently because it thinks it has no border. The default system `WM_NCPAINT` processing does nothing.

The fix is to restore `wxTextCtrl::CanApplyThemeBorder()` as it worked before d5aacc4. Instead of relying on that function to determine whether our custom border is drawn, the `WM_NCPAINT` handler is modified to detect this condition. This way, the control is always created consistently, regardless of dark mode.
