### PR TITLE
Use wxSizerFlags and DPI-independent borders in samples

### DIFF
--- a/samples/artprov/artbrows.cpp
+++ b/samples/artprov/artbrows.cpp
@@ -149,16 +149,17 @@ wxArtBrowserDialog::wxArtBrowserDialog(wxWindow *parent)
     FillClients(choice);
 
     subsizer = new wxBoxSizer(wxHORIZONTAL);
-    subsizer->Add(new wxStaticText(this, wxID_ANY, "Client:"), 0, wxALIGN_CENTER_VERTICAL);
-    subsizer->Add(choice, 1, wxLEFT, 5);
-    sizer->Add(subsizer, 0, wxALL | wxEXPAND, 10);
+    subsizer->Add(new wxStaticText(this, wxID_ANY, "Client:"),
+                  wxSizerFlags().CenterVertical());
+    subsizer->Add(choice, wxSizerFlags(1).Border(wxLEFT));
+    sizer->Add(subsizer, wxSizerFlags().Expand().DoubleBorder());
 
     subsizer = new wxBoxSizer(wxHORIZONTAL);
 
     m_list = new wxListCtrl(this, wxID_ANY, wxDefaultPosition, wxSize(250, 300),
                             wxLC_REPORT | wxSUNKEN_BORDER);
     m_list->AppendColumn("wxArtID");
-    subsizer->Add(m_list, 0, wxEXPAND | wxRIGHT, 10);
+    subsizer->Add(m_list, wxSizerFlags().Expand().DoubleBorder(wxRIGHT));
 
     wxSizer *subsub = new wxBoxSizer(wxVERTICAL);
 
@@ -171,21 +172,21 @@ wxArtBrowserDialog::wxArtBrowserDialog(wxWindow *parent)
         m_sizes->Append( wxString::Format("%d x %d", *p, *p ) );
     }
     m_sizes->SetSelection(0);
-    subsub->Add(m_sizes, 0, wxALL, 4);
+    subsub->Add(m_sizes, wxSizerFlags().Border());
 
     m_text = new wxStaticText(this, wxID_ANY, "Size: 333x333");
-    subsub->Add(m_text, 0, wxALL, 4);
+    subsub->Add(m_text, wxSizerFlags().Border());
 
     m_canvas = new wxStaticBitmap(this, wxID_ANY, wxBitmap(null_xpm));
     subsub->Add(m_canvas);
     subsub->Add(256, 256);
-    subsizer->Add(subsub, 1, wxLEFT, 4 );
+    subsizer->Add(subsub, wxSizerFlags(1).Border(wxLEFT));
 
-    sizer->Add(subsizer, 1, wxEXPAND | wxLEFT|wxRIGHT, 10);
+    sizer->Add(subsizer, wxSizerFlags(1).Expand().DoubleBorder(wxLEFT|wxRIGHT));
 
     wxButton *ok = new wxButton(this, wxID_OK, "Close");
     ok->SetDefault();
-    sizer->Add(ok, 0, wxALIGN_RIGHT | wxALL, 10);
+    sizer->Add(ok, wxSizerFlags().Right().DoubleBorder());
 
     SetSizerAndFit(sizer);
 

--- a/samples/artprov/artbrows.cpp
+++ b/samples/artprov/artbrows.cpp
@@ -182,7 +182,7 @@ wxArtBrowserDialog::wxArtBrowserDialog(wxWindow *parent)
     subsub->Add(256, 256);
     subsizer->Add(subsub, wxSizerFlags(1).Border(wxLEFT));
 
-    sizer->Add(subsizer, wxSizerFlags(1).Expand().DoubleBorder(wxLEFT|wxRIGHT));
+    sizer->Add(subsizer, wxSizerFlags(1).Expand().DoubleHorzBorder());
 
     wxButton *ok = new wxButton(this, wxID_OK, "Close");
     ok->SetDefault();

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -337,38 +337,38 @@ public:
     {
         //wxBoxSizer* vert = new wxBoxSizer(wxVERTICAL);
 
-        //vert->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        //vert->AddStretchSpacer(1);
 
         wxSize const elementSize = FromDIP(wxSize(180, 20));
 
         wxBoxSizer* s1 = new wxBoxSizer(wxHORIZONTAL);
         m_borderSize = new wxSpinCtrl(this, ID_PaneBorderSize, wxString::Format("%d", frame->GetDockArt()->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE)), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, FromDIP(100), frame->GetDockArt()->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
-        s1->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s1->AddStretchSpacer(1);
         s1->Add(new wxStaticText(this, wxID_ANY, "Pane Border Size:"));
         s1->Add(m_borderSize);
-        s1->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s1->AddStretchSpacer(1);
         s1->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s1, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
         wxBoxSizer* s2 = new wxBoxSizer(wxHORIZONTAL);
         m_sashSize = new wxSpinCtrl(this, ID_SashSize, wxString::Format("%d", frame->GetDockArt()->GetMetric(wxAUI_DOCKART_SASH_SIZE)), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, FromDIP(100), frame->GetDockArt()->GetMetric(wxAUI_DOCKART_SASH_SIZE));
-        s2->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s2->AddStretchSpacer(1);
         s2->Add(new wxStaticText(this, wxID_ANY, "Sash Size:"));
         s2->Add(m_sashSize);
-        s2->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s2->AddStretchSpacer(1);
         s2->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s2, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
         wxBoxSizer* s3 = new wxBoxSizer(wxHORIZONTAL);
         m_captionSize = new wxSpinCtrl(this, ID_CaptionSize, wxString::Format("%d", frame->GetDockArt()->GetMetric(wxAUI_DOCKART_CAPTION_SIZE)), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, FromDIP(100), frame->GetDockArt()->GetMetric(wxAUI_DOCKART_CAPTION_SIZE));
-        s3->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s3->AddStretchSpacer(1);
         s3->Add(new wxStaticText(this, wxID_ANY, "Caption Size:"));
         s3->Add(m_captionSize);
-        s3->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s3->AddStretchSpacer(1);
         s3->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s3, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
-        //vert->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        //vert->AddStretchSpacer(1);
 
 
         wxBitmapBundle const b = CreateColorBitmap(*wxBLACK);
@@ -376,82 +376,82 @@ public:
 
         wxBoxSizer* s4 = new wxBoxSizer(wxHORIZONTAL);
         m_backgroundColor = new wxBitmapButton(this, ID_BackgroundColor, b, wxDefaultPosition, bitmapSize);
-        s4->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s4->AddStretchSpacer(1);
         s4->Add(new wxStaticText(this, wxID_ANY, "Background Color:"));
         s4->Add(m_backgroundColor);
-        s4->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s4->AddStretchSpacer(1);
         s4->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s5 = new wxBoxSizer(wxHORIZONTAL);
         m_sashColor = new wxBitmapButton(this, ID_SashColor, b, wxDefaultPosition, bitmapSize);
-        s5->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s5->AddStretchSpacer(1);
         s5->Add(new wxStaticText(this, wxID_ANY, "Sash Color:"));
         s5->Add(m_sashColor);
-        s5->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s5->AddStretchSpacer(1);
         s5->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s6 = new wxBoxSizer(wxHORIZONTAL);
         m_inactiveCaptionColor = new wxBitmapButton(this, ID_InactiveCaptionColor, b, wxDefaultPosition, bitmapSize);
-        s6->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s6->AddStretchSpacer(1);
         s6->Add(new wxStaticText(this, wxID_ANY, "Normal Caption:"));
         s6->Add(m_inactiveCaptionColor);
-        s6->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s6->AddStretchSpacer(1);
         s6->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s7 = new wxBoxSizer(wxHORIZONTAL);
         m_inactiveCaptionGradientColor = new wxBitmapButton(this, ID_InactiveCaptionGradientColor, b, wxDefaultPosition, bitmapSize);
-        s7->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s7->AddStretchSpacer(1);
         s7->Add(new wxStaticText(this, wxID_ANY, "Normal Caption Gradient:"));
         s7->Add(m_inactiveCaptionGradientColor);
-        s7->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s7->AddStretchSpacer(1);
         s7->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s8 = new wxBoxSizer(wxHORIZONTAL);
         m_inactiveCaptionTextColor = new wxBitmapButton(this, ID_InactiveCaptionTextColor, b, wxDefaultPosition, bitmapSize);
-        s8->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s8->AddStretchSpacer(1);
         s8->Add(new wxStaticText(this, wxID_ANY, "Normal Caption Text:"));
         s8->Add(m_inactiveCaptionTextColor);
-        s8->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s8->AddStretchSpacer(1);
         s8->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s9 = new wxBoxSizer(wxHORIZONTAL);
         m_activeCaptionColor = new wxBitmapButton(this, ID_ActiveCaptionColor, b, wxDefaultPosition, bitmapSize);
-        s9->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s9->AddStretchSpacer(1);
         s9->Add(new wxStaticText(this, wxID_ANY, "Active Caption:"));
         s9->Add(m_activeCaptionColor);
-        s9->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s9->AddStretchSpacer(1);
         s9->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s10 = new wxBoxSizer(wxHORIZONTAL);
         m_activeCaptionGradientColor = new wxBitmapButton(this, ID_ActiveCaptionGradientColor, b, wxDefaultPosition, bitmapSize);
-        s10->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s10->AddStretchSpacer(1);
         s10->Add(new wxStaticText(this, wxID_ANY, "Active Caption Gradient:"));
         s10->Add(m_activeCaptionGradientColor);
-        s10->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s10->AddStretchSpacer(1);
         s10->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s11 = new wxBoxSizer(wxHORIZONTAL);
         m_activeCaptionTextColor = new wxBitmapButton(this, ID_ActiveCaptionTextColor, b, wxDefaultPosition, bitmapSize);
-        s11->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s11->AddStretchSpacer(1);
         s11->Add(new wxStaticText(this, wxID_ANY, "Active Caption Text:"));
         s11->Add(m_activeCaptionTextColor);
-        s11->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s11->AddStretchSpacer(1);
         s11->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s12 = new wxBoxSizer(wxHORIZONTAL);
         m_borderColor = new wxBitmapButton(this, ID_BorderColor, b, wxDefaultPosition, bitmapSize);
-        s12->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s12->AddStretchSpacer(1);
         s12->Add(new wxStaticText(this, wxID_ANY, "Border Color:"));
         s12->Add(m_borderColor);
-        s12->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s12->AddStretchSpacer(1);
         s12->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s13 = new wxBoxSizer(wxHORIZONTAL);
         m_gripperColor = new wxBitmapButton(this, ID_GripperColor, b, wxDefaultPosition, bitmapSize);
-        s13->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s13->AddStretchSpacer(1);
         s13->Add(new wxStaticText(this, wxID_ANY, "Gripper Color:"));
         s13->Add(m_gripperColor);
-        s13->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
+        s13->AddStretchSpacer(1);
         s13->SetItemMinSize((size_t)1, elementSize);
 
         wxGridSizer* gridSizer = new wxGridSizer(2);
@@ -465,7 +465,7 @@ public:
         gridSizer->Add(s8);  gridSizer->Add(s11);
 
         wxBoxSizer* contSizer = new wxBoxSizer(wxVERTICAL);
-        contSizer->Add(gridSizer, 1, wxEXPAND | wxALL, FromDIP(5));
+        contSizer->Add(gridSizer, wxSizerFlags(1).Expand().Border());
         SetSizer(contSizer);
         GetSizer()->SetSizeHints(this);
 
@@ -2624,12 +2624,12 @@ wxAuiNotebook* MyFrame::CreateNotebook()
    flex->AddGrowableRow( 3 );
    flex->AddGrowableCol( 1 );
    flex->Add( FromDIP(5), FromDIP(5) );   flex->Add( FromDIP(5), FromDIP(5) );
-   flex->Add( new wxStaticText( panel, -1, "wxTextCtrl:" ), 0, wxALL|wxALIGN_CENTRE, FromDIP(5) );
+   flex->Add( new wxStaticText( panel, -1, "wxTextCtrl:" ), wxSizerFlags().Centre().Border() );
    flex->Add( new wxTextCtrl( panel, -1, "", wxDefaultPosition, FromDIP(wxSize(100,-1))),
-                1, wxALL|wxALIGN_CENTRE, FromDIP(5) );
-   flex->Add( new wxStaticText( panel, -1, "wxSpinCtrl:" ), 0, wxALL|wxALIGN_CENTRE, FromDIP(5) );
+                wxSizerFlags(1).Centre().Border() );
+   flex->Add( new wxStaticText( panel, -1, "wxSpinCtrl:" ), wxSizerFlags().Centre().Border() );
    flex->Add( new wxSpinCtrl( panel, -1, "5", wxDefaultPosition, wxDefaultSize,
-                wxSP_ARROW_KEYS, 5, 50, 5 ), 0, wxALL|wxALIGN_CENTRE, FromDIP(5) );
+                wxSP_ARROW_KEYS, 5, 50, 5 ), wxSizerFlags().Centre().Border() );
    flex->Add( FromDIP(5), FromDIP(5) );   flex->Add( FromDIP(5), FromDIP(5) );
    panel->SetSizer( flex );
    ctrl->AddPage( panel, "wxPanel", false, pageBmp );

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -337,38 +337,38 @@ public:
     {
         //wxBoxSizer* vert = new wxBoxSizer(wxVERTICAL);
 
-        //vert->AddStretchSpacer(1);
+        //vert->AddStretchSpacer();
 
         wxSize const elementSize = FromDIP(wxSize(180, 20));
 
         wxBoxSizer* s1 = new wxBoxSizer(wxHORIZONTAL);
         m_borderSize = new wxSpinCtrl(this, ID_PaneBorderSize, wxString::Format("%d", frame->GetDockArt()->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE)), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, FromDIP(100), frame->GetDockArt()->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
-        s1->AddStretchSpacer(1);
+        s1->AddStretchSpacer();
         s1->Add(new wxStaticText(this, wxID_ANY, "Pane Border Size:"));
         s1->Add(m_borderSize);
-        s1->AddStretchSpacer(1);
+        s1->AddStretchSpacer();
         s1->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s1, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
         wxBoxSizer* s2 = new wxBoxSizer(wxHORIZONTAL);
         m_sashSize = new wxSpinCtrl(this, ID_SashSize, wxString::Format("%d", frame->GetDockArt()->GetMetric(wxAUI_DOCKART_SASH_SIZE)), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, FromDIP(100), frame->GetDockArt()->GetMetric(wxAUI_DOCKART_SASH_SIZE));
-        s2->AddStretchSpacer(1);
+        s2->AddStretchSpacer();
         s2->Add(new wxStaticText(this, wxID_ANY, "Sash Size:"));
         s2->Add(m_sashSize);
-        s2->AddStretchSpacer(1);
+        s2->AddStretchSpacer();
         s2->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s2, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
         wxBoxSizer* s3 = new wxBoxSizer(wxHORIZONTAL);
         m_captionSize = new wxSpinCtrl(this, ID_CaptionSize, wxString::Format("%d", frame->GetDockArt()->GetMetric(wxAUI_DOCKART_CAPTION_SIZE)), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, FromDIP(100), frame->GetDockArt()->GetMetric(wxAUI_DOCKART_CAPTION_SIZE));
-        s3->AddStretchSpacer(1);
+        s3->AddStretchSpacer();
         s3->Add(new wxStaticText(this, wxID_ANY, "Caption Size:"));
         s3->Add(m_captionSize);
-        s3->AddStretchSpacer(1);
+        s3->AddStretchSpacer();
         s3->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s3, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
-        //vert->AddStretchSpacer(1);
+        //vert->AddStretchSpacer();
 
 
         wxBitmapBundle const b = CreateColorBitmap(*wxBLACK);
@@ -376,82 +376,82 @@ public:
 
         wxBoxSizer* s4 = new wxBoxSizer(wxHORIZONTAL);
         m_backgroundColor = new wxBitmapButton(this, ID_BackgroundColor, b, wxDefaultPosition, bitmapSize);
-        s4->AddStretchSpacer(1);
+        s4->AddStretchSpacer();
         s4->Add(new wxStaticText(this, wxID_ANY, "Background Color:"));
         s4->Add(m_backgroundColor);
-        s4->AddStretchSpacer(1);
+        s4->AddStretchSpacer();
         s4->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s5 = new wxBoxSizer(wxHORIZONTAL);
         m_sashColor = new wxBitmapButton(this, ID_SashColor, b, wxDefaultPosition, bitmapSize);
-        s5->AddStretchSpacer(1);
+        s5->AddStretchSpacer();
         s5->Add(new wxStaticText(this, wxID_ANY, "Sash Color:"));
         s5->Add(m_sashColor);
-        s5->AddStretchSpacer(1);
+        s5->AddStretchSpacer();
         s5->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s6 = new wxBoxSizer(wxHORIZONTAL);
         m_inactiveCaptionColor = new wxBitmapButton(this, ID_InactiveCaptionColor, b, wxDefaultPosition, bitmapSize);
-        s6->AddStretchSpacer(1);
+        s6->AddStretchSpacer();
         s6->Add(new wxStaticText(this, wxID_ANY, "Normal Caption:"));
         s6->Add(m_inactiveCaptionColor);
-        s6->AddStretchSpacer(1);
+        s6->AddStretchSpacer();
         s6->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s7 = new wxBoxSizer(wxHORIZONTAL);
         m_inactiveCaptionGradientColor = new wxBitmapButton(this, ID_InactiveCaptionGradientColor, b, wxDefaultPosition, bitmapSize);
-        s7->AddStretchSpacer(1);
+        s7->AddStretchSpacer();
         s7->Add(new wxStaticText(this, wxID_ANY, "Normal Caption Gradient:"));
         s7->Add(m_inactiveCaptionGradientColor);
-        s7->AddStretchSpacer(1);
+        s7->AddStretchSpacer();
         s7->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s8 = new wxBoxSizer(wxHORIZONTAL);
         m_inactiveCaptionTextColor = new wxBitmapButton(this, ID_InactiveCaptionTextColor, b, wxDefaultPosition, bitmapSize);
-        s8->AddStretchSpacer(1);
+        s8->AddStretchSpacer();
         s8->Add(new wxStaticText(this, wxID_ANY, "Normal Caption Text:"));
         s8->Add(m_inactiveCaptionTextColor);
-        s8->AddStretchSpacer(1);
+        s8->AddStretchSpacer();
         s8->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s9 = new wxBoxSizer(wxHORIZONTAL);
         m_activeCaptionColor = new wxBitmapButton(this, ID_ActiveCaptionColor, b, wxDefaultPosition, bitmapSize);
-        s9->AddStretchSpacer(1);
+        s9->AddStretchSpacer();
         s9->Add(new wxStaticText(this, wxID_ANY, "Active Caption:"));
         s9->Add(m_activeCaptionColor);
-        s9->AddStretchSpacer(1);
+        s9->AddStretchSpacer();
         s9->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s10 = new wxBoxSizer(wxHORIZONTAL);
         m_activeCaptionGradientColor = new wxBitmapButton(this, ID_ActiveCaptionGradientColor, b, wxDefaultPosition, bitmapSize);
-        s10->AddStretchSpacer(1);
+        s10->AddStretchSpacer();
         s10->Add(new wxStaticText(this, wxID_ANY, "Active Caption Gradient:"));
         s10->Add(m_activeCaptionGradientColor);
-        s10->AddStretchSpacer(1);
+        s10->AddStretchSpacer();
         s10->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s11 = new wxBoxSizer(wxHORIZONTAL);
         m_activeCaptionTextColor = new wxBitmapButton(this, ID_ActiveCaptionTextColor, b, wxDefaultPosition, bitmapSize);
-        s11->AddStretchSpacer(1);
+        s11->AddStretchSpacer();
         s11->Add(new wxStaticText(this, wxID_ANY, "Active Caption Text:"));
         s11->Add(m_activeCaptionTextColor);
-        s11->AddStretchSpacer(1);
+        s11->AddStretchSpacer();
         s11->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s12 = new wxBoxSizer(wxHORIZONTAL);
         m_borderColor = new wxBitmapButton(this, ID_BorderColor, b, wxDefaultPosition, bitmapSize);
-        s12->AddStretchSpacer(1);
+        s12->AddStretchSpacer();
         s12->Add(new wxStaticText(this, wxID_ANY, "Border Color:"));
         s12->Add(m_borderColor);
-        s12->AddStretchSpacer(1);
+        s12->AddStretchSpacer();
         s12->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s13 = new wxBoxSizer(wxHORIZONTAL);
         m_gripperColor = new wxBitmapButton(this, ID_GripperColor, b, wxDefaultPosition, bitmapSize);
-        s13->AddStretchSpacer(1);
+        s13->AddStretchSpacer();
         s13->Add(new wxStaticText(this, wxID_ANY, "Gripper Color:"));
         s13->Add(m_gripperColor);
-        s13->AddStretchSpacer(1);
+        s13->AddStretchSpacer();
         s13->SetItemMinSize((size_t)1, elementSize);
 
         wxGridSizer* gridSizer = new wxGridSizer(2);

--- a/samples/calendar/calendar.cpp
+++ b/samples/calendar/calendar.cpp
@@ -759,8 +759,8 @@ MyPanel::MyPanel(wxWindow *parent)
     bool horizontal = ( wxSystemSettings::GetMetric(wxSYS_SCREEN_X) > wxSystemSettings::GetMetric(wxSYS_SCREEN_Y) );
     m_sizer = new wxBoxSizer( horizontal ? wxHORIZONTAL : wxVERTICAL );
 
-    m_sizer->Add(m_date, 0, wxALIGN_CENTER | wxALL, 10 );
-    m_sizer->Add(m_calendar, 0, wxALIGN_CENTER | wxALIGN_LEFT);
+    m_sizer->Add(m_date, wxSizerFlags().Center().DoubleBorder());
+    m_sizer->Add(m_calendar, wxSizerFlags().Center());
 
     SetSizer( m_sizer );
     m_sizer->SetSizeHints( this );

--- a/samples/collpane/collpane.cpp
+++ b/samples/collpane/collpane.cpp
@@ -207,10 +207,14 @@ MyFrame::MyFrame()
     m_paneSizer->AddSpacer( 20 );
     m_paneSizer->Add( paneSubSizer, 1 );
 
-    paneSubSizer->Add( new wxStaticText(win, -1, "Static text" ), 0, wxALIGN_LEFT | wxALL, 3 );
-    paneSubSizer->Add( new wxStaticText(win, -1, "Yet another one!" ), 0, wxALIGN_LEFT | wxALL, 3 );
-    paneSubSizer->Add( new wxTextCtrl(win, PANE_TEXTCTRL, "Text control", wxDefaultPosition, wxSize(80,-1) ), 0, wxALIGN_LEFT | wxALL, 3 );
-    paneSubSizer->Add( new wxButton(win, PANE_BUTTON, "Press to align right" ), 0, wxALIGN_LEFT | wxALL, 3 );
+    paneSubSizer->Add( new wxStaticText(win, -1, "Static text" ),
+                       wxSizerFlags().Left().Border() );
+    paneSubSizer->Add( new wxStaticText(win, -1, "Yet another one!" ),
+                       wxSizerFlags().Left().Border() );
+    paneSubSizer->Add( new wxTextCtrl(win, PANE_TEXTCTRL, "Text control", wxDefaultPosition, wxSize(80,-1) ),
+                       wxSizerFlags().Left().Border() );
+    paneSubSizer->Add( new wxButton(win, PANE_BUTTON, "Press to align right" ),
+                       wxSizerFlags().Left().Border() );
 
     win->SetSizer( m_paneSizer );
 
@@ -315,24 +319,28 @@ MyDialog::MyDialog(wxFrame *parent)
     wxSizer *sz = new wxBoxSizer(wxVERTICAL);
     sz->Add(new wxStaticText(this, -1,
         "This dialog allows you to test the wxCollapsiblePane control"),
-        0, wxALL, 5);
+        wxSizerFlags().Border());
     sz->Add(new wxButton(this, PANEDLG_TOGGLESTATUS_BTN, "Change status"),
-        1, wxGROW|wxALL, 5);
+        wxSizerFlags(1).Expand().Border());
 
     m_collPane = new wxCollapsiblePane(this, -1, "Click here for a surprise");
-    sz->Add(m_collPane, 0, wxGROW|wxALL, 5);
-    sz->Add(new wxTextCtrl(this, -1, "just a test"), 0, wxGROW|wxALL, 5);
+    sz->Add(m_collPane, wxSizerFlags().Expand().Border());
+    sz->Add(new wxTextCtrl(this, -1, "just a test"), wxSizerFlags().Expand().Border());
     sz->AddSpacer(10);
-    sz->Add(new wxButton(this, wxID_OK), 0, wxALIGN_RIGHT|wxALL, 5);
+    sz->Add(new wxButton(this, wxID_OK), wxSizerFlags().Right().Border());
 
     // now add test controls in the collapsible pane
     wxWindow *win = m_collPane->GetPane();
     m_paneSizer = new wxGridSizer(4, 1, 5, 5);
 
-    m_paneSizer->Add( new wxStaticText(win, -1, "Static text" ), 0, wxALIGN_LEFT );
-    m_paneSizer->Add( new wxStaticText(win, -1, "Yet another one!" ), 0, wxALIGN_LEFT );
-    m_paneSizer->Add( new wxTextCtrl(win, PANE_TEXTCTRL, "Text control", wxDefaultPosition, wxSize(80,-1) ), 0, wxALIGN_LEFT );
-    m_paneSizer->Add( new wxButton(win, PANE_BUTTON, "Press to align right" ), 0, wxALIGN_LEFT );
+    m_paneSizer->Add( new wxStaticText(win, -1, "Static text" ),
+                      wxSizerFlags().Left() );
+    m_paneSizer->Add( new wxStaticText(win, -1, "Yet another one!" ),
+                      wxSizerFlags().Left() );
+    m_paneSizer->Add( new wxTextCtrl(win, PANE_TEXTCTRL, "Text control", wxDefaultPosition, wxSize(80,-1) ),
+                      wxSizerFlags().Left() );
+    m_paneSizer->Add( new wxButton(win, PANE_BUTTON, "Press to align right" ),
+                      wxSizerFlags().Left() );
     win->SetSizer( m_paneSizer );
 
     win->SetSizer( m_paneSizer );

--- a/samples/combo/combo.cpp
+++ b/samples/combo/combo.cpp
@@ -653,7 +653,7 @@ MyFrame::MyFrame(const wxString& title)
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
                    "OwnerDrawnComboBox with owner-drawn items:"),
-                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT) );
     colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
@@ -684,7 +684,7 @@ MyFrame::MyFrame(const wxString& title)
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
                    "OwnerDrawnComboBox with owner-drawn items and button on the left:"),
-                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT) );
     colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
@@ -808,7 +808,7 @@ MyFrame::MyFrame(const wxString& title)
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
                    "OwnerDrawnComboBox with simple dropbutton graphics:"),
-                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT) );
 
     colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
@@ -860,7 +860,7 @@ MyFrame::MyFrame(const wxString& title)
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
                         "wxComboCtrl with custom button and custom main control:"),
-                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT) );
 
 
     colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());

--- a/samples/combo/combo.cpp
+++ b/samples/combo/combo.cpp
@@ -652,9 +652,9 @@ MyFrame::MyFrame(const wxString& title)
     //
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
-                   "OwnerDrawnComboBox with owner-drawn items:"), 1,
-                   wxALIGN_CENTER_VERTICAL|wxRIGHT, 4 );
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+                   "OwnerDrawnComboBox with owner-drawn items:"),
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
 
@@ -672,9 +672,9 @@ MyFrame::MyFrame(const wxString& title)
 
     odc->SetSelection(0);
 
-    rowSizer->Add( odc, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
+    rowSizer->Add( odc, wxSizerFlags(1).CenterVertical().Border() );
     rowSizer->AddStretchSpacer(1);
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
 
 
@@ -683,9 +683,9 @@ MyFrame::MyFrame(const wxString& title)
     //
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
-                   "OwnerDrawnComboBox with owner-drawn items and button on the left:"), 1,
-                   wxALIGN_CENTER_VERTICAL|wxRIGHT, 4 );
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+                   "OwnerDrawnComboBox with owner-drawn items and button on the left:"),
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
 
@@ -711,9 +711,9 @@ MyFrame::MyFrame(const wxString& title)
                            2 // horizontal spacing
                           );
 
