### PR TITLE
fix wxDocument::UpdateAllViews() handling mutiple wxView removals

### DIFF
--- a/build/cmake/tests/gui/CMakeLists.txt
+++ b/build/cmake/tests/gui/CMakeLists.txt
@@ -85,6 +85,7 @@ set(TEST_GUI_SRC
     controls/webtest.cpp
     controls/windowtest.cpp
     controls/dialogtest.cpp
+    docview/doc-updateallviews.cpp
     events/clone.cpp
     events/enterleave.cpp
     # Duplicate this file here to test GUI event loops too.

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -624,13 +624,22 @@ void wxDocument::OnChangedViewList()
 
 void wxDocument::UpdateAllViews(wxView *sender, wxObject *hint)
 {
-    wxList::compatibility_iterator node = m_documentViews.GetFirst();
-    while (node)
+    // Tolerate wxView::OnUpdate() performing multiple removals
+    wxViewVector initialState = GetViewsVector();
+    for (wxView *view : initialState)
     {
-        wxView *view = (wxView *)node->GetData();
-        if (view != sender)
-            view->OnUpdate(sender, hint);
-        node = node->GetNext();
+        wxList::compatibility_iterator node = m_documentViews.GetFirst();
+        while (node)
+        {
+            wxView *present = (wxView *)node->GetData();
+            if (present == view)
+            {
+                view->OnUpdate(sender, hint);
+                break;
+            }
+            node = node->GetNext();
+            wxASSERT(node);
+        }
     }
 }
 

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -624,21 +624,26 @@ void wxDocument::OnChangedViewList()
 
 void wxDocument::UpdateAllViews(wxView *sender, wxObject *hint)
 {
-    // Tolerate wxView::OnUpdate() performing multiple removals
-    wxViewVector initialState = GetViewsVector();
-    for (wxView *view : initialState)
+    // wxView::OnUpdate() may remove the view it's called on (relatively common)
+    // or, potentially, even another view from the document, so make a
+    // copy of the existing view container before starting to iterate
+    // over it.
+    const wxViewVector initialState = GetViewsVector();
+    for (wxView * const view : initialState)
     {
-        wxList::compatibility_iterator node = m_documentViews.GetFirst();
-        while (node)
+        if (view != sender)
         {
-            wxView *present = (wxView *)node->GetData();
-            if (present == view)
+            wxList::compatibility_iterator node = m_documentViews.GetFirst();
+            while (node)
             {
-                view->OnUpdate(sender, hint);
-                break;
+                wxView * const present = (wxView *)node->GetData();
+                if (present == view)
+                {
+                    view->OnUpdate(sender, hint);
+                    break;
+                }
+                node = node->GetNext();
             }
-            node = node->GetNext();
-            wxASSERT(node);
         }
     }
 }

--- a/tests/docview/doc-updateallviews.cpp
+++ b/tests/docview/doc-updateallviews.cpp
@@ -1,0 +1,202 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/docview/doc-updateallviews.cpp
+// Purpose:     Unit test for wxDocument::UpdateAllViews()
+// Author:      Bill Su
+// Created:     2026-08-16
+// Copyright:   (c) 2026 Bill Su
+///////////////////////////////////////////////////////////////////////////////
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+#include "testprec.h"
+
+
+#ifndef WX_PRECOMP
+#endif // WX_PRECOMP
+
+#include <memory>
+
+#include "asserthelper.h"
+
+#include "wx/docview.h"
+
+// ----------------------------------------------------------------------------
+// tests helpers
+// ----------------------------------------------------------------------------
+
+namespace
+{
+
+class MyDocument : public wxDocument
+{
+public:
+    virtual ~MyDocument() override;
+    virtual void OnChangedViewList() override;
+
+protected:
+};
+
+class MyView : public wxView
+{
+public:
+    MyView(int serialNumber);
+    virtual void OnUpdate(wxView* sender, wxObject* hint = nullptr) override;
+
+    virtual void OnDraw(wxDC* WXUNUSED(dc)) override { /* do nothing */ }
+
+private:
+    const int serialNumber;
+};
+
+MyDocument::~MyDocument()
+{
+    // avoid memory leak of views
+    DeleteAllViews();
+}
+
+void MyDocument::OnChangedViewList()
+{
+    // base class deletes this when no views remain,
+    // but dtor removes views, so base class version
+    // must not be called
+}
+
+MyView::MyView(int sn) :
+    serialNumber(sn)
+{
+}
+
+struct Accum : public wxObject
+{
+    enum Command
+    {
+        SIMPLE,
+        SERNO_50_REMOVE_SELF,
+        SERNO_50_REMOVE_ODD,
+    };
+
+    Accum(Command c) : command(c) {}
+
+    const Command command;
+    wxVector<int> v;
+};
+
+void MyView::OnUpdate(wxView* WXUNUSED(sender), wxObject* hint /*= nullptr*/)
+{
+    Accum* const accum = static_cast<Accum*>(hint);
+    switch ( accum->command )
+    {
+        case Accum::SIMPLE:
+            accum->v.push_back(serialNumber);
+            break;
+
+        case Accum::SERNO_50_REMOVE_SELF:
+            if (serialNumber == 50)
+            {
+                GetDocument()->RemoveView(this);
+                delete this;
+            }
+            break;
+
+        case Accum::SERNO_50_REMOVE_ODD:
+            if (serialNumber == 50)
+            {
+                wxDocument* const doc = GetDocument();
+                const wxViewVector initialState = doc->GetViewsVector();
+                for (wxView* const view : initialState)
+                {
+                    MyView* const myView = static_cast<MyView*>(view);
+                    if (myView->serialNumber % 2 == 1)
+                    {
+                        doc->RemoveView(view);
+                        delete view;
+                    }
+                }
+            }
+            break;
+    }
+}
+
+} // anonymous namespace
+
+// ----------------------------------------------------------------------------
+// tests themselves
+// ----------------------------------------------------------------------------
+
+TEST_CASE("wxDocument::UpdateAllViews", "[docview]")
+{
+    const std::unique_ptr<wxDocument> doc(new MyDocument());
+    wxView* view50 = nullptr;
+    for (int i = 0; i < 100; ++i)
+    {
+        wxView* view = new MyView(i);
+        if (i == 50)
+        {
+            view50 = view;
+        }
+        doc->AddView(view);
+        view->SetDocument(doc.get());
+    }
+
+    // test UpdateAllViews() when not removing view(s)
+    SECTION("Simple")
+    {
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(nullptr, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 100 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v.back() == 99 );
+    }
+
+    // test UpdateAllViews() doesn't call sender
+    SECTION("SkipSender")
+    {
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(view50, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 99 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v[49] == 49 );
+        REQUIRE( accum.v[50] == 51 );
+        REQUIRE( accum.v.back() == 99 );
+    }
+
+    // test UpdateAllViews() when view removes (only) itself
+    SECTION("RemoveSelf")
+    {
+        {
+            Accum accum(Accum::SERNO_50_REMOVE_SELF);
+            doc->UpdateAllViews(nullptr, &accum);
+        }
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(nullptr, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 99 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v[49] == 49);
+        REQUIRE( accum.v[50] == 51 );
+        REQUIRE( accum.v.back() == 99 );
+    }
+
+    // test UpdateAllViews() when view removes many views
+    SECTION("RemoveOdd")
+    {
+        {
+            Accum accum(Accum::SERNO_50_REMOVE_ODD);
+            doc->UpdateAllViews(nullptr, &accum);
+        }
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(nullptr, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 50 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v.back() == 98 );
+    }
+}

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -169,6 +169,7 @@
             asserthelper.cpp
             test.cpp
             testableframe.cpp
+            docview/doc-updateallviews.cpp
             geometry/rect.cpp
             geometry/size.cpp
             geometry/point.cpp


### PR DESCRIPTION
If `wxView::Update()` closes itself, it invalidates the iteration in `wxDocument::UpdateAllViews()`.

This PR handles that case, but it also handles my specific use case, which is even more extreme:  I (sometimes) remove other views in `wxView::Update()`.  To handle this case, the implementation becomes O(n<sup>2</sup>).

Since I think my use case is probably unusual, and `wxDocument::UpdateAllViews()` is virtual, if you want to reject this PR due to the O(n<sup>2</sup>) implementation, I can make these changes in an override in my application.  (I suspect it is possible to handle just the self-close case with O(n) code.)