### PR TITLE
Try to avoid spurious msgfmt failures in CMake/clang CI job

### DIFF
--- a/build/cmake/locale/CMakeLists.txt
+++ b/build/cmake/locale/CMakeLists.txt
@@ -20,17 +20,29 @@ endif()
 
 # list and process the po files
 file(GLOB _po_files "${wxSOURCE_DIR}/locale/*.po")
+set(_gmo_files)
 foreach(_po_file ${_po_files})
     get_filename_component(name "${_po_file}" NAME)
     string(REGEX REPLACE "\\.[^.]*$" "" lang ${name})
+    set(_gmo_file "${CMAKE_CURRENT_BINARY_DIR}/${lang}.gmo")
 
-    gettext_process_po_files(${lang} ALL PO_FILES "${_po_file}")
+    add_custom_command(OUTPUT "${_gmo_file}"
+        COMMAND ${CMAKE_COMMAND}
+                -DMSGFMT=${GETTEXT_MSGFMT_EXECUTABLE}
+                -DPO=${_po_file} -DGMO=${_gmo_file}
+                -P ${wxSOURCE_DIR}/build/cmake/modules/msgfmt.cmake
+        DEPENDS "${_po_file}"
+        COMMENT "Generating ${lang}.gmo"
+        VERBATIM)
+    list(APPEND _gmo_files "${_gmo_file}")
 
-    wx_install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/${lang}.gmo"
+    wx_install(FILES       "${_gmo_file}"
                DESTINATION "share/locale/${lang}/LC_MESSAGES"
                RENAME      "wxstd-${wxMAJOR_VERSION}.${wxMINOR_VERSION}.mo"
     )
 endforeach()
+
+add_custom_target(wxstd_translations ALL DEPENDS ${_gmo_files})
 
 # put all pofiles targets in a group to not clutter visual studio
 set(base_name "pofiles")

--- a/build/cmake/modules/msgfmt.cmake
+++ b/build/cmake/modules/msgfmt.cmake
@@ -1,0 +1,23 @@
+# This is used from build/cmake/locale/CMakeLists.txt to generate .gmo files
+# from .po files using msgfmt in a more flexible way than done by the standard
+# gettext_process_po_files.
+foreach(attempt RANGE 1 5)
+    execute_process(
+        COMMAND "${MSGFMT}" -o "${GMO}" "${PO}"
+        RESULT_VARIABLE res
+        ERROR_VARIABLE err
+    )
+
+    if(res EQUAL 0)
+        # Don't swallow msgfmt's own warnings about the .po file.
+        if(err)
+            message("${err}")
+        endif()
+        return()
+    endif()
+
+    message(STATUS "msgfmt failed for ${PO} (attempt ${attempt}): ${err}")
+    execute_process(COMMAND "${CMAKE_COMMAND}" -E sleep ${attempt})
+endforeach()
+
+message(FATAL_ERROR "msgfmt failed for ${PO} after 5 attempts: ${err}")


### PR DESCRIPTION
This job periodically fails with a mysterious error message:

/usr/bin/msgfmt: error while writing "D:/a/wxWidgets/wxWidgets/build_cmake/locale/ne.gmo" file: Device or resource busy

It's not clear why is the file busy, there should be nothing else using it, but try to work around this by retrying a few times if this happens again.