### PR TITLE
Respect swapped mouse buttons in wxUIActionSimulator

### DIFF
--- a/docs/contributing/how-to-write-unit-tests.md
+++ b/docs/contributing/how-to-write-unit-tests.md
@@ -96,6 +96,10 @@ clicking buttons or typing text. A simple example of this can be found in
 `tests/controls/buttontest.cpp`. After simulating some user input always
 call `wxYield()` to allow event processing. When writing a test using
 `wxUIActionSimulator` wrap it in `#if wxUSE_UIACTIONSIMULATOR` block.
+On MSW, `wxUIActionSimulator` respects the user's swapped mouse-button
+configuration, so `MouseClick()` still produces a primary-button click,
+while `MouseClick(wxMOUSE_BTN_RIGHT)` still produces a secondary-button
+click.
 
 There are a number of classes that are available to help with testing GUI
 elements. Firstly throughout the test run there is a frame of type

--- a/src/msw/uiaction.cpp
+++ b/src/msw/uiaction.cpp
@@ -54,9 +54,28 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxUIActionSimulatorMSWImpl);
 };
 
+int PhysicalButtonForLogicalButton(int button)
+{
+    if ( ::GetSystemMetrics(SM_SWAPBUTTON) )
+    {
+        switch ( button )
+        {
+            case wxMOUSE_BTN_LEFT:
+                return wxMOUSE_BTN_RIGHT;
+
+            case wxMOUSE_BTN_RIGHT:
+                return wxMOUSE_BTN_LEFT;
+        }
+    }
+
+    return button;
+}
+
 DWORD EventTypeForMouseButton(int button, bool isDown)
 {
-    switch (button)
+    // wxUIActionSimulator uses logical left/right buttons. mouse_event() needs
+    // the physical MSW button producing them when the user swaps buttons.
+    switch ( PhysicalButtonForLogicalButton(button) )
     {
         case wxMOUSE_BTN_LEFT:
             return isDown ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP;


### PR DESCRIPTION
On MSW, translate logical left and right mouse buttons to their physical buttons before passing them to mouse_event(). This keeps MouseClick() as a primary-button click and MouseClick(wxMOUSE_BTN_RIGHT) as a secondary click when the user swaps the mouse buttons.

Document this behavior for GUI tests.