-    rowSizer->Add( odc, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
+    rowSizer->Add( odc, wxSizerFlags(1).CenterVertical().Border() );
     rowSizer->AddStretchSpacer(1);
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
 
     //
@@ -724,10 +724,10 @@ MyFrame::MyFrame(const wxString& title)
     rowSizer->Add( new wxStaticText(panel,
                         wxID_ANY,
                         "List View wxComboCtrl (custom animation):"),
-                   1, wxALIGN_CENTER_VERTICAL|wxRIGHT, 4 );
-    rowSizer->Add( new wxStaticText(panel,wxID_ANY,"Tree Ctrl wxComboCtrl:"), 1,
-                   wxALIGN_CENTER_VERTICAL|wxRIGHT, 4 );
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT) );
+    rowSizer->Add( new wxStaticText(panel,wxID_ANY,"Tree Ctrl wxComboCtrl:"),
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT) );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     cc = new wxComboCtrlWithCustomPopupAnim();
@@ -750,7 +750,7 @@ MyFrame::MyFrame(const wxString& title)
     for ( i=0; i<100; i++ )
         iface->AddSelection( wxString::Format("Item %02i",i));
 
-    rowSizer->Add( cc, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    rowSizer->Add( cc, wxSizerFlags(1).CenterVertical().Border() );
 
 
     //
@@ -794,9 +794,9 @@ MyFrame::MyFrame(const wxString& title)
                            0 // horizontal spacing
                           );
 
-    rowSizer->Add( gcc, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    rowSizer->Add( gcc, wxSizerFlags(1).CenterVertical().Border() );
 
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
 #if wxUSE_IMAGE
     wxInitAllImageHandlers();
@@ -807,10 +807,10 @@ MyFrame::MyFrame(const wxString& title)
     //
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
-                   "OwnerDrawnComboBox with simple dropbutton graphics:"), 1,
-                   wxALIGN_CENTER_VERTICAL|wxRIGHT, 4 );
+                   "OwnerDrawnComboBox with simple dropbutton graphics:"),
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
 
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
 
@@ -848,9 +848,9 @@ MyFrame::MyFrame(const wxString& title)
     //                        0 // horizontal spacing
     //                       );
 
-    rowSizer->Add( odc, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
-    rowSizer->Add( odc2, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+    rowSizer->Add( odc, wxSizerFlags(1).CenterVertical().Border() );
+    rowSizer->Add( odc2, wxSizerFlags(1).CenterVertical().Border() );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 #endif
 
 
@@ -859,11 +859,11 @@ MyFrame::MyFrame(const wxString& title)
     //
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
-                        "wxComboCtrl with custom button and custom main control:"), 1,
-                   wxALIGN_CENTER_VERTICAL|wxRIGHT, 4 );
+                        "wxComboCtrl with custom button and custom main control:"),
+                   wxSizerFlags(1).CenterVertical().Border(wxRIGHT, FromDIP(4)) );
 
 
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     wxFileSelectorCombo* fsc;
@@ -896,25 +896,27 @@ MyFrame::MyFrame(const wxString& title)
 
     comboCustom->SetPopupControl(new ListViewComboPopup());
 
-    rowSizer->Add( fsc, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
-    rowSizer->Add( comboCustom, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
-    colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
+    rowSizer->Add( fsc, wxSizerFlags(1).CenterVertical().Border() );
+    rowSizer->Add( comboCustom, wxSizerFlags(1).CenterVertical().Border() );
+    colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
 
     // Make sure GetFeatures is implemented
     wxComboCtrl::GetFeatures();
 
 
-    topRowSizer->Add( colSizer, 1, wxALL, 2 );
+    topRowSizer->Add( colSizer, wxSizerFlags(1).Border(wxALL, FromDIP(2)) );
 
     colSizer = new wxBoxSizer( wxVERTICAL );
 
     colSizer->AddSpacer(8);
-    colSizer->Add( new wxStaticText(panel, wxID_ANY, "Log Messages:"), 0, wxTOP|wxLEFT, 3 );
-    colSizer->Add( m_logWin, 1, wxEXPAND|wxALL, 3 );
+    colSizer->Add( new wxStaticText(panel, wxID_ANY, "Log Messages:"),
+                   wxSizerFlags(0).Border(wxTOP|wxLEFT, FromDIP(3)) );
+    colSizer->Add( m_logWin,
+                   wxSizerFlags(1).Expand().Border(wxALL, FromDIP(3)));
 
-    topRowSizer->Add( colSizer, 1, wxEXPAND|wxALL, 2 );
-    topSizer->Add( topRowSizer, 1, wxEXPAND );
+    topRowSizer->Add( colSizer, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
+    topSizer->Add( topRowSizer, wxSizerFlags(1).Expand());
 
     panel->SetSizer( topSizer );
     topSizer->SetSizeHints( panel );
@@ -959,8 +961,6 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     wxComboBox* cb;
     wxOwnerDrawnComboBox* odc;
 
-    const int border = 4;
-
     wxDialog* dlg = new wxDialog(this,wxID_ANY,
                                  "Compare against wxComboBox",
                                  wxDefaultPosition,wxDefaultSize,
@@ -975,7 +975,7 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
 
     groupSizer->Add( new wxStaticText(groupSizer->GetStaticBox(), wxID_ANY,
                      "Writable, with margins, sorted:"),
-                     wxSizerFlags().Expand().Border(wxRIGHT, border) );
+                     wxSizerFlags().Expand().Border(wxRIGHT) );
 
     odc = new wxOwnerDrawnComboBox(groupSizer->GetStaticBox(),wxID_ANY,wxEmptyString,
                                    wxDefaultPosition, wxDefaultSize,
@@ -987,14 +987,14 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
 
     odc->SetValue("Dot Dash");
     odc->SetMargins(15, 10);
-    groupSizer->Add( odc, wxSizerFlags().Border(wxALL, border) );
+    groupSizer->Add( odc, wxSizerFlags().Border() );
     groupSizer->AddStretchSpacer();
 
     //
     // Readonly ODComboBox
     groupSizer->Add( new wxStaticText(groupSizer->GetStaticBox(),wxID_ANY,
                      "Read-only, big font:"),
-                     wxSizerFlags().Border(wxRIGHT, border) );
+                     wxSizerFlags().Border(wxRIGHT) );
 
     odc = new wxOwnerDrawnComboBox(groupSizer->GetStaticBox(),wxID_ANY,wxEmptyString,
                                    wxDefaultPosition, wxDefaultSize,
@@ -1006,13 +1006,13 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     odc->SetValue("Dot Dash");
     odc->SetText("Dot Dash (Testing SetText)");
 
-    groupSizer->Add( odc, 0, wxALL, border );
+    groupSizer->Add( odc, wxSizerFlags().Border() );
     groupSizer->AddStretchSpacer();
 
     //
     // Disabled read-only ODComboBox
     groupSizer->Add( new wxStaticText(groupSizer->GetStaticBox(),wxID_ANY,"Read-only disabled:"),
-                   wxSizerFlags().Border(wxRIGHT, border) );
+                   wxSizerFlags().Border(wxRIGHT) );
 
     odc = new wxOwnerDrawnComboBox(groupSizer->GetStaticBox(),wxID_ANY,wxEmptyString,
                                      wxDefaultPosition, wxDefaultSize,
@@ -1023,11 +1023,11 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     odc->SetValue("Dot Dash");
     odc->Enable(false);
 
-    groupSizer->Add( odc, wxSizerFlags(3).Expand().Border(wxALL, border) );
+    groupSizer->Add( odc, wxSizerFlags(3).Expand().Border() );
 
     // Disabled ODComboBox
     groupSizer->Add(new wxStaticText(groupSizer->GetStaticBox(), wxID_ANY, "Disabled:"),
-        wxSizerFlags().Border(wxRIGHT, border));
+        wxSizerFlags().Border(wxRIGHT));
 
     odc = new wxOwnerDrawnComboBox(groupSizer->GetStaticBox(), wxID_ANY, wxEmptyString,
         wxDefaultPosition, wxDefaultSize, m_arrItems);
@@ -1035,9 +1035,9 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     odc->SetValue("Dot Dash");
     odc->Enable(false);
 
-    groupSizer->Add(odc, wxSizerFlags(3).Expand().Border(wxALL, border));
+    groupSizer->Add(odc, wxSizerFlags(3).Expand().Border());
 
-    rowSizer->Add( groupSizer, 1, wxEXPAND|wxALL, border );
+    rowSizer->Add( groupSizer, wxSizerFlags(1).Expand().Border() );
 
 
     groupSizer = new wxStaticBoxSizer(new wxStaticBox(dlg,wxID_ANY," wxComboBox "),
@@ -1048,7 +1048,7 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     //
     groupSizer->Add( new wxStaticText(groupSizer->GetStaticBox(),wxID_ANY,
                      "Writable, with margins, sorted:"),
-                     wxSizerFlags().Expand().Border(wxRIGHT, border) );
+                     wxSizerFlags().Expand().Border(wxRIGHT) );
 
     cb = new wxComboBox(groupSizer->GetStaticBox(),wxID_ANY,wxEmptyString,
                         wxDefaultPosition, wxDefaultSize,
@@ -1060,14 +1060,14 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
 
     cb->SetValue("Dot Dash");
     cb->SetMargins(15, 10);
-    groupSizer->Add( cb, wxSizerFlags().Border(wxALL, border) );
+    groupSizer->Add( cb, wxSizerFlags().Border() );
     groupSizer->AddStretchSpacer();
 
     //
     // Readonly wxComboBox
     groupSizer->Add( new wxStaticText(groupSizer->GetStaticBox(), wxID_ANY,
                      "Read-only, big font:"),
-                     wxSizerFlags().Border(wxRIGHT, border) );
+                     wxSizerFlags().Border(wxRIGHT) );
 
     cb = new wxComboBox(groupSizer->GetStaticBox(),wxID_ANY,wxEmptyString,
                         wxDefaultPosition, wxDefaultSize,
@@ -1078,13 +1078,13 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     cb->SetFont(cb->GetFont().Scale(1.5));
     cb->SetValue("Dot Dash");
 
-    groupSizer->Add( cb, 0, wxALL, border );
+    groupSizer->Add( cb, wxSizerFlags().Border() );
     groupSizer->AddStretchSpacer();
 
     //
     // Disabled read-only wxComboBox
     groupSizer->Add( new wxStaticText(groupSizer->GetStaticBox(),wxID_ANY,"Read-only disabled:"),
-                   wxSizerFlags().Border(wxRIGHT, border) );
+                   wxSizerFlags().Border(wxRIGHT) );
 
     cb = new wxComboBox(groupSizer->GetStaticBox(),wxID_ANY,wxEmptyString,
                         wxDefaultPosition, wxDefaultSize,
@@ -1095,12 +1095,12 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     cb->SetValue("Dot Dash");
     cb->Enable(false);
 
-    groupSizer->Add( cb, wxSizerFlags(3).Expand().Border(wxALL, border) );
+    groupSizer->Add( cb, wxSizerFlags(3).Expand().Border() );
 
     //
     // Disabled wxComboBox
     groupSizer->Add(new wxStaticText(groupSizer->GetStaticBox(), wxID_ANY, "Disabled:"),
-        wxSizerFlags().Border(wxRIGHT, border));
+        wxSizerFlags().Border(wxRIGHT));
 
     cb = new wxComboBox(groupSizer->GetStaticBox(), wxID_ANY, wxEmptyString,
         wxDefaultPosition, wxDefaultSize, m_arrItems);
@@ -1108,11 +1108,11 @@ void MyFrame::OnShowComparison( wxCommandEvent& WXUNUSED(event) )
     cb->SetValue("Dot Dash");
     cb->Enable(false);
 
-    groupSizer->Add(cb, wxSizerFlags(3).Expand().Border(wxALL, border));
+    groupSizer->Add(cb, wxSizerFlags(3).Expand().Border());
 
-    rowSizer->Add( groupSizer, 1, wxEXPAND|wxALL, border );
+    rowSizer->Add( groupSizer, wxSizerFlags(1).Expand().Border() );
 
-    colSizer->Add( rowSizer, 1, wxEXPAND|wxALL, border );
+    colSizer->Add( rowSizer, wxSizerFlags(1).Expand().Border());
 
     dlg->SetSizer( colSizer );
     colSizer->SetSizeHints( dlg );

--- a/samples/combo/combo.cpp
+++ b/samples/combo/combo.cpp
@@ -673,7 +673,7 @@ MyFrame::MyFrame(const wxString& title)
     odc->SetSelection(0);
 
     rowSizer->Add( odc, wxSizerFlags(1).CenterVertical().Border() );
-    rowSizer->AddStretchSpacer(1);
+    rowSizer->AddStretchSpacer();
     colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
 
@@ -712,7 +712,7 @@ MyFrame::MyFrame(const wxString& title)
                           );
 
     rowSizer->Add( odc, wxSizerFlags(1).CenterVertical().Border() );
-    rowSizer->AddStretchSpacer(1);
+    rowSizer->AddStretchSpacer();
     colSizer->Add( rowSizer, wxSizerFlags().Expand().Border());
 
 

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -643,6 +643,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     m_logOld = wxLog::SetActiveTarget(new wxLogTextCtrl(m_log));
     wxLogMessage( "This is the log window" );
 
+    const wxSizerFlags doubleBorder = wxSizerFlags().DoubleBorder();
 
     // first page of the notebook
     // --------------------------
@@ -673,7 +674,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
 
     wxSizer *firstPanelSz = new wxBoxSizer( wxVERTICAL );
     m_ctrl[Page_Music]->SetMinSize(wxSize(-1, 200));
-    firstPanelSz->Add(m_ctrl[Page_Music], 1, wxGROW|wxALL, 5);
+    firstPanelSz->Add(m_ctrl[Page_Music], wxSizerFlags(1).Expand().Border());
     firstPanelSz->Add(button_sizer);
     firstPanelSz->Add(sizerCurrent);
     firstPanel->SetSizerAndFit(firstPanelSz);
@@ -687,12 +688,12 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     BuildDataViewCtrl(secondPanel, Page_List);
 
     wxBoxSizer *button_sizer2 = new wxBoxSizer( wxHORIZONTAL );
-    button_sizer2->Add( new wxButton( secondPanel, ID_PREPEND_LIST,"Prepend"),                0, wxALL, 10 );
-    button_sizer2->Add( new wxButton( secondPanel, ID_DELETE_LIST, "Delete selected"),        0, wxALL, 10 );
-    button_sizer2->Add( new wxButton( secondPanel, ID_GOTO,        "Goto 50"),                0, wxALL, 10 );
-    button_sizer2->Add( new wxButton( secondPanel, ID_ADD_MANY,    "Add 1000"),               0, wxALL, 10 );
-    button_sizer2->Add( new wxButton( secondPanel, ID_HIDE_ATTRIBUTES,    "Hide attributes"), 0, wxALL, 10 );
-    button_sizer2->Add( new wxButton( secondPanel, ID_SHOW_ATTRIBUTES,    "Show attributes"), 0, wxALL, 10 );
+    button_sizer2->Add( new wxButton( secondPanel, ID_PREPEND_LIST,"Prepend"),                doubleBorder );
+    button_sizer2->Add( new wxButton( secondPanel, ID_DELETE_LIST, "Delete selected"),        doubleBorder );
+    button_sizer2->Add( new wxButton( secondPanel, ID_GOTO,        "Goto 50"),                doubleBorder );
+    button_sizer2->Add( new wxButton( secondPanel, ID_ADD_MANY,    "Add 1000"),               doubleBorder );
+    button_sizer2->Add( new wxButton( secondPanel, ID_HIDE_ATTRIBUTES,    "Hide attributes"), doubleBorder );
+    button_sizer2->Add( new wxButton( secondPanel, ID_SHOW_ATTRIBUTES,    "Show attributes"), doubleBorder );
 
     wxBoxSizer *sortSizer = new wxBoxSizer(wxHORIZONTAL);
     sortSizer->Add(new wxCheckBox(secondPanel, ID_SORT_BY_FIRST_COLUMN, "Sort by first column"),
@@ -701,7 +702,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
                    wxSizerFlags().Centre().DoubleBorder());
 
     wxSizer *secondPanelSz = new wxBoxSizer( wxVERTICAL );
-    secondPanelSz->Add(m_ctrl[Page_List], 1, wxGROW|wxALL, 5);
+    secondPanelSz->Add(m_ctrl[Page_List], wxSizerFlags(1).Expand().Border());
     secondPanelSz->Add(button_sizer2);
     secondPanelSz->Add(sortSizer);
     secondPanel->SetSizerAndFit(secondPanelSz);
@@ -715,7 +716,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     BuildDataViewCtrl(thirdPanel, Page_ListStore);
 
     wxSizer *thirdPanelSz = new wxBoxSizer( wxVERTICAL );
-    thirdPanelSz->Add(m_ctrl[Page_ListStore], 1, wxGROW|wxALL, 5);
+    thirdPanelSz->Add(m_ctrl[Page_ListStore], wxSizerFlags(1).Expand().Border());
     thirdPanel->SetSizerAndFit(thirdPanelSz);
 
 
@@ -727,13 +728,13 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     BuildDataViewCtrl(fourthPanel, Page_TreeStore);
     // Buttons
     wxBoxSizer *button_sizer4 = new wxBoxSizer( wxHORIZONTAL );
-    button_sizer4->Add( new wxButton( fourthPanel, ID_DELETE_TREE_ITEM, "Delete Selected"), 0, wxALL, 10 );
-    button_sizer4->Add( new wxButton( fourthPanel, ID_DELETE_ALL_TREE_ITEMS, "Delete All"), 0, wxALL, 10 );
-    button_sizer4->Add( new wxButton( fourthPanel, ID_ADD_TREE_ITEM, "Add Item"), 0, wxALL, 10 );
-    button_sizer4->Add( new wxButton( fourthPanel, ID_ADD_TREE_CONTAINER_ITEM, "Add Container"), 0, wxALL, 10 );
+    button_sizer4->Add( new wxButton( fourthPanel, ID_DELETE_TREE_ITEM, "Delete Selected"), doubleBorder );
+    button_sizer4->Add( new wxButton( fourthPanel, ID_DELETE_ALL_TREE_ITEMS, "Delete All"), doubleBorder );
+    button_sizer4->Add( new wxButton( fourthPanel, ID_ADD_TREE_ITEM, "Add Item"), doubleBorder );
+    button_sizer4->Add( new wxButton( fourthPanel, ID_ADD_TREE_CONTAINER_ITEM, "Add Container"), doubleBorder );
 
     wxSizer *fourthPanelSz = new wxBoxSizer( wxVERTICAL );
-    fourthPanelSz->Add(m_ctrl[Page_TreeStore], 1, wxGROW|wxALL, 5);
+    fourthPanelSz->Add(m_ctrl[Page_TreeStore], wxSizerFlags(1).Expand().Border());
     fourthPanelSz->Add(button_sizer4);
     fourthPanel->SetSizerAndFit(fourthPanelSz);
 
@@ -751,7 +752,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
         wxSizerFlags().DoubleBorder());
 
     wxSizer *fifthPanelSz = new wxBoxSizer(wxVERTICAL);
-    fifthPanelSz->Add(m_ctrl[Page_VarHeight], 1, wxGROW | wxALL, 5);
+    fifthPanelSz->Add(m_ctrl[Page_VarHeight], wxSizerFlags(1).Expand().Border());
     fifthPanelSz->Add(button_sizer5);
     fifthPanel->SetSizerAndFit(fifthPanelSz);
 
@@ -783,7 +784,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     BuildDataViewCtrl(seventhPanel, Page_HasValue);
 
     wxSizer *seventhPanelSz = new wxBoxSizer( wxVERTICAL );
-    seventhPanelSz->Add(m_ctrl[Page_HasValue], 1, wxGROW|wxALL, 5);
+    seventhPanelSz->Add(m_ctrl[Page_HasValue], wxSizerFlags(1).Expand().Border());
     seventhPanel->SetSizerAndFit(seventhPanelSz);
 
     // complete GUI
@@ -799,8 +800,8 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
 
     wxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
-    mainSizer->Add( m_notebook, 1, wxGROW );
-    mainSizer->Add( m_log, 0, wxGROW );
+    mainSizer->Add( m_notebook, wxSizerFlags(1).Expand());
+    mainSizer->Add( m_log, wxSizerFlags().Expand());
 
     SetSizerAndFit(mainSizer);
 
@@ -1406,7 +1407,7 @@ void MyFrame::OnStyleChange( wxCommandEvent& WXUNUSED(event) )
     BuildDataViewCtrl((wxPanel*)m_notebook->GetPage(nPanel),
         nPanel, style, flags);
 
-    sz->Prepend(m_ctrl[nPanel], 1, wxGROW|wxALL, 5);
+    sz->Prepend(m_ctrl[nPanel], wxSizerFlags(1).Expand().Border());
     sz->Layout();
 }
 

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3882,7 +3882,7 @@ StdButtonSizerDialog::StdButtonSizerDialog(wxWindow *parent)
 
     sizerTop->Add(sizer3, wxSizerFlags().Border());
 
-    sizerTop->Add(m_chkboxNoDefault, wxSizerFlags().DoubleBorder(wxLEFT|wxRIGHT));
+    sizerTop->Add(m_chkboxNoDefault, wxSizerFlags().DoubleHorzBorder());
 
     EnableDisableControls();
 
@@ -4146,7 +4146,7 @@ wxPanel* SettingsDialog::CreateAestheticSettingsPage(wxWindow* parent)
     spinCtrl->SetValidator(wxGenericValidator(&m_settingsData.m_titleFontSize));
     itemSizer5->Add(spinCtrl, wxSizerFlags().Center().Border());
 
-    item0->Add(itemSizer5, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT));
+    item0->Add(itemSizer5, wxSizerFlags().Expand().HorzBorder());
 #endif
 
     topSizer->Add( item0, wxSizerFlags(1).Expand().Border() );

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3738,8 +3738,8 @@ MyModelessDialog::MyModelessDialog(wxWindow *parent)
     wxCheckBox *check = new wxCheckBox(this, wxID_ANY, "Should be disabled");
     check->Disable();
 
-    sizerTop->Add(btn, 1, wxEXPAND | wxALL, 5);
-    sizerTop->Add(check, 1, wxEXPAND | wxALL, 5);
+    sizerTop->Add(btn, wxSizerFlags(1).Expand().Border());
+    sizerTop->Add(check, wxSizerFlags(1).Expand().Border());
 
     SetSizerAndFit(sizerTop);
 }
@@ -3775,10 +3775,11 @@ MyModalDialog::MyModalDialog(wxWindow *parent)
     m_btnModeless = new wxButton(this, wxID_ANY, "Mode&less dialog");
     m_btnDelete = new wxButton(this, wxID_ANY, "&Delete button");
 
-    sizerTop->Add(m_btnModal, 0, wxALIGN_CENTER | wxALL, 5);
-    sizerTop->Add(m_btnModeless, 0, wxALIGN_CENTER | wxALL, 5);
-    sizerTop->Add(m_btnDelete, 0, wxALIGN_CENTER | wxALL, 5);
-    sizerTop->Add(new wxButton(this, wxID_CLOSE), 0, wxALIGN_CENTER | wxALL, 5);
+    const wxSizerFlags centerWithBorder = wxSizerFlags().Centre().Border();
+    sizerTop->Add(m_btnModal, centerWithBorder);
+    sizerTop->Add(m_btnModeless, centerWithBorder);
+    sizerTop->Add(m_btnDelete, centerWithBorder);
+    sizerTop->Add(new wxButton(this, wxID_CLOSE), centerWithBorder);
 
     SetSizerAndFit(sizerTop);
 
@@ -3857,31 +3858,31 @@ StdButtonSizerDialog::StdButtonSizerDialog(wxWindow *parent)
 
     m_chkboxNoDefault = new wxCheckBox(this, wxID_ANY, "No Default");
 
-    sizer1->Add(m_radiobtnOk, 0, wxALL, 5);
-    sizer1->Add(m_radiobtnYes, 0, wxALL, 5);
+    sizer1->Add(m_radiobtnOk, wxSizerFlags().Border());
+    sizer1->Add(m_radiobtnYes, wxSizerFlags().Border());
 
-    sizer->Add(sizerInside1, 0, 0, 0);
-    sizerInside1->Add(m_chkboxAffirmativeButton, 0, wxALL, 5);
-    sizerInside1->Add(sizer1, 0, wxALL, 5);
+    sizer->Add(sizerInside1);
+    sizerInside1->Add(m_chkboxAffirmativeButton, wxSizerFlags().Border());
+    sizerInside1->Add(sizer1, wxSizerFlags().Border());
     sizerInside1->SetItemMinSize(sizer1, sizer1Box->GetBestSize());    // to prevent wrapping of static box label
 
-    sizer2->Add(m_radiobtnCancel, 0, wxALL, 5);
-    sizer2->Add(m_radiobtnClose, 0, wxALL, 5);
+    sizer2->Add(m_radiobtnCancel, wxSizerFlags().Border());
+    sizer2->Add(m_radiobtnClose, wxSizerFlags().Border());
 
-    sizer->Add(sizerInside2, 0, 0, 0);
-    sizerInside2->Add(m_chkboxDismissButton, 0, wxALL, 5);
-    sizerInside2->Add(sizer2, 0, wxALL, 5);
+    sizer->Add(sizerInside2);
+    sizerInside2->Add(m_chkboxDismissButton, wxSizerFlags().Border());
+    sizerInside2->Add(sizer2, wxSizerFlags().Border());
     sizerInside2->SetItemMinSize(sizer2, sizer2Box->GetBestSize());    // to prevent wrapping of static box label
 
-    sizerTop->Add(sizer, 0, wxALL, 5);
+    sizerTop->Add(sizer, wxSizerFlags().Border());
 
-    sizer3->Add(m_chkboxNo, 0, wxALL, 5);
-    sizer3->Add(m_chkboxHelp, 0, wxALL, 5);
-    sizer3->Add(m_chkboxApply, 0, wxALL, 5);
+    sizer3->Add(m_chkboxNo, wxSizerFlags().Border());
+    sizer3->Add(m_chkboxHelp, wxSizerFlags().Border());
+    sizer3->Add(m_chkboxApply, wxSizerFlags().Border());
 
-    sizerTop->Add(sizer3, 0, wxALL, 5);
+    sizerTop->Add(sizer3, wxSizerFlags().Border());
 
-    sizerTop->Add(m_chkboxNoDefault, 0, wxLEFT|wxRIGHT, 10);
+    sizerTop->Add(m_chkboxNoDefault, wxSizerFlags().DoubleBorder(wxLEFT|wxRIGHT));
 
     EnableDisableControls();
 
@@ -3950,7 +3951,7 @@ void StdButtonSizerDialog::OnEvent(wxCommandEvent& WXUNUSED(event))
     }
 
     m_buttonsSizer = CreateStdDialogButtonSizer(flags);
-    GetSizer()->Add(m_buttonsSizer, 0, wxGROW|wxALL, 5);
+    GetSizer()->Add(m_buttonsSizer, wxSizerFlags().Expand().Border());
 
     Layout();
     GetSizer()->SetSizeHints(this);
@@ -4058,8 +4059,8 @@ wxPanel* SettingsDialog::CreateGeneralSettingsPage(wxWindow* parent)
     wxBoxSizer* itemSizer3 = new wxBoxSizer( wxHORIZONTAL );
     wxCheckBox* checkBox3 = new wxCheckBox(panel, ID_LOAD_LAST_PROJECT, "&Load last project on startup", wxDefaultPosition, wxDefaultSize);
     checkBox3->SetValidator(wxGenericValidator(&m_settingsData.m_loadLastOnStartup));
