### PR TITLE
MSW: Dark mode support for wxGauge

### DIFF
--- a/include/wx/msw/gauge.h
+++ b/include/wx/msw/gauge.h
@@ -61,6 +61,7 @@ public:
 protected:
     virtual wxSize DoGetBestSize() const override;
 
+    virtual void MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
     virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
 
 private:

--- a/include/wx/msw/gauge.h
+++ b/include/wx/msw/gauge.h
@@ -61,6 +61,8 @@ public:
 protected:
     virtual wxSize DoGetBestSize() const override;
 
+    virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
+
 private:
     // returns true if the control is currently in indeterminate (a.k.a.
     // "marquee") mode

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -96,36 +96,54 @@ wxGauge::~wxGauge()
 {
 }
 
+void wxGauge::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    if ( wxCheckOsVersion(10, 0, 26200) )
+        support.themeName = L"DarkMode_DarkTheme";
+    else
+        wxGaugeBase::MSWGetDarkModeSupport(support);
+}
+
 void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
 {
     wxGaugeBase::MSWSetDarkOrLightMode(setmode);
 
-    // Get window styles, for the border style.
-    auto style = ::GetWindowLong(m_hWnd, GWL_STYLE);
-    auto exStyle = ::GetWindowLong(m_hWnd, GWL_EXSTYLE);
-
-    if ( wxMSWDarkMode::IsActive() )
+    // Adjust colours unless we use DarkMode_DarkTheme in
+    // MSWGetDarkModeSupport().
+    if ( !wxCheckOsVersion(10, 0, 26200) )
     {
-        // Disable visual styles so colour messages take effect.
-        ::SetWindowTheme(m_hWnd, L"", L"");
-        // Colours taken from a progress bar with DarkMode_DarkTheme.
-        ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, 0x131313);
-        ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, 0x5fcb6c);
-
-        // The default border looks bad. Use simple border.
-        style |= WS_BORDER;
-        exStyle &= ~WS_EX_STATICEDGE;
-    }
-    else
-    {
-        // Restore default border.
-        style &= ~WS_BORDER;
-        exStyle |= WS_EX_STATICEDGE;
+        if ( wxMSWDarkMode::IsActive() )
+        {
+            // Disable visual styles so colour messages take effect.
+            ::SetWindowTheme(m_hWnd, L"", L"");
+            // Colours taken from a progress bar with DarkMode_DarkTheme.
+            ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, 0x131313);
+            ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, 0x5fcb6c);
+        }
+        else
+        {
+            ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, CLR_DEFAULT);
+            ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, CLR_DEFAULT);
+        }
     }
 
-    // Set new border unless a non-default border was specified.
+    // Adjust the border unless a border was specified.
     if ( (GetWindowStyleFlag() & wxBORDER_MASK) == wxBORDER_DEFAULT )
     {
+        auto style = ::GetWindowLong(m_hWnd, GWL_STYLE);
+        auto exStyle = ::GetWindowLong(m_hWnd, GWL_EXSTYLE);
+        if ( wxMSWDarkMode::IsActive() )
+        {
+            // The default border looks bad. Use simple border.
+            style |= WS_BORDER;
+            exStyle &= ~WS_EX_STATICEDGE;
+        }
+        else
+        {
+            // Restore default border.
+            style &= ~WS_BORDER;
+            exStyle |= WS_EX_STATICEDGE;
+        }
         ::SetWindowLong(m_hWnd, GWL_STYLE, style);
         ::SetWindowLong(m_hWnd, GWL_EXSTYLE, exStyle);
         ::SetWindowPos(m_hWnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED |

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -120,11 +120,8 @@ void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
             ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, 0x131313);
             ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, 0x5fcb6c);
         }
-        else
-        {
-            ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, CLR_DEFAULT);
-            ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, CLR_DEFAULT);
-        }
+        // Else when going to light mode, the theme was restored by the base
+        // class MSWSetDarkOrLightMode() call above.
     }
 
     // Adjust the border unless a border was specified.

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -31,7 +31,9 @@
 
 #include "wx/appprogress.h"
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/winstyle.h"
+#include "wx/msw/uxtheme.h"
 
 // ----------------------------------------------------------------------------
 // constants
@@ -92,6 +94,43 @@ bool wxGauge::Create(wxWindow *parent,
 
 wxGauge::~wxGauge()
 {
+}
+
+void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
+{
+    wxGaugeBase::MSWSetDarkOrLightMode(setmode);
+
+    // Get window styles, for the border style.
+    auto style = ::GetWindowLong(m_hWnd, GWL_STYLE);
+    auto exStyle = ::GetWindowLong(m_hWnd, GWL_EXSTYLE);
+
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        // Disable visual styles so colour messages take effect.
+        ::SetWindowTheme(m_hWnd, L"", L"");
+        // Colours taken from a progress bar with DarkMode_DarkTheme.
+        ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, 0x131313);
+        ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, 0x5fcb6c);
+
+        // The default border looks bad. Use simple border.
+        style |= WS_BORDER;
+        exStyle &= ~WS_EX_STATICEDGE;
+    }
+    else
+    {
+        // Restore default border.
+        style &= ~WS_BORDER;
+        exStyle |= WS_EX_STATICEDGE;
+    }
+
+    // Set new border unless a non-default border was specified.
+    if ( (GetWindowStyleFlag() & wxBORDER_MASK) == wxBORDER_DEFAULT )
+    {
+        ::SetWindowLong(m_hWnd, GWL_STYLE, style);
+        ::SetWindowLong(m_hWnd, GWL_EXSTYLE, exStyle);
+        ::SetWindowPos(m_hWnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED |
+            SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER);
+    }
 }
 
 WXDWORD wxGauge::MSWGetStyle(long style, WXDWORD *exstyle) const


### PR DESCRIPTION
Add dark mode support for the `wxGauge` control. The background and bar color values were taken from observing a progress bar using the `DarkMode_DarkTheme`. ~~I did not try to actually use `DarkMode_DarkTheme` in this implementation because it was too complicated.~~ I did not use colors from WinUI 3 because the control there has a very different overall look, and very different colors.

<img width="400" height="94" alt="image" src="https://github.com/user-attachments/assets/c88bb8cc-5913-4fe1-aa5a-868834812cdd" />

See #26767.
