### PR TITLE
Fix leaking wxFSFile in GTK WebKit

### DIFF
--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -731,7 +731,9 @@ public:
     wxWebViewHandler(const wxString& scheme);
 
     /**
-        @return A pointer to the file represented by @c uri.
+        @return A pointer to the file represented by @c uri, or @NULL. The
+        caller takes ownership of the returned pointer and is responsible for
+        deleting it.
     */
     virtual wxFSFile* GetFile(const wxString &uri);
 

--- a/src/gtk/webview_webkit.cpp
+++ b/src/gtk/webview_webkit.cpp
@@ -20,6 +20,7 @@
 #include "wx/log.h"
 
 #include "wx/private/webview.h"
+#include "wx/scopedptr.h"
 
 #include <webkit/webkit.h>
 
@@ -158,7 +159,7 @@ wxgtk_webview_webkit_navigation(WebKitWebView *,
         if(handler)
         {
             webKitCtrl->m_guard = true;
-            wxFSFile* file = handler->GetFile(wxuri);
+            wxScopedPtr<wxFSFile> file(handler->GetFile(wxuri));
             if(file)
             {
                 webKitCtrl->SetPage(*file->GetStream(), wxuri);
@@ -385,7 +386,7 @@ wxgtk_webview_webkit_resource_req(WebKitWebView *,
         if(webKitCtrl->m_vfsurl == uri)
             return;
 
-        wxFSFile* file = handler->GetFile(uri);
+        wxScopedPtr<wxFSFile> file(handler->GetFile(uri));
         if(file)
         {
             //We load the data into a data url to save it being written out again

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -38,6 +38,7 @@
 #include "wx/gtk/private/object.h"
 #include "wx/gtk/private/variant.h"
 #include "wx/private/jsscriptwrapper.h"
+#include "wx/scopedptr.h"
 #include <webkit2/webkit2.h>
 #include <JavaScriptCore/JSValueRef.h>
 #include <JavaScriptCore/JSStringRef.h>
@@ -500,7 +501,7 @@ wxgtk_webview_webkit_uri_scheme_request_cb(WebKitURISchemeRequest *request,
     {
         const wxString uri = wxString::FromUTF8(webkit_uri_scheme_request_get_uri(request));
 
-        wxFSFile* file = handler->GetFile(uri);
+        wxScopedPtr<wxFSFile> file(handler->GetFile(uri));
         if(file)
         {
             gint64 length = file->GetStream()->GetLength();


### PR DESCRIPTION
Also, document `wxWebViewHandler::GetFile()` ownership.

The file returned from `wxWebViewHandler::GetFile()` wasn't being deleted in the GTK WebKit backends.

Please let me know if I am not correct, but from my research:

For IE (`src\msw\webview_ie.cpp`), the returned file from `GetFile()` gets this upon read completion: `wxDELETE(m_file);`

For Edge, `GetFile()`'s return is wrapped in a `wxWebViewHandlerResponseDataFile`, which deletes the file in its DTOR.

In the base implementation (`src/common/webview.cpp`), `wxWebViewHandlerResponseDataFile` does the same thing of deleting the file from `GetFile()` in its DTOR.

Finally, it appears that all `wxFileSystemHandler::OpenFile()`s return `new wxFSFile` (which `GetFile()` calls), so this seems to confirm this expected ownership contract (that GTK WebKit is currently not following).