-    itemSizer3->Add(checkBox3, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
-    item0->Add(itemSizer3, 0, wxGROW|wxALL, 0);
+    itemSizer3->Add(checkBox3, wxSizerFlags().CenterVertical().Border());
+    item0->Add(itemSizer3, wxSizerFlags().Expand());
 
     //// AUTOSAVE
 
@@ -4075,22 +4076,22 @@ wxPanel* SettingsDialog::CreateGeneralSettingsPage(wxWindow* parent)
     spinCtrl12->SetValidator(wxGenericValidator(&m_settingsData.m_autoSaveInterval));
 #endif
 
-    itemSizer12->Add(checkBox12, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+    itemSizer12->Add(checkBox12, wxSizerFlags().CenterVertical().Border());
 #if wxUSE_SPINCTRL
-    itemSizer12->Add(spinCtrl12, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+    itemSizer12->Add(spinCtrl12, wxSizerFlags().CenterVertical().Border());
 #endif
-    itemSizer12->Add(new wxStaticText(panel, wxID_STATIC, minsLabel), 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
-    item0->Add(itemSizer12, 0, wxGROW|wxALL, 0);
+    itemSizer12->Add(new wxStaticText(panel, wxID_STATIC, minsLabel), wxSizerFlags().CenterVertical().Border());
+    item0->Add(itemSizer12, wxSizerFlags().Expand());
 
     //// TOOLTIPS
 
     wxBoxSizer* itemSizer8 = new wxBoxSizer( wxHORIZONTAL );
     wxCheckBox* checkBox6 = new wxCheckBox(panel, ID_SHOW_TOOLTIPS, "Show &tooltips", wxDefaultPosition, wxDefaultSize);
     checkBox6->SetValidator(wxGenericValidator(&m_settingsData.m_showToolTips));
-    itemSizer8->Add(checkBox6, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
-    item0->Add(itemSizer8, 0, wxGROW|wxALL, 0);
+    itemSizer8->Add(checkBox6, wxSizerFlags().CenterVertical().Border());
+    item0->Add(itemSizer8, wxSizerFlags().Expand());
 
-    topSizer->Add( item0, wxSizerFlags(1).Expand().Border(wxALL) );
+    topSizer->Add( item0, wxSizerFlags(1).Expand().Border() );
 
     panel->SetSizerAndFit(topSizer);
 
@@ -4112,7 +4113,7 @@ wxPanel* SettingsDialog::CreateAestheticSettingsPage(wxWindow* parent)
     wxRadioBox* projectOrGlobal = new wxRadioBox(panel, ID_APPLY_SETTINGS_TO, "&Apply settings to:",
         wxDefaultPosition, wxDefaultSize, 2, globalOrProjectChoices);
     projectOrGlobal->SetValidator(wxGenericValidator(&m_settingsData.m_applyTo));
-    item0->Add(projectOrGlobal, 0, wxGROW|wxALL, 5);
+    item0->Add(projectOrGlobal, wxSizerFlags().Expand().Border());
 
     projectOrGlobal->SetSelection(0);
 
@@ -4123,18 +4124,18 @@ wxPanel* SettingsDialog::CreateAestheticSettingsPage(wxWindow* parent)
 
     wxStaticBoxSizer* styleSizer = new wxStaticBoxSizer(wxVERTICAL, panel, "Background style:");
     wxStaticBox* const styleSizerBox = styleSizer->GetStaticBox();
-    item0->Add(styleSizer, 0, wxGROW|wxALL, 5);
+    item0->Add(styleSizer, wxSizerFlags().Expand().Border());
 
     wxBoxSizer* itemSizer2 = new wxBoxSizer( wxHORIZONTAL );
 
     wxChoice* choice2 = new wxChoice(styleSizerBox, ID_BACKGROUND_STYLE, wxDefaultPosition, wxDefaultSize, backgroundStyleChoices);
     choice2->SetValidator(wxGenericValidator(&m_settingsData.m_bgStyle));
 
-    itemSizer2->Add(new wxStaticText(styleSizerBox, wxID_ANY, "&Window:"), 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
-    itemSizer2->Add(5, 5, 1, wxALL, 0);
-    itemSizer2->Add(choice2, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+    itemSizer2->Add(new wxStaticText(styleSizerBox, wxID_ANY, "&Window:"), wxSizerFlags().CenterVertical().Border());
+    itemSizer2->AddSpacer(5);
+    itemSizer2->Add(choice2, wxSizerFlags().CenterVertical().Border());
 
-    styleSizer->Add(itemSizer2, 0, wxGROW|wxALL, 5);
+    styleSizer->Add(itemSizer2, wxSizerFlags().Expand().Border());
 
 #if wxUSE_SPINCTRL
     //// FONT SIZE SELECTION
@@ -4143,12 +4144,12 @@ wxPanel* SettingsDialog::CreateAestheticSettingsPage(wxWindow* parent)
 
     wxSpinCtrl* spinCtrl = new wxSpinCtrl(itemSizer5->GetStaticBox(), ID_FONT_SIZE, wxEmptyString);
     spinCtrl->SetValidator(wxGenericValidator(&m_settingsData.m_titleFontSize));
-    itemSizer5->Add(spinCtrl, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    itemSizer5->Add(spinCtrl, wxSizerFlags().Center().Border());
 
-    item0->Add(itemSizer5, 0, wxGROW|wxLEFT|wxRIGHT, 5);
+    item0->Add(itemSizer5, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT));
 #endif
 
-    topSizer->Add( item0, wxSizerFlags(1).Expand().Border(wxALL) );
+    topSizer->Add( item0, wxSizerFlags(1).Expand().Border() );
     topSizer->AddSpacer(5);
 
     panel->SetSizerAndFit(topSizer);

--- a/samples/dll/my_dll.cpp
+++ b/samples/dll/my_dll.cpp
@@ -98,13 +98,13 @@ MyDllFrame::MyDllFrame(wxWindow *parent, const wxString& label)
                            wxThread::GetCurrentId()
                        )
                    ),
-               wxSizerFlags(1).Expand().DoubleBorder(wxALL)
+               wxSizerFlags(1).Expand().DoubleBorder()
            );
 
     sizer->Add
            (
                new wxButton(p, wxID_ABOUT, "Show info"),
-               wxSizerFlags(0).Right().DoubleBorder(wxALL)
+               wxSizerFlags(0).Right().DoubleBorder()
            );
 
     p->SetSizerAndFit(sizer);

--- a/samples/dll/wx_exe.cpp
+++ b/samples/dll/wx_exe.cpp
@@ -93,13 +93,13 @@ MainFrame::MainFrame()
                            wxThread::GetCurrentId()
                        )
                    ),
-               wxSizerFlags(1).Expand().DoubleBorder(wxALL)
+               wxSizerFlags(1).Expand().DoubleBorder()
            );
 
     sizer->Add
            (
                new wxButton(p, ID_RUN_DLL, "Run GUI from DLL"),
-               wxSizerFlags(0).Right().DoubleBorder(wxALL)
+               wxSizerFlags(0).Right().DoubleBorder()
            );
 
     p->SetSizerAndFit(sizer);

--- a/samples/dnd/dnd.cpp
+++ b/samples/dnd/dnd.cpp
@@ -1036,23 +1036,23 @@ DnDFrame::DnDFrame()
 #endif // wxUSE_DRAG_AND_DROP
 
     wxBoxSizer *sizer_top = new wxBoxSizer( wxHORIZONTAL );
-    sizer_top->Add(m_ctrlFile, 1, wxEXPAND );
-    sizer_top->Add(m_ctrlText, 1, wxEXPAND );
+    sizer_top->Add(m_ctrlFile, wxSizerFlags(1).Expand());
+    sizer_top->Add(m_ctrlText, wxSizerFlags(1).Expand());
 
     wxBoxSizer *sizerDirCtrl = new wxBoxSizer(wxVERTICAL);
     sizerDirCtrl->Add(new wxStaticText(this, wxID_ANY, "Drag files from here"),
                       wxSizerFlags().Centre().Border());
     sizerDirCtrl->Add(m_ctrlDir, wxSizerFlags(1).Expand());
-    sizer_top->Add(sizerDirCtrl, 1, wxEXPAND );
+    sizer_top->Add(sizerDirCtrl, wxSizerFlags(1).Expand());
 
     // make all columns of reasonable minimal size
     for ( unsigned n = 0; n < sizer_top->GetChildren().size(); n++ )
         sizer_top->SetItemMinSize(n, 200, 300);
 
     wxBoxSizer *sizer = new wxBoxSizer( wxVERTICAL );
-    sizer->Add(sizer_top, 1, wxEXPAND );
+    sizer->Add(sizer_top, wxSizerFlags(1).Expand());
 #if wxUSE_LOG
-    sizer->Add(m_ctrlLog, 1, wxEXPAND);
+    sizer->Add(m_ctrlLog, wxSizerFlags(1).Expand());
     sizer->SetItemMinSize(m_ctrlLog, 450, 200);
 #endif // wxUSE_LOG
     sizer->AddSpacer(50);
@@ -1615,8 +1615,8 @@ DnDShapeDialog::DnDShapeDialog(wxWindow *parent, DnDShape *shape)
     m_radio = new wxRadioBox( this, wxID_ANY, "&Shape",
                               wxDefaultPosition, wxDefaultSize, 4, choices, 4,
                               wxRA_SPECIFY_COLS );
-    shapesSizer->Add( m_radio, 0, wxGROW|wxALL, 5 );
-    topSizer->Add( shapesSizer, 0, wxALL, 2 );
+    shapesSizer->Add( m_radio, wxSizerFlags().Expand().Border());
+    topSizer->Add( shapesSizer, wxSizerFlags().Border(wxALL, FromDIP(2)) );
 
     // attributes
     wxStaticBox* box = new wxStaticBox( this, wxID_ANY, "&Attributes" );
@@ -1628,40 +1628,40 @@ DnDShapeDialog::DnDShapeDialog(wxWindow *parent, DnDShape *shape)
     st = new wxStaticText( this, wxID_ANY, "Position &X:" );
     m_textX = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition,
                               wxSize( 30, 20 ) );
-    xywhSizer->Add( st, 1, wxGROW|wxALL, 2 );
-    xywhSizer->Add( m_textX, 1, wxGROW|wxALL, 2 );
+    xywhSizer->Add( st, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)) );
+    xywhSizer->Add( m_textX, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)) );
 
     st = new wxStaticText( this, wxID_ANY, "Size &width:" );
     m_textW = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition,
                               wxSize( 30, 20 ) );
-    xywhSizer->Add( st, 1, wxGROW|wxALL, 2 );
-    xywhSizer->Add( m_textW, 1, wxGROW|wxALL, 2 );
+    xywhSizer->Add( st, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)) );
+    xywhSizer->Add( m_textW, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)) );
 
     st = new wxStaticText( this, wxID_ANY, "&Y:" );
     m_textY = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition,
                               wxSize( 30, 20 ) );
-    xywhSizer->Add( st, 1, wxALL|wxALIGN_RIGHT, 2 );
-    xywhSizer->Add( m_textY, 1, wxGROW|wxALL, 2 );
+    xywhSizer->Add( st, wxSizerFlags(1).Right().Border(wxALL, FromDIP(2)) );
+    xywhSizer->Add( m_textY, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)) );
 
     st = new wxStaticText( this, wxID_ANY, "&height:" );
     m_textH = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition,
                               wxSize( 30, 20 ) );
-    xywhSizer->Add( st, 1, wxALL|wxALIGN_RIGHT, 2 );
-    xywhSizer->Add( m_textH, 1, wxGROW|wxALL, 2 );
+    xywhSizer->Add( st, wxSizerFlags(1).Right().Border(wxALL, FromDIP(2)) );
+    xywhSizer->Add( m_textH, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)) );
 
     wxButton* col = new wxButton( this, Button_Colour, "&Colour..." );
-    attrSizer->Add( xywhSizer, 1, wxGROW );
-    attrSizer->Add( col, 0, wxALL|wxALIGN_CENTRE_VERTICAL, 2 );
-    topSizer->Add( attrSizer, 0, wxGROW|wxALL, 5 );
+    attrSizer->Add( xywhSizer, wxSizerFlags(1).Expand());
+    attrSizer->Add( col, wxSizerFlags().CenterVertical().Border(wxALL, FromDIP(2)) );
+    topSizer->Add( attrSizer, wxSizerFlags().Expand().Border());
 
     // buttons
     wxBoxSizer* buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton* bt;
     bt = new wxButton( this, wxID_OK, "Ok" );
-    buttonSizer->Add( bt, 0, wxALL, 2 );
+    buttonSizer->Add( bt, wxSizerFlags().Border(wxALL, FromDIP(2)) );
     bt = new wxButton( this, wxID_CANCEL, "Cancel" );
-    buttonSizer->Add( bt, 0, wxALL, 2 );
-    topSizer->Add( buttonSizer, 0, wxALL|wxALIGN_RIGHT, 2 );
+    buttonSizer->Add( bt, wxSizerFlags().Border(wxALL, FromDIP(2)) );
+    topSizer->Add( buttonSizer, wxSizerFlags().Right().Border(wxALL, FromDIP(2)));
 
     SetSizerAndFit( topSizer );
 }

--- a/samples/event/event.cpp
+++ b/samples/event/event.cpp
@@ -428,9 +428,9 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
     m_btnDynamic = new wxButton(panel, Event_Dynamic, "&Dynamic button");
     sizer->Add(m_btnDynamic, centreY);
 
-    mainSizer->Add(sizer, 1, wxEXPAND);
-    mainSizer->Add(new wxStaticLine(panel), 0, wxEXPAND);
-    mainSizer->Add(new wxStaticLine(panel), 0, wxEXPAND);
+    mainSizer->Add(sizer, wxSizerFlags(1).Expand());
+    mainSizer->Add(new wxStaticLine(panel), wxSizerFlags().Expand());
+    mainSizer->Add(new wxStaticLine(panel), wxSizerFlags().Expand());
 
     m_testBtn = new MyEvtTestButton(panel, "Test Event Handlers Execution Order");
 

--- a/samples/except/except.cpp
+++ b/samples/except/except.cpp
@@ -643,15 +643,15 @@ MyDialog::MyDialog(wxFrame *parent)
     wxSizer *sizerTop = new wxBoxSizer(wxVERTICAL);
 
     sizerTop->Add(new wxButton(this, Except_ThrowInt, "Throw &int"),
-                  0, wxEXPAND | wxALL, 5);
+                  wxSizerFlags().Expand().Border());
     sizerTop->Add(new wxButton(this, Except_ThrowObject, "Throw &object"),
-                  0, wxEXPAND | wxALL, 5);
+                  wxSizerFlags().Expand().Border());
     sizerTop->Add(new wxButton(this, Except_ThrowUnhandled, "Throw &unhandled"),
-                  0, wxEXPAND | wxALL, 5);
+                  wxSizerFlags().Expand().Border());
     sizerTop->Add(new wxButton(this, Except_Crash, "&Crash"),
-                  0, wxEXPAND | wxALL, 5);
+                  wxSizerFlags().Expand().Border());
     sizerTop->Add(new wxButton(this, wxID_CANCEL, "&Cancel"),
-                  0, wxEXPAND | wxALL, 5);
+                  wxSizerFlags().Expand().Border());
 
     SetSizerAndFit(sizerTop);
 }

--- a/samples/exec/exec.cpp
+++ b/samples/exec/exec.cpp
@@ -1464,21 +1464,21 @@ MyPipeFrame::MyPipeFrame(wxFrame *parent,
     m_textErr->SetEditable(false);
 
     wxSizer *sizerTop = new wxBoxSizer(wxVERTICAL);
-    sizerTop->Add(m_textOut, 0, wxGROW | wxALL, 5);
+    sizerTop->Add(m_textOut, wxSizerFlags().Expand().Border());
 
     wxSizer *sizerBtns = new wxBoxSizer(wxHORIZONTAL);
     sizerBtns->
-        Add(new wxButton(panel, Exec_Btn_Send, "&Send"), 0, wxALL, 5);
+        Add(new wxButton(panel, Exec_Btn_Send, "&Send"), wxSizerFlags().Border());
     sizerBtns->
-        Add(new wxButton(panel, Exec_Btn_SendFile, "&File..."), 0, wxALL, 5);
+        Add(new wxButton(panel, Exec_Btn_SendFile, "&File..."), wxSizerFlags().Border());
     sizerBtns->
-        Add(new wxButton(panel, Exec_Btn_Get, "&Get"), 0, wxALL, 5);
+        Add(new wxButton(panel, Exec_Btn_Get, "&Get"), wxSizerFlags().Border());
     sizerBtns->
-        Add(new wxButton(panel, Exec_Btn_Close, "&Close"), 0, wxALL, 5);
+        Add(new wxButton(panel, Exec_Btn_Close, "&Close"), wxSizerFlags().Border());
 
-    sizerTop->Add(sizerBtns, 0, wxCENTRE | wxALL, 5);
-    sizerTop->Add(m_textIn, 1, wxGROW | wxALL, 5);
-    sizerTop->Add(m_textErr, 1, wxGROW | wxALL, 5);
+    sizerTop->Add(sizerBtns, wxSizerFlags().Centre().Border());
+    sizerTop->Add(m_textIn, wxSizerFlags(1).Expand().Border());
+    sizerTop->Add(m_textErr, wxSizerFlags(1).Expand().Border());
 
     panel->SetSizer(sizerTop);
     sizerTop->Fit(this);

--- a/samples/fswatcher/fswatcher.cpp
+++ b/samples/fswatcher/fswatcher.cpp
@@ -203,7 +203,7 @@ MyFrame::MyFrame(const wxString& title)
 
     // label
     wxStaticText* label = new wxStaticText(panel, wxID_ANY, "Watched paths");
-    leftSizer->Add(label, wxSizerFlags().Center().Border(wxALL));
+    leftSizer->Add(label, wxSizerFlags().Center().Border());
 
     // list of files
     m_filesList = new wxListView(panel, wxID_ANY, wxPoint(-1,-1),
@@ -216,10 +216,10 @@ MyFrame::MyFrame(const wxString& title)
     wxButton* buttonRemove = new wxButton(panel, BTN_ID_REMOVE, "&Remove");
     wxButton* buttonRemoveAll = new wxButton(panel, BTN_ID_REMOVE_ALL, "Remove a&ll");
     wxSizer *btnSizer = new wxGridSizer(2);
-    btnSizer->Add(buttonAdd, wxSizerFlags().Center().Border(wxALL));
-    btnSizer->Add(buttonAddTree, wxSizerFlags().Center().Border(wxALL));
-    btnSizer->Add(buttonRemove, wxSizerFlags().Center().Border(wxALL));
-    btnSizer->Add(buttonRemoveAll, wxSizerFlags().Center().Border(wxALL));
+    btnSizer->Add(buttonAdd, wxSizerFlags().Center().Border());
+    btnSizer->Add(buttonAddTree, wxSizerFlags().Center().Border());
+    btnSizer->Add(buttonRemove, wxSizerFlags().Center().Border());
+    btnSizer->Add(buttonRemoveAll, wxSizerFlags().Center().Border());
 
     // and put it all together
     leftSizer->Add(btnSizer, wxSizerFlags(0).Expand());

--- a/samples/help/demo.cpp
+++ b/samples/help/demo.cpp
@@ -689,20 +689,20 @@ MyModalDialog::MyModalDialog(wxWindow *parent)
     wxButton* btnCancel = new wxButton(this, wxID_CANCEL, "&Cancel");
     btnCancel->SetHelpText(_("The Cancel button cancels the dialog."));
 
-    sizerRow->Add(btnOK, 0, wxALIGN_CENTER | wxALL, 5);
-    sizerRow->Add(btnCancel, 0, wxALIGN_CENTER | wxALL, 5);
+    sizerRow->Add(btnOK, wxSizerFlags().Center().Border());
+    sizerRow->Add(btnCancel, wxSizerFlags().Center().Border());
 
     // Add explicit context-sensitive help button for non-MSW
 #ifndef __WXMSW__
-    sizerRow->Add(new wxContextHelpButton(this), 0, wxALIGN_CENTER | wxALL, 5);
+    sizerRow->Add(new wxContextHelpButton(this), wxSizerFlags().Center().Border());
 #endif
 
     wxTextCtrl *text = new wxTextCtrl(this, wxID_ANY, "A demo text control",
                                       wxDefaultPosition, wxSize(300, 100),
                                       wxTE_MULTILINE);
     text->SetHelpText(_("Type text here if you have got nothing more interesting to do"));
-    sizerTop->Add(text, 0, wxEXPAND|wxALL, 5 );
-    sizerTop->Add(sizerRow, 0, wxALIGN_RIGHT|wxALL, 5 );
+    sizerTop->Add(text, wxSizerFlags().Expand().Border());
+    sizerTop->Add(sizerRow, wxSizerFlags().Right().Border());
 
     SetSizerAndFit(sizerTop);
 

--- a/samples/htlbox/htlbox.cpp
+++ b/samples/htlbox/htlbox.cpp
@@ -306,8 +306,8 @@ MyFrame::MyFrame()
 
     // and lay them out
     wxSizer *sizer = new wxBoxSizer(wxHORIZONTAL);
-    sizer->Add(m_hlbox, 2, wxGROW);
-    sizer->Add(text, 3, wxGROW);
+    sizer->Add(m_hlbox, wxSizerFlags(2).Expand());
+    sizer->Add(text, wxSizerFlags(3).Expand());
 
     SetSizer(sizer);
 }

--- a/samples/html/about/about.cpp
+++ b/samples/html/about/about.cpp
@@ -158,7 +158,7 @@ void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
     topsizer -> Add(html, wxSizerFlags(1).DoubleBorder());
 
 #if wxUSE_STATLINE
-    topsizer -> Add(new wxStaticLine(&dlg, wxID_ANY), wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT));
+    topsizer -> Add(new wxStaticLine(&dlg, wxID_ANY), wxSizerFlags().Expand().DoubleHorzBorder());
 #endif // wxUSE_STATLINE
 
     wxButton *bu1 = new wxButton(&dlg, wxID_OK, _("OK"));

--- a/samples/html/about/about.cpp
+++ b/samples/html/about/about.cpp
@@ -155,16 +155,16 @@ void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
     html -> SetInitialSize(wxSize(html -> GetInternalRepresentation() -> GetWidth(),
                                   html -> GetInternalRepresentation() -> GetHeight()));
 
-    topsizer -> Add(html, 1, wxALL, 10);
+    topsizer -> Add(html, wxSizerFlags(1).DoubleBorder());
 
 #if wxUSE_STATLINE
-    topsizer -> Add(new wxStaticLine(&dlg, wxID_ANY), 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+    topsizer -> Add(new wxStaticLine(&dlg, wxID_ANY), wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT));
 #endif // wxUSE_STATLINE
 
     wxButton *bu1 = new wxButton(&dlg, wxID_OK, _("OK"));
     bu1 -> SetDefault();
 
-    topsizer -> Add(bu1, 0, wxALL | wxALIGN_RIGHT, 15);
+    topsizer -> Add(bu1, 0, wxALL | wxALIGN_RIGHT, FromDIP(15));
 
     dlg.SetSizer(topsizer);
     topsizer -> Fit(&dlg);

--- a/samples/html/about/about.cpp
+++ b/samples/html/about/about.cpp
@@ -164,7 +164,7 @@ void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
     wxButton *bu1 = new wxButton(&dlg, wxID_OK, _("OK"));
     bu1 -> SetDefault();
 
-    topsizer -> Add(bu1, 0, wxALL | wxALIGN_RIGHT, FromDIP(15));
+    topsizer -> Add(bu1, wxSizerFlags().Right().TripleBorder());
 
     dlg.SetSizer(topsizer);
     topsizer -> Fit(&dlg);

--- a/samples/html/test/test.cpp
+++ b/samples/html/test/test.cpp
@@ -262,8 +262,8 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
     delete wxLog::SetActiveTarget(new wxLogTextCtrl(text));
 
     wxSizer *sz = new wxBoxSizer(wxVERTICAL);
-    sz->Add(m_Html, 3, wxGROW);
-    sz->Add(text, 1, wxGROW);
+    sz->Add(m_Html, wxSizerFlags(3).Expand());
+    sz->Add(text, wxSizerFlags(1).Expand());
     SetSizer(sz);
 }
 

--- a/samples/ipc/client.cpp
+++ b/samples/ipc/client.cpp
@@ -125,68 +125,68 @@ MyFrame::MyFrame(wxFrame *frame, const wxString& title)
     wxGridSizer * const sizerCmds = new wxGridSizer( 4, 0, 0 );
 
     wxButton * const btnConnect = new wxButton( panel, ID_START, "Connect to server", wxDefaultPosition, wxDefaultSize, 0 );
