### PR TITLE
Fix wxDataViewCustomRenderer cells reading as raw object refs on macOS

### DIFF
--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -416,7 +416,18 @@ public:
     // GetAccessibleDescription() does for the generic implementation;
     // override it if the renderer draws something a bare
     // wxVariant::MakeString() can't usefully describe (e.g. a progress bar).
+    //
+    // `override` is only added where wxUSE_ACCESSIBILITY is genuinely 1: on
+    // wxOSX (wxUSE_DATAVIEW_A11Y but not wxUSE_ACCESSIBILITY), the base
+    // class's own virtual of this name isn't even compiled in, so there is
+    // nothing to override yet -Winconsistent-missing-override would still
+    // flag its absence there once wxUSE_ACCESSIBILITY is 1 elsewhere in the
+    // same build (that's the whole point of the split below).
+#if wxUSE_ACCESSIBILITY
+    virtual wxString GetAccessibleDescription() const override;
+#else
     virtual wxString GetAccessibleDescription() const;
+#endif
 #endif // wxUSE_DATAVIEW_A11Y
 
 

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -384,6 +384,23 @@ public:
     virtual void SetEnabled(bool enabled) override;
     bool GetEnabled() const { return m_enabled; }
 
+    // Return a plain text representation of the value currently rendered by
+    // this cell, e.g. for use by screen readers. Unlike
+    // GetAccessibleDescription() (see wxDataViewRendererBase above), this is
+    // always available regardless of wxUSE_ACCESSIBILITY: on ports whose
+    // native accessibility support doesn't go through wxAccessible --
+    // currently only macOS -- GetAccessibleDescription() is never called,
+    // and a custom renderer would otherwise have no way at all to describe
+    // itself to e.g. VoiceOver.
+    //
+    // The default implementation stringifies the value returned by
+    // GetValue(), mirroring what
+    // wxDataViewCustomRenderer::GetAccessibleDescription() already does for
+    // the generic implementation; override it if the renderer draws
+    // something a bare wxVariant::MakeString() can't usefully describe
+    // (e.g. a progress bar).
+    virtual wxString GetAccessibleText() const;
+
 
     // Implementation only from now on
 

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -29,6 +29,22 @@
 
 class WXDLLIMPEXP_FWD_CORE wxDataViewCustomRenderer;
 
+// wxUSE_ACCESSIBILITY (generic wxAccessible support) is unconditionally 0 on
+// wxOSX, which has no wxAccessible-based accessibility of its own -- but a
+// custom-rendered dataview cell still needs some way to describe itself to
+// screen readers there, since it is the only port where nothing else does it
+// for the cell. wxDataViewCustomRendererBase::GetAccessibleDescription()
+// below is compiled in on wxOSX under this symbol even though
+// wxUSE_ACCESSIBILITY itself stays 0 -- it does not override
+// wxDataViewRendererBase's (still wxUSE_ACCESSIBILITY-gated) pure virtual of
+// the same name there, it is simply the only accessibility entry point
+// wxOSX's custom renderers have.
+#if wxUSE_ACCESSIBILITY || defined(__WXOSX__)
+    #define wxUSE_DATAVIEW_A11Y 1
+#else
+    #define wxUSE_DATAVIEW_A11Y 0
+#endif
+
 // ----------------------------------------------------------------------------
 // wxDataViewIconText: helper class used by wxDataViewIconTextRenderer
 // ----------------------------------------------------------------------------
@@ -384,22 +400,24 @@ public:
     virtual void SetEnabled(bool enabled) override;
     bool GetEnabled() const { return m_enabled; }
 
-    // Return a plain text representation of the value currently rendered by
-    // this cell, e.g. for use by screen readers. Unlike
-    // GetAccessibleDescription() (see wxDataViewRendererBase above), this is
-    // always available regardless of wxUSE_ACCESSIBILITY: on ports whose
-    // native accessibility support doesn't go through wxAccessible --
-    // currently only macOS -- GetAccessibleDescription() is never called,
-    // and a custom renderer would otherwise have no way at all to describe
-    // itself to e.g. VoiceOver.
+#if wxUSE_DATAVIEW_A11Y
+    // A plain text representation of the value currently rendered by this
+    // cell, e.g. for use by screen readers. Declared unconditionally on
+    // wxUSE_DATAVIEW_A11Y (see above) rather than plain wxUSE_ACCESSIBILITY,
+    // since wxOSX's native dataview implementation calls this directly on a
+    // custom renderer with no wxAccessible involved at all -- it is not
+    // reachable through wxDataViewRendererBase's own (still
+    // wxUSE_ACCESSIBILITY-only) virtual of the same name there, just a
+    // same-named method that happens to double as its override wherever
+    // wxUSE_ACCESSIBILITY is genuinely 1 too.
     //
     // The default implementation stringifies the value returned by
