### PR TITLE
Fix (file) memory leak in IE webview

### DIFF
--- a/include/wx/msw/private/webview_ie.h
+++ b/include/wx/msw/private/webview_ie.h
@@ -85,7 +85,7 @@ protected:
 
 public:
     VirtualProtocol(wxSharedPtr<wxWebViewHandler> handler);
-    virtual ~VirtualProtocol() = default;
+    virtual ~VirtualProtocol();
 
     //IUnknown
     DECLARE_IUNKNOWN_METHODS;

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -1623,6 +1623,11 @@ VirtualProtocol::VirtualProtocol(wxSharedPtr<wxWebViewHandler> handler)
     m_handler = handler;
 }
 
+VirtualProtocol::~VirtualProtocol()
+{
+    wxDELETE(m_file);
+}
+
 COM_DECLSPEC_NOTHROW
 STDMETHODIMP VirtualProtocol::QueryInterface(REFIID riid, void **ppv)
 {
@@ -1711,7 +1716,7 @@ HRESULT STDMETHODCALLTYPE VirtualProtocol::Start(LPCWSTR szUrl, wxIInternetProto
 
 HRESULT STDMETHODCALLTYPE VirtualProtocol::Read(void *pv, ULONG cb, ULONG *pcbRead)
 {
-    //If the file is null we return false to indicte it is finished
+    //If the file is null we return false to indicate it is finished
     if(!m_file)
         return S_FALSE;
 


### PR DESCRIPTION
Refer to https://github.com/wxWidgets/wxWidgets/pull/26802

I left the other `wxDELETE(m_file)`s as-is since `m_file` gets nulled out at that point and the DTOR will be a no-op then.

Also, fixed typo in the comments while I'm in here.