-    sizerCmds->Add( btnConnect, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( btnConnect, wxSizerFlags().Expand().CentreVertical().Border() );
 
     wxChoice * const choiceHost = new wxChoice( panel, ID_HOSTNAME, wxDefaultPosition, wxSize(100,-1), 2, strs5, 0 );
-    sizerCmds->Add( choiceHost, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( choiceHost, wxSizerFlags().Centre().Border() );
 
     wxChoice * const choiceServer = new wxChoice( panel, ID_SERVERNAME, wxDefaultPosition, wxSize(100,-1), 2, strs4, 0 );
-    sizerCmds->Add( choiceServer, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( choiceServer, wxSizerFlags().Expand().CentreVertical().Border() );
 
     wxChoice * const choiceTopic = new wxChoice( panel, ID_TOPIC, wxDefaultPosition, wxSize(100,-1), 2, strs6, 0 );
-    sizerCmds->Add( choiceTopic, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( choiceTopic, wxSizerFlags().Centre().Border() );
 
     wxButton * const btnDisconnect = new wxButton( panel, ID_DISCONNECT, "Disconnect ", wxDefaultPosition, wxDefaultSize, 0 );
-    sizerCmds->Add( btnDisconnect, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( btnDisconnect, wxSizerFlags().Expand().CentreVertical().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
     wxButton * const btnStartAdvise = new wxButton( panel, ID_STARTADVISE, "StartAdvise", wxDefaultPosition, wxDefaultSize, 0 );
-    sizerCmds->Add( btnStartAdvise, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( btnStartAdvise, wxSizerFlags().Expand().CentreVertical().Border() );
 
     wxButton * const btnStopAdvise = new wxButton( panel, ID_STOPADVISE, "StopAdvise", wxDefaultPosition, wxDefaultSize, 0 );
-    sizerCmds->Add( btnStopAdvise, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( btnStopAdvise, wxSizerFlags().Expand().CentreVertical().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
     wxButton * const btnExecute = new wxButton( panel, ID_EXECUTE, "Execute", wxDefaultPosition, wxDefaultSize, 0 );
-    sizerCmds->Add( btnExecute, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( btnExecute, wxSizerFlags().Expand().CentreVertical().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
     wxButton * const btnPoke = new wxButton( panel, ID_POKE, "Poke", wxDefaultPosition, wxDefaultSize, 0 );
-    sizerCmds->Add( btnPoke, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( btnPoke, wxSizerFlags().Expand().CentreVertical().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
     wxButton * const btnRequest = new wxButton( panel, ID_REQUEST, "Request", wxDefaultPosition, wxDefaultSize, 0 );
-    sizerCmds->Add( btnRequest, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( btnRequest, wxSizerFlags().Expand().CentreVertical().Border() );
 
-    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, wxSizerFlags().Centre().Border() );
 
-    sizerMain->Add( sizerCmds, wxSizerFlags().Expand().Border(wxALL) );
+    sizerMain->Add( sizerCmds, wxSizerFlags().Expand().Border() );
 
     wxStaticBoxSizer * const
         sizerLog = new wxStaticBoxSizer(wxVERTICAL, panel, "Client log");
 
     wxTextCtrl * const textLog = new wxTextCtrl( sizerLog->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(500,140), wxTE_MULTILINE );
-    sizerLog->Add( textLog, wxSizerFlags(1).Expand().Border(wxALL) );
+    sizerLog->Add( textLog, wxSizerFlags(1).Expand().Border() );
 
-    sizerMain->Add( sizerLog, wxSizerFlags(1).Expand().Border(wxALL) );
+    sizerMain->Add( sizerLog, wxSizerFlags(1).Expand().Border() );
 
     panel->SetSizer( sizerMain );
     SetClientSize( panel->GetBestSize() );

--- a/samples/ipc/server.cpp
+++ b/samples/ipc/server.cpp
@@ -98,7 +98,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString& title)
     wxButton *btn;
 
     btn = new wxButton(panel, ID_START, "&Start Server");
-    sizerCmds->Add(btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    sizerCmds->Add(btn, wxSizerFlags().Expand().CenterVertical().Border());
 
     const wxString choices[] = { IPC_SERVICE, "..." };
     wxChoice * const choice = new wxChoice
@@ -108,17 +108,17 @@ MyFrame::MyFrame(wxFrame *frame, const wxString& title)
                                     wxDefaultPosition, wxSize(100, -1),
                                     WXSIZEOF(choices), choices
                                   );
-    sizerCmds->Add(choice, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    sizerCmds->Add(choice, wxSizerFlags().Expand().CenterVertical().Border());
 
     btn = new wxButton(panel, ID_DISCONNECT, "&Disconnect Client");
-    sizerCmds->Add(btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    sizerCmds->Add(btn, wxSizerFlags().Expand().CenterVertical().Border());
     sizerCmds->AddSpacer(20);
 
     btn = new wxButton( panel, ID_ADVISE, "&Advise");
-    sizerCmds->Add(btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    sizerCmds->Add(btn, wxSizerFlags().Expand().CenterVertical().Border());
     sizerCmds->AddSpacer(20);
 
-    sizerMain->Add(sizerCmds, wxSizerFlags().Expand().Border(wxALL));
+    sizerMain->Add(sizerCmds, wxSizerFlags().Expand().Border());
 
     wxStaticBoxSizer * const
         sizerLog = new wxStaticBoxSizer(wxVERTICAL, panel, "Server &log");
@@ -132,9 +132,9 @@ MyFrame::MyFrame(wxFrame *frame, const wxString& title)
                                     FromDIP(wxSize(500, 140)),
                                     wxTE_MULTILINE
                                  );
-    sizerLog->Add(textLog, wxSizerFlags(1).Expand().Border(wxALL));
+    sizerLog->Add(textLog, wxSizerFlags(1).Expand().Border());
 
-    sizerMain->Add(sizerLog, wxSizerFlags(1).Expand().Border(wxALL));
+    sizerMain->Add(sizerLog, wxSizerFlags(1).Expand().Border());
 
     panel->SetSizer(sizerMain);
     sizerMain->SetSizeHints(panel);

--- a/samples/layout/layout.cpp
+++ b/samples/layout/layout.cpp
@@ -130,7 +130,7 @@ MyFrame::MyFrame()
     // 2) top: create wxTextCtrl with minimum size (100x60)
     topsizer->Add(
         new wxTextCtrl( p, wxID_ANY, "My text (wxEXPAND).", wxDefaultPosition, FromDIP(wxSize(100,60)), wxTE_MULTILINE),
-        wxSizerFlags(1).Expand().Border(wxALL));
+        wxSizerFlags(1).Expand().Border());
 
     // 2.5) Gratuitous test of wxStaticBoxSizers
     wxBoxSizer *statsizer = new wxStaticBoxSizer(
@@ -140,25 +140,24 @@ MyFrame::MyFrame()
         wxSizerFlags().Border(wxALL, FromDIP(30)));
     topsizer->Add(
         statsizer,
-        wxSizerFlags(1).Expand().DoubleBorder(wxALL));
+        wxSizerFlags(1).Expand().DoubleBorder());
 
     // 2.7) And a test of wxGridSizer
     wxGridSizer *gridsizer = new wxGridSizer(2, 5, 5);
     gridsizer->Add(new wxStaticText(p, wxID_ANY, "Label"),
-                wxSizerFlags().Align(wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL));
+                wxSizerFlags().Right().CenterVertical());
     gridsizer->Add(new wxTextCtrl(p, wxID_ANY, "Grid sizer demo"),
-                wxSizerFlags(1).Align(wxGROW | wxALIGN_CENTER_VERTICAL));
+                wxSizerFlags(1).Expand().CenterVertical());
     gridsizer->Add(new wxStaticText(p, wxID_ANY, "Another label"),
-                wxSizerFlags().Align(wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL));
+                wxSizerFlags().Right().CenterVertical());
     gridsizer->Add(new wxTextCtrl(p, wxID_ANY, "More text"),
-                wxSizerFlags(1).Align(wxGROW | wxALIGN_CENTER_VERTICAL));
+                wxSizerFlags(1).Expand().CenterVertical());
     gridsizer->Add(new wxStaticText(p, wxID_ANY, "Final label"),
-                wxSizerFlags().Align(wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL));
+                wxSizerFlags().Right().CenterVertical());
     gridsizer->Add(new wxTextCtrl(p, wxID_ANY, "And yet more text"),
-                wxSizerFlags().Align(wxGROW | wxALIGN_CENTER_VERTICAL));
-    topsizer->Add(
-        gridsizer,
-        wxSizerFlags().Proportion(1).Expand().DoubleBorder(wxALL));
+                wxSizerFlags().Expand().CenterVertical());
+    topsizer->Add(gridsizer,
+                wxSizerFlags().Proportion(1).Expand().DoubleBorder());
 
 
 #if wxUSE_STATLINE
@@ -310,7 +309,7 @@ void MyFlexSizerFrame::InitFlexSizer(wxFlexGridSizer *sizer, wxWindow* parent)
                                         );
             if ( (i + j) % 2 )
                 cell->SetBackgroundColour( *wxLIGHT_GREY );
-            sizer->Add(cell, 0, wxEXPAND | wxALIGN_CENTER_VERTICAL | wxALL, 3);
+            sizer->Add(cell, wxSizerFlags().Expand().CenterVertical().Border(wxALL, FromDIP(3)));
         }
     }
 }
@@ -323,70 +322,70 @@ MyFlexSizerFrame::MyFlexSizerFrame(wxFrame* parent)
 
     // construct the first column
     wxSizer *sizerCol1 = new wxBoxSizer(wxVERTICAL);
-    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "Ungrowable:"), 0, wxCENTER | wxTOP, 20);
+    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "Ungrowable:"), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
-    sizerCol1->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol1->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
-    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "Growable middle column:"), 0, wxCENTER | wxTOP, 20);
+    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "Growable middle column:"), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
     sizerFlex->AddGrowableCol(1);
-    sizerCol1->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol1->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
-    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "Growable middle row:"), 0, wxCENTER | wxTOP, 20);
+    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "Growable middle row:"), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
     sizerFlex->AddGrowableRow(1);
-    sizerCol1->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol1->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
-    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "All growable columns:"), 0, wxCENTER | wxTOP, 20);
+    sizerCol1->Add(new wxStaticText(p, wxID_ANY, "All growable columns:"), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
     sizerFlex->AddGrowableCol(0, 1);
     sizerFlex->AddGrowableCol(1, 2);
     sizerFlex->AddGrowableCol(2, 3);
-    sizerCol1->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol1->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
     // the second one
     wxSizer *sizerCol2 = new wxBoxSizer(wxVERTICAL);
-    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Growable middle row and column:"), 0, wxCENTER | wxTOP, 20);
+    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Growable middle row and column:"), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
     sizerFlex->AddGrowableCol(1);
     sizerFlex->AddGrowableRow(1);
-    sizerCol2->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol2->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
-    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Same with horz flex direction"), 0, wxCENTER | wxTOP, 20);
+    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Same with horz flex direction"), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
     sizerFlex->AddGrowableCol(1);
     sizerFlex->AddGrowableRow(1);
     sizerFlex->SetFlexibleDirection(wxHORIZONTAL);
-    sizerCol2->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol2->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
-    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Same with grow mode == \"none\""), 0, wxCENTER | wxTOP, 20);
+    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Same with grow mode == \"none\""), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
     sizerFlex->AddGrowableCol(1);
     sizerFlex->AddGrowableRow(1);
     sizerFlex->SetFlexibleDirection(wxHORIZONTAL);
     sizerFlex->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_NONE);
-    sizerCol2->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol2->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
-    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Same with grow mode == \"all\""), 0, wxCENTER | wxTOP, 20);
+    sizerCol2->Add(new wxStaticText(p, wxID_ANY, "Same with grow mode == \"all\""), wxSizerFlags().Center().Border(wxTOP, FromDIP(20)));
     sizerFlex = new wxFlexGridSizer(3, 3, wxSize(5, 5));
     InitFlexSizer(sizerFlex, p);
     sizerFlex->AddGrowableCol(1);
     sizerFlex->AddGrowableRow(1);
     sizerFlex->SetFlexibleDirection(wxHORIZONTAL);
     sizerFlex->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_ALL);
-    sizerCol2->Add(sizerFlex, 1, wxALL | wxEXPAND, 10);
+    sizerCol2->Add(sizerFlex, wxSizerFlags(1).Expand().DoubleBorder());
 
     // add both columns to grid sizer
     wxGridSizer *sizerTop = new wxGridSizer(2, 0, 20);
-    sizerTop->Add(sizerCol1, 1, wxEXPAND);
-    sizerTop->Add(sizerCol2, 1, wxEXPAND);
+    sizerTop->Add(sizerCol1, wxSizerFlags(1).Expand());
+    sizerTop->Add(sizerCol2, wxSizerFlags(1).Expand());
 
     p->SetSizer(sizerTop);
     sizerTop->SetSizeHints(this);
@@ -407,10 +406,10 @@ MyNotebookWithSizerDialog::MyNotebookWithSizerDialog(wxWindow *parent, const wxS
     wxBoxSizer *topsizer = new wxBoxSizer( wxVERTICAL );
 
     wxNotebook *notebook = new wxNotebook( this, wxID_ANY );
-    topsizer->Add( notebook, 1, wxGROW );
+    topsizer->Add( notebook, wxSizerFlags(1).Expand());
 
     wxButton *button = new wxButton( this, wxID_OK, "OK" );
-    topsizer->Add( button, 0, wxALIGN_RIGHT | wxALL, 10 );
+    topsizer->Add( button, wxSizerFlags().Right().DoubleBorder() );
 
     // First page: one big text ctrl
     wxTextCtrl *multi = new wxTextCtrl( notebook, wxID_ANY, "TextCtrl.", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
@@ -422,12 +421,12 @@ MyNotebookWithSizerDialog::MyNotebookWithSizerDialog(wxWindow *parent, const wxS
 
     wxSizer *panelsizer = new wxBoxSizer( wxVERTICAL );
 
-    wxTextCtrl *text = new wxTextCtrl( panel, wxID_ANY, "TextLine 1.", wxDefaultPosition, wxSize(250,wxDefaultCoord) );
-    panelsizer->Add( text, 0, wxGROW|wxALL, 30 );
-    text = new wxTextCtrl( panel, wxID_ANY, "TextLine 2.", wxDefaultPosition, wxSize(250,wxDefaultCoord) );
-    panelsizer->Add( text, 0, wxGROW|wxALL, 30 );
+    wxTextCtrl *text = new wxTextCtrl( panel, wxID_ANY, "TextLine 1.", wxDefaultPosition, wxSize(250, wxDefaultCoord) );
+    panelsizer->Add( text, wxSizerFlags().Expand().Border(wxALL, FromDIP(30)));
+    text = new wxTextCtrl( panel, wxID_ANY, "TextLine 2.", wxDefaultPosition, wxSize(250, wxDefaultCoord) );
+    panelsizer->Add( text, wxSizerFlags().Expand().Border(wxALL, FromDIP(30)));
     wxButton *button2 = new wxButton( panel, wxID_ANY, "Hallo" );
-    panelsizer->Add( button2, 0, wxALIGN_RIGHT | wxLEFT|wxRIGHT|wxBOTTOM, 30 );
+    panelsizer->Add( button2, wxSizerFlags().Right().Border(wxLEFT|wxRIGHT|wxBOTTOM, FromDIP(30)) );
 
     panel->SetSizer( panelsizer );
 
@@ -603,9 +602,9 @@ MySimpleSizerFrame::MySimpleSizerFrame(wxFrame* parent)
     wxBoxSizer *main_sizer = new wxBoxSizer( wxHORIZONTAL );
 
     m_target = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 80, wxDefaultCoord ) );
-    main_sizer->Add( m_target, 1, wxALL, 5 );
+    main_sizer->Add( m_target, wxSizerFlags(1).Border() );
 
-    main_sizer->Add( new wxStaticText( this, wxID_ANY, "Set alternating sizes using F4 and F5" ), 0, wxALL, 5 );
+    main_sizer->Add( new wxStaticText( this, wxID_ANY, "Set alternating sizes using F4 and F5" ), wxSizerFlags().Border() );
 
     SetSizer( main_sizer);
 
@@ -647,24 +646,24 @@ MyNestedSizerFrame::MyNestedSizerFrame(wxFrame* parent)
 
     wxBoxSizer *main_sizer = new wxBoxSizer( wxVERTICAL );
 
-    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), 0, wxALIGN_CENTER );
-    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), 0, wxALIGN_CENTER );
-    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), 0, wxALIGN_CENTER );
-    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), 0, wxALIGN_CENTER );
+    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), wxSizerFlags().Center() );
+    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), wxSizerFlags().Center() );
+    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), wxSizerFlags().Center() );
+    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), wxSizerFlags().Center() );
 
     wxPanel *panel = new wxPanel( this, -1, wxDefaultPosition, wxDefaultSize,
                                   wxTAB_TRAVERSAL | wxSUNKEN_BORDER );
-    main_sizer->Add( panel, 0, wxALIGN_CENTER );
+    main_sizer->Add( panel, wxSizerFlags().Center() );
     wxBoxSizer *panel_sizer = new wxBoxSizer( wxVERTICAL );
     panel->SetSizer( panel_sizer );
     panel_sizer->Add( new wxStaticText( panel, -1, "Hello inside" ) );
     panel_sizer->Add( new wxStaticText( panel, -1, "Hello inside" ) );
     panel_sizer->Add( new wxStaticText( panel, -1, "Hello inside" ) );
 
-    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), 0, wxALIGN_CENTER );
+    main_sizer->Add( new wxStaticText( this, -1, "Hello outside" ), wxSizerFlags().Center() );
 
     m_target = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 80, wxDefaultCoord ) );
-    main_sizer->Add( m_target, 1, wxALL|wxGROW, 5 );
+    main_sizer->Add( m_target, wxSizerFlags(1).Expand().Border());
 
     SetSizerAndFit( main_sizer);
 }
@@ -709,12 +708,12 @@ MyWrapSizerFrame::MyWrapSizerFrame(wxFrame* parent)
     // A shaped item inside a box sizer
     wxSizer *bottomSizer = new wxStaticBoxSizer( wxVERTICAL, this, "With wxSHAPED item" );
     wxSizer *horzBoxSizer = new wxBoxSizer(wxHORIZONTAL);
-    bottomSizer->Add( horzBoxSizer, 100, wxEXPAND );
-    horzBoxSizer->Add( new wxListBox(this,wxID_ANY,wxPoint(0,0),wxSize(70,70)), 0, wxEXPAND|wxSHAPED );
-    horzBoxSizer->Add( 10,10 );
-    horzBoxSizer->Add( new wxCheckBox(this,wxID_ANY,"A much longer option..."), 100, 0, 5 );
+    bottomSizer->Add( horzBoxSizer, wxSizerFlags(100).Expand() );
+    horzBoxSizer->Add( new wxListBox(this,wxID_ANY,wxPoint(0,0),wxSize(70,70)), wxSizerFlags().Expand().Shaped() );
+    horzBoxSizer->Add( 10, 10 );
+    horzBoxSizer->Add( new wxCheckBox(this,wxID_ANY,"A much longer option..."), wxSizerFlags(100) );
 
-    root->Add( bottomSizer, 1, wxEXPAND | wxALL, 5 );
+    root->Add( bottomSizer, wxSizerFlags(1).Expand().Border());
 
     // Set sizer for window
     SetSizerAndFit( root );

--- a/samples/mediaplayer/mediaplayer.cpp
+++ b/samples/mediaplayer/mediaplayer.cpp
@@ -1541,7 +1541,7 @@ wxMediaPlayerNotebookPage::wxMediaPlayerNotebookPage(wxMediaPlayerFrame* parentF
     m_playlist->SetDropTarget(new wxPlayListDropTarget(*m_playlist));
 #endif
 
-    sizer->Add(m_playlist, 0, wxALIGN_CENTER_HORIZONTAL|wxALL|wxEXPAND, 5);
+    sizer->Add(m_playlist, wxSizerFlags().CentreHorizontal().Expand().Border());
 
     //
     //  Create the control buttons
@@ -1571,14 +1571,14 @@ wxMediaPlayerNotebookPage::wxMediaPlayerNotebookPage(wxMediaPlayerFrame* parentF
     m_vuButton->Create(this, wxID_BUTTONVU, "))");
     m_vuButton->SetToolTip("Volume up");
 
-    vertsizer->Add(m_prevButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-    vertsizer->Add(m_playButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-    vertsizer->Add(m_stopButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-    vertsizer->Add(m_nextButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-    vertsizer->Add(m_vdButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-    vertsizer->Add(m_vuButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-    horsizer1->Add(vertsizer, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-    sizer->Add(horsizer1, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
+    vertsizer->Add(m_prevButton, wxSizerFlags().CentreVertical().Border());
+    vertsizer->Add(m_playButton, wxSizerFlags().CentreVertical().Border());
+    vertsizer->Add(m_stopButton, wxSizerFlags().CentreVertical().Border());
+    vertsizer->Add(m_nextButton, wxSizerFlags().CentreVertical().Border());
+    vertsizer->Add(m_vdButton, wxSizerFlags().CentreVertical().Border());
+    vertsizer->Add(m_vuButton, wxSizerFlags().CentreVertical().Border());
+    horsizer1->Add(vertsizer, wxSizerFlags().CentreVertical().Border());
+    sizer->Add(horsizer1, wxSizerFlags().Centre().Border());
 
 
     //
@@ -1589,7 +1589,7 @@ wxMediaPlayerNotebookPage::wxMediaPlayerNotebookPage(wxMediaPlayerFrame* parentF
                             1, // end, dummy but must be greater than start
                             wxDefaultPosition, wxDefaultSize,
                             wxSL_HORIZONTAL );
-    sizer->Add(m_slider, 0, wxALIGN_CENTER_HORIZONTAL|wxALL|wxEXPAND , 5);
+    sizer->Add(m_slider, wxSizerFlags().CentreHorizontal().Expand().Border());
 
     //
     //  Create the gauge
@@ -1597,7 +1597,7 @@ wxMediaPlayerNotebookPage::wxMediaPlayerNotebookPage(wxMediaPlayerFrame* parentF
     m_gauge = new wxGauge();
     m_gauge->Create(this, wxID_GAUGE, 0, wxDefaultPosition, wxDefaultSize,
                         wxGA_HORIZONTAL | wxGA_SMOOTH);
-    sizer->Add(m_gauge, 0, wxALIGN_CENTER_HORIZONTAL|wxALL|wxEXPAND , 5);
+    sizer->Add(m_gauge, wxSizerFlags().CentreHorizontal().Expand().Border());
 
 
     //
@@ -1610,15 +1610,15 @@ wxMediaPlayerNotebookPage::wxMediaPlayerNotebookPage(wxMediaPlayerFrame* parentF
                             100, // end
                             wxDefaultPosition, wxDefaultSize,
                             wxSL_HORIZONTAL );
-    horsizer3->Add(m_volSlider, 1, wxALL, 5);
+    horsizer3->Add(m_volSlider, wxSizerFlags(1).Border());
 
     m_pbSlider = new wxSlider(this, wxID_PBSLIDER, 4, // init
                             1, // start
                             16, // end
                             wxDefaultPosition, wxDefaultSize,
                             wxSL_HORIZONTAL );
-    horsizer3->Add(m_pbSlider, 1, wxALL, 5);
-    sizer->Add(horsizer3, 1, wxCENTRE | wxALL, 5);
+    horsizer3->Add(m_pbSlider, wxSizerFlags(1).Border());
+    sizer->Add(horsizer3, wxSizerFlags(1).Centre().Border());
 
     // Now that we have all our rows make some of them growable
     sizer->AddGrowableRow(0);

--- a/samples/notebook/notebook.cpp
+++ b/samples/notebook/notebook.cpp
@@ -99,8 +99,8 @@ wxPanel *CreateRadioButtonsPage(wxBookCtrlBase *parent)
         4, computers, 0, wxRA_SPECIFY_COLS);
 
     wxBoxSizer *sizerPanel = new wxBoxSizer(wxVERTICAL);
-    sizerPanel->Add(radiobox1, 2, wxEXPAND);
-    sizerPanel->Add(radiobox2, 1, wxEXPAND);
+    sizerPanel->Add(radiobox1, wxSizerFlags(2).Expand());
+    sizerPanel->Add(radiobox2, wxSizerFlags(1).Expand());
     panel->SetSizer(sizerPanel);
 
     return panel;
@@ -419,7 +419,7 @@ MyFrame::MyFrame()
     m_sizerFrame = new wxBoxSizer(wxVERTICAL);
 
 #if USE_LOG
-    m_sizerFrame->Add(m_text, 1, wxEXPAND);
+    m_sizerFrame->Add(m_text, wxSizerFlags(1).Expand());
 #endif // USE_LOG
 
     RecreateBook();

--- a/samples/popup/popup.cpp
+++ b/samples/popup/popup.cpp
@@ -382,8 +382,8 @@ MyFrame::MyFrame(const wxString& title)
     logger->DisableTimestamp();
 
     wxBoxSizer *topSizer = new wxBoxSizer( wxVERTICAL );
-    topSizer->Add( button1, wxSizerFlags().Expand().Border());
-    topSizer->Add( button2, wxSizerFlags().Expand().Border());
+    topSizer->Add( button1, wxSizerFlags().Border());
+    topSizer->Add( button2, wxSizerFlags().Border());
     topSizer->Add( m_logWin, wxSizerFlags(1).Expand().Border());
 
     panel->SetSizer( topSizer );

--- a/samples/popup/popup.cpp
+++ b/samples/popup/popup.cpp
@@ -132,12 +132,12 @@ SimpleTransientPopup::SimpleTransientPopup( wxWindow *parent, bool scrolled )
                                    "<- Test Mouse ->");
 
     wxBoxSizer *topSizer = new wxBoxSizer( wxVERTICAL );
-    topSizer->Add( text, 0, wxALL, 5 );
-    topSizer->Add( m_button, 0, wxALL, 5 );
-    topSizer->Add( m_spinCtrl, 0, wxALL, 5 );
+    topSizer->Add( text, wxSizerFlags().Border());
+    topSizer->Add( m_button, wxSizerFlags().Border());
+    topSizer->Add( m_spinCtrl, wxSizerFlags().Border());
     topSizer->Add( new wxTextCtrl(m_panel, wxID_ANY, "Try to type here"),
-                   0, wxEXPAND|wxALL, 5 );
-    topSizer->Add( m_mouseText, 0, wxCENTRE|wxALL, 5 );
+                   wxSizerFlags().Expand().Border());
+    topSizer->Add( m_mouseText, wxSizerFlags().Centre().Border() );
 
     if ( scrolled )
     {
@@ -382,9 +382,9 @@ MyFrame::MyFrame(const wxString& title)
     logger->DisableTimestamp();
 
     wxBoxSizer *topSizer = new wxBoxSizer( wxVERTICAL );
-    topSizer->Add( button1, 0, wxALL, 5 );
-    topSizer->Add( button2, 0, wxALL, 5 );
-    topSizer->Add( m_logWin, 1, wxEXPAND|wxALL, 5 );
+    topSizer->Add( button1, wxSizerFlags().Expand().Border());
+    topSizer->Add( button2, wxSizerFlags().Expand().Border());
+    topSizer->Add( m_logWin, wxSizerFlags(1).Expand().Border());
 
     panel->SetSizer( topSizer );
 
@@ -471,10 +471,10 @@ MyDialog::MyDialog(const wxString& title)
     wxButton *okButton = new wxButton( panel, wxID_OK, "OK", wxPoint(20,200) );
 
     wxBoxSizer *topSizer = new wxBoxSizer( wxVERTICAL );
-    topSizer->Add( button1, 0, wxALL, 5 );
-    topSizer->Add( button2, 0, wxALL, 5 );
+    topSizer->Add( button1, wxSizerFlags().Border());
+    topSizer->Add( button2, wxSizerFlags().Border());
     topSizer->AddSpacer(40);
-    topSizer->Add( okButton, 0, wxALL, 5 );
+    topSizer->Add( okButton, wxSizerFlags().Border());
 
     panel->SetSizerAndFit( topSizer );
 }

--- a/samples/propgrid/propgrid.cpp
+++ b/samples/propgrid/propgrid.cpp
@@ -2161,11 +2161,11 @@ FormMain::FormMain(const wxString& title)
     wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);
     btnSizer->Add(new wxButton(m_panel, wxID_ANY,
         "Should be able to move here with Tab"),
-        wxSizerFlags(1).DoubleBorder(wxALL));
+        wxSizerFlags(1).DoubleBorder());
     btnSizer->Add(new wxButton(m_panel, ID_SHOWPOPUP,
         "Show Popup"),
-        wxSizerFlags(1).DoubleBorder(wxALL));
-    m_topSizer->Add(btnSizer, wxSizerFlags(0).Border(wxALL).Expand());
+        wxSizerFlags(1).DoubleBorder());
+    m_topSizer->Add(btnSizer, wxSizerFlags(0).Border().Expand());
 
     m_panel->SetSizer(m_topSizer);
     m_topSizer->SetSizeHints(m_panel);
@@ -3352,7 +3352,7 @@ struct PropertyGridPopup : wxPopupWindow
         ::SetMinSize(m_grid);
 
         m_sizer = new wxBoxSizer( wxVERTICAL );
-        m_sizer->Add(m_grid, wxSizerFlags(0).Expand().Border(wxALL, 0));
+        m_sizer->Add(m_grid, wxSizerFlags().Expand());
         m_panel->SetAutoLayout(true);
         m_panel->SetSizer(m_sizer);
         m_sizer->Fit(m_panel);

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -587,10 +587,10 @@ MyFrame::MyFrame()
 
         wxSizer* sizer_panelsizer_h = new wxBoxSizer(wxHORIZONTAL);
         wxSizer* sizer_panelsizer_v = new wxBoxSizer(wxVERTICAL);
-        sizer_panelsizer_v->AddStretchSpacer(1);
+        sizer_panelsizer_v->AddStretchSpacer();
         sizer_panelsizer_v->Add(sizer_panelcombo, wxSizerFlags().Expand().Border(wxALL, FromDIP(2)));
         sizer_panelsizer_v->Add(sizer_panelcombo2, wxSizerFlags().Expand().Border(wxALL, FromDIP(2)));
-        sizer_panelsizer_v->AddStretchSpacer(1);
+        sizer_panelsizer_v->AddStretchSpacer();
         sizer_panelsizer_h->Add(bar, wxSizerFlags().Expand());
         sizer_panelsizer_h->Add(sizer_panelsizer_v, 0);
         sizer_panel->SetSizer(sizer_panelsizer_h);

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -588,10 +588,10 @@ MyFrame::MyFrame()
         wxSizer* sizer_panelsizer_h = new wxBoxSizer(wxHORIZONTAL);
         wxSizer* sizer_panelsizer_v = new wxBoxSizer(wxVERTICAL);
         sizer_panelsizer_v->AddStretchSpacer(1);
-        sizer_panelsizer_v->Add(sizer_panelcombo, 0, wxALL|wxEXPAND, 2);
-        sizer_panelsizer_v->Add(sizer_panelcombo2, 0, wxALL|wxEXPAND, 2);
+        sizer_panelsizer_v->Add(sizer_panelcombo, wxSizerFlags().Expand().Border(wxALL, FromDIP(2)));
+        sizer_panelsizer_v->Add(sizer_panelcombo2, wxSizerFlags().Expand().Border(wxALL, FromDIP(2)));
         sizer_panelsizer_v->AddStretchSpacer(1);
-        sizer_panelsizer_h->Add(bar, 0, wxEXPAND);
+        sizer_panelsizer_h->Add(bar, wxSizerFlags().Expand());
         sizer_panelsizer_h->Add(sizer_panelsizer_v, 0);
         sizer_panel->SetSizer(sizer_panelsizer_h);
 
@@ -731,8 +731,8 @@ MyFrame::MyFrame()
 
     wxSizer *s = new wxBoxSizer(wxVERTICAL);
 
-    s->Add(m_ribbon, 0, wxEXPAND);
-    s->Add(m_logwindow, 1, wxEXPAND);
+    s->Add(m_ribbon, wxSizerFlags().Expand());
+    s->Add(m_logwindow, wxSizerFlags(1).Expand());
     s->Add(m_togglePanels, wxSizerFlags().Border());
 
     SetSizer(s);

--- a/samples/richtext/richtext.cpp
+++ b/samples/richtext/richtext.cpp
@@ -893,7 +893,7 @@ MyFrame::MyFrame(const wxString& title, wxWindowID id, const wxPoint& pos,
     wxToolBar* toolBar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                        wxNO_BORDER|wxTB_FLAT|wxTB_NODIVIDER|wxTB_NOALIGN);
 
-    sizer->Add(toolBar, 0, wxEXPAND);
+    sizer->Add(toolBar, wxSizerFlags().Expand());
 
     toolBar->AddTool(wxID_OPEN, wxEmptyString, wxBitmap(open_xpm), _("Open"));
     toolBar->AddTool(wxID_SAVEAS, wxEmptyString, wxBitmap(save_xpm), _("Save"));
@@ -925,7 +925,7 @@ MyFrame::MyFrame(const wxString& title, wxWindowID id, const wxPoint& pos,
     toolBar->Realize();
 
     wxSplitterWindow* splitter = new wxSplitterWindow(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE);
-    sizer->Add(splitter, 1, wxEXPAND);
+    sizer->Add(splitter, wxSizerFlags(1).Expand());
 
     m_richTextCtrl = new MyRichTextCtrl(splitter, ID_RICHTEXT_CTRL, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxVSCROLL|wxHSCROLL/*|wxWANTS_CHARS*/);
     wxASSERT(!m_richTextCtrl->GetBuffer().GetAttributes().HasFontPixelSize());
@@ -1774,10 +1774,10 @@ void MyFrame::OnViewHTML(wxCommandEvent& WXUNUSED(event))
     dialog.SetSizer(boxSizer);
 
     wxHtmlWindow* win = new wxHtmlWindow(& dialog, wxID_ANY, wxDefaultPosition, wxSize(500, 400), wxSUNKEN_BORDER);
-    boxSizer->Add(win, 1, wxALL, 5);
+    boxSizer->Add(win, wxSizerFlags(1).Border());
 
     wxButton* cancelButton = new wxButton(& dialog, wxID_CANCEL, "&Close");
-    boxSizer->Add(cancelButton, 0, wxALL|wxCENTRE, 5);
+    boxSizer->Add(cancelButton, wxSizerFlags().Center().Border());
 
     wxString text;
     wxStringOutputStream strStream(& text);

--- a/samples/statbar/statbar.cpp
+++ b/samples/statbar/statbar.cpp
@@ -873,13 +873,13 @@ MyAboutDialog::MyAboutDialog(wxWindow *parent)
     statbarBottom->SetStatusText("in a dialog", 1);
 
     wxBoxSizer *sizerTop = new wxBoxSizer(wxVERTICAL);
-    sizerTop->Add(statbarTop, 0, wxGROW);
-    sizerTop->Add(-1, 10, 1, wxGROW);
-    sizerTop->Add(text, 0, wxCENTRE | wxRIGHT | wxLEFT, 20);
-    sizerTop->Add(-1, 10, 1, wxGROW);
-    sizerTop->Add(btn, 0, wxCENTRE | wxRIGHT | wxLEFT, 20);
-    sizerTop->Add(-1, 10, 1, wxGROW);
-    sizerTop->Add(statbarBottom, 0, wxGROW);
+    sizerTop->Add(statbarTop, wxSizerFlags().Expand());
+    sizerTop->Add(-1, 10, wxSizerFlags(1).Expand());
+    sizerTop->Add(text, wxSizerFlags().Centre().Border(wxLEFT|wxRIGHT, FromDIP(20)));
+    sizerTop->Add(-1, 10, wxSizerFlags(1).Expand());
+    sizerTop->Add(btn, wxSizerFlags().Centre().Border(wxLEFT|wxRIGHT, FromDIP(20)));
+    sizerTop->Add(-1, 10, wxSizerFlags(1).Expand());
+    sizerTop->Add(statbarBottom, wxSizerFlags().Expand());
 
     SetSizerAndFit(sizerTop);
 }

--- a/samples/stc/edit.cpp
+++ b/samples/stc/edit.cpp
@@ -845,15 +845,15 @@ EditProperties::EditProperties (Edit *edit,
     wxGridSizer *textinfo = new wxGridSizer (4, 0, 2);
     textinfo->Add (new wxStaticText (this, wxID_ANY, _("Language"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
+                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT));
     textinfo->Add (new wxStaticText (this, wxID_ANY, edit->m_language->name),
-                   wxSizerFlags().Left().CenterVertical().Border(wxRIGHT, FromDIP(4)));
+                   wxSizerFlags().Left().CenterVertical().Border(wxRIGHT));
     textinfo->Add (new wxStaticText (this, wxID_ANY, _("Lexer-ID: "),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
+                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT));
     text = wxString::Format ("%d", edit->GetLexer());
     textinfo->Add (new wxStaticText (this, wxID_ANY, text),
-                   wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
+                   wxSizerFlags().Right().CenterVertical().Border(wxRIGHT));
     wxString EOLtype;
     switch (edit->GetEOLMode()) {
         case wxSTC_EOL_CR: {EOLtype = "CR (Unix)"; break; }
@@ -862,9 +862,9 @@ EditProperties::EditProperties (Edit *edit,
     }
     textinfo->Add (new wxStaticText (this, wxID_ANY, _("Line endings"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
+                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT));
     textinfo->Add (new wxStaticText (this, wxID_ANY, EOLtype),
-                   wxSizerFlags().Left().CenterVertical().Border(wxRIGHT, FromDIP(4)));
+                   wxSizerFlags().Left().CenterVertical().Border(wxRIGHT));
 
     // text info box
     wxStaticBoxSizer *textinfos = new wxStaticBoxSizer (
@@ -877,28 +877,28 @@ EditProperties::EditProperties (Edit *edit,
     wxGridSizer *statistic = new wxGridSizer (4, 0, 2);
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Total lines"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT));
     text = wxString::Format ("%d", edit->GetLineCount());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT));
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Total chars"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT));
     text = wxString::Format ("%d", edit->GetTextLength());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT));
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Current line"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT));
     text = wxString::Format ("%d", edit->GetCurrentLine());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT));
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Current pos"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT));
     text = wxString::Format ("%d", edit->GetCurrentPos());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT));
 
     // char/line statistics
     wxStaticBoxSizer *statistics = new wxStaticBoxSizer (

--- a/samples/stc/edit.cpp
+++ b/samples/stc/edit.cpp
@@ -911,9 +911,9 @@ EditProperties::EditProperties (Edit *edit,
     wxBoxSizer *totalpane = new wxBoxSizer (wxVERTICAL);
     totalpane->Add (fullname, wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT | wxTOP));
     totalpane->Add (0, 6);
-    totalpane->Add (textinfos, wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT));
+    totalpane->Add (textinfos, wxSizerFlags().Expand().DoubleHorzBorder());
     totalpane->Add (0, 10);
-    totalpane->Add (statistics, wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT));
+    totalpane->Add (statistics, wxSizerFlags().Expand().DoubleHorzBorder());
     totalpane->Add (0, 6);
     wxButton *okButton = new wxButton (this, wxID_OK, _("OK"));
     okButton->SetDefault();

