### PR TITLE
Stop GridBagSizer empty cells inflating gaps

### DIFF
--- a/src/common/gbsizer.cpp
+++ b/src/common/gbsizer.cpp
@@ -447,6 +447,9 @@ wxSize wxGridBagSizer::CalcMin()
     m_rowHeights.Empty();
     m_colWidths.Empty();
 
+    wxArrayInt rowHasItem;
+    wxArrayInt colHasItem;
+
     wxSizerItemList::compatibility_iterator node = m_children.GetFirst();
     while (node)
     {
@@ -460,18 +463,42 @@ wxSize wxGridBagSizer::CalcMin()
 
             // fill heights and widths up to this item if needed
             while ( (int)m_rowHeights.GetCount() <= endrow )
-                m_rowHeights.Add(m_emptyCellSize.GetHeight());
+            {
+                m_rowHeights.Add(0);
+                rowHasItem.Add(0);
+            }
             while ( (int)m_colWidths.GetCount() <= endcol )
-                m_colWidths.Add(m_emptyCellSize.GetWidth());
+            {
+                m_colWidths.Add(0);
+                colHasItem.Add(0);
+            }
 
             // See if this item increases the size of its row(s) or col(s)
             wxSize size(item->CalcMin());
             for (idx=row; idx <= endrow; idx++)
+            {
+                rowHasItem[idx] = 1;
                 m_rowHeights[idx] = wxMax(m_rowHeights[idx], size.GetHeight() / (endrow-row+1));
+            }
             for (idx=col; idx <= endcol; idx++)
+            {
+                colHasItem[idx] = 1;
                 m_colWidths[idx] = wxMax(m_colWidths[idx], size.GetWidth() / (endcol-col+1));
+            }
         }
         node = node->GetNext();
+    }
+
+    for (idx=0; idx < (int)m_rowHeights.GetCount(); idx++)
+    {
+        if ( !rowHasItem[idx] )
+            m_rowHeights[idx] = m_emptyCellSize.GetHeight();
+    }
+
+    for (idx=0; idx < (int)m_colWidths.GetCount(); idx++)
+    {
+        if ( !colHasItem[idx] )
+            m_colWidths[idx] = m_emptyCellSize.GetWidth();
     }
 
     AdjustForOverflow();

--- a/tests/sizers/gridsizer.cpp
+++ b/tests/sizers/gridsizer.cpp
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Name:        tests/sizers/gridsizer.cpp
-// Purpose:     Unit tests for wxGridSizer and wxFlexGridSizer.
+// Purpose:     Unit tests for wxGridSizer, wxFlexGridSizer and wxGridBagSizer.
 // Author:      Vadim Zeitlin
 // Created:     2015-04-03
 // Copyright:   (c) 2015 Vadim Zeitlin <vadim@wxwidgets.org>
@@ -18,6 +18,8 @@
     #include "wx/sizer.h"
     #include "wx/vector.h"
 #endif // WX_PRECOMP
+
+#include "wx/gbsizer.h"
 
 #include "asserthelper.h"
 
@@ -251,4 +253,21 @@ TEST_CASE_METHOD(FlexGridSizerTestCase,
     CHECK( children[1]->GetSize() == wxSize(80, 50) );
     CHECK( children[2]->GetSize() == wxSize(20, 50) );
     CHECK( children[3]->GetSize() == wxSize(80, 50) );
+}
+
+TEST_CASE("wxGridBagSizer::EmptyCellSize", "[grid-bag-sizer][sizer]")
+{
+    wxGridBagSizer sizer;
+
+    sizer.Add(2, 1, wxGBPosition(0, 0), wxGBSpan(1, 2));
+    CHECK( sizer.CalcMin() == wxSize(2, 1) );
+
+    sizer.Add(1, 1, wxGBPosition(0, 3));
+    CHECK( sizer.CalcMin() == wxSize(13, 1) );
+
+    sizer.Add(1, 1, wxGBPosition(2, 0));
+    CHECK( sizer.CalcMin() == wxSize(13, 22) );
+
+    sizer.SetEmptyCellSize(wxSize(0, 0));
+    CHECK( sizer.CalcMin() == wxSize(3, 2) );
 }


### PR DESCRIPTION
Track which GridBagSizer rows and columns are occupied while calculating minimum size, and apply the configured empty-cell size only to rows and columns with no shown item.

Add a regression test covering spanned items and genuinely empty rows and columns.

Fixes #3105