### PR TITLE
MSW: Dark mode switching for wxToolTip

### DIFF
--- a/include/wx/msw/tooltip.h
+++ b/include/wx/msw/tooltip.h
@@ -69,6 +69,8 @@ public:
     // the window it's associated with is hidden.
     static void UpdateVisibility();
 
+    static void SetDarkOrLightMode();
+
 private:
     // This module calls our DeleteToolTipCtrl().
     friend class wxToolTipModule;

--- a/src/msw/tooltip.cpp
+++ b/src/msw/tooltip.cpp
@@ -318,7 +318,7 @@ WXHWND wxToolTip::GetToolTipCtrl()
        if ( ms_hwndTT )
        {
            HWND hwnd = (HWND)ms_hwndTT;
-           wxMSWDarkMode::AllowForWindow(hwnd);
+           SetDarkOrLightMode();
            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
                         SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 
@@ -654,6 +654,12 @@ void wxToolTip::DoForAllWindows(void (wxToolTip::*func)(WXHWND))
             (this->*func)(*it);
         }
     }
+}
+
+void wxToolTip::SetDarkOrLightMode()
+{
+    if ( ms_hwndTT )
+        wxMSWDarkMode::AllowForWindow(ms_hwndTT);
 }
 
 #endif // wxUSE_TOOLTIPS

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4177,10 +4177,12 @@ void wxWindowMSW::MSWSetDarkOrLightMode(SetMode WXUNUSED(setmode))
         ::SetClassLongPtr(m_hWnd, GCLP_HBRBACKGROUND, LONG_PTR(hbr));
     }
 
+#if wxUSE_TOOLTIPS
     if ( m_tooltip )
     {
         wxToolTip::SetDarkOrLightMode();
     }
+#endif
 }
 
 // ===========================================================================

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4176,6 +4176,11 @@ void wxWindowMSW::MSWSetDarkOrLightMode(SetMode WXUNUSED(setmode))
         HBRUSH hbr = GetHbrushOf(*brush);
         ::SetClassLongPtr(m_hWnd, GCLP_HBRBACKGROUND, LONG_PTR(hbr));
     }
+
+    if ( m_tooltip )
+    {
+        wxToolTip::SetDarkOrLightMode();
+    }
 }
 
 // ===========================================================================


### PR DESCRIPTION
Enable dark mode switching for `wxToolTip`.