--- a/samples/stc/edit.cpp
+++ b/samples/stc/edit.cpp
@@ -837,23 +837,23 @@ EditProperties::EditProperties (Edit *edit,
     fullname->Add (10, 0);
     fullname->Add (new wxStaticText (this, wxID_ANY, _("Full filename"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                   0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
+                   wxSizerFlags().Left().CenterVertical());
     fullname->Add (new wxStaticText (this, wxID_ANY, edit->GetFilename()),
-                   0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
+                   wxSizerFlags().Left().CenterVertical());
 
     // text info
     wxGridSizer *textinfo = new wxGridSizer (4, 0, 2);
     textinfo->Add (new wxStaticText (this, wxID_ANY, _("Language"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                   0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT, 4);
+                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
     textinfo->Add (new wxStaticText (this, wxID_ANY, edit->m_language->name),
-                   0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxRIGHT, 4);
+                   wxSizerFlags().Left().CenterVertical().Border(wxRIGHT, FromDIP(4)));
     textinfo->Add (new wxStaticText (this, wxID_ANY, _("Lexer-ID: "),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                   0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT, 4);
+                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
     text = wxString::Format ("%d", edit->GetLexer());
     textinfo->Add (new wxStaticText (this, wxID_ANY, text),
-                   0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxRIGHT, 4);
+                   wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
     wxString EOLtype;
     switch (edit->GetEOLMode()) {
         case wxSTC_EOL_CR: {EOLtype = "CR (Unix)"; break; }
@@ -862,62 +862,62 @@ EditProperties::EditProperties (Edit *edit,
     }
     textinfo->Add (new wxStaticText (this, wxID_ANY, _("Line endings"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                   0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT, 4);
+                   wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
     textinfo->Add (new wxStaticText (this, wxID_ANY, EOLtype),
-                   0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxRIGHT, 4);
+                   wxSizerFlags().Left().CenterVertical().Border(wxRIGHT, FromDIP(4)));
 
     // text info box
     wxStaticBoxSizer *textinfos = new wxStaticBoxSizer (
                      new wxStaticBox (this, wxID_ANY, _("Information")),
                      wxVERTICAL);
-    textinfos->Add (textinfo, 0, wxEXPAND);
+    textinfos->Add (textinfo, wxSizerFlags().Expand());
     textinfos->Add (0, 6);
 
     // statistic
     wxGridSizer *statistic = new wxGridSizer (4, 0, 2);
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Total lines"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT, 4);
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
     text = wxString::Format ("%d", edit->GetLineCount());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxRIGHT, 4);
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Total chars"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT, 4);
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
     text = wxString::Format ("%d", edit->GetTextLength());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxRIGHT, 4);
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Current line"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT, 4);
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
     text = wxString::Format ("%d", edit->GetCurrentLine());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxRIGHT, 4);
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
     statistic->Add (new wxStaticText (this, wxID_ANY, _("Current pos"),
                                      wxDefaultPosition, wxSize(80, wxDefaultCoord)),
-                    0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT, 4);
+                    wxSizerFlags().Left().CenterVertical().Border(wxLEFT, FromDIP(4)));
     text = wxString::Format ("%d", edit->GetCurrentPos());
     statistic->Add (new wxStaticText (this, wxID_ANY, text),
-                    0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxRIGHT, 4);
+                    wxSizerFlags().Right().CenterVertical().Border(wxRIGHT, FromDIP(4)));
 
     // char/line statistics
     wxStaticBoxSizer *statistics = new wxStaticBoxSizer (
                      new wxStaticBox (this, wxID_ANY, _("Statistics")),
                      wxVERTICAL);
-    statistics->Add (statistic, 0, wxEXPAND);
+    statistics->Add (statistic, wxSizerFlags().Expand());
     statistics->Add (0, 6);
 
     // total pane
     wxBoxSizer *totalpane = new wxBoxSizer (wxVERTICAL);
-    totalpane->Add (fullname, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
+    totalpane->Add (fullname, wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT | wxTOP));
     totalpane->Add (0, 6);
-    totalpane->Add (textinfos, 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+    totalpane->Add (textinfos, wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT));
     totalpane->Add (0, 10);
-    totalpane->Add (statistics, 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+    totalpane->Add (statistics, wxSizerFlags().Expand().DoubleBorder(wxLEFT | wxRIGHT));
     totalpane->Add (0, 6);
     wxButton *okButton = new wxButton (this, wxID_OK, _("OK"));
     okButton->SetDefault();
-    totalpane->Add (okButton, 0, wxALIGN_CENTER | wxALL, 10);
+    totalpane->Add (okButton, wxSizerFlags().Center().DoubleBorder());
 
     SetSizerAndFit (totalpane);
 

--- a/samples/stc/stctest.cpp
+++ b/samples/stc/stctest.cpp
@@ -720,7 +720,7 @@ AppAbout::AppAbout (wxWindow *parent,
     appname->SetFont (wxFontInfo(24).Bold());
     totalpane->Add (appname, wxSizerFlags().Centre().Border(wxLEFT | wxRIGHT, FromDIP(40)));
     totalpane->Add (0, 10);
-    totalpane->Add (aboutpane, wxSizerFlags().Expand().Border(wxALL, FromDIP(4)));
+    totalpane->Add (aboutpane, wxSizerFlags().Expand().Border());
     totalpane->Add (new wxStaticText(this, wxID_ANY, APP_DESCR),
                     wxSizerFlags().Centre().DoubleBorder());
     wxButton *okButton = new wxButton (this, wxID_OK, _("OK"));

--- a/samples/stc/stctest.cpp
+++ b/samples/stc/stctest.cpp
@@ -689,28 +689,28 @@ AppAbout::AppAbout (wxWindow *parent,
     // about info
     wxGridSizer *aboutinfo = new wxGridSizer (2, 0, 2);
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, _("Written by: ")),
-                    0, wxALIGN_LEFT);
+                    wxSizerFlags().Left());
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, APP_MAINT),
-                    1, wxEXPAND | wxALIGN_LEFT);
+                    wxSizerFlags(1).Expand().Left());
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, _("Version: ")),
-                    0, wxALIGN_LEFT);
+                    wxSizerFlags().Left());
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, versionInfo),
-                    1, wxEXPAND | wxALIGN_LEFT);
+                    wxSizerFlags(1).Expand().Left());
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, _("Licence type: ")),
-                    0, wxALIGN_LEFT);
+                    wxSizerFlags().Left());
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, APP_LICENCE),
-                    1, wxEXPAND | wxALIGN_LEFT);
+                    wxSizerFlags(1).Expand().Left());
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, _("Copyright: ")),
-                    0, wxALIGN_LEFT);
+                    wxSizerFlags().Left());
     aboutinfo->Add (new wxStaticText(this, wxID_ANY, APP_COPYRIGTH),
-                    1, wxEXPAND | wxALIGN_LEFT);
+                    wxSizerFlags(1).Expand().Left());
 
     // about icontitle//info
     wxBoxSizer *aboutpane = new wxBoxSizer (wxHORIZONTAL);
     wxBitmap bitmap = wxBitmap(wxICON (sample));
     aboutpane->Add (new wxStaticBitmap (this, wxID_ANY, bitmap),
-                    0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT, 20);
-    aboutpane->Add (aboutinfo, 1, wxEXPAND);
+                    wxSizerFlags().Left().CentreVertical().Border(wxLEFT|wxRIGHT, FromDIP(20)));
+    aboutpane->Add (aboutinfo, wxSizerFlags(1).Expand());
     aboutpane->Add (60, 0);
 
     // about complete
@@ -718,14 +718,14 @@ AppAbout::AppAbout (wxWindow *parent,
     totalpane->Add (0, 20);
     wxStaticText *appname = new wxStaticText(this, wxID_ANY, *g_appname);
     appname->SetFont (wxFontInfo(24).Bold());
-    totalpane->Add (appname, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT, 40);
+    totalpane->Add (appname, wxSizerFlags().Centre().Border(wxLEFT | wxRIGHT, FromDIP(40)));
     totalpane->Add (0, 10);
-    totalpane->Add (aboutpane, 0, wxEXPAND | wxALL, 4);
+    totalpane->Add (aboutpane, wxSizerFlags().Expand().Border(wxALL, FromDIP(4)));
     totalpane->Add (new wxStaticText(this, wxID_ANY, APP_DESCR),
-                    0, wxALIGN_CENTER | wxALL, 10);
+                    wxSizerFlags().Centre().DoubleBorder());
     wxButton *okButton = new wxButton (this, wxID_OK, _("OK"));
     okButton->SetDefault();
-    totalpane->Add (okButton, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+    totalpane->Add (okButton, wxSizerFlags().Centre().DoubleBorder(wxLEFT | wxRIGHT | wxBOTTOM));
 
     SetSizerAndFit (totalpane);
 
@@ -860,7 +860,7 @@ public:
         MinimalEditor* editor = new MinimalEditor(this);
         editor->SetFont(wxFontInfo().Family(wxFONTFAMILY_TELETYPE));
         wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
-        sizer->Add(editor, 1, wxEXPAND);
+        sizer->Add(editor, wxSizerFlags(1).Expand());
         SetSizer(sizer);
         editor->SetText(
            "<xml>\n"

--- a/samples/taskbar/tbtest.cpp
+++ b/samples/taskbar/tbtest.cpp
@@ -89,7 +89,7 @@ MyDialog::MyDialog(const wxString& title)
     wxSizer * const sizerTop = new wxBoxSizer(wxVERTICAL);
 
     wxSizerFlags flags;
-    flags.DoubleBorder(wxALL);
+    flags.DoubleBorder();
 
     sizerTop->Add(new wxStaticText
                       (

--- a/samples/taskbarbutton/taskbarbutton.cpp
+++ b/samples/taskbarbutton/taskbarbutton.cpp
@@ -234,8 +234,8 @@ MyFrame::MyFrame(const wxString& title)
         new wxStaticBoxSizer(wxVERTICAL, panel, "SetThumbnailTooltip");
     m_textCtrl = new wxTextCtrl(panel, wxID_ANY);
     wxButton *btn = new wxButton(panel, ThumbnailTooltipSetBtn, "Set");
-    sttSizer->Add(m_textCtrl, 1, wxEXPAND | wxALL, 2);
-    sttSizer->Add(btn, 1, wxEXPAND | wxALL, 2);
+    sttSizer->Add(m_textCtrl, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
+    sttSizer->Add(btn, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
 
     // SetProgressState section.
     wxStaticBoxSizer *spsSizer =
@@ -251,7 +251,7 @@ MyFrame::MyFrame(const wxString& title)
     m_stateChoice = new wxChoice(panel, ProgressStateChoice,
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(choices), choices);
-    spsSizer->Add(m_stateChoice, 0, wxALL | wxGROW, 5);
+    spsSizer->Add(m_stateChoice, wxSizerFlags().Expand().Border());
 
     // SetOverlayIcon section.
     wxStaticBoxSizer *soiSizer =
@@ -260,8 +260,8 @@ MyFrame::MyFrame(const wxString& title)
         new wxButton(panel, SetOverlayIconBtn, "Set Overlay Icon");
     wxButton *clearOverlayIconBtn =
         new wxButton(panel, ClearOverlayIconBtn, "Clear Overlay Icon");
-    soiSizer->Add(setOverlayIconBtn, 1, wxEXPAND | wxALL, 2);
-    soiSizer->Add(clearOverlayIconBtn, 1, wxEXPAND | wxALL, 2);
+    soiSizer->Add(setOverlayIconBtn, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
+    soiSizer->Add(clearOverlayIconBtn, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
 
     // SetThumbnailClip section.
     wxStaticBoxSizer *stcSizer =
@@ -271,8 +271,8 @@ MyFrame::MyFrame(const wxString& title)
     wxButton *restoreThumbnailClipBtn =
         new wxButton(panel, RestoreThumbnailClipBtn,
                      "Restore Thumbnail Clip");
-    stcSizer->Add(setThumbnailClipBtn, 1, wxEXPAND | wxALL, 2);
-    stcSizer->Add(restoreThumbnailClipBtn, 1, wxEXPAND | wxALL, 2);
+    stcSizer->Add(setThumbnailClipBtn, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
+    stcSizer->Add(restoreThumbnailClipBtn, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
 
     // Thumbnail Toolbar Buttons section.
     wxStaticBoxSizer *ttbSizer =
@@ -282,20 +282,20 @@ MyFrame::MyFrame(const wxString& title)
     wxButton *showThumbnailToolbarBtn =
         new wxButton(panel, RemoveThumbBarButtonBtn,
                      "Remove Last ThumbBar Button");
-    ttbSizer->Add(addThumbBarButtonBtn, 1, wxEXPAND | wxALL, 2);
-    ttbSizer->Add(showThumbnailToolbarBtn, 1, wxEXPAND | wxALL, 2);
+    ttbSizer->Add(addThumbBarButtonBtn, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
+    ttbSizer->Add(showThumbnailToolbarBtn, wxSizerFlags(1).Expand().Border(wxALL, FromDIP(2)));
 
-    gs->Add(spvSizer, 0, wxEXPAND);
-    gs->Add(m_visibilityRadioBox, 0, wxEXPAND);
-    gs->Add(sttSizer, 0, wxEXPAND);
-    gs->Add(spsSizer, 0, wxEXPAND);
-    gs->Add(soiSizer, 0, wxEXPAND);
-    gs->Add(stcSizer, 0, wxEXPAND);
-    gs->Add(ttbSizer, 0, wxEXPAND);
+    gs->Add(spvSizer, wxSizerFlags().Expand());
+    gs->Add(m_visibilityRadioBox, wxSizerFlags().Expand());
+    gs->Add(sttSizer, wxSizerFlags().Expand());
+    gs->Add(spsSizer, wxSizerFlags().Expand());
+    gs->Add(soiSizer, wxSizerFlags().Expand());
+    gs->Add(stcSizer, wxSizerFlags().Expand());
+    gs->Add(ttbSizer, wxSizerFlags().Expand());
 
     wxStaticText *text = new wxStaticText(
         panel, wxID_ANY, "Welcome to wxTaskBarButton sample");
-    mainSizer->Add(text, 0, wxALIGN_CENTRE_HORIZONTAL);
+    mainSizer->Add(text, wxSizerFlags().Centre());
     mainSizer->Add(gs);
 
     panel->SetSizer(mainSizer);

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1310,30 +1310,30 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
 
     // lay out the controls
     wxBoxSizer *column1 = new wxBoxSizer(wxVERTICAL);
-    column1->Add( m_text, 0, wxALL | wxEXPAND, 10 );
-    column1->Add( m_password, 0, wxALL | wxEXPAND, 10 );
-    column1->Add( m_readonly, 0, wxALL, 10 );
-    column1->Add( m_limited, 0, wxALL, 10 );
-    column1->Add( m_limitedMultiline, 0, wxALL, 10 );
-    column1->Add( upperOnly, 0, wxALL, 10 );
-    column1->Add( m_horizontal, 1, wxALL | wxEXPAND, 10 );
+    column1->Add( m_text, wxSizerFlags().Expand().DoubleBorder() );
+    column1->Add( m_password, wxSizerFlags().Expand().DoubleBorder() );
+    column1->Add( m_readonly, wxSizerFlags().DoubleBorder() );
+    column1->Add( m_limited, wxSizerFlags().DoubleBorder() );
+    column1->Add( m_limitedMultiline, wxSizerFlags().DoubleBorder() );
+    column1->Add( upperOnly, wxSizerFlags().DoubleBorder() );
+    column1->Add( m_horizontal, wxSizerFlags(1).Expand().DoubleBorder() );
 
     wxBoxSizer *column2 = new wxBoxSizer(wxVERTICAL);
-    column2->Add( m_multitext, 1, wxALL | wxEXPAND, 10 );
-    column2->Add( m_tab, 0, wxALL | wxEXPAND, 10 );
-    column2->Add( m_enter, 1, wxALL | wxEXPAND, 10 );
+    column2->Add( m_multitext, wxSizerFlags(1).Expand().DoubleBorder() );
+    column2->Add( m_tab, wxSizerFlags().Expand().DoubleBorder() );
+    column2->Add( m_enter, wxSizerFlags(1).Expand().DoubleBorder() );
 
     auto* const row1 = new wxGridSizer(3, FromDIP(wxSize(10, 10)));
-    row1->Add( column1, 0, wxALL | wxEXPAND, 10 );
-    row1->Add( column2, 1, wxALL | wxEXPAND, 10 );
-    row1->Add( m_textrich, 1, wxALL | wxEXPAND, 10 );
+    row1->Add( column1, wxSizerFlags().Expand().DoubleBorder() );
+    row1->Add( column2, wxSizerFlags(1).Expand().DoubleBorder() );
+    row1->Add( m_textrich, wxSizerFlags(1).Expand().DoubleBorder() );
     row1->SetItemMinSize( m_textrich, FromDIP(wxSize(300, 200)) );
 
     wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
-    topSizer->Add( row1, 2, wxALL | wxEXPAND, 10 );
+    topSizer->Add( row1, wxSizerFlags(2).Expand().DoubleBorder() );
 
 #if wxUSE_LOG
-    topSizer->Add( m_log, 1, wxALL | wxEXPAND, 10 );
+    topSizer->Add( m_log, wxSizerFlags(1).Expand().DoubleBorder() );
 #endif
 
     SetSizer(topSizer);

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -722,9 +722,9 @@ MyFrame::MyFrame()
     m_panel->SetSizer(sizer);
 #if USE_UNMANAGED_TOOLBAR
     if (m_extraToolBar)
-        sizer->Add(m_extraToolBar, 0, wxEXPAND, 0);
+        sizer->Add(m_extraToolBar, wxSizerFlags().Expand());
 #endif
-    sizer->Add(m_textWindow, 1, wxEXPAND, 0);
+    sizer->Add(m_textWindow, wxSizerFlags(1).Expand());
 
     SetInitialSize(FromDIP(wxSize(650, 350)));
 }

--- a/samples/validate/validate.cpp
+++ b/samples/validate/validate.cpp
@@ -249,7 +249,7 @@ MyDialog::MyDialog( wxWindow *parent, const wxString& title,
     m_text = new wxTextCtrl(this, VALIDATE_TEXT);
     m_text->SetToolTip("wxTextValidator not set");
     m_text->SetHint("Enter some text here, please...");
-    flexgridsizer->Add(m_text, 1, wxGROW);
+    flexgridsizer->Add(m_text, wxSizerFlags(1).Expand());
 
     // Make it possible to change the wxTextValidator for m_text at runtime.
     wxButton* const button =
@@ -261,14 +261,14 @@ MyDialog::MyDialog( wxWindow *parent, const wxString& title,
                         wxDefaultPosition, wxDefaultSize,
                         3, g_listbox_choices, wxLB_MULTIPLE,
                         wxGenericValidator(&g_data.m_listbox_choices)),
-                       1, wxGROW);
+                       wxSizerFlags(1).Expand());
 
     m_combobox = new wxComboBox(this, VALIDATE_COMBO, wxEmptyString,
                                 wxDefaultPosition, wxDefaultSize,
                                 3, g_combobox_choices, 0L,
                                 MyComboBoxValidator(&g_data.m_combobox_choice));
     m_combobox->SetToolTip("uses a custom validator (MyComboBoxValidator)");
-    flexgridsizer->Add(m_combobox, 1, wxALIGN_CENTER);
+    flexgridsizer->Add(m_combobox, wxSizerFlags(1).Center());
 
     // This wxCheckBox* doesn't need to be assigned to any pointer
     // because we don't use it elsewhere--it can be anonymous.
@@ -361,7 +361,7 @@ MyDialog::MyDialog( wxWindow *parent, const wxString& title,
 
     wxBoxSizer *mainsizer = new wxBoxSizer( wxVERTICAL );
 
-    mainsizer->Add(flexgridsizer, 1, wxGROW | wxALL, 10);
+    mainsizer->Add(flexgridsizer, wxSizerFlags(1).Expand().DoubleBorder());
 
     mainsizer->Add(new wxRadioBox((wxWindow*)this, VALIDATE_RADIO, "Pick a color",
                                     wxDefaultPosition, wxDefaultSize,
@@ -492,7 +492,7 @@ TextValidatorDialog::TextValidatorDialog(wxWindow *parent, wxTextCtrl* txtCtrl)
     // Set the main sizer.
     wxBoxSizer *mainsizer = new wxBoxSizer( wxVERTICAL );
 
-    mainsizer->Add(fgSizer, wxSizerFlags(1).DoubleBorder(wxALL).Expand());
+    mainsizer->Add(fgSizer, wxSizerFlags(1).DoubleBorder().Expand());
 
     mainsizer->Add(CreateButtonSizer(wxOK | wxCANCEL),
                    wxSizerFlags().Expand().DoubleBorder());

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -1314,7 +1314,7 @@ void WebFrame::OnViewTextRequest(wxCommandEvent& WXUNUSED(evt))
                                       wxTE_READONLY);
 #endif // wxUSE_STC/!wxUSE_STC
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
-    sizer->Add(text, 1, wxEXPAND);
+    sizer->Add(text, wxSizerFlags(1).Expand());
     textViewDialog.SetSizer(sizer);
     textViewDialog.ShowModal();
 }
@@ -1877,6 +1877,6 @@ SourceViewDialog::SourceViewDialog(wxWindow* parent, wxString source) :
 #endif // wxUSE_STC/!wxUSE_STC
 
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
-    sizer->Add(text, 1, wxEXPAND);
+    sizer->Add(text, wxSizerFlags(1).Expand());
     SetSizer(sizer);
 }

--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -334,7 +334,7 @@ void BitmapComboBoxWidgetsPage::CreateContent()
                                                 &m_textChangeHeight,
                                                 sizerOptions->GetStaticBox());
     m_textChangeHeight->SetSize(20, wxDefaultCoord);
-    sizerOptions->Add(sizerRow, wxSizerFlags().FixedMinSize().Border() /*| wxGROW*/);
+    sizerOptions->Add(sizerRow, wxSizerFlags().FixedMinSize().Border());
 
     sizerLeft->Add( sizerOptions, wxSizerFlags().Expand().Border(wxTOP, FromDIP(2)));
 

--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -275,8 +275,8 @@ wxSizer *BitmapComboBoxWidgetsPage::CreateSizerWithSmallTextAndLabel(const wxStr
     wxTextCtrl *text = new wxTextCtrl(parent ? parent : this, id, wxEmptyString,
         wxDefaultPosition, wxSize(50,wxDefaultCoord), wxTE_PROCESS_ENTER);
 
-    sizerRow->Add(control, 0, wxRIGHT | wxALIGN_CENTRE_VERTICAL, 5);
-    sizerRow->Add(text, 1, wxFIXED_MINSIZE | wxLEFT | wxALIGN_CENTRE_VERTICAL, 5);
+    sizerRow->Add(control, wxSizerFlags().CentreVertical().Border(wxRIGHT));
+    sizerRow->Add(text, wxSizerFlags(1).FixedMinSize().CentreVertical().Border(wxLEFT));
 
     if ( ppText )
         *ppText = text;
@@ -321,10 +321,10 @@ void BitmapComboBoxWidgetsPage::CreateContent()
     m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerStyle, "&Read only", wxID_ANY, sizerStyleBox);
 
     wxButton *btn = new wxButton(sizerStyleBox, BitmapComboBoxPage_Reset, "&Reset");
-    sizerStyle->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 3);
+    sizerStyle->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, FromDIP(3)));
 
     sizerLeft->Add(sizerStyle, wxSizerFlags().Expand());
-    sizerLeft->Add(m_radioKind, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioKind, wxSizerFlags().Expand().Border());
 
     // left pane - other options
     wxStaticBoxSizer *sizerOptions = new wxStaticBoxSizer(wxVERTICAL, this, "Demo options");
@@ -334,7 +334,7 @@ void BitmapComboBoxWidgetsPage::CreateContent()
                                                 &m_textChangeHeight,
                                                 sizerOptions->GetStaticBox());
     m_textChangeHeight->SetSize(20, wxDefaultCoord);
-    sizerOptions->Add(sizerRow, 0, wxALL | wxFIXED_MINSIZE /*| wxGROW*/, 5);
+    sizerOptions->Add(sizerRow, wxSizerFlags().FixedMinSize().Border() /*| wxGROW*/);
 
     sizerLeft->Add( sizerOptions, wxSizerFlags().Expand().Border(wxTOP, FromDIP(2)));
 
@@ -343,40 +343,40 @@ void BitmapComboBoxWidgetsPage::CreateContent()
     wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_ContainerTests, "Run &tests");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
 #if wxUSE_IMAGE
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddWidgetIcons, "Add &widget icons");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_LoadFromFile, "Insert image from &file");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_SetFromFile, "&Set image from file");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 #endif
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddSeveralWithImages, "A&ppend a few strings with images");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddSeveral, "Append a &few strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddMany, "Append &many strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(BitmapComboBoxPage_Delete,
                                             "&Delete this item",
                                             BitmapComboBoxPage_DeleteText,
                                             &m_textDelete,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_DeleteSel, "Delete &selection");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_Clear, "&Clear");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
 #if wxUSE_IMAGE
     wxInitAllImageHandlers();
