### PR TITLE
MSW: Internal dark mode color organization

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -260,6 +260,15 @@ inline void wxRGBToColour(wxColour& c, COLORREF rgb)
     c.Set(GetRValue(rgb), GetGValue(rgb), GetBValue(rgb));
 }
 
+// Convert colour from hex format 0xRRGGBB to COLORREF 0xBBGGRR
+inline COLORREF wxHexToCR(DWORD hex)
+{
+    BYTE r = (hex >> 16) & 0xff;
+    BYTE g = (hex >> 8) & 0xff;
+    BYTE b = hex & 0xff;
+    return RGB(r, g, b);
+}
+
 // get the standard colour map for some standard colours - see comment in this
 // function to understand why is it needed and when should it be used
 //

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -20,7 +20,7 @@ namespace wxMSWDarkMode
 // for Windows dark mode support. When possible, these colours are chosen to
 // accurately match the native Windows look.
 enum Colour {
-    // Generic border. Value choosen arbitrarily. There does not seem to be
+    // Generic border. Value chosen arbitrarily. There does not seem to be
     // any standard colour.
     COLOUR_BORDER = 0x808080,
     // Simple EDIT control border. Taken from appearance with

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -15,6 +15,31 @@
 namespace wxMSWDarkMode
 {
 
+// Colour values needed for dark mode support. Unlike wxSystemColour, these
+// colours have no useful equivalent on other platforms and are only needed
+// for Windows dark mode support. When possible, these colours are chosen to
+// accurately match the native Windows look.
+enum Colour {
+    // Generic border. Value choosen arbitrarily. There does not seem to be
+    // any standard colour.
+    COLOUR_BORDER = 0x808080,
+    // Simple EDIT control border. Taken from appearance with
+    // DarkMode_DarkTheme on Windows 11 25H2.
+    COLOUR_EDIT_OUTER = 0x383838,
+    COLOUR_EDIT_INNER_FOCUS = 0x212121,
+    COLOUR_EDIT_INNER_NOFOCUS = 0x2c2c2c,
+    COLOUR_EDIT_BOTTOM_FOCUS = 0x4cc2ff,
+    COLOUR_EDIT_BOTTOM_NOFOCUS = 0xa4a4a4,
+    // wxGauge background and bar. Dark colours taken from appearance with
+    // DarkMode_DarkTheme on Windows 11 25H2. Light colours taken from the
+    // default theme on the most recent Windows without DarkMode_DarkTheme,
+    // Windows 11 24H2.
+    COLOUR_GAUGE_DARK_BK = 0x131313,
+    COLOUR_GAUGE_DARK_BAR = 0x6ccb5f,
+    COLOUR_GAUGE_LIGHT_BK = 0xe6e6e6,
+    COLOUR_GAUGE_LIGHT_BAR = 0x0f7b0f,
+};
+
 // Return true if the application is using dark mode: note that this will only
 // be the case if wxApp::MSWEnableDarkMode() was called.
 WXDLLIMPEXP_CORE

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -484,11 +484,7 @@ wxColour wxDarkModeSettings::GetMenuColour(wxMenuColour which)
 
 wxPen wxDarkModeSettings::GetBorderPen()
 {
-    // Use a darker pen than the default white one by default. There doesn't
-    // seem to be any standard colour to use for it, Windows itself uses both
-    // 0x666666 and 0x797979 for the borders in the "Colours" control panel
-    // window, so it doesn't seem like anybody cares about consistency here.
-    return *wxGREY_PEN;
+    return wxColour(wxMSWDarkMode::COLOUR_BORDER);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -117,8 +117,8 @@ void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
             // Disable visual styles so colour messages take effect.
             ::SetWindowTheme(m_hWnd, L"", L"");
             // Colours taken from a progress bar with DarkMode_DarkTheme.
-            ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, 0x131313);
-            ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, 0x5fcb6c);
+            ::SendMessage(m_hWnd, PBM_SETBKCOLOR, 0, wxHexToCR(wxMSWDarkMode::COLOUR_GAUGE_DARK_BK));
+            ::SendMessage(m_hWnd, PBM_SETBARCOLOR, 0, wxHexToCR(wxMSWDarkMode::COLOUR_GAUGE_DARK_BAR));
         }
         // Else when going to light mode, the theme was restored by the base
         // class MSWSetDarkOrLightMode() call above.

