### PR TITLE
CMake: Fix warning about backslashes in macro

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -98,7 +98,7 @@ endmacro()
 # wx_install_symlink(...)
 # Create symlink dst pointing to src
 # try different symlink and copy methods until one succeeds
-macro(wx_install_symlink src dst)
+function(wx_install_symlink src dst)
     if(wxBUILD_INSTALL)
         install(CODE "
             set(SYMLINK_SRC \"${src}\")
@@ -129,7 +129,7 @@ macro(wx_install_symlink src dst)
             endif()
         ")
     endif()
-endmacro()
+endfunction()
 
 # Get a valid flavour name with optional prefix
 macro(wx_get_flavour flavour prefix)

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -67,7 +67,7 @@ else()
 
     wx_get_install_platform_dir(runtime)
     install(DIRECTORY DESTINATION "${runtime_dir}")
-    set(CONFIG_DIR "\\\$ENV{DESTDIR}\\\${CMAKE_INSTALL_PREFIX}")
+    set(CONFIG_DIR "\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}")
     set(CONFIG_SRC "${CONFIG_DIR}/${library_dir}/wx/config/${wxBUILD_FILE_ID}")
     set(CONFIG_DST "${CONFIG_DIR}/${runtime_dir}/wx-config")
     wx_install_symlink(${CONFIG_SRC} ${CONFIG_DST})

--- a/build/cmake/utils/CMakeLists.txt
+++ b/build/cmake/utils/CMakeLists.txt
@@ -38,7 +38,7 @@ if(wxUSE_XRC)
             set(EXE_SUFFIX ${CMAKE_EXECUTABLE_SUFFIX})
         endif()
 
-        set(WXRC_DIR "\\\$ENV{DESTDIR}\\\${CMAKE_INSTALL_PREFIX}")
+        set(WXRC_DIR "\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}")
         set(WXRC_SRC "${WXRC_DIR}/${runtime_dir}/${wxrc_output_name}${EXE_SUFFIX}")
         set(WXRC_DST "${WXRC_DIR}/${runtime_dir}/wxrc${EXE_SUFFIX}")
         wx_install_symlink(${WXRC_SRC} ${WXRC_DST})


### PR DESCRIPTION
CMake 4.4 added a new policy [CMP0219](https://cmake.org/cmake/help/latest/policy/CMP0219.html) to preserve backslashes in macros. Ideally we want to use the new policy, but older CMake version will still use the old one. Change the macro to a function so we don't have to deal with handling old and new policies.