### PR TITLE
MSW: Add function to detect DarkMode_DarkTheme

### DIFF
--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -80,6 +80,10 @@ HandleMenuMessage(WXLRESULT* result,
 
 void NotifySysColorChange();
 
+// Return true if the DarkMode_DarkTheme theme is available. This theme was
+// added in Windows 11 25H2 (build 26200).
+bool HasDarkModeDarkTheme();
+
 } // namespace wxMSWDarkMode
 
 namespace wxMSWImpl

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -82,7 +82,7 @@ void NotifySysColorChange();
 
 // Return true if the DarkMode_DarkTheme theme is available. This theme was
 // added in Windows 11 25H2 (build 26200).
-bool HasDarkModeDarkTheme();
+bool HasDarkTheme();
 
 } // namespace wxMSWDarkMode
 

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -217,7 +217,7 @@ void wxChoice::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
     // Theme DarkMode_DarkTheme looks good, so use it if available. Theme
     // "CFD" works well on older Windows versions although the border is a bit
     // light.
-    if ( wxCheckOsVersion(10, 0, 26200) )
+    if ( wxMSWDarkMode::HasDarkModeDarkTheme() )
         support.themeName = L"DarkMode_DarkTheme";
     else
         support.themeName = L"CFD";
@@ -232,10 +232,9 @@ void wxChoice::MSWSetDarkOrLightMode(SetMode setmode)
     if ( ::GetComboBoxInfo(GetHwnd(), &info) && info.hwndList )
     {
         // The default theme does not look good on starting with Windows 11
-        // build 26300.8553. DarkMode_DarkTheme looks OK and is available
-        // starting with Windows 11 25H2 (build 26200), but is always dark, so
+        // build 26300.8553. DarkMode_DarkTheme looks OK, but is always dark, so
         // don't use it in light mode or the scrollbar would be dark in it too.
-        if ( wxMSWDarkMode::IsActive() && wxCheckOsVersion(10, 0, 26200) )
+        if ( wxMSWDarkMode::IsActive() && wxMSWDarkMode::HasDarkModeDarkTheme() )
             wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
         else
             wxMSWDarkMode::AllowForWindow(info.hwndList);

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -217,7 +217,7 @@ void wxChoice::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
     // Theme DarkMode_DarkTheme looks good, so use it if available. Theme
     // "CFD" works well on older Windows versions although the border is a bit
     // light.
-    if ( wxMSWDarkMode::HasDarkModeDarkTheme() )
+    if ( wxMSWDarkMode::HasDarkTheme() )
         support.themeName = L"DarkMode_DarkTheme";
     else
         support.themeName = L"CFD";
@@ -234,7 +234,7 @@ void wxChoice::MSWSetDarkOrLightMode(SetMode setmode)
         // The default theme does not look good on starting with Windows 11
         // build 26300.8553. DarkMode_DarkTheme looks OK, but is always dark, so
         // don't use it in light mode or the scrollbar would be dark in it too.
-        if ( wxMSWDarkMode::IsActive() && wxMSWDarkMode::HasDarkModeDarkTheme() )
+        if ( wxMSWDarkMode::IsActive() && wxMSWDarkMode::HasDarkTheme() )
             wxMSWDarkMode::AllowForWindow(info.hwndList, L"DarkMode_DarkTheme");
         else
             wxMSWDarkMode::AllowForWindow(info.hwndList);

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -849,6 +849,11 @@ void NotifySysColorChange()
         gs_hasChanged = true;
 }
 
+bool HasDarkModeDarkTheme()
+{
+    return wxCheckOsVersion(10, 0, 26200);
+}
+
 } // namespace wxMSWDarkMode
 
 void wxMSWImpl::PaintScrollBarCorner(HWND hwnd)
@@ -965,6 +970,11 @@ HandleMenuMessage(WXLRESULT* WXUNUSED(result),
 
 void NotifySysColorChange()
 {
+}
+
+bool HasDarkModeDarkTheme()
+{
+    return false;
 }
 
 } // namespace wxMSWDarkMode

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -849,7 +849,7 @@ void NotifySysColorChange()
         gs_hasChanged = true;
 }
 
-bool HasDarkModeDarkTheme()
+bool HasDarkTheme()
 {
     return wxCheckOsVersion(10, 0, 26200);
 }
@@ -972,7 +972,7 @@ void NotifySysColorChange()
 {
 }
 
-bool HasDarkModeDarkTheme()
+bool HasDarkTheme()
 {
     return false;
 }

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -98,7 +98,7 @@ wxGauge::~wxGauge()
 
 void wxGauge::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
-    if ( wxMSWDarkMode::HasDarkModeDarkTheme() )
+    if ( wxMSWDarkMode::HasDarkTheme() )
         support.themeName = L"DarkMode_DarkTheme";
     else
         wxGaugeBase::MSWGetDarkModeSupport(support);
@@ -110,7 +110,7 @@ void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
 
     // Adjust colours unless we use DarkMode_DarkTheme in
     // MSWGetDarkModeSupport().
-    if ( !wxMSWDarkMode::HasDarkModeDarkTheme() )
+    if ( !wxMSWDarkMode::HasDarkTheme() )
     {
         if ( wxMSWDarkMode::IsActive() )
         {

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -98,7 +98,7 @@ wxGauge::~wxGauge()
 
 void wxGauge::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
-    if ( wxCheckOsVersion(10, 0, 26200) )
+    if ( wxMSWDarkMode::HasDarkModeDarkTheme() )
         support.themeName = L"DarkMode_DarkTheme";
     else
         wxGaugeBase::MSWGetDarkModeSupport(support);
@@ -110,7 +110,7 @@ void wxGauge::MSWSetDarkOrLightMode(SetMode setmode)
 
     // Adjust colours unless we use DarkMode_DarkTheme in
     // MSWGetDarkModeSupport().
-    if ( !wxCheckOsVersion(10, 0, 26200) )
+    if ( !wxMSWDarkMode::HasDarkModeDarkTheme() )
     {
         if ( wxMSWDarkMode::IsActive() )
         {

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/dc.h"
 
 #include <windowsx.h>
@@ -176,9 +177,8 @@ WXDWORD wxListBox::MSWGetStyle(long style, WXDWORD *exstyle) const
 void wxListBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
     // The default theme does not look good on starting with Windows 11
-    // build 26300.8553. DarkMode_DarkTheme looks OK and was available
-    // starting with Windows 11 build 26200.
-    if ( wxCheckOsVersion(10, 0, 26200) )
+    // build 26300.8553. DarkMode_DarkTheme looks OK.
+    if ( wxMSWDarkMode::HasDarkModeDarkTheme() )
         support.themeName = L"DarkMode_DarkTheme";
     else
         wxListBoxBase::MSWGetDarkModeSupport(support);

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -178,7 +178,7 @@ void wxListBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
     // The default theme does not look good on starting with Windows 11
     // build 26300.8553. DarkMode_DarkTheme looks OK.
-    if ( wxMSWDarkMode::HasDarkModeDarkTheme() )
+    if ( wxMSWDarkMode::HasDarkTheme() )
         support.themeName = L"DarkMode_DarkTheme";
     else
         wxListBoxBase::MSWGetDarkModeSupport(support);


### PR DESCRIPTION
To detect whether DarkMode_DarkTheme is available, use a dedicated function rather than wxCheckOsVersion, for improved readability.