### PR TITLE
osx: added `#if wxUSE_TOOLBAR` around the usage of `wxToolBar`

### DIFF
--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -60,6 +60,7 @@ bool wxFrame::Create(wxWindow *parent,
     if ( !wxTopLevelWindow::Create(parent, id, title, pos, size, style, name) )
         return false;
 
+#if wxUSE_TOOLBAR
     if ( wxTheApp->OSXIsFullScreenApp() )
     {
         if ((parent != nullptr) && (HasFlag(wxCAPTION) || HasFlag(wxCLOSE_BOX)))
@@ -80,6 +81,7 @@ bool wxFrame::Create(wxWindow *parent,
             tb->Realize();
         }
     }
+#endif
 
     return true;
 }


### PR DESCRIPTION
Hi!

I use wxWidgets 3.3.0 on macOS with `set(wxUSE_TOOLBAR OFF)`. When I tried to update to 3.3.3, I got compile errors:
```
<...>
build_wxw333/wxWidgets/src/osx/carbon/frame.cpp:79:19: error: member access into incomplete type 'wxToolBar'
   79 |                 tb->AddStretchableSpace();
<...>
```

I wrapped usage of wxToolBar in `#if wxUSE_TOOLBAR`. Code compiled successfully.

P.S. 
Not the duplicate of #26797, different macOS build issue.