### PR TITLE
MSW: Fix wxGauge dark mode support

### DIFF
--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -557,10 +557,7 @@ void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
     if ( wxMSWImpl::AllowDarkModeForWindow(hwnd, true) )
         wxLogTrace(TRACE_DARKMODE, "Allow dark mode for %p failed", hwnd);
 
-    if ( themeName || themeId )
-    {
-        SetTheme(hwnd, themeName, themeId);
-    }
+    SetTheme(hwnd, themeName, themeId);
 
     // Some native controls need this message to switch themes, such as
     // buttons, tooltips and controls with scroll bars

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -112,16 +112,24 @@ void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
     // MSWGetDarkModeSupport().
     if ( !wxCheckOsVersion(10, 0, 26200) )
     {
+        // Disable visual styles so colour messages take effect.
+        ::SetWindowTheme(m_hWnd, L"", L"");
         if ( wxMSWDarkMode::IsActive() )
         {
-            // Disable visual styles so colour messages take effect.
-            ::SetWindowTheme(m_hWnd, L"", L"");
             // Colours taken from a progress bar with DarkMode_DarkTheme.
             ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, 0x131313);
             ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, 0x5fcb6c);
         }
-        // Else when going to light mode, the theme was restored by the base
-        // class MSWSetDarkOrLightMode() call above.
+        else
+        {
+            // The control does not go back into themed mode, so we must
+            // explicitly set the colours.
+            ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, CLR_DEFAULT);
+            // For the foreground, CLR_DEFAULT apparently sets the unthemed
+            // colour, which is blue instead of green. Use the actual observed
+            // theme colour.
+            ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, 0x25b006);
+        }
     }
 
     // Adjust the border unless a border was specified.

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -99,7 +99,10 @@ wxGauge::~wxGauge()
 void wxGauge::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
     if ( wxCheckOsVersion(10, 0, 26200) )
+    {
         support.themeName = L"DarkMode_DarkTheme";
+        support.themeId = L"Progress";
+    }
     else
         wxGaugeBase::MSWGetDarkModeSupport(support);
 }

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -157,6 +157,9 @@ void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
         ::SetWindowPos(m_hWnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED |
             SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER);
     }
+
+    // Restore the position shown by the control.
+    ::SendMessage(m_hWnd, PBM_SETPOS, GetValue(), 0);
 }
 
 WXDWORD wxGauge::MSWGetStyle(long style, WXDWORD *exstyle) const

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4155,11 +4155,8 @@ void wxWindowMSW::MSWSetDarkOrLightMode(SetMode WXUNUSED(setmode))
     {
         MSWGetDarkModeSupport(support);
     }
-    else
-    {
-        // This is the theme name for light mode.
-        support.themeName = L"Explorer";
-    }
+    // Else to restore light mode, use support.themeName == nullptr and
+    // support.themeId == nullptr.
 
     // This updates scroll bars, if there are any.
     wxMSWDarkMode::AllowForWindow(m_hWnd, support.themeName, support.themeId);


### PR DESCRIPTION
The problem is when switching from dark mode to light mode on an old Windows version, the colors incorrectly remain dark mode. The fix is to explicitly set the colors upon this transition. I previously thought that `SetWindowTheme()` would restore default colors, but that is only true for new Windows versions, not old Windows.