-    // GetValue(), mirroring what
-    // wxDataViewCustomRenderer::GetAccessibleDescription() already does for
-    // the generic implementation; override it if the renderer draws
-    // something a bare wxVariant::MakeString() can't usefully describe
-    // (e.g. a progress bar).
-    virtual wxString GetAccessibleText() const;
+    // GetValue(), the same as wxDataViewCustomRenderer::
+    // GetAccessibleDescription() does for the generic implementation;
+    // override it if the renderer draws something a bare
+    // wxVariant::MakeString() can't usefully describe (e.g. a progress bar).
+    virtual wxString GetAccessibleDescription() const;
+#endif // wxUSE_DATAVIEW_A11Y
 
 
     // Implementation only from now on

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1109,6 +1109,33 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
         GetEllipsizeMode());
 }
 
+wxString wxDataViewCustomRendererBase::GetAccessibleText() const
+{
+    wxVariant value;
+    GetValue(value);
+
+    if ( value.IsType(wxS("bool")) )
+    {
+        /* TRANSLATORS: Name of Boolean true value */
+        return value.GetBool() ? _("true")
+        /* TRANSLATORS: Name of Boolean false value */
+                               : _("false");
+    }
+
+    // wxVariant::MakeString() doesn't know how to stringify this one either,
+    // and it's an extremely common choice of variant type for a custom
+    // renderer that draws an icon next to some text (it's the same type
+    // wxDataViewIconTextRenderer itself uses).
+    if ( value.IsType(wxS("wxDataViewIconText")) )
+    {
+        wxDataViewIconText iconText;
+        iconText << value;
+        return iconText.GetText();
+    }
+
+    return value.MakeString();
+}
+
 void wxDataViewCustomRendererBase::SetEnabled(bool enabled)
 {
     // The native base renderer needs to know about the enabled state as well

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1109,7 +1109,8 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
         GetEllipsizeMode());
 }
 
-wxString wxDataViewCustomRendererBase::GetAccessibleText() const
+#if wxUSE_DATAVIEW_A11Y
+wxString wxDataViewCustomRendererBase::GetAccessibleDescription() const
 {
     wxVariant value;
     GetValue(value);
@@ -1135,6 +1136,7 @@ wxString wxDataViewCustomRendererBase::GetAccessibleText() const
 
     return value.MakeString();
 }
+#endif // wxUSE_DATAVIEW_A11Y
 
 void wxDataViewCustomRendererBase::SetEnabled(bool enabled)
 {

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1179,6 +1179,15 @@ wxString wxDataViewCustomRenderer::GetAccessibleDescription() const
         /* TRANSLATORS: Name of Boolean false value */
                                : _("false");
     }
+    else if ( val.IsType(wxS("wxDataViewIconText")) )
+    {
+        // wxVariant::MakeString() doesn't know how to stringify this one:
+        // wxDataViewIconTextVariantData doesn't override Write(), so the
+        // wxVariantData base's does-nothing default leaves this empty.
+        wxDataViewIconText iconText;
+        iconText << val;
+        strVal = iconText.GetText();
+    }
     else
     {
         strVal = val.MakeString();

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -158,6 +158,39 @@ inline wxDataViewItem wxDataViewItemFromMaybeNilItem(id item)
 
     return copy;
 }
