### PR TITLE
MSW: True themed border drawing for wxTextCtrl using DarkMode_DarkTheme

### DIFF
--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -247,8 +247,10 @@ protected:
 
     virtual wxString DoGetValue() const override;
 
+    virtual bool MSWShouldDrawDarkThemeBorder() const override;
     virtual void MSWDrawThemeBorder(WXHDC hdc) override;
 
+    virtual void MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
     virtual void MSWSetDarkOrLightMode(SetMode setmode) override;
 
 #if wxUSE_RICHEDIT

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -650,6 +650,10 @@ protected:
     // if themed border should be used, depending on CanApplyThemeBorder().
     wxBorder DoTranslateBorder(wxBorder border) const;
 
+    // Returns true if the window does not draw a good dark mode themed
+    // border and therefore we should explicitly draw it.
+    virtual bool MSWShouldDrawDarkThemeBorder() const { return true; }
+
 #if wxUSE_MENUS_NATIVE
     virtual bool DoPopupMenu( wxMenu *menu, int x, int y ) override;
 #endif // wxUSE_MENUS_NATIVE

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2859,9 +2859,10 @@ void wxTextCtrl::OnSetFocus(wxFocusEvent& event)
 
 bool wxTextCtrl::MSWShouldDrawDarkThemeBorder() const
 {
-    // The non-rich control draws a good themed border if we are using
-    // DarkMode_DarkTheme.
-    return IsRich() && !wxCheckOsVersion(10, 0, 26200);
+    // We need to draw the border for rich edit and when we are not using
+    // DarkMode_DarkTheme. The non-rich control draws a good themed border
+    // with DarkMode_DarkTheme.
+    return IsRich() && !wxMSWDarkMode::HasDarkTheme();
 }
 
 void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc)
@@ -2988,7 +2989,7 @@ void wxTextCtrl::MSWSetRichZoom()
 
 void wxTextCtrl::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
-    if ( wxCheckOsVersion(10, 0, 26200) )
+    if ( wxMSWDarkMode::HasDarkTheme() )
         support.themeName = L"DarkMode_DarkTheme";
     else
         wxTextCtrlBase::MSWGetDarkModeSupport(support);

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2861,7 +2861,7 @@ bool wxTextCtrl::MSWShouldDrawDarkThemeBorder() const
 {
     // The non-rich control draws a good themed border if we are using
     // DarkMode_DarkTheme.
-    return IsRich() || GetBorder() != wxBORDER_THEME || !wxCheckOsVersion(10, 0, 26200);
+    return IsRich() && !wxCheckOsVersion(10, 0, 26200);
 }
 
 void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc)

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2857,6 +2857,13 @@ void wxTextCtrl::OnSetFocus(wxFocusEvent& event)
     event.Skip();
 }
 
+bool wxTextCtrl::MSWShouldDrawDarkThemeBorder() const
+{
+    // The non-rich control draws a good themed border if we are using
+    // DarkMode_DarkTheme.
+    return IsRich() || GetBorder() != wxBORDER_THEME || !wxCheckOsVersion(10, 0, 26200);
+}
+
 void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc)
 {
     if ( IsRich() )
@@ -2978,6 +2985,14 @@ void wxTextCtrl::MSWSetRichZoom()
 }
 
 #endif // wxUSE_RICHEDIT
+
+void wxTextCtrl::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    if ( wxCheckOsVersion(10, 0, 26200) )
+        support.themeName = L"DarkMode_DarkTheme";
+    else
+        wxTextCtrlBase::MSWGetDarkModeSupport(support);
+}
 
 void wxTextCtrl::MSWSetDarkOrLightMode(SetMode setmode)
 {

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3846,9 +3846,16 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                     case wxBORDER_STATIC:
                     case wxBORDER_RAISED:
-                    case wxBORDER_SUNKEN:
-                        // In dark mode, explicitly draw these border styles when
+                        // In dark mode, explicitly draw these border styles because
                         // the default drawing uses light mode colours.
+                        drawBorder = wxMSWDarkMode::IsActive();
+                        break;
+
+                    case wxBORDER_SUNKEN:
+                        // In dark mode, explicitly draw the border unless the window
+                        // draws a good border itself. When the window draws a good
+                        // border, DoTranslateBorder() translates wxBORDER_THEME to
+                        // wxBORDER_SUNKEN.
                         drawBorder = wxMSWDarkMode::IsActive() &&
                             MSWShouldDrawDarkThemeBorder();
                         break;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3847,9 +3847,10 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                     case wxBORDER_STATIC:
                     case wxBORDER_RAISED:
                     case wxBORDER_SUNKEN:
-                        // In dark mode, explicitly draw these border styles because
+                        // In dark mode, explicitly draw these border styles when
                         // the default drawing uses light mode colours.
-                        drawBorder = wxMSWDarkMode::IsActive();
+                        drawBorder = wxMSWDarkMode::IsActive() &&
+                            MSWShouldDrawDarkThemeBorder();
                         break;
 
                     case wxBORDER_NONE:


### PR DESCRIPTION
Use `DarkMode_DarkTheme` with `wxTextCtrl` when possible for true themed border drawing.

If `DarkMode_DarkTheme` is not available, the explicit border drawing added in fb7f082 is used. The `DarkMode_DarkTheme` border drawing has some intricate effects compared to the explicit drawing including rounded corners and mouse hover highlighting.
