### PR TITLE
Handle MSW tiny rectangle drawing limits

### DIFF
--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -1235,6 +1235,11 @@ public:
         The current pen is used for the outline and the current brush
         for filling the shape.  Special case:  If the current pen is
         transparent, then the current brush is used for the entire rectangle.
+
+        @note Under wxMSW, very small rectangles drawn with a non-transparent
+              pen can be affected by limitations of the native GDI Rectangle()
+              function.  1x1 physical rectangles are handled specially, but
+              corner pixels can be missing from other tiny outlined rectangles.
     */
     void DrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord height);
 

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -992,7 +992,7 @@ void MyCanvas::DrawDefault(wxDC& dc)
     dc.DrawLine(dc.FromDIP(400), dc.FromDIP(170), dc.FromDIP(400), dc.FromDIP(210));
     dc.DrawLine(dc.FromDIP(300), dc.FromDIP(200), dc.FromDIP(410), dc.FromDIP(200));
 
-    // a few more tests of this kind
+    // Draw tiny rectangles, including MSW GDI edge cases.
     dc.SetPen(*wxRED_PEN);
     dc.SetBrush( *wxWHITE_BRUSH );
     dc.DrawRectangle(dc.FromDIP(300), dc.FromDIP(220), dc.FromDIP(1), dc.FromDIP(1));

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -938,7 +938,19 @@ void wxMSWDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord h
         y2dev++;
     }
 
-    (void)Rectangle(GetHdc(), x1dev, y1dev, x2dev, y2dev);
+    const wxCoord widthDev = x2dev - x1dev;
+    const wxCoord heightDev = y2dev - y1dev;
+    if ( m_pen.IsNonTransparent() && (widthDev == 1 || widthDev == -1) &&
+         (heightDev == 1 || heightDev == -1) )
+    {
+        // GDI Rectangle() doesn't draw this degenerate outline at all.
+        SetPixel(GetHdc(), widthDev > 0 ? x1dev : x2dev,
+                 heightDev > 0 ? y1dev : y2dev, m_pen.GetColour().GetPixel());
+    }
+    else
+    {
+        (void)Rectangle(GetHdc(), x1dev, y1dev, x2dev, y2dev);
+    }
 
     if ( AreAutomaticBoundingBoxUpdatesEnabled() )
         CalcBoundingBox(x, y, x2, y2);


### PR DESCRIPTION
Note in wxDC::DrawRectangle() that MSW's native GDI rectangle drawing may omit 1x1 outlined rectangles and corner pixels in other tiny outlined rectangles.

Point the drawing sample's tiny-rectangle block at this behavior and show DrawPoint() as the portable single-pixel alternative.

Fixes #3096