### PR TITLE
wxQt: Fix incorrect `wxGLAttributes::Stencil`

### DIFF
--- a/src/qt/glcanvas.cpp
+++ b/src/qt/glcanvas.cpp
@@ -263,7 +263,7 @@ wxGLAttributes& wxGLAttributes::Stencil(int val)
 {
     if ( val >= 0 )
     {
-        AddAttribute(WX_GL_DEPTH_SIZE);
+        AddAttribute(WX_GL_STENCIL_SIZE);
         AddAttribute(val);
     }
     return *this;


### PR DESCRIPTION
Noticed this while looking at the problem that eventually led to #26820.

This fixes an apparent copy-paste mistake. Setting `WX_GL_DEPTH_SIZE`
behind `Stencil()` doesn't make a great deal of sense. So we're simply
fixing the attribute assignment.