--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -209,7 +209,7 @@ void wxSpinButton::OnPaint(wxPaintEvent& event)
         wxImage::RGBValue border;
         if ( drawBorder )
         {
-            const auto col = wxMSWDarkMode::GetBorderPen().GetColour();
+            const auto col = wxColour(wxMSWDarkMode::COLOUR_BORDER);
             border.red = col.GetRed();
             border.green = col.GetGreen();
             border.blue = col.GetBlue();

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2874,24 +2874,20 @@ void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc)
 
         // Colors taken from the Edit control rendered with
         // DarkMode_DarkTheme, as can be seen with wxFindReplaceDialog.
-        const COLORREF colOuter = 0x383838;
-        const COLORREF colInnerFocus = 0x212121;
-        const COLORREF colInnerNoFocus = 0x2c2c2c;
-        const COLORREF colBottomFocus = 0xffc24c;
-        const COLORREF colBottomNoFocus = 0xa4a4a4;
+        const COLORREF colOuter = wxHexToCR(wxMSWDarkMode::COLOUR_EDIT_OUTER);
         COLORREF colInner;
         COLORREF colBottom;
         int thicknessBot;
         if ( HasFocus() )
         {
-            colInner = colInnerFocus;
-            colBottom = colBottomFocus;
+            colInner = wxHexToCR(wxMSWDarkMode::COLOUR_EDIT_INNER_FOCUS);
+            colBottom = wxHexToCR(wxMSWDarkMode::COLOUR_EDIT_BOTTOM_FOCUS);
             thicknessBot = 2;
         }
         else
         {
-            colInner = colInnerNoFocus;
-            colBottom = colBottomNoFocus;
+            colInner = wxHexToCR(wxMSWDarkMode::COLOUR_EDIT_INNER_NOFOCUS);
+            colBottom = wxHexToCR(wxMSWDarkMode::COLOUR_EDIT_BOTTOM_NOFOCUS);
             thicknessBot = 1;
         }
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3923,9 +3923,8 @@ void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc)
     {
         // There does not seem to be a theme class that draws a good
         // border on all supported versions of Windows. Manually draw a
-        // 1-pixel thick border. Use the observed colour of the simple
-        // border, WS_BORDER.
-        AutoHBRUSH brushBorder(0x646464);
+        // 1-pixel thick border.
+        AutoHBRUSH brushBorder(wxHexToCR(wxMSWDarkMode::COLOUR_BORDER));
         ::FrameRect(hdc, &rcBorder, brushBorder);
         // Draw the background with consecutively smaller 1-pixel thick
         // rectangles.


### PR DESCRIPTION
This PR introduces enum `wxMSWDarkMode::Colour` to centralize internally used constant color values for colors that cannot reasonably be determined at run-time. Unlike `wxSystemColour`, `wxMSWDarkMode::Colour` is for colors that have no equivalent on other systems and are only needed for dark mode support. These colors are not customizable by the user. The purpose is to provide consistency with the native look and feel. Therefore, `wxMSWDarkMode::Colour` is completely independent from `wxDarkModeSettings::GetColour()`.

The values are in hex RGB format 0xRRGGBB, which is easily converted to `wxColour`. The new helper function `wxHexToCR()` converts to the commonly needed Windows `COLORREF` format.

The value `COLOUR_BORDER` is arbitrary. The value `0x808080` is taken from `wxDarkModeSettings::GetBorderPen()` rather than the value `0x646464` used in `wxWindowMSW::MSWDrawThemeBorder()` because the introduction of `wxDarkModeSettings::GetBorderPen()` preceded `wxWindowMSW::MSWDrawThemeBorder()`. An alternative is the WinUI 3 `ListView` border color. This is the only WinUI 3 control I know of that uses the same border color on all four sides. The color is `0x9a9a9a`, which seems too bright.
