### PR TITLE
Fix/add pointer checks in Edge WebView

### DIFF
--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -837,7 +837,11 @@ HRESULT wxWebViewEdgeImpl::OnWebResourceRequested(ICoreWebView2* WXUNUSED(sender
     wxSharedPtr<wxWebViewHandler> handler;
 
     if (uri.HasServer())
-        handler = m_handlers[uri.GetServer()];
+    {
+        const auto it = m_handlers.find(uri.GetServer());
+        if ( it != m_handlers.end() )
+            handler = it->second;
+    }
 
     if (!handler)
     {

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -555,7 +555,7 @@ void wxWebViewEdgeImpl::UpdateBounds()
 {
     RECT r;
     wxCopyRectToRECT(m_ctrl->GetClientRect(), r);
-    if (m_webView)
+    if ( m_webViewController )
         m_webViewController->put_Bounds(r);
 }
 

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -216,11 +216,14 @@ public:
             return false;
         }
         // Mark event as completed
-        hr = m_deferral->Complete();
-        if (FAILED(hr))
+        if ( m_deferral )
         {
-            wxLogApiError("deferral->Complete()", hr);
-            return false;
+            hr = m_deferral->Complete();
+            if (FAILED(hr))
+            {
+                wxLogApiError("deferral->Complete()", hr);
+                return false;
+            }
         }
 
         return true;
@@ -369,7 +372,8 @@ public:
     {
         wxPoint result(-1, -1);
         BOOL hasPosition;
-        if (SUCCEEDED(m_windowFeatures->get_HasPosition(&hasPosition)) && hasPosition)
+        if (m_windowFeatures &&
+            SUCCEEDED(m_windowFeatures->get_HasPosition(&hasPosition)) && hasPosition)
         {
             UINT32 x, y;
             if (SUCCEEDED(m_windowFeatures->get_Left(&x)) &&
@@ -383,7 +387,8 @@ public:
     {
         wxSize result(-1, -1);
         BOOL hasSize;
-        if (SUCCEEDED(m_windowFeatures->get_HasSize(&hasSize)) && hasSize)
+        if (m_windowFeatures &&
+            SUCCEEDED(m_windowFeatures->get_HasSize(&hasSize)) && hasSize)
         {
             UINT32 width, height;
             if (SUCCEEDED(m_windowFeatures->get_Width(&width)) &&
@@ -396,7 +401,8 @@ public:
     virtual bool ShouldDisplayMenuBar() const override
     {
         BOOL result;
-        if (SUCCEEDED(m_windowFeatures->get_ShouldDisplayMenuBar(&result)))
+        if (m_windowFeatures &&
+            SUCCEEDED(m_windowFeatures->get_ShouldDisplayMenuBar(&result)))
             return result;
         else
             return true;
@@ -405,7 +411,8 @@ public:
     virtual bool ShouldDisplayStatusBar() const override
     {
         BOOL result;
-        if (SUCCEEDED(m_windowFeatures->get_ShouldDisplayStatus(&result)))
+        if (m_windowFeatures &&
+            SUCCEEDED(m_windowFeatures->get_ShouldDisplayStatus(&result)))
             return result;
         else
             return true;
@@ -413,7 +420,8 @@ public:
     virtual bool ShouldDisplayToolBar() const override
     {
         BOOL result;
-        if (SUCCEEDED(m_windowFeatures->get_ShouldDisplayToolbar(&result)))
+        if (m_windowFeatures &&
+            SUCCEEDED(m_windowFeatures->get_ShouldDisplayToolbar(&result)))
             return result;
         else
             return true;
@@ -422,7 +430,8 @@ public:
     virtual bool ShouldDisplayScrollBars() const override
     {
         BOOL result;
-        if (SUCCEEDED(m_windowFeatures->get_ShouldDisplayScrollBars(&result)))
+        if (m_windowFeatures &&
+            SUCCEEDED(m_windowFeatures->get_ShouldDisplayScrollBars(&result)))
             return result;
         else
             return true;
@@ -1005,7 +1014,7 @@ HRESULT wxWebViewEdgeImpl::OnWebViewCreated(HRESULT result, ICoreWebView2Control
     {
         if (FAILED(m_newWindowArgs->put_NewWindow(baseWebView)))
             SendErrorEventForAPI("WebView2::WebViewCreated (put_NewWindow)", hr);
-        if (FAILED(m_newWindowDeferral->Complete()))
+        if (m_newWindowDeferral && FAILED(m_newWindowDeferral->Complete()))
             SendErrorEventForAPI("WebView2::WebViewCreated (Complete)", hr);
         m_newWindowArgs.reset();
         m_newWindowDeferral.reset();
@@ -1631,6 +1640,9 @@ void wxWebViewEdge::EnableAccessToDevTools(bool enable)
 
 bool wxWebViewEdge::ShowDevTools()
 {
+    if ( !m_impl->m_webView )
+        return false;
+
     const HRESULT hr = m_impl->m_webView->OpenDevToolsWindow();
     if ( FAILED(hr) )
     {
@@ -1718,6 +1730,9 @@ bool wxWebViewEdge::SetProxy(const wxString& proxy)
 
 bool wxWebViewEdge::ClearBrowsingData(int types, wxDateTime since)
 {
+    if ( !m_impl->m_webView )
+        return false;
+
     wxCOMPtr<ICoreWebView2_13> webView13;
     if (FAILED(m_impl->m_webView->QueryInterface(IID_PPV_ARGS(&webView13))))
         return false;


### PR DESCRIPTION
[Don't insert null handler when looking up Edge WebView handlers](https://github.com/wxWidgets/wxWidgets/commit/eca8f513ba8432f855e211e1ea38e71a9a166323) may need a review, but I believe this fixes a possible null handler being added to the handler collection and crashing.

The original `handler = m_handlers[uri.GetServer()];` code would insert a bogus entry into `m_handlers` if `uri.GetServer()`'s return wasn't already in there. This would return a null handler into `handler`. At this point, `m_handlers` is poisoned with a server with a null handler. Then, with `handler` being null, this line `if (kv.second->GetName() == scheme)` further down will access this poisoned key and crash. The fix I did is to call find with `uri.GetServer()` in `m_handlers` and use the value from that if found, rather than relying on the mutating `operator[]`. I think `RegisterHandler()` is the only place that `m_handlers` should be getting mutated. Please correct me if I am mistaken.