@@ -396,14 +396,14 @@ void BitmapComboBoxWidgetsPage::CreateContent()
     m_combobox->SetPopupMaxHeight(600);
 #endif
 
-    sizerRight->Add(m_combobox, 0, wxGROW | wxALL, 5);
+    sizerRight->Add(m_combobox, wxSizerFlags().Expand().Border());
     sizerRight->SetMinSize(150, 0);
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 5, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 4, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags(5).Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(4).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -495,7 +495,7 @@ void BitmapComboBoxWidgetsPage::CreateCombo()
         m_combobox->Append(item.text, item.bitmap);
     }
 
-    m_sizerCombo->Add(m_combobox, 0, wxGROW | wxALL, 5);
+    m_sizerCombo->Add(m_combobox, wxSizerFlags().Expand().Border());
     m_sizerCombo->Layout();
 
     // Allow changing height in order to demonstrate flexible

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -344,7 +344,7 @@ void ButtonWidgetsPage::CreateContent()
     sizerLeft->AddSpacer(5);
 
     wxButton *btn = new wxButton(sizerLeftBox, ButtonPage_Reset, "&Reset");
-    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder(wxALL));
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Operations");
@@ -377,7 +377,7 @@ void ButtonWidgetsPage::CreateContent()
     sizerTop->Add(sizerLeft,
                   wxSizerFlags(0).Expand().DoubleBorder(wxALL & ~wxLEFT));
     sizerTop->Add(sizerMiddle,
-                  wxSizerFlags(1).Expand().DoubleBorder(wxALL));
+                  wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(m_sizerButton,
                   wxSizerFlags(1).Expand().DoubleBorder((wxALL & ~wxRIGHT)));
 

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -176,7 +176,7 @@ void CheckBoxWidgetsPage::CreateContent()
                     sizerLeftBox
                  );
 
-    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->AddSpacer(FromDIP(15));
 
     static const wxString kinds[] =
     {

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -176,7 +176,7 @@ void CheckBoxWidgetsPage::CreateContent()
                     sizerLeftBox
                  );
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
 
     static const wxString kinds[] =
     {
@@ -189,9 +189,9 @@ void CheckBoxWidgetsPage::CreateContent()
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(kinds), kinds,
                                  1);
-    sizerLeft->Add(m_radioKind, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioKind, wxSizerFlags().Expand().Border());
     wxButton *btn = new wxButton(sizerLeftBox, CheckboxPage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Operations");
@@ -202,28 +202,28 @@ void CheckBoxWidgetsPage::CreateContent()
                                                      wxID_ANY,
                                                      &m_textLabel,
                                                      sizerMiddleBox),
-                     0, wxALL | wxGROW, 5);
+                     wxSizerFlags().Expand().Border());
     sizerMiddle->Add(new wxButton(sizerMiddleBox, CheckboxPage_Check, "&Check it"),
-                     0, wxALL | wxGROW, 5);
+                     wxSizerFlags().Expand().Border());
     sizerMiddle->Add(new wxButton(sizerMiddleBox, CheckboxPage_Uncheck, "&Uncheck it"),
-                     0, wxALL | wxGROW, 5);
+                     wxSizerFlags().Expand().Border());
     sizerMiddle->Add(new wxButton(sizerMiddleBox, CheckboxPage_PartCheck,
                                   "Put in &3rd state"),
-                     0, wxALL | wxGROW, 5);
+                     wxSizerFlags().Expand().Border());
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxHORIZONTAL);
     m_checkbox = new wxCheckBox(this, CheckboxPage_Checkbox, "&Check me!");
-    sizerRight->Add(0, 0, 1, wxCENTRE);
-    sizerRight->Add(m_checkbox, 1, wxCENTRE);
-    sizerRight->Add(0, 0, 1, wxCENTRE);
+    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->Add(m_checkbox, wxSizerFlags(1).Centre());
+    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
     sizerRight->SetMinSize(150, 0);
     m_sizerCheckbox = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 1, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags(1).Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -278,9 +278,9 @@ void CheckBoxWidgetsPage::CreateCheckbox()
 
     NotifyWidgetRecreation(m_checkbox);
 
-    m_sizerCheckbox->Add(0, 0, 1, wxCENTRE);
-    m_sizerCheckbox->Add(m_checkbox, 1, wxCENTRE);
-    m_sizerCheckbox->Add(0, 0, 1, wxCENTRE);
+    m_sizerCheckbox->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerCheckbox->Add(m_checkbox, wxSizerFlags(1).Centre());
+    m_sizerCheckbox->Add(0, 0, wxSizerFlags(1).Centre());
     m_sizerCheckbox->Layout();
 }
 

--- a/samples/widgets/choice.cpp
+++ b/samples/widgets/choice.cpp
@@ -209,7 +209,7 @@ void ChoiceWidgetsPage::CreateContent()
     m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeft, "&Sort items", wxID_ANY, sizerLeftBox);
 
     wxButton *btn = new wxButton(sizerLeftBox, ChoicePage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change choice contents");
@@ -218,50 +218,50 @@ void ChoiceWidgetsPage::CreateContent()
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(sizerMiddleBox, ChoicePage_Add, "&Add this string");
     m_textAdd = new wxTextCtrl(sizerMiddleBox, ChoicePage_AddText, "test item 0");
-    sizerRow->Add(btn, 0, wxRIGHT, 5);
-    sizerRow->Add(m_textAdd, 1, wxLEFT, 5);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerRow->Add(btn, wxSizerFlags().Border(wxRIGHT));
+    sizerRow->Add(m_textAdd, wxSizerFlags(1).Border(wxLEFT));
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ChoicePage_AddSeveral, "&Insert a few strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ChoicePage_AddMany, "Add &many strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(sizerMiddleBox, ChoicePage_Change, "C&hange current");
     m_textChange = new wxTextCtrl(sizerMiddleBox, ChoicePage_ChangeText, wxEmptyString);
-    sizerRow->Add(btn, 0, wxRIGHT, 5);
-    sizerRow->Add(m_textChange, 1, wxLEFT, 5);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerRow->Add(btn, wxSizerFlags().Border(wxRIGHT));
+    sizerRow->Add(m_textChange, wxSizerFlags(1).Border(wxLEFT));
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Border().Expand());
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(sizerMiddleBox, ChoicePage_Delete, "&Delete this item");
     m_textDelete = new wxTextCtrl(sizerMiddleBox, ChoicePage_DeleteText, wxEmptyString);
-    sizerRow->Add(btn, 0, wxRIGHT, 5);
-    sizerRow->Add(m_textDelete, 1, wxLEFT, 5);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerRow->Add(btn, wxSizerFlags().Border(wxRIGHT));
+    sizerRow->Add(m_textDelete, wxSizerFlags(1).Border(wxLEFT));
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ChoicePage_DeleteSel, "Delete &selection");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ChoicePage_Clear, "&Clear");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ChoicePage_ContainerTests, "Run &tests");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
     m_choice = new wxChoice(this, ChoicePage_Choice);
-    sizerRight->Add(m_choice, 0, wxALL | wxGROW, 5);
+    sizerRight->Add(m_choice, wxSizerFlags().Border().Expand());
     sizerRight->SetMinSize(150, 0);
     m_sizerChoice = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 1, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags(1).Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -306,7 +306,7 @@ void ChoiceWidgetsPage::CreateChoice()
     NotifyWidgetRecreation(m_choice);
 
     m_choice->Set(items);
-    m_sizerChoice->Add(m_choice, 0, wxGROW | wxALL, 5);
+    m_sizerChoice->Add(m_choice, wxSizerFlags().Expand().Border());
     m_sizerChoice->Layout();
 }
 

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -148,10 +148,10 @@ void ColourPickerWidgetsPage::CreateContent()
     m_chkColourTextCtrl = CreateCheckBoxAndAddToSizer(styleSizer, "With textctrl", wxID_ANY, styleSizerBox);
     m_chkColourShowLabel = CreateCheckBoxAndAddToSizer(styleSizer, "With label", wxID_ANY, styleSizerBox);
     m_chkColourShowAlpha = CreateCheckBoxAndAddToSizer(styleSizer, "With opacity", wxID_ANY, styleSizerBox);
-    boxleft->Add(styleSizer, 0, wxALL|wxGROW, 5);
+    boxleft->Add(styleSizer, wxSizerFlags().Expand().Border());
 
     boxleft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
-                 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+                 wxSizerFlags().CentreHorizontal().TripleBorder());
 
     Reset();    // set checkboxes state
 
@@ -161,14 +161,14 @@ void ColourPickerWidgetsPage::CreateContent()
 
     // right pane
     m_sizer = new wxBoxSizer(wxVERTICAL);
-    m_sizer->Add(1, 1, 1, wxGROW | wxALL, 5); // spacer
-    m_sizer->Add(m_clrPicker, 0, wxALIGN_CENTER|wxALL, 5);
-    m_sizer->Add(1, 1, 1, wxGROW | wxALL, 5); // spacer
+    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->Add(m_clrPicker, wxSizerFlags().Centre().Border());
+    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);
-    sz->Add(boxleft, 0, wxGROW|wxALL, 5);
-    sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
+    sz->Add(boxleft, wxSizerFlags().Expand().Border());
+    sz->Add(m_sizer, wxSizerFlags(1).Expand().Border());
 
     SetSizer(sz);
 }
@@ -199,7 +199,7 @@ void ColourPickerWidgetsPage::RecreatePicker()
 {
     m_sizer->Remove(1);
     CreatePicker();
-    m_sizer->Insert(1, m_clrPicker, 0, wxALIGN_CENTER|wxALL, 5);
+    m_sizer->Insert(1, m_clrPicker, wxSizerFlags().Centre().Border());
 
     m_sizer->Layout();
 }

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -161,9 +161,9 @@ void ColourPickerWidgetsPage::CreateContent()
 
     // right pane
     m_sizer = new wxBoxSizer(wxVERTICAL);
-    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->AddStretchSpacer();
     m_sizer->Add(m_clrPicker, wxSizerFlags().Centre().Border());
-    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->AddStretchSpacer();
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -289,7 +289,7 @@ void ComboboxWidgetsPage::CreateContent()
     m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerLeftBottom, "&Read only", wxID_ANY, sizerLeftBottomBox);
     m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerLeftBottom, "Process &Enter", wxID_ANY, sizerLeftBottomBox);
 
-    sizerLeftBottom->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeftBottom->AddSpacer(FromDIP(15));
     sizerLeftBottom->Add(m_radioKind, wxSizerFlags().Expand().Border());
 
     wxButton *btn = new wxButton(sizerLeftBottomBox, ComboPage_Reset, "&Reset");

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -289,11 +289,11 @@ void ComboboxWidgetsPage::CreateContent()
     m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerLeftBottom, "&Read only", wxID_ANY, sizerLeftBottomBox);
     m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerLeftBottom, "Process &Enter", wxID_ANY, sizerLeftBottomBox);
 
-    sizerLeftBottom->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
-    sizerLeftBottom->Add(m_radioKind, 0, wxGROW | wxALL, 5);
+    sizerLeftBottom->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeftBottom->Add(m_radioKind, wxSizerFlags().Expand().Border());
 
     wxButton *btn = new wxButton(sizerLeftBottomBox, ComboPage_Reset, "&Reset");
-    sizerLeftBottom->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeftBottom->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
 
     wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);
@@ -313,7 +313,7 @@ void ComboboxWidgetsPage::CreateContent()
                                             &m_textCur,
                                             sizerMiddleBox);
 
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     wxTextCtrl *text;
     sizerRow = CreateSizerWithTextAndLabel("Insertion Point",
@@ -322,64 +322,64 @@ void ComboboxWidgetsPage::CreateContent()
                                            sizerMiddleBox);
     text->SetEditable(false);
 
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Insert,
                                             "&Insert this string",
                                             ComboPage_InsertText,
                                             &m_textInsert,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Add,
                                             "&Add this string",
                                             ComboPage_AddText,
                                             &m_textAdd,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_SetFirst,
                                             "Change &1st string",
                                             ComboPage_SetFirstText,
                                             &m_textSetFirst,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ComboPage_AddSeveral, "&Append a few strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ComboPage_AddMany, "Append &many strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Change,
                                             "C&hange current",
                                             ComboPage_ChangeText,
                                             &m_textChange,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Delete,
                                             "&Delete this item",
                                             ComboPage_DeleteText,
                                             &m_textDelete,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ComboPage_DeleteSel, "Delete &selection");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ComboPage_Clear, "&Clear");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_SetValue,
                                             "SetValue",
                                             ComboPage_SetValueText,
                                             &m_textSetValue,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ComboPage_ContainerTests, "Run &tests");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
 
 
@@ -389,21 +389,21 @@ void ComboboxWidgetsPage::CreateContent()
                                 wxDefaultPosition, wxDefaultSize,
                                 0, nullptr,
                                 0);
-    sizerRight->Add(m_combobox, 0, wxGROW | wxALL, 5);
+    sizerRight->Add(m_combobox, wxSizerFlags().Expand().Border());
     m_combobox1 = new wxComboBox( this, ComboPage_Dynamic );
     m_combobox1->Append( "Dynamic ComboBox Test - Click me!" );
     m_combobox1->SetSelection( 0 );
-    sizerRight->Add( 20, 20, 0, wxEXPAND, 0 );
-    sizerRight->Add( m_combobox1, 0, wxGROW | wxALL, 5 );
+    sizerRight->Add( 20, 20, wxSizerFlags().Expand() );
+    sizerRight->Add( m_combobox1, wxSizerFlags().Expand().Border());
     m_combobox1->Bind( wxEVT_COMBOBOX_DROPDOWN, &ComboboxWidgetsPage::OnPopup, this );
     m_combobox1->Bind( wxEVT_COMBOBOX_CLOSEUP, &ComboboxWidgetsPage::OnDismiss, this );
     sizerRight->SetMinSize(150, 0);
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 1, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags(1).Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -223,15 +223,15 @@ void DatePickerWidgetsPage::CreateContent()
 
     m_datePicker = new wxDatePickerCtrl(this, DatePickerPage_Picker);
 
-    sizerRight->Add(0, 0, 1, wxCENTRE);
-    sizerRight->Add(m_datePicker, 1, wxCENTRE);
-    sizerRight->Add(0, 0, 1, wxCENTRE);
+    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->Add(m_datePicker, wxSizerFlags(1).Centre());
+    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
     m_sizerDatePicker = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 0, (wxTOP | wxBOTTOM), 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags().DoubleBorder(wxTOP | wxBOTTOM));
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     m_chkStyleCentury->SetValue(true);
@@ -287,9 +287,9 @@ void DatePickerWidgetsPage::CreateDatePicker()
 
     NotifyWidgetRecreation(m_datePicker);
 
-    m_sizerDatePicker->Add(0, 0, 1, wxCENTRE);
-    m_sizerDatePicker->Add(m_datePicker, 1, wxCENTRE);
-    m_sizerDatePicker->Add(0, 0, 1, wxCENTRE);
+    m_sizerDatePicker->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerDatePicker->Add(m_datePicker, wxSizerFlags(1).Centre());
+    m_sizerDatePicker->Add(0, 0, wxSizerFlags(1).Centre());
     m_sizerDatePicker->Layout();
 }
 

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -181,7 +181,7 @@ void DirCtrlWidgetsPage::CreateContent()
     wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     sizerLeft->Add( CreateSizerWithTextAndButton( DirCtrlPage_SetPath , "Set &path", wxID_ANY, &m_path, sizerLeftBox),
-                    0, wxALL | wxALIGN_RIGHT , 5 );
+                    wxSizerFlags().Right().Border() );
 
     wxStaticBoxSizer *sizerFlags = new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox, "&Flags");
     wxStaticBox* const sizerFlagsBox = sizerFlags->GetStaticBox();
@@ -205,7 +205,7 @@ void DirCtrlWidgetsPage::CreateContent()
     sizerLeft->Add(sizerFilters, wxSizerFlags().Expand().Border());
 
     wxButton *btn = new wxButton(sizerFiltersBox, DirCtrlPage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // keep consistency between enum and labels of radiobox
     wxCOMPILE_TIME_ASSERT( stdPathMax == WXSIZEOF(stdPaths), EnumForRadioBoxMismatch);
@@ -226,9 +226,9 @@ void DirCtrlWidgetsPage::CreateContent()
     );
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(m_radioStdPath, 0, wxGROW | wxALL , 10);
-    sizerTop->Add(m_dirCtrl, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(m_radioStdPath, wxSizerFlags().Expand().DoubleBorder());
+    sizerTop->Add(m_dirCtrl, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     SetSizer(sizerTop);
 

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -153,7 +153,7 @@ void DirPickerWidgetsPage::CreateContent()
     m_chkDirMustExist = CreateCheckBoxAndAddToSizer(sizerStyle, "Dir must exist", wxID_ANY, sizerStyleBox);
     m_chkDirChangeDir = CreateCheckBoxAndAddToSizer(sizerStyle, "Change working dir", wxID_ANY, sizerStyleBox);
     m_chkSmall = CreateCheckBoxAndAddToSizer(sizerStyle, "&Small version", wxID_ANY, sizerStyleBox);
-    sizerLeft->Add(sizerStyle, 0, wxALL|wxGROW, 5);
+    sizerLeft->Add(sizerStyle, wxSizerFlags().Expand().Border());
 
     sizerLeft->Add(CreateSizerWithTextAndButton
                  (
@@ -166,7 +166,7 @@ void DirPickerWidgetsPage::CreateContent()
     sizerLeft->AddSpacer(10);
 
     sizerLeft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
-                 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+                 wxSizerFlags().CentreHorizontal().TripleBorder());
 
     Reset();    // set checkboxes state
 
@@ -176,14 +176,14 @@ void DirPickerWidgetsPage::CreateContent()
 
     // right pane
     m_sizer = new wxBoxSizer(wxVERTICAL);
-    m_sizer->Add(1, 1, 1, wxGROW | wxALL, 5); // spacer
-    m_sizer->Add(m_dirPicker, 0, wxEXPAND|wxALL, 5);
-    m_sizer->Add(1, 1, 1, wxGROW | wxALL, 5); // spacer
+    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->Add(m_dirPicker, wxSizerFlags().Expand().Border());
+    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);
-    sz->Add(sizerLeft, 0, wxGROW|wxALL, 5);
-    sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
+    sz->Add(sizerLeft, wxSizerFlags().Expand().Border());
+    sz->Add(m_sizer, wxSizerFlags(1).Expand().Border());
 
     SetSizer(sz);
 }
@@ -218,7 +218,7 @@ void DirPickerWidgetsPage::RecreatePicker()
 {
     m_sizer->Remove(1);
     CreatePicker();
-    m_sizer->Insert(1, m_dirPicker, 0, wxEXPAND|wxALL, 5);
+    m_sizer->Insert(1, m_dirPicker, wxSizerFlags().Expand().Border());
 
     m_sizer->Layout();
 }

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -176,9 +176,9 @@ void DirPickerWidgetsPage::CreateContent()
 
     // right pane
     m_sizer = new wxBoxSizer(wxVERTICAL);
-    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->AddStretchSpacer();
     m_sizer->Add(m_dirPicker, wxSizerFlags().Expand().Border());
-    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->AddStretchSpacer();
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);

--- a/samples/widgets/editlbox.cpp
+++ b/samples/widgets/editlbox.cpp
@@ -139,20 +139,20 @@ void EditableListboxWidgetsPage::CreateContent()
     m_chkAllowNoReorder = CreateCheckBoxAndAddToSizer(sizerLeft, "Block user reordering", wxID_ANY, sizerLeftBox);
 
     wxButton *btn = new wxButton(sizerLeftBox, EditableListboxPage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
     m_lbox = new wxEditableListBox(this, EditableListboxPage_Listbox,
                                     _("Match these wildcards:"),
                                     wxDefaultPosition, wxDefaultSize, 0);
-    sizerRight->Add(m_lbox, 1, wxGROW | wxALL, 5);
+    sizerRight->Add(m_lbox, wxSizerFlags(1).Expand().Border());
     sizerRight->SetMinSize(150, 0);
     m_sizerLbox = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -201,7 +201,7 @@ void EditableListboxWidgetsPage::CreateLbox()
     NotifyWidgetRecreation(m_lbox);
 
     m_lbox->SetStrings(items);
-    m_sizerLbox->Add(m_lbox, 1, wxGROW | wxALL, 5);
+    m_sizerLbox->Add(m_lbox, wxSizerFlags(1).Expand().Border());
     m_sizerLbox->Layout();
 }
 

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -164,14 +164,14 @@ void FileCtrlWidgetsPage::CreateContent()
                                           WXSIZEOF( mode ), mode );
 
     sizerLeft->Add( m_radioFileCtrlMode,
-                    0, wxALL | wxEXPAND , 5 );
+                    wxSizerFlags().Expand().Border());
 
     sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetDirectory , "Set &directory", wxID_ANY, &m_dir ),
-                    0, wxALL | wxEXPAND , 5 );
+                    wxSizerFlags().Expand().Border());
     sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetPath , "Set &path", wxID_ANY, &m_path ),
-                    0, wxALL | wxEXPAND , 5 );
+                    wxSizerFlags().Expand().Border());
     sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetFilename , "Set &filename", wxID_ANY, &m_filename ),
-                    0, wxALL | wxEXPAND , 5 );
+                    wxSizerFlags().Expand().Border());
 
     wxStaticBoxSizer *sizerFlags = new wxStaticBoxSizer( wxVERTICAL, this, "&Flags");
     wxStaticBox* const sizerFlagsBox = sizerFlags->GetStaticBox();
@@ -190,7 +190,7 @@ void FileCtrlWidgetsPage::CreateContent()
     sizerLeft->Add( sizerFilters, wxSizerFlags().Expand().Border() );
 
     wxButton *btn = new wxButton( this, FileCtrlPage_Reset, "&Reset" );
-    sizerLeft->Add( btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15 );
+    sizerLeft->Add( btn, wxSizerFlags().CentreHorizontal().TripleBorder() );
 
     // right pane
     m_fileCtrl = new wxFileCtrl(
@@ -205,8 +205,8 @@ void FileCtrlWidgetsPage::CreateContent()
                  );
 
     // the 3 panes panes compose the window
-    sizerTop->Add( sizerLeft, 0, ( wxALL & ~wxLEFT ), 10 );
-    sizerTop->Add( m_fileCtrl, 1, wxGROW | ( wxALL & ~wxRIGHT ), 10 );
+    sizerTop->Add( sizerLeft, wxSizerFlags().DoubleBorder(wxALL & ~wxLEFT) );
+    sizerTop->Add( m_fileCtrl, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT) );
 
     // final initializations
     Reset();

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -167,7 +167,7 @@ void FilePickerWidgetsPage::CreateContent()
     m_radioFilePickerMode = new wxRadioBox(this, wxID_ANY, "wxFilePicker mode",
                                            wxDefaultPosition, wxDefaultSize,
                                            WXSIZEOF(mode), mode);
-    leftSizer->Add(m_radioFilePickerMode, 0, wxALL|wxGROW, 5);
+    leftSizer->Add(m_radioFilePickerMode, wxSizerFlags().Expand().Border());
 
     wxStaticBoxSizer *styleSizer = new wxStaticBoxSizer(wxVERTICAL, this, "&FilePicker style");
     wxStaticBox* const styleSizerBox = styleSizer->GetStaticBox();
@@ -178,7 +178,7 @@ void FilePickerWidgetsPage::CreateContent()
     m_chkFileChangeDir = CreateCheckBoxAndAddToSizer(styleSizer, "Change working dir", wxID_ANY, styleSizerBox);
     m_chkSmall = CreateCheckBoxAndAddToSizer(styleSizer, "&Small version", wxID_ANY, styleSizerBox);
 
-    leftSizer->Add(styleSizer, 0, wxALL|wxGROW, 5);
+    leftSizer->Add(styleSizer, wxSizerFlags().Expand().Border());
 
     leftSizer->Add(CreateSizerWithTextAndButton
                  (
@@ -191,7 +191,7 @@ void FilePickerWidgetsPage::CreateContent()
     leftSizer->AddSpacer(10);
 
     leftSizer->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
-                 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+                 wxSizerFlags().CentreHorizontal().TripleBorder());
 
     Reset();    // set checkboxes state
 
@@ -211,8 +211,8 @@ void FilePickerWidgetsPage::CreateContent()
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);
-    sz->Add(leftSizer, 0, wxGROW|wxALL, 5);
-    sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
+    sz->Add(leftSizer, wxSizerFlags().Expand().Border());
+    sz->Add(m_sizer, wxSizerFlags(1).Expand().Border());
 
     SetSizer(sz);
 }