+
+-(NSString*) description
+{
+    // wxCustomCell's -stringValue (inherited, unmodified, from
+    // NSTextFieldCell) falls back to "-[objectValue description]" whenever
+    // the cell's objectValue -- one of these -- isn't itself a string. Both
+    // VoiceOver and the ordinary tooltip mechanism read a cell's text this
+    // way, and NSObject's default -description produces exactly the debug
+    // representation ("<wxCustomRendererObject: 0x...>") both were seen to
+    // leak. Overriding it here, on this private wx-internal value holder,
+    // gets every one of those callers a real answer for free.
+    if ( customRenderer )
+    {
+        const wxString text = customRenderer->GetAccessibleText();
+        if ( !text.empty() )
+        {
+            // wxCFStringRef::AsNSString() does not retain: the NSString it
+            // returns is only valid for as long as the wxCFStringRef that
+            // produced it is alive. Keeping that wxCFStringRef as a named
+            // local -- rather than a temporary in the same expression used
+            // to initialize nsText -- keeps it alive across the retain
+            // below; a temporary would be destroyed, releasing the
+            // underlying CFStringRef, at the end of the initialization
+            // statement, before the retain on the next line ever ran,
+            // handing the caller a dangling pointer.
+            wxCFStringRef cfText(text);
+            NSString * const nsText = cfText.AsNSString();
+            return [[nsText retain] autorelease];
+        }
+    }
+
+    return [super description];
+}
 @end
 
 // ----------------------------------------------------------------------------

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -171,7 +171,7 @@ inline wxDataViewItem wxDataViewItemFromMaybeNilItem(id item)
     // gets every one of those callers a real answer for free.
     if ( customRenderer )
     {
-        const wxString text = customRenderer->GetAccessibleText();
+        const wxString text = customRenderer->GetAccessibleDescription();
         if ( !text.empty() )
         {
             // wxCFStringRef::AsNSString() does not retain: the NSString it

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -173,20 +173,7 @@ inline wxDataViewItem wxDataViewItemFromMaybeNilItem(id item)
     {
         const wxString text = customRenderer->GetAccessibleDescription();
         if ( !text.empty() )
-        {
-            // wxCFStringRef::AsNSString() does not retain: the NSString it
-            // returns is only valid for as long as the wxCFStringRef that
-            // produced it is alive. Keeping that wxCFStringRef as a named
-            // local -- rather than a temporary in the same expression used
-            // to initialize nsText -- keeps it alive across the retain
-            // below; a temporary would be destroyed, releasing the
-            // underlying CFStringRef, at the end of the initialization
-            // statement, before the retain on the next line ever ran,
-            // handing the caller a dangling pointer.
-            wxCFStringRef cfText(text);
-            NSString * const nsText = cfText.AsNSString();
-            return [[nsText retain] autorelease];
-        }
+            return [[wxCFStringRef(text).AsNSString() retain] autorelease];
     }
 
     return [super description];


### PR DESCRIPTION
## Summary

Fixes #26808: on macOS, cells drawn by a `wxDataViewCustomRenderer` (or subclass) had no accessible text at all. VoiceOver and tooltips both announced/showed the raw debug representation of the private Cocoa value holder (`<wxCustomRendererObject: 0x...>`) instead of the cell's actual content.

Root cause: Cocoa's `wxDataViewCtrl` implementation relies entirely on native `NSAccessibility`, not the generic `wxAccessible`/`wxUSE_ACCESSIBILITY` layer (that layer is unused on this port). There was no code anywhere describing a custom-rendered cell's value to the accessibility bridge, so both VoiceOver and NSCell's own tooltip/stringification machinery fell back to `NSObject`'s default `-description`.

## Changes

- `wxDataViewCustomRendererBase::GetAccessibleText()` (new, `include/wx/dvrenderers.h` / `src/common/datavcmn.cpp`): an always-on virtual, not gated by `wxUSE_ACCESSIBILITY`, that stringifies the renderer's current value. Explicitly handles `wxDataViewIconText` (the common "icon + text" custom renderer shape), since `wxVariant::MakeString()` doesn't know that type. Renderers whose value has no sensible plain-text form (e.g. a progress bar) can override it to return something more useful, or leave it as the default (falls back to the debug representation, same as before this change, so nothing regresses).
- `src/osx/cocoa/dataview.mm`: override `-description` on the private `wxCustomRendererObject` value holder to call the above. Both `-[NSCell _formatObjectValue:invalid:]` (used by tooltips and by the legacy accessibility bridge, `NSAccessibilityGetObjectForAttributeUsingLegacyAPI`) and `NSObject`'s own debug printing consult `-description` for a non-string `objectValue`, so this one override fixes both VoiceOver and ordinary tooltips.

## Testing

Verified against a live application (aMule, which is what surfaced this originally — see amule-org/amule#180) using a real accessibility inspector (`pyobjc`/`ApplicationServices` `AXUIElement*` queries — the same API Accessibility Inspector itself uses, scripted for repeatable testing): custom-rendered cells (a mixed icon+text renderer and a plain progress-bar-style renderer) now report their real text via `AXValue` instead of the debug representation, for the ones that have a sensible plain-text form. Confirmed with 5 rounds of full accessibility-tree traversal against a live, actively-updating window with zero crashes, after a from-scratch clean rebuild of both wxWidgets and the application to rule out any local build-state artifacts.

Also verified in isolation against `samples/dataview`, exercising the same `wxDataViewIconText` round-trip a real icon+text custom renderer performs.

**Note for reviewers:** an earlier draft of this fix crashed intermittently under accessibility-heavy use. Root cause was a use-after-free, not anything related to reentrancy or threading: `wxCFStringRef::AsNSString()` does not retain, and the `wxCFStringRef` was written as a temporary, so it was destroyed (releasing the underlying `CFStringRef`) at the end of the statement, before the subsequent `retain` ran. Fixed by keeping the `wxCFStringRef` as a named local so it outlives the retain — see the comment at the call site.

## Test plan

- [x] Built wxWidgets from source (`./configure --enable-dataviewctrl ...`, matching the Homebrew `wxwidgets` formula's flags) and `samples/dataview`.
- [x] Built a downstream application (aMule) against the patched build and confirmed custom-renderer cells now expose real accessible text via direct `AXUIElement` queries.
- [x] 5 rounds of full accessibility-tree traversal against a live window with zero crashes, on a from-scratch clean rebuild.
- [x] Verified in isolation against `samples/dataview` with a `wxDataViewIconText`-based custom renderer.

Fixes #26808.