### PR TITLE
osx: added `#if wxUSE_TOGGLEBTN` around `NSToggleButton`

### DIFF
--- a/src/osx/cocoa/button.mm
+++ b/src/osx/cocoa/button.mm
@@ -142,7 +142,9 @@ wxOSXSetBezelStyleFromBorderFlags(WX_NSButton v,
             case wxBORDER_NONE:
                 bezel = NSShadowlessSquareBezelStyle;
                 [v setBordered:NO];
+#if wxUSE_TOGGLEBTN
                 toggleButtonType = NSToggleButton;
+#endif
                 break;
 
             case wxBORDER_SIMPLE:


### PR DESCRIPTION
Hi!

I use wxWidgets 3.3.0 on macOS with `set(wxUSE_TOGGLEBTN OFF)`. When I tried to update to 3.3.3, I got a compile error:
```
build_wxw333/wxWidgets/src/osx/cocoa/button.mm:145:17: error: use of undeclared identifier 'toggleButtonType'
  145 |                 toggleButtonType = NSToggleButton;
```

Tried to do a simple fix. Since `bool isToggleButton` is under `#if wxUSE_TOGGLEBTN` then its usage should be under the same condition. Code compiled successfully.