@@ -257,7 +257,7 @@ void FilePickerWidgetsPage::RecreatePicker()
 {
     m_sizer->Remove(1);
     CreatePicker();
-    m_sizer->Insert(1, m_filePicker, 0, wxEXPAND|wxALL, 5);
+    m_sizer->Insert(1, m_filePicker, wxSizerFlags().Expand().Border());
 
     m_sizer->Layout();
 }

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -142,10 +142,10 @@ void FontPickerWidgetsPage::CreateContent()
     m_chkFontTextCtrl = CreateCheckBoxAndAddToSizer(styleSizer, "With textctrl", wxID_ANY, styleSizerBox);
     m_chkFontDescAsLabel = CreateCheckBoxAndAddToSizer(styleSizer, "Font desc as btn label", wxID_ANY, styleSizerBox);
     m_chkFontUseFontForLabel = CreateCheckBoxAndAddToSizer(styleSizer, "Use font for label", wxID_ANY, styleSizerBox);
-    leftSizer->Add(styleSizer, 0, wxALL|wxGROW, 5);
+    leftSizer->Add(styleSizer, wxSizerFlags().Expand().Border());
 
     leftSizer->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
-                 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+                 wxSizerFlags().CentreHorizontal().TripleBorder());
 
     Reset();    // set checkboxes state
 
@@ -155,14 +155,14 @@ void FontPickerWidgetsPage::CreateContent()
 
     // right pane
     m_sizer = new wxBoxSizer(wxVERTICAL);
-    m_sizer->Add(1, 1, 1, wxGROW | wxALL, 5); // spacer
-    m_sizer->Add(m_fontPicker, 0, wxALIGN_CENTER|wxALL, 5);
-    m_sizer->Add(1, 1, 1, wxGROW | wxALL, 5); // spacer
+    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->Add(m_fontPicker, wxSizerFlags().Centre().Border());
+    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);
-    sz->Add(leftSizer, 0, wxGROW|wxALL, 5);
-    sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
+    sz->Add(leftSizer, wxSizerFlags().Expand().Border());
+    sz->Add(m_sizer, wxSizerFlags(1).Expand().Border());
 
     SetSizer(sz);
 }
@@ -194,7 +194,7 @@ void FontPickerWidgetsPage::RecreatePicker()
 {
     m_sizer->Remove(1);
     CreatePicker();
-    m_sizer->Insert(1, m_fontPicker, 0, wxALIGN_CENTER|wxALL, 5);
+    m_sizer->Insert(1, m_fontPicker, wxSizerFlags().Centre().Border());
 
     m_sizer->Layout();
 }

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -155,9 +155,9 @@ void FontPickerWidgetsPage::CreateContent()
 
     // right pane
     m_sizer = new wxBoxSizer(wxVERTICAL);
-    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->AddStretchSpacer();
     m_sizer->Add(m_fontPicker, wxSizerFlags().Centre().Border());
-    m_sizer->Add(1, 1, wxSizerFlags(1).Expand().Border()); // spacer
+    m_sizer->AddStretchSpacer();
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -203,10 +203,10 @@ void GaugeWidgetsPage::CreateContent()
     m_chkSmooth = CreateCheckBoxAndAddToSizer(sizerLeft, "&Smooth", wxID_ANY, sizerLeftBox);
     m_chkProgress = CreateCheckBoxAndAddToSizer(sizerLeft, "&Progress", wxID_ANY, sizerLeftBox);
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
 
     wxButton *btn = new wxButton(sizerLeftBox, GaugePage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change gauge value");
@@ -219,14 +219,14 @@ void GaugeWidgetsPage::CreateContent()
                                                     sizerMiddleBox);
     text->SetEditable(false);
 
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(GaugePage_SetValue,
                                             "Set &value",
                                             GaugePage_ValueText,
                                             &m_textValue,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(GaugePage_SetRange,
                                             "Set &range",
@@ -234,29 +234,29 @@ void GaugeWidgetsPage::CreateContent()
                                             &m_textRange,
                                             sizerMiddleBox);
     m_textRange->SetValue( wxString::Format("%lu", m_range) );
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, GaugePage_Progress, "Simulate &progress");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, GaugePage_IndeterminateProgress,
                        "Simulate &indeterminate job");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, GaugePage_Clear, "&Clear");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxHORIZONTAL);
     m_gauge = new wxGauge(this, GaugePage_Gauge, m_range);
-    sizerRight->Add(m_gauge, 1, wxCENTRE | wxALL, 5);
+    sizerRight->Add(m_gauge, wxSizerFlags(1).Centre().Border());
     sizerRight->SetMinSize(150, 0);
     m_sizerGauge = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 1, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags(1).Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -313,9 +313,9 @@ void GaugeWidgetsPage::CreateGauge()
     m_gauge->SetValue(val);
 
     if ( flags & wxGA_VERTICAL )
-        m_sizerGauge->Add(m_gauge, 0, wxGROW | wxALL, 5);
+        m_sizerGauge->Add(m_gauge, wxSizerFlags().Expand().Border());
     else
-        m_sizerGauge->Add(m_gauge, 1, wxCENTRE | wxALL, 5);
+        m_sizerGauge->Add(m_gauge, wxSizerFlags(1).Centre().Border());
 
     m_sizerGauge->Layout();
 }

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -203,7 +203,7 @@ void GaugeWidgetsPage::CreateContent()
     m_chkSmooth = CreateCheckBoxAndAddToSizer(sizerLeft, "&Smooth", wxID_ANY, sizerLeftBox);
     m_chkProgress = CreateCheckBoxAndAddToSizer(sizerLeft, "&Progress", wxID_ANY, sizerLeftBox);
 
-    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->AddSpacer(FromDIP(15));
 
     wxButton *btn = new wxButton(sizerLeftBox, GaugePage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -165,10 +165,10 @@ void HyperlinkWidgetsPage::CreateContent()
     wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     sizerLeft->Add( CreateSizerWithTextAndButton( HyperlinkPage_SetLabel , "Set &Label", wxID_ANY, &m_label, sizerLeftBox ),
-                    0, wxALL | wxALIGN_RIGHT , 5 );
+                    wxSizerFlags().Right().Border() );
 
     sizerLeft->Add( CreateSizerWithTextAndButton( HyperlinkPage_SetURL , "Set &URL", wxID_ANY, &m_url, sizerLeftBox ),
-                    0, wxALL | wxALIGN_RIGHT , 5 );
+                    wxSizerFlags().Right().Border() );
 
     static const wxString alignments[] =
     {
@@ -184,11 +184,11 @@ void HyperlinkWidgetsPage::CreateContent()
                                       WXSIZEOF(alignments), alignments);
     m_radioAlignMode->SetSelection(1);  // start with "centre" selected since
                                         // wxHL_DEFAULT_STYLE contains wxHL_ALIGN_CENTRE
-    sizerLeft->Add(m_radioAlignMode, 0, wxALL|wxGROW, 5);
+    sizerLeft->Add(m_radioAlignMode, wxSizerFlags().Expand().Border());
 
     m_checkGeneric = new wxCheckBox(sizerLeftBox, wxID_ANY, "Use generic version",
                                     wxDefaultPosition, wxDefaultSize);
-    sizerLeft->Add(m_checkGeneric, 0, wxALL|wxGROW, 5);
+    sizerLeft->Add(m_checkGeneric, wxSizerFlags().Expand().Border());
 
     // right pane
     wxSizer *szHyperlinkLong = new wxBoxSizer(wxVERTICAL);
@@ -213,11 +213,11 @@ void HyperlinkWidgetsPage::CreateContent()
 
     m_fun = new wxStaticText(this, wxID_ANY, " for fun!");
 
-    szHyperlink->Add(0, 0, 1, wxCENTRE);
-    szHyperlink->Add(m_visit, 0, wxCENTRE);
-    szHyperlink->Add(m_hyperlink, 0, wxCENTRE);
-    szHyperlink->Add(m_fun, 0, wxCENTRE);
-    szHyperlink->Add(0, 0, 1, wxCENTRE);
+    szHyperlink->Add(0, 0, wxSizerFlags(1).Centre());
+    szHyperlink->Add(m_visit, wxSizerFlags().Centre());
+    szHyperlink->Add(m_hyperlink, wxSizerFlags().Centre());
+    szHyperlink->Add(m_fun, wxSizerFlags().Centre());
+    szHyperlink->Add(0, 0, wxSizerFlags(1).Centre());
     szHyperlink->SetMinSize(150, 0);
 
     if (m_checkGeneric->IsChecked())
@@ -235,16 +235,16 @@ void HyperlinkWidgetsPage::CreateContent()
                                               "www.wxwidgets.org");
     }
 
-    szHyperlinkLong->Add(0, 0, 1, wxCENTRE);
-    szHyperlinkLong->Add(szHyperlink, 0, wxCENTRE|wxGROW);
-    szHyperlinkLong->Add(0, 0, 1, wxCENTRE);
-    szHyperlinkLong->Add(m_hyperlinkLong, 0, wxGROW);
-    szHyperlinkLong->Add(0, 0, 1, wxCENTRE);
+    szHyperlinkLong->Add(0, 0, wxSizerFlags(1).Centre());
+    szHyperlinkLong->Add(szHyperlink, wxSizerFlags().Centre().Expand());
+    szHyperlinkLong->Add(0, 0, wxSizerFlags(1).Centre());
+    szHyperlinkLong->Add(m_hyperlinkLong, wxSizerFlags().Expand());
+    szHyperlinkLong->Add(0, 0, wxSizerFlags(1).Centre());
 
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(szHyperlinkLong, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(szHyperlinkLong, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -319,14 +319,14 @@ void ListboxWidgetsPage::CreateContent()
                                     WXSIZEOF(listTypes), listTypes,
                                     1, wxRA_SPECIFY_COLS);
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
-    sizerLeft->Add(m_radioSelMode, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->Add(m_radioSelMode, wxSizerFlags().Expand().Border());
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
-    sizerLeft->Add(m_radioListType, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->Add(m_radioListType, wxSizerFlags().Expand().Border());
 
     wxButton *btn = new wxButton(sizerLeftBox, ListboxPage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change listbox contents");
@@ -335,57 +335,57 @@ void ListboxWidgetsPage::CreateContent()
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(sizerMiddleBox, ListboxPage_Add, "&Add this string");
     m_textAdd = new wxTextCtrl(sizerMiddleBox, ListboxPage_AddText, "test item \t0");
-    sizerRow->Add(btn, 0, wxRIGHT, 5);
-    sizerRow->Add(m_textAdd, 1, wxLEFT, 5);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerRow->Add(btn, wxSizerFlags().Border(wxRIGHT));
+    sizerRow->Add(m_textAdd, wxSizerFlags(1).Border(wxLEFT));
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_AddSeveral, "&Insert a few strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_AddMany, "Add &many strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(sizerMiddleBox, ListboxPage_Change, "C&hange current");
     m_textChange = new wxTextCtrl(sizerMiddleBox, ListboxPage_ChangeText, wxEmptyString);
-    sizerRow->Add(btn, 0, wxRIGHT, 5);
-    sizerRow->Add(m_textChange, 1, wxLEFT, 5);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerRow->Add(btn, wxSizerFlags().Border(wxRIGHT));
+    sizerRow->Add(m_textChange, wxSizerFlags(1).Border(wxLEFT));
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Border().Expand());
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(sizerMiddleBox, ListboxPage_EnsureVisible, "Make item &visible");
     m_textEnsureVisible = new wxTextCtrl(sizerMiddleBox, ListboxPage_EnsureVisibleText, wxEmptyString);
-    sizerRow->Add(btn, 0, wxRIGHT, 5);
-    sizerRow->Add(m_textEnsureVisible, 1, wxLEFT, 5);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerRow->Add(btn, wxSizerFlags().Border(wxRIGHT));
+    sizerRow->Add(m_textEnsureVisible, wxSizerFlags(1).Border(wxLEFT));
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Border().Expand());
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(sizerMiddleBox, ListboxPage_Delete, "&Delete this item");
     m_textDelete = new wxTextCtrl(sizerMiddleBox, ListboxPage_DeleteText, wxEmptyString);
-    sizerRow->Add(btn, 0, wxRIGHT, 5);
-    sizerRow->Add(m_textDelete, 1, wxLEFT, 5);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerRow->Add(btn, wxSizerFlags().Border(wxRIGHT));
+    sizerRow->Add(m_textDelete, wxSizerFlags(1).Border(wxLEFT));
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_DeleteSel, "Delete &selection");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_Clear, "&Clear");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_MoveUp, "Move item &up");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_MoveDown, "Move item &down");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_GetTopItem, "Get top item");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_GetCountPerPage, "Get count per page");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_ContainerTests, "Run &tests");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Border().Expand());
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
@@ -393,14 +393,14 @@ void ListboxWidgetsPage::CreateContent()
                            wxDefaultPosition, wxDefaultSize,
                            0, nullptr,
                            wxLB_HSCROLL);
-    sizerRight->Add(m_lbox, 1, wxGROW | wxALL, 5);
+    sizerRight->Add(m_lbox, wxSizerFlags(1).Expand().Border());
     sizerRight->SetMinSize(150, 0);
     m_sizerLbox = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 1, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags(1).Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -508,7 +508,7 @@ void ListboxWidgetsPage::CreateLbox()
 
     NotifyWidgetRecreation(m_lbox);
 
-    m_sizerLbox->Add(m_lbox, 1, wxGROW | wxALL, 5);
+    m_sizerLbox->Add(m_lbox, wxSizerFlags(1).Expand().Border());
     m_sizerLbox->Layout();
 }
 

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -217,12 +217,12 @@ void BookWidgetsPage::CreateContent()
                                    wxDefaultPosition, wxDefaultSize,
                                    orientations, 1, wxRA_SPECIFY_COLS);
 
-    sizerLeft->Add(m_chkImages, 0, wxALL, 5);
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
-    sizerLeft->Add(m_radioOrient, 0, wxALL, 5);
+    sizerLeft->Add(m_chkImages, wxSizerFlags().Border());
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->Add(m_radioOrient, wxSizerFlags().Border());
 
     wxButton *btn = new wxButton(sizerLeftBox, BookPage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Contents");
@@ -234,49 +234,49 @@ void BookWidgetsPage::CreateContent()
                                                     &text,
                                                     sizerMidleBox);
     text->SetEditable(false);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndLabel("Current selection: ",
                                            BookPage_CurSelectText,
                                            &text,
                                            sizerMidleBox);
     text->SetEditable(false);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(BookPage_SelectPage,
                                             "&Select page",
                                             BookPage_SelectText,
                                             &m_textSelect,
                                             sizerMidleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMidleBox, BookPage_AddPage, "&Add page");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(BookPage_InsertPage,
                                             "&Insert page at",
                                             BookPage_InsertText,
                                             &m_textInsert,
                                             sizerMidleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(BookPage_RemovePage,
                                             "&Remove page",
                                             BookPage_RemoveText,
                                             &m_textRemove,
                                             sizerMidleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMidleBox, BookPage_DeleteAll, "&Delete All");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     // right pane
     m_sizerBook = new wxBoxSizer(wxHORIZONTAL);
 
     // the 3 panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 0, wxGROW | wxALL, 10);
-    sizerTop->Add(m_sizerBook, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags().Expand().DoubleBorder());
+    sizerTop->Add(m_sizerBook, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     RecreateBook();
 
@@ -395,7 +395,7 @@ void BookWidgetsPage::RecreateBook()
         }
     }
 
-    m_sizerBook->Add(m_book, 1, wxGROW | wxALL, 5);
+    m_sizerBook->Add(m_book, wxSizerFlags(1).Expand().Border());
     m_sizerBook->SetMinSize(150, 0);
     m_sizerBook->Layout();
 }

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -218,7 +218,7 @@ void BookWidgetsPage::CreateContent()
                                    orientations, 1, wxRA_SPECIFY_COLS);
 
     sizerLeft->Add(m_chkImages, wxSizerFlags().Border());
-    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->AddSpacer(FromDIP(15));
     sizerLeft->Add(m_radioOrient, wxSizerFlags().Border());
 
     wxButton *btn = new wxButton(sizerLeftBox, BookPage_Reset, "&Reset");

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -342,7 +342,7 @@ void ODComboboxWidgetsPage::CreateContent()
     m_chkStdbutton = CreateCheckBoxAndAddToSizer(sizerStyle, "B&lank button background", wxID_ANY, sizerStyleBox);
 
     wxButton *btn = new wxButton(sizerStyleBox, ODComboPage_Reset, "&Reset");
-    sizerStyle->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 3);
+    sizerStyle->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, FromDIP(3)));
 
     sizerLeft->Add(sizerStyle, wxSizerFlags().Expand());
 
@@ -355,14 +355,14 @@ void ODComboboxWidgetsPage::CreateContent()
                                            &m_textPopupMinWidth,
                                            sizerPopupPosBox);
     m_textPopupMinWidth->SetValue("-1");
-    sizerPopupPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerPopupPos->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndLabel("Max. Height:",
                                            ODComboPage_PopupHeight,
                                            &m_textPopupHeight,
                                            sizerPopupPosBox);
     m_textPopupHeight->SetValue("-1");
-    sizerPopupPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerPopupPos->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     m_chkAlignpopupright = CreateCheckBoxAndAddToSizer(sizerPopupPos, "Align Right", wxID_ANY, sizerPopupPosBox);
 
@@ -377,21 +377,21 @@ void ODComboboxWidgetsPage::CreateContent()
                                            &m_textButtonWidth,
                                            sizerButtonPosBox);
     m_textButtonWidth->SetValue("-1");
-    sizerButtonPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerButtonPos->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndLabel("VSpacing:",
                                            ODComboPage_ButtonSpacing,
                                            &m_textButtonSpacing,
                                            sizerButtonPosBox);
     m_textButtonSpacing->SetValue("0");
-    sizerButtonPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerButtonPos->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndLabel("Height:",
                                            ODComboPage_ButtonHeight,
                                            &m_textButtonHeight,
                                            sizerButtonPosBox);
     m_textButtonHeight->SetValue("-1");
-    sizerButtonPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerButtonPos->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     m_chkAlignbutleft = CreateCheckBoxAndAddToSizer(sizerButtonPos, "Align Left", wxID_ANY, sizerButtonPosBox);
 
@@ -402,7 +402,7 @@ void ODComboboxWidgetsPage::CreateContent()
     wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     btn = new wxButton(sizerMiddleBox, ODComboPage_ContainerTests, "Run &tests");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndLabel("Current selection",
                                            ODComboPage_CurText,
@@ -410,7 +410,7 @@ void ODComboboxWidgetsPage::CreateContent()
                                            sizerMiddleBox);
     text->SetEditable(false);
 
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndLabel("Insertion Point",
                                            ODComboPage_InsertionPointText,
@@ -418,47 +418,47 @@ void ODComboboxWidgetsPage::CreateContent()
                                            sizerMiddleBox);
     text->SetEditable(false);
 
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Insert,
                                             "&Insert this string",
                                             ODComboPage_InsertText,
                                             &m_textInsert,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Add,
                                             "&Add this string",
                                             ODComboPage_AddText,
                                             &m_textAdd,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ODComboPage_AddSeveral, "&Append a few strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ODComboPage_AddMany, "Append &many strings");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Change,
                                             "C&hange current",
                                             ODComboPage_ChangeText,
                                             &m_textChange,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Delete,
                                             "&Delete this item",
                                             ODComboPage_DeleteText,
                                             &m_textDelete,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ODComboPage_DeleteSel, "Delete &selection");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     btn = new wxButton(sizerMiddleBox, ODComboPage_Clear, "&Clear");
-    sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(btn, wxSizerFlags().Expand().Border());
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
@@ -467,14 +467,14 @@ void ODComboboxWidgetsPage::CreateContent()
                        wxDefaultPosition, wxDefaultSize,
                        0, nullptr,
                        0);
-    sizerRight->Add(m_combobox, 0, wxGROW | wxALL, 5);
+    sizerRight->Add(m_combobox, wxSizerFlags().Expand().Border());
     sizerRight->SetMinSize(150, 0);
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 4, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 5, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 4, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags(4).Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags(5).Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(4).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -552,7 +552,7 @@ void ODComboboxWidgetsPage::CreateCombo()
         m_combobox->SetButtonBitmaps(bmpNormal,m_chkStdbutton->GetValue(),bmpPressed,bmpHover);
     }
 
-    m_sizerCombo->Add(m_combobox, 0, wxGROW | wxALL, 5);
+    m_sizerCombo->Add(m_combobox, wxSizerFlags().Expand().Border());
     m_sizerCombo->Layout();
 }
 

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -226,7 +226,7 @@ void RadioWidgetsPage::CreateContent()
     sizerLeft->AddSpacer(5);
 
     btn = new wxButton(sizerleftBox, RadioPage_Reset, "&Reset");
-    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, FromDIP(15)));
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change parameters");
@@ -279,7 +279,7 @@ void RadioWidgetsPage::CreateContent()
     sizerTop->Add(sizerLeft,
                   wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxLEFT)));
     sizerTop->Add(sizerMiddle,
-                  wxSizerFlags(1).Expand().DoubleBorder(wxALL));
+                  wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(sizerRight,
                   wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxRIGHT)));
 

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -310,7 +310,7 @@ void SliderWidgetsPage::CreateContent()
     sizerLeft->AddSpacer(5);
 
     wxButton *btn = new wxButton(sizerLeftBox, SliderPage_Reset, "&Reset");
-    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, FromDIP(15)));
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change slider value");
@@ -405,7 +405,7 @@ void SliderWidgetsPage::CreateContent()
     sizerTop->Add(sizerLeft,
                   wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxLEFT)));
     sizerTop->Add(sizerMiddle,
-                  wxSizerFlags(1).Expand().DoubleBorder(wxALL));
+                  wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(sizerRight,
                   wxSizerFlags(1).Expand().DoubleBorder((wxALL & ~wxRIGHT)));
 

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -521,9 +521,9 @@ void SliderWidgetsPage::CreateSlider()
 
     if ( m_slider->HasFlag(wxSL_VERTICAL) )
     {
-        m_sizerSlider->AddStretchSpacer(1);
+        m_sizerSlider->AddStretchSpacer();
         m_sizerSlider->Add(m_slider, wxSizerFlags(0).Expand().Border());
-        m_sizerSlider->AddStretchSpacer(1);
+        m_sizerSlider->AddStretchSpacer();
     }
     else
     {

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -435,19 +435,19 @@ void SpinBtnWidgetsPage::CreateSpin()
     NotifyWidgetRecreation(m_spinctrldbl);
 
     // Add spacers, labels and spin controls to the sizer.
-    m_sizerSpin->AddStretchSpacer(1);
+    m_sizerSpin->AddStretchSpacer();
     m_sizerSpin->Add(new wxStaticText(this, wxID_ANY, "wxSpinButton"),
                      wxSizerFlags().Centre().Border());
     m_sizerSpin->Add(m_spinbtn, wxSizerFlags().Centre().Border());
-    m_sizerSpin->AddStretchSpacer(1);
+    m_sizerSpin->AddStretchSpacer();
     m_sizerSpin->Add(new wxStaticText(this, wxID_ANY, "wxSpinCtrl"),
                      wxSizerFlags().Centre().Border());
     m_sizerSpin->Add(m_spinctrl, wxSizerFlags().Centre().Border());
-    m_sizerSpin->AddStretchSpacer(1);
+    m_sizerSpin->AddStretchSpacer();
     m_sizerSpin->Add(new wxStaticText(this, wxID_ANY, "wxSpinCtrlDouble"),
                      wxSizerFlags().Centre().Border());
     m_sizerSpin->Add(m_spinctrldbl, wxSizerFlags().Centre().Border());
-    m_sizerSpin->AddStretchSpacer(1);
+    m_sizerSpin->AddStretchSpacer();
 
     m_sizerSpin->Layout();
 }

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -261,7 +261,7 @@ void SpinBtnWidgetsPage::CreateContent()
                                                     "Process &Enter",
                                                      wxID_ANY, sizerLeftBox);
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
 
     static const wxString halign[] =
     {
@@ -274,12 +274,12 @@ void SpinBtnWidgetsPage::CreateContent()
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(halign), halign, 1);
 
-    sizerLeft->Add(m_radioAlign, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioAlign, wxSizerFlags().Expand().Border());
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
 
     wxButton *btn = new wxButton(sizerLeftBox, SpinBtnPage_Reset, "&Reset");
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change spinbtn value");
@@ -292,14 +292,14 @@ void SpinBtnWidgetsPage::CreateContent()
                                                     sizerMiddleBox);
     text->SetEditable(false);
 
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(SpinBtnPage_SetValue,
                                             "Set &value",
                                             SpinBtnPage_ValueText,
                                             &m_textValue,
                                             sizerMiddleBox);
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(SpinBtnPage_SetMinAndMax,
                                             "&Min and max",
@@ -308,12 +308,12 @@ void SpinBtnWidgetsPage::CreateContent()
                                             sizerMiddleBox);
 
     m_textMax = new wxTextCtrl(sizerMiddleBox, SpinBtnPage_MaxText, wxEmptyString);
-    sizerRow->Add(m_textMax, 1, wxLEFT | wxALIGN_CENTRE_VERTICAL, 5);
+    sizerRow->Add(m_textMax, wxSizerFlags(1).CentreVertical().Border(wxLEFT));
 
     m_textMin->SetValue( wxString::Format("%d", m_min) );
     m_textMax->SetValue( wxString::Format("%d", m_max) );
 
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(SpinBtnPage_SetBase,
                                             "Set &base",
@@ -321,7 +321,7 @@ void SpinBtnWidgetsPage::CreateContent()
                                             &m_textBase,
                                             sizerMiddleBox);
     m_textBase->SetValue("10");
-    sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+    sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton( SpinBtnPage_SetIncrement,
                                              "Set Increment",
@@ -329,7 +329,7 @@ void SpinBtnWidgetsPage::CreateContent()
                                              &m_textIncrement,
                                              sizerMiddleBox);
     m_textIncrement->SetValue( "1" );
-    sizerMiddle->Add( sizerRow, 0, wxALL | wxGROW, 5 );
+    sizerMiddle->Add( sizerRow, wxSizerFlags().Expand().Border() );
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
@@ -340,9 +340,9 @@ void SpinBtnWidgetsPage::CreateContent()
     CreateSpin();
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 0, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags().Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     SetSizer(sizerTop);
@@ -435,19 +435,19 @@ void SpinBtnWidgetsPage::CreateSpin()
     NotifyWidgetRecreation(m_spinctrldbl);
 
     // Add spacers, labels and spin controls to the sizer.
-    m_sizerSpin->Add(0, 0, 1);
+    m_sizerSpin->AddStretchSpacer(1);
     m_sizerSpin->Add(new wxStaticText(this, wxID_ANY, "wxSpinButton"),
-                     0, wxALIGN_CENTRE | wxALL, 5);
-    m_sizerSpin->Add(m_spinbtn, 0, wxALIGN_CENTRE | wxALL, 5);
-    m_sizerSpin->Add(0, 0, 1);
+                     wxSizerFlags().Centre().Border());
+    m_sizerSpin->Add(m_spinbtn, wxSizerFlags().Centre().Border());
+    m_sizerSpin->AddStretchSpacer(1);
     m_sizerSpin->Add(new wxStaticText(this, wxID_ANY, "wxSpinCtrl"),
-                     0, wxALIGN_CENTRE | wxALL, 5);
-    m_sizerSpin->Add(m_spinctrl, 0, wxALIGN_CENTRE | wxALL, 5);
-    m_sizerSpin->Add(0, 0, 1);
+                     wxSizerFlags().Centre().Border());
+    m_sizerSpin->Add(m_spinctrl, wxSizerFlags().Centre().Border());
+    m_sizerSpin->AddStretchSpacer(1);
     m_sizerSpin->Add(new wxStaticText(this, wxID_ANY, "wxSpinCtrlDouble"),
-                     0, wxALIGN_CENTRE | wxALL, 5);
-    m_sizerSpin->Add(m_spinctrldbl, 0, wxALIGN_CENTRE | wxALL, 5);
-    m_sizerSpin->Add(0, 0, 1);
+                     wxSizerFlags().Centre().Border());
+    m_sizerSpin->Add(m_spinctrldbl, wxSizerFlags().Centre().Border());
+    m_sizerSpin->AddStretchSpacer(1);
 
     m_sizerSpin->Layout();
 }

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -247,7 +247,7 @@ void StaticWidgetsPage::CreateContent()
     m_chkWrap = CreateCheckBoxAndAddToSizer(sizerLeft, "&Wrap", wxID_ANY, sizerLeftBox);
     m_chkWrap->Bind(wxEVT_CHECKBOX, &StaticWidgetsPage::OnRecreate, this);
 
