### PR TITLE
MSW: Fix wxDataViewTreeCtrl expander style switching to light mode

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -627,6 +627,10 @@ protected:
         // The theme IDs to use. If neither this field nor the theme name is
         // set, no theme is applied to the window.
         const wchar_t* themeId = nullptr;
+
+        // True if we should apply theme L"Explorer" when switching to light
+        // mode. Otherwise, nullptr is used.
+        bool isLightModeThemed = true;
     };
 
     virtual void MSWGetDarkModeSupport(MSWDarkModeSupport& support) const;

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -102,6 +102,7 @@ void wxGauge::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
     {
         support.themeName = L"DarkMode_DarkTheme";
         support.themeId = L"Progress";
+        support.isLightModeThemed = false;
     }
     else
         wxGaugeBase::MSWGetDarkModeSupport(support);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4150,16 +4150,20 @@ void wxWindowMSW::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 
 void wxWindowMSW::MSWSetDarkOrLightMode(SetMode WXUNUSED(setmode))
 {
+    const wchar_t* themeName = nullptr;
+    const wchar_t* themeId = nullptr;
     MSWDarkModeSupport support;
+    MSWGetDarkModeSupport(support);
     if ( wxMSWDarkMode::IsActive() )
     {
-        MSWGetDarkModeSupport(support);
+        themeName = support.themeName;
+        themeId = support.themeId;
     }
-    // Else to restore light mode, use support.themeName == nullptr and
-    // support.themeId == nullptr.
+    else if ( support.isLightModeThemed )
+        themeName = L"Explorer";
 
     // This updates scroll bars, if there are any.
-    wxMSWDarkMode::AllowForWindow(m_hWnd, support.themeName, support.themeId);
+    wxMSWDarkMode::AllowForWindow(m_hWnd, themeName, themeId);
 
     // If the window class has a background brush, update it.
     // This is the value in WNDCLASS::hbrBackground.


### PR DESCRIPTION
When switching from dark to light mode, the `wxDataViewTreeCtrl` expander button style changes from the themed chevron to unthemed box containing a plus or minus. This was broken by 01c6cb1cbc7. The solution is to again apply theme `"Explorer"` upon switching to light mode, except for the `wxGauge`, which needs `SetWindowTheme(,nullptr,nullptr)`.
