### PR TITLE
Improve wxRendererXP::DrawGauge() in wxMSW dark mode

### DIFF
--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -99,6 +99,7 @@ void EnableRoundCorners(HWND hwnd);
 // This function draws over the section where the scroll bars meet
 // to maintain a consistent theme
 void PaintScrollBarCorner(wxWindow* w);
+void DrawGauge(wxDC& dc, const wxRect& rect, int value, int max, int flags);
 
 } // namespace wxMSWImpl
 

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -33,12 +33,13 @@
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/dc.h"
     #include "wx/settings.h"
 #endif
 
 #include "wx/dynlib.h"
 #include "wx/module.h"
-#include "wx/dcclient.h"
+#include "wx/renderer.h"
 
 #include "wx/msw/darkmode.h"
 #include "wx/msw/uxtheme.h"
@@ -1127,6 +1128,36 @@ void wxMSWImpl::PaintScrollBarCorner(wxWindow* w)
     ::FillRect(hdcWin, &rectToPaint, hBrush);
 }
 
+void wxMSWImpl::DrawGauge(wxDC& dc, const wxRect& rect, int value, int max, int flags)
+{
+    const wxColour bkColour(0x131313); // @TODO: Do not hardcode the color
+    const wxPen borderPen = wxMSWDarkMode::GetBorderPen();
+    const wxDCPenChanger penChanger(dc, borderPen);
+    const wxDCBrushChanger brushChanger(dc, *wxTheBrushList->FindOrCreateBrush(bkColour));
+    wxRect paintRect(rect);
+
+    dc.DrawRectangle(paintRect);
+    paintRect.Inflate(-borderPen.GetWidth());
+
+    max = wxMax(0, max);
+    value = wxMax(0, wxMin(value, max));
+
+    if ( value > 0 )
+    {
+        const bool isVertical = (flags & wxCONTROL_SPECIAL) == wxCONTROL_SPECIAL;
+        const int barFilled = wxMulDivInt32(isVertical ? paintRect.GetHeight() : paintRect.GetWidth(), value, max);
+        const wxColour barColour(0x5fcb6c); // @TODO: Do not hardcode the color
+
+        dc.SetPen(*wxThePenList->FindOrCreatePen(barColour));
+        dc.SetBrush(*wxTheBrushList->FindOrCreateBrush(barColour));
+        if ( isVertical )
+           dc.DrawRectangle(paintRect.x, paintRect.GetBottom() - barFilled + 1, paintRect.GetWidth(), barFilled);
+        else
+           dc.DrawRectangle(paintRect.x, paintRect.y, barFilled, paintRect.GetHeight());
+    }
+}
+
+
 #else // !wxUSE_DARK_MODE
 
 bool
@@ -1234,6 +1265,11 @@ bool HasDarkTheme()
 } // namespace wxMSWDarkMode
 
 void wxMSWImpl::PaintScrollBarCorner(wxWindow* WXUNUSED(w))
+{
+}
+
+void wxMSWImpl::DrawGauge(wxDC& WXUNUSED(dc), const wxRect& WXUNUSED(rect),
+    int WXUNUSED(value), int WXUNUSED(max), int WXUNUSED(flags))
 {
 }
 

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -35,6 +35,7 @@
 #include "wx/msw/private.h"
 #include "wx/msw/uxtheme.h"
 #include "wx/msw/wrapcctl.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/dynlib.h"
 
 // ----------------------------------------------------------------------------
@@ -1180,7 +1181,15 @@ void wxRendererXP::DrawGauge(wxWindow* win,
     int max,
     int flags)
 {
-    wxUxThemeHandle hTheme(win, L"PROGRESS");
+    // if DarkTheme is not available, draw the gauge fully by ourselves
+    if ( wxMSWDarkMode::IsActive() && !wxMSWDarkMode::HasDarkTheme() )
+    {
+        wxMSWImpl::DrawGauge(dc, rect, value, max, flags);
+        return;
+    }
+
+    wxUxThemeHandle hTheme(win, L"PROGRESS", L"DarkMode_DarkTheme::Progress");
+
     if ( !hTheme )
     {
         m_rendererNative.DrawGauge(win, dc, rect, value, max, flags);
@@ -1225,6 +1234,15 @@ void wxRendererXP::DrawGauge(wxWindow* win,
         contentRect,
         flags & wxCONTROL_SPECIAL ? PP_CHUNKVERT : PP_CHUNK
     );
+
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        // We get here only when wxMSWDarkMode::HasDarkTheme() returns true
+        // but even the DarkTheme still draws a wrong (too dark) border color
+        // so we need to draw the border ourselves with the correct color.
+        AutoHBRUSH hBrush(wxMSWDarkMode::GetBorderPen().GetColour().GetPixel());
+        ::FrameRect(GetHdcOf(dc.GetTempHDC()), &r, hBrush);
+    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Some things may need to be improved later (see the comments), when possible (i.e., dark mode colors interface extended), but IMO, it is better to push this now, the default appearance is not that good

Samples _render_ and _dataview_ before and after
<img width="377" height="235" alt="image" src="https://github.com/user-attachments/assets/7276966e-e149-4b0e-8216-93f800f9c67d" />
<img width="386" height="240" alt="image" src="https://github.com/user-attachments/assets/6114d2d4-cf2d-4274-a3fb-240cb3d4fe0e" />


I wonder if should copy the "hack" from the generic renderer:
https://github.com/wxWidgets/wxWidgets/blob/96ea2557b1c6ae55eca61d5be46cf48a07af64db/src/generic/renderg.cpp#L943-L960
which probably wasn't used for the XP renderer.