### PR TITLE
Improve example code in XRC overview

### DIFF
--- a/docs/doxygen/overviews/xrc.h
+++ b/docs/doxygen/overviews/xrc.h
@@ -365,16 +365,16 @@ protected:
     wxButton* B;
 
 private:
-    void InitWidgetsFromXRC()
+    void InitWidgetsFromXRC(wxWindow* parent)
     {
-        wxXmlResource::Get()->LoadObject(this, nullptr, "TestWnd", "wxFrame");
+        wxXmlResource::Get()->LoadObject(this, parent, "TestWnd_Base", "wxFrame");
         A = XRCCTRL(*this, "A", wxTextCtrl);
         B = XRCCTRL(*this, "B", wxButton);
     }
 public:
-    TestWnd::TestWnd()
+    TestWnd_Base(wxWindow* parent = nullptr)
     {
-        InitWidgetsFromXRC();
+        InitWidgetsFromXRC(parent);
     }
 };
 @endcode


### PR DESCRIPTION
Fix typos in the ctor and resource names and make the code look more similar to the one actually generated by wxrc utility.