-    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->AddSpacer(FromDIP(15));
 
     static const wxString halign[] =
     {
@@ -278,7 +278,7 @@ void StaticWidgetsPage::CreateContent()
     sizerLeft->Add(m_radioVAlign, wxSizerFlags().Expand().Border());
 
 
-    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
+    sizerLeft->AddSpacer(FromDIP(15));
 
     m_chkEllipsize = CreateCheckBoxAndAddToSizer(sizerLeft, "&Ellipsize", wxID_ANY, sizerLeftBox);
     m_chkEllipsize->Bind(wxEVT_CHECKBOX,

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -247,7 +247,7 @@ void StaticWidgetsPage::CreateContent()
     m_chkWrap = CreateCheckBoxAndAddToSizer(sizerLeft, "&Wrap", wxID_ANY, sizerLeftBox);
     m_chkWrap->Bind(wxEVT_CHECKBOX, &StaticWidgetsPage::OnRecreate, this);
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
 
     static const wxString halign[] =
     {
@@ -274,11 +274,11 @@ void StaticWidgetsPage::CreateContent()
     m_radioVAlign->SetToolTip("Relevant for Generic wxStaticText only");
     m_radioVAlign->Bind(wxEVT_RADIOBOX, &StaticWidgetsPage::OnRecreate, this);
 
-    sizerLeft->Add(m_radioHAlign, 0, wxGROW | wxALL, 5);
-    sizerLeft->Add(m_radioVAlign, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioHAlign, wxSizerFlags().Expand().Border());
+    sizerLeft->Add(m_radioVAlign, wxSizerFlags().Expand().Border());
 
 
-    sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
+    sizerLeft->Add(5, 5, wxSizerFlags().Expand().Border()); // spacer
 
     m_chkEllipsize = CreateCheckBoxAndAddToSizer(sizerLeft, "&Ellipsize", wxID_ANY, sizerLeftBox);
     m_chkEllipsize->Bind(wxEVT_CHECKBOX,
@@ -297,11 +297,11 @@ void StaticWidgetsPage::CreateContent()
                                       3);
     m_radioEllipsize->Bind(wxEVT_RADIOBOX, &StaticWidgetsPage::OnRecreate, this);
 
-    sizerLeft->Add(m_radioEllipsize, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioEllipsize, wxSizerFlags().Expand().Border());
 
     wxButton *b0 = new wxButton(sizerLeftBox, wxID_ANY, "&Reset");
     b0->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonReset, this);
-    sizerLeft->Add(b0, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(b0, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change labels");
@@ -310,16 +310,16 @@ void StaticWidgetsPage::CreateContent()
     m_textBox = new wxTextCtrl(sizerMiddleBox, wxID_ANY, wxEmptyString);
     wxButton *b1 = new wxButton(sizerMiddleBox, wxID_ANY, "Change &box label");
     b1->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonBoxText, this);
-    sizerMiddle->Add(m_textBox, 0, wxEXPAND|wxALL, 5);
-    sizerMiddle->Add(b1, 0, wxLEFT|wxBOTTOM, 5);
+    sizerMiddle->Add(m_textBox, wxSizerFlags().Expand().Border());
+    sizerMiddle->Add(b1, wxSizerFlags().Border(wxLEFT | wxBOTTOM));
 
     m_textLabel = new wxTextCtrl(sizerMiddleBox, wxID_ANY, wxEmptyString,
                                  wxDefaultPosition, wxDefaultSize,
                                  wxTE_MULTILINE|wxHSCROLL);
     wxButton *b2 = new wxButton(sizerMiddleBox, wxID_ANY, "Change &text label");
     b2->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonLabelText, this);
-    sizerMiddle->Add(m_textLabel, 0, wxEXPAND|wxALL, 5);
-    sizerMiddle->Add(b2, 0, wxLEFT|wxBOTTOM, 5);
+    sizerMiddle->Add(m_textLabel, wxSizerFlags().Expand().Border());
+    sizerMiddle->Add(b2, wxSizerFlags().Border(wxLEFT | wxBOTTOM));
 
 #if wxUSE_MARKUP
     m_textLabelWithMarkup = new wxTextCtrl(sizerMiddleBox, wxID_ANY, wxEmptyString,
@@ -328,8 +328,8 @@ void StaticWidgetsPage::CreateContent()
 
     wxButton *b3 = new wxButton(sizerMiddleBox, wxID_ANY, "Change decorated text label");
     b3->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonLabelWithMarkupText, this);
-    sizerMiddle->Add(m_textLabelWithMarkup, 0, wxEXPAND|wxALL, 5);
-    sizerMiddle->Add(b3, 0, wxLEFT|wxBOTTOM, 5);
+    sizerMiddle->Add(m_textLabelWithMarkup, wxSizerFlags().Expand().Border());
+    sizerMiddle->Add(b3, wxSizerFlags().Border(wxLEFT | wxBOTTOM));
 
     m_chkGreen = CreateCheckBoxAndAddToSizer(sizerMiddle,
                                              "Decorated label on g&reen",
@@ -359,9 +359,9 @@ void StaticWidgetsPage::CreateContent()
     CreateStatic();
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 0, wxGROW | wxALL, 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags().Expand().DoubleBorder());
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     SetSizer(sizerTop);
 }
@@ -554,9 +554,9 @@ void StaticWidgetsPage::CreateStatic()
                                   isVert ? wxLI_VERTICAL : wxLI_HORIZONTAL);
 #endif // wxUSE_STATLINE
 
-    m_sizerStatBox->Add(m_statText, 0, wxGROW);
+    m_sizerStatBox->Add(m_statText, wxSizerFlags().Expand());
 #if wxUSE_STATLINE
-    m_sizerStatBox->Add(m_statLine, 0, wxGROW | wxTOP | wxBOTTOM, 10);
+    m_sizerStatBox->Add(m_statLine, wxSizerFlags().Expand().DoubleBorder(wxTOP | wxBOTTOM));
 #endif // wxUSE_STATLINE
 #if wxUSE_MARKUP
     m_sizerStatBox->Add(m_statMarkup);
@@ -570,7 +570,7 @@ void StaticWidgetsPage::CreateStatic()
     NotifyWidgetRecreation(m_statLine);
 #endif
 
-    m_sizerStatic->Add(m_sizerStatBox, 1, wxGROW);
+    m_sizerStatic->Add(m_sizerStatBox, wxSizerFlags(1).Expand());
 
     m_sizerStatic->Layout();
 

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -538,7 +538,7 @@ void TextWidgetsPage::CreateContent()
                     "Col:",
                     m_textColCur, "", nullptr, sizerMiddleDownBox
                   ),
-                  wxSizerFlags().Border(wxLEFT | wxRIGHT));
+                  wxSizerFlags().HorzBorder());
     sizerRow->Add(CreateTextWithLabelSizer
                   (
                     "Row:",
@@ -654,7 +654,7 @@ wxSizer *TextWidgetsPage::CreateTextWithLabelSizer(const wxString& label,
     if ( text2 )
     {
         sizerRow->Add(new wxStaticText(statBoxParent ? statBoxParent : this, wxID_ANY, label2),
-                      wxSizerFlags().CentreVertical().Border(wxLEFT | wxRIGHT));
+                      wxSizerFlags().CentreVertical().HorzBorder());
         sizerRow->Add(text2, wxSizerFlags().CentreVertical());
     }
 

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -425,7 +425,7 @@ void TextWidgetsPage::CreateContent()
                                       WXSIZEOF(modes), modes,
                                       1, wxRA_SPECIFY_COLS);
 
-    sizerLeft->Add(m_radioTextLines, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioTextLines, wxSizerFlags().Expand().Border());
     sizerLeft->AddSpacer(5);
 
     m_chkPassword = CreateCheckBoxAndAddToSizer(
@@ -462,7 +462,7 @@ void TextWidgetsPage::CreateContent()
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(wrap), wrap,
                                  1, wxRA_SPECIFY_COLS);
-    sizerLeft->Add(m_radioWrap, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioWrap, wxSizerFlags().Expand().Border());
 
     static const wxString halign[] =
     {
@@ -474,7 +474,7 @@ void TextWidgetsPage::CreateContent()
     m_radioAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Text alignment",
                                     wxDefaultPosition, wxDefaultSize,
                                     WXSIZEOF(halign), halign, 1);
-    sizerLeft->Add(m_radioAlign, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioAlign, wxSizerFlags().Expand().Border());
 
 #ifdef __WXMSW__
     static const wxString kinds[] =
@@ -490,34 +490,34 @@ void TextWidgetsPage::CreateContent()
                                  1, wxRA_SPECIFY_COLS);
 
     sizerLeft->AddSpacer(5);
-    sizerLeft->Add(m_radioKind, 0, wxGROW | wxALL, 5);
+    sizerLeft->Add(m_radioKind, wxSizerFlags().Expand().Border());
 #endif // __WXMSW__
 
     wxButton *btn = new wxButton(sizerLeftBox, TextPage_Reset, "&Reset");
-    sizerLeft->Add(2, 2, 0, wxGROW | wxALL, 1); // spacer
-    sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    sizerLeft->Add(2, 2, wxSizerFlags().Expand().Border(wxALL, FromDIP(1))); // spacer
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddleUp = new wxStaticBoxSizer(wxVERTICAL, this, "&Change contents:");
     wxStaticBox* const sizerMiddleUpBox = sizerMiddleUp->GetStaticBox();
 
     btn = new wxButton(sizerMiddleUpBox, TextPage_Set, "&Set text value");
-    sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
+    sizerMiddleUp->Add(btn, wxSizerFlags().Expand().Border(wxALL, FromDIP(1)));
 
     btn = new wxButton(sizerMiddleUpBox, TextPage_Add, "&Append text");
-    sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
+    sizerMiddleUp->Add(btn, wxSizerFlags().Expand().Border(wxALL, FromDIP(1)));
 
     btn = new wxButton(sizerMiddleUpBox, TextPage_Insert, "&Insert text");
-    sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
+    sizerMiddleUp->Add(btn, wxSizerFlags().Expand().Border(wxALL, FromDIP(1)));
 
     btn = new wxButton(sizerMiddleUpBox, TextPage_Load, "&Load file");
-    sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
+    sizerMiddleUp->Add(btn, wxSizerFlags().Expand().Border(wxALL, FromDIP(1)));
 
     btn = new wxButton(sizerMiddleUpBox, TextPage_Clear, "&Clear");
-    sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
+    sizerMiddleUp->Add(btn, wxSizerFlags().Expand().Border(wxALL, FromDIP(1)));
 
     btn = new wxButton(sizerMiddleUpBox, TextPage_StreamRedirector, "St&ream redirection");
-    sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
+    sizerMiddleUp->Add(btn, wxSizerFlags().Expand().Border(wxALL, FromDIP(1)));
 
     wxStaticBoxSizer *sizerMiddleDown = new wxStaticBoxSizer(wxVERTICAL, this, "&Info:");
     wxStaticBox* const sizerMiddleDownBox = sizerMiddleDown->GetStaticBox();
@@ -532,20 +532,20 @@ void TextWidgetsPage::CreateContent()
                     "Current pos:",
                     m_textPosCur, "", nullptr, sizerMiddleDownBox
                   ),
-                  0, wxRIGHT, 5);
+                  wxSizerFlags().Border(wxRIGHT));
     sizerRow->Add(CreateTextWithLabelSizer
                   (
                     "Col:",
                     m_textColCur, "", nullptr, sizerMiddleDownBox
                   ),
-                  0, wxLEFT | wxRIGHT, 5);
+                  wxSizerFlags().Border(wxLEFT | wxRIGHT));
     sizerRow->Add(CreateTextWithLabelSizer
                   (
                     "Row:",
                     m_textRowCur, "", nullptr, sizerMiddleDownBox
                   ),
-                  0, wxLEFT, 5);
-    sizerMiddleDown->Add(sizerRow, 0, wxALL, 5);
+                  wxSizerFlags().Border(wxLEFT));
+    sizerMiddleDown->Add(sizerRow, wxSizerFlags().Border());
 
     m_textLineLast = CreateInfoText(sizerMiddleDownBox);
     m_textPosLast = CreateInfoText(sizerMiddleDownBox);
@@ -559,7 +559,7 @@ void TextWidgetsPage::CreateContent()
                           m_textPosLast,
                           sizerMiddleDownBox
                         ),
-                        0, wxALL, 5
+                        wxSizerFlags().Border()
                      );
 
     m_textSelFrom = CreateInfoText(sizerMiddleDownBox);
@@ -574,7 +574,7 @@ void TextWidgetsPage::CreateContent()
                           m_textSelTo,
                           sizerMiddleDownBox
                         ),
-                        0, wxALL, 5
+                        wxSizerFlags().Border()
                      );
 
     m_textRange = new wxTextCtrl(sizerMiddleDownBox, wxID_ANY, wxEmptyString,
@@ -588,7 +588,7 @@ void TextWidgetsPage::CreateContent()
                           m_textRange,
                           "", nullptr, sizerMiddleDownBox
                         ),
-                        0, wxALL, 5
+                        wxSizerFlags().Border()
                      );
 
     sizerMiddleDown->Add
@@ -603,8 +603,8 @@ void TextWidgetsPage::CreateContent()
                      );
 
     wxSizer *sizerMiddle = new wxBoxSizer(wxVERTICAL);
-    sizerMiddle->Add(sizerMiddleUp, 0, wxGROW);
-    sizerMiddle->Add(sizerMiddleDown, 1, wxGROW | wxTOP, 5);
+    sizerMiddle->Add(sizerMiddleUp, wxSizerFlags().Expand());
+    sizerMiddle->Add(sizerMiddleDown, wxSizerFlags(1).Expand().Border(wxTOP));
 
     // right pane
     m_sizerText = new wxStaticBoxSizer(wxHORIZONTAL, this, "&Text:");
@@ -614,9 +614,9 @@ void TextWidgetsPage::CreateContent()
 
     // the 3 panes panes compose the upper part of the window
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 0, wxGROW | wxALL, 10);
-    sizerTop->Add(m_sizerText, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags().Expand().DoubleBorder());
+    sizerTop->Add(m_sizerText, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     SetSizer(sizerTop);
 }
@@ -648,14 +648,14 @@ wxSizer *TextWidgetsPage::CreateTextWithLabelSizer(const wxString& label,
                                                  wxWindow* statBoxParent)
 {
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    sizerRow->Add(new wxStaticText(statBoxParent ? statBoxParent : this, wxID_ANY, label), 0,
-                  wxALIGN_CENTRE_VERTICAL | wxRIGHT, 5);
-    sizerRow->Add(text, 0, wxALIGN_CENTRE_VERTICAL);
+    sizerRow->Add(new wxStaticText(statBoxParent ? statBoxParent : this, wxID_ANY, label),
+                  wxSizerFlags().CentreVertical().Border(wxRIGHT));
+    sizerRow->Add(text, wxSizerFlags().CentreVertical());
     if ( text2 )
     {
-        sizerRow->Add(new wxStaticText(statBoxParent ? statBoxParent : this, wxID_ANY, label2), 0,
-                      wxALIGN_CENTRE_VERTICAL | wxLEFT | wxRIGHT, 5);
-        sizerRow->Add(text2, 0, wxALIGN_CENTRE_VERTICAL);
+        sizerRow->Add(new wxStaticText(statBoxParent ? statBoxParent : this, wxID_ANY, label2),
+                      wxSizerFlags().CentreVertical().Border(wxLEFT | wxRIGHT));
+        sizerRow->Add(text2, wxSizerFlags().CentreVertical());
     }
 
     return sizerRow;
@@ -794,10 +794,9 @@ void TextWidgetsPage::CreateText()
         ;
 #endif // TODO
 
-    // cast to int needed to silence gcc warning about different enums
-    m_sizerText->Add(m_text, 1, wxALL |
-                     (flags & wxTE_MULTILINE ? (int)wxGROW
-                                             : wxALIGN_TOP), 5);
+    m_sizerText->Add(m_text,
+                     (flags & wxTE_MULTILINE ? wxSizerFlags(1).Expand()
+                                              : wxSizerFlags(1).Top()).Border());
     m_sizerText->Layout();
 }
 

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -494,7 +494,7 @@ void TextWidgetsPage::CreateContent()
 #endif // __WXMSW__
 
     wxButton *btn = new wxButton(sizerLeftBox, TextPage_Reset, "&Reset");
-    sizerLeft->Add(2, 2, wxSizerFlags().Expand().Border(wxALL, FromDIP(1))); // spacer
+    sizerLeft->AddSpacer(FromDIP(4));
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane

--- a/samples/widgets/timepick.cpp
+++ b/samples/widgets/timepick.cpp
@@ -156,15 +156,15 @@ void TimePickerWidgetsPage::CreateContent()
 
     m_timePicker = new wxTimePickerCtrl(this, TimePickerPage_Picker);
 
-    sizerRight->Add(0, 0, 1, wxCENTRE);
-    sizerRight->Add(m_timePicker, 1, wxCENTRE);
-    sizerRight->Add(0, 0, 1, wxCENTRE);
+    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->Add(m_timePicker, wxSizerFlags(1).Centre());
+    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
     m_sizerTimePicker = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 0, (wxTOP | wxBOTTOM), 10);
-    sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
+    sizerTop->Add(sizerLeft, wxSizerFlags().DoubleBorder(wxALL & ~wxLEFT));
+    sizerTop->Add(sizerMiddle, wxSizerFlags().DoubleBorder(wxTOP | wxBOTTOM));
+    sizerTop->Add(sizerRight, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~wxRIGHT));
 
     // final initializations
     Reset();
@@ -200,9 +200,9 @@ void TimePickerWidgetsPage::CreateTimePicker()
 
     NotifyWidgetRecreation(m_timePicker);
 
-    m_sizerTimePicker->Add(0, 0, 1, wxCENTRE);
-    m_sizerTimePicker->Add(m_timePicker, 1, wxCENTRE);
-    m_sizerTimePicker->Add(0, 0, 1, wxCENTRE);
+    m_sizerTimePicker->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerTimePicker->Add(m_timePicker, wxSizerFlags(1).Centre());
+    m_sizerTimePicker->Add(0, 0, wxSizerFlags(1).Centre());
     m_sizerTimePicker->Layout();
 }
 

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -299,7 +299,7 @@ void ToggleWidgetsPage::CreateContent()
     sizerLeft->AddSpacer(5);
 
     wxButton *btn = new wxButton(sizerLeftBox, TogglePage_Reset, "&Reset");
-    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, FromDIP(15)));
+    sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Operations");
@@ -321,7 +321,7 @@ void ToggleWidgetsPage::CreateContent()
     sizerTop->Add(sizerLeft,
                   wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxLEFT)));
     sizerTop->Add(sizerMiddle,
-                  wxSizerFlags(1).Expand().DoubleBorder(wxALL));
+                  wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(m_sizerToggle,
                   wxSizerFlags(1).Expand().DoubleBorder((wxALL & ~wxRIGHT)));
 

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -509,9 +509,9 @@ void ToggleWidgetsPage::AddButtonToSizer()
 {
     if ( m_chkFit->GetValue() )
     {
-        m_sizerToggle->AddStretchSpacer(1);
+        m_sizerToggle->AddStretchSpacer();
         m_sizerToggle->Add(m_toggle, wxSizerFlags(0).Centre().Border());
-        m_sizerToggle->AddStretchSpacer(1);
+        m_sizerToggle->AddStretchSpacer();
     }
     else // take up the entire space
     {

--- a/samples/wizard/wizard.cpp
+++ b/samples/wizard/wizard.cpp
@@ -128,9 +128,7 @@ public:
             new wxStaticText(this, wxID_ANY,
                              "You need to check the checkbox\n"
                              "below before going to the next page\n"),
-            0,
-            wxALL,
-            5
+            wxSizerFlags().Border()
         );
 
         mainSizer->Add(
@@ -303,7 +301,7 @@ public:
 
 
         wxTextCtrl* textCtrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, textSize, wxTE_MULTILINE);
-        mainSizer->Add(textCtrl, 0, wxALL|wxEXPAND, 5);
+        mainSizer->Add(textCtrl, wxSizerFlags().Expand().Border());
 
         SetSizerAndFit(mainSizer);
     }

--- a/samples/xti/classlist.cpp
+++ b/samples/xti/classlist.cpp
@@ -92,11 +92,11 @@ void ClassListDialog::CreateControls()
     this->SetSizer(itemBoxSizer2);
 
     wxStaticText* itemStaticText3 = new wxStaticText( this, wxID_STATIC, _("This is the list of wxWidgets classes registered in the XTI system.\nNote that not all wxWidgets classes are registered nor all registered classes are completely _described_ using XTI metadata."), wxDefaultPosition, wxDefaultSize, 0 );
-    itemBoxSizer2->Add(itemStaticText3, 0, wxALIGN_LEFT|wxALL, 5);
+    itemBoxSizer2->Add(itemStaticText3, wxSizerFlags().Left().Border());
 
     // filters
     wxBoxSizer* filters = new wxBoxSizer(wxHORIZONTAL);
-    itemBoxSizer2->Add(filters, 0, wxGROW|wxLEFT|wxRIGHT|wxBOTTOM, 5);
+    itemBoxSizer2->Add(filters, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT|wxBOTTOM));
     filters->Add(new wxCheckBox(this, ID_SHOW_ONLY_XTI,
                                 "Show only classes with eXtended infos"));
     filters->AddSpacer(10);
@@ -108,10 +108,10 @@ void ClassListDialog::CreateControls()
                 "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                 wxDefaultPosition, wxDefaultSize, 0 );
     m_pClassCountText->SetFont(wxFontInfo(8).Family(wxFONTFAMILY_SWISS).Bold());
-    itemBoxSizer2->Add(m_pClassCountText, 0, wxALIGN_LEFT|wxLEFT|wxRIGHT|wxBOTTOM, 5);
+    itemBoxSizer2->Add(m_pClassCountText, wxSizerFlags().Left().Border(wxLEFT|wxRIGHT|wxBOTTOM));
 
     wxBoxSizer* itemBoxSizer5 = new wxBoxSizer(wxHORIZONTAL);
-    itemBoxSizer2->Add(itemBoxSizer5, 1, wxGROW, 5);
+    itemBoxSizer2->Add(itemBoxSizer5, wxSizerFlags(1).Expand());
 
     m_pChoiceBook = new wxChoicebook( this, ID_LISTMODE, wxDefaultPosition, wxDefaultSize, wxCHB_DEFAULT );
 
@@ -122,7 +122,7 @@ void ClassListDialog::CreateControls()
 
     wxArrayString m_pRawListBoxStrings;
     m_pRawListBox = new wxListBox( itemPanel7, ID_LISTBOX, wxDefaultPosition, wxDefaultSize, m_pRawListBoxStrings, wxLB_SINGLE );
-    itemBoxSizer8->Add(m_pRawListBox, 1, wxGROW, 5);
+    itemBoxSizer8->Add(m_pRawListBox, wxSizerFlags(1).Expand());
 
     m_pChoiceBook->AddPage(itemPanel7, _("Raw list"));
 
@@ -133,7 +133,7 @@ void ClassListDialog::CreateControls()
 
     wxArrayString m_pSizeListBoxStrings;
     m_pSizeListBox = new wxListBox( itemPanel13, ID_LISTBOX, wxDefaultPosition, wxDefaultSize, m_pSizeListBoxStrings, wxLB_SINGLE );
-    itemBoxSizer14->Add(m_pSizeListBox, 1, wxGROW, 5);
+    itemBoxSizer14->Add(m_pSizeListBox, wxSizerFlags(1).Expand());
 
     m_pChoiceBook->AddPage(itemPanel13, _("Classes by size"));
 
@@ -143,19 +143,19 @@ void ClassListDialog::CreateControls()
     itemPanel10->SetSizer(itemBoxSizer11);
 
     m_pParentTreeCtrl = new wxTreeCtrl( itemPanel10, ID_TREECTRL, wxDefaultPosition, wxSize(100, 100), wxTR_HAS_BUTTONS |wxTR_SINGLE );
-    itemBoxSizer11->Add(m_pParentTreeCtrl, 1, wxGROW, 5);
+    itemBoxSizer11->Add(m_pParentTreeCtrl, wxSizerFlags(1).Expand());
 
     m_pChoiceBook->AddPage(itemPanel10, _("Classes by parent"));
 
 
-    itemBoxSizer5->Add(m_pChoiceBook, 0, wxGROW|wxALL, 5);
+    itemBoxSizer5->Add(m_pChoiceBook, wxSizerFlags().Expand().Border());
 
     m_pTextCtrl = new wxTextCtrl( this, ID_TEXTCTRL, "", wxDefaultPosition, wxSize(500, -1), wxTE_MULTILINE|wxTE_READONLY );
-    itemBoxSizer5->Add(m_pTextCtrl, 3, wxGROW|wxALL, 5);
+    itemBoxSizer5->Add(m_pTextCtrl, wxSizerFlags(3).Expand().Border());
 
     wxStdDialogButtonSizer* itemStdDialogButtonSizer17 = new wxStdDialogButtonSizer;
 
-    itemBoxSizer2->Add(itemStdDialogButtonSizer17, 0, wxGROW|wxALL, 5);
+    itemBoxSizer2->Add(itemStdDialogButtonSizer17, wxSizerFlags().Expand().Border());
     wxButton* itemButton18 = new wxButton( this, wxID_OK, _("&OK"), wxDefaultPosition, wxDefaultSize, 0 );
     itemStdDialogButtonSizer17->AddButton(itemButton18);
 

--- a/samples/xti/xti.cpp
+++ b/samples/xti/xti.cpp
@@ -708,8 +708,8 @@ void MyFrame::OnGenerateCode(wxCommandEvent& WXUNUSED(event))
         sz->Add(new wxTextCtrl(panel, wxID_ANY, str.GetString(),
                                wxDefaultPosition, wxDefaultSize,
                                wxTE_MULTILINE|wxTE_READONLY|wxTE_DONTWRAP),
-                1, wxGROW|wxALL, 5);
-        sz->Add(new wxButton(panel, wxID_OK), 0, wxALIGN_RIGHT|wxALL, 5);
+                wxSizerFlags(1).Expand().Border());
+        sz->Add(new wxButton(panel, wxID_OK), wxSizerFlags().Right().Border());
         panel->SetSizerAndFit(sz);
         dlg3.ShowModal();
     }

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2086,9 +2086,9 @@ wxSize wxAuiToolBar::RealizeHelper(wxReadOnlyDC& dc, wxOrientation orientation)
                 wxSizerItem* ctrl_m_sizerItem;
 
                 wxBoxSizer* vert_sizer = new wxBoxSizer(wxVERTICAL);
-                vert_sizer->AddStretchSpacer(1);
+                vert_sizer->AddStretchSpacer();
                 ctrl_m_sizerItem = vert_sizer->Add(item.m_window, 0, wxEXPAND);
-                vert_sizer->AddStretchSpacer(1);
+                vert_sizer->AddStretchSpacer();
                 if ( (m_windowStyle & wxAUI_TB_TEXT) &&
                      m_toolTextOrientation == wxAUI_TBTOOL_TEXT_BOTTOM &&
                      !item.GetLabel().empty() )

--- a/src/generic/dbgrptg.cpp
+++ b/src/generic/dbgrptg.cpp
@@ -335,12 +335,12 @@ wxDebugReportDialog::wxDebugReportDialog(wxDebugReport& dbgrpt)
 
     // ... and the list of files in this debug report with buttons to view them
     wxSizer *sizerFileBtns = new wxBoxSizer(wxVERTICAL);
-    sizerFileBtns->AddStretchSpacer(1);
+    sizerFileBtns->AddStretchSpacer();
     sizerFileBtns->Add(new wxButton(this, wxID_VIEW_DETAILS, _("&View...")),
                         wxSizerFlags().Border(wxBOTTOM));
     sizerFileBtns->Add(new wxButton(this, wxID_OPEN, _("&Open...")),
                         wxSizerFlags().Border(wxTOP));
-    sizerFileBtns->AddStretchSpacer(1);
+    sizerFileBtns->AddStretchSpacer();
 
 #if wxUSE_CHECKLISTBOX
     m_checklst = new wxCheckListBox(this, wxID_ANY);


### PR DESCRIPTION
This is an LLM-assisted change as doing it by hand turned out to be too time-consuming and not worth spending time on it.

See #24755.