### PR TITLE
Use image-relative coordinates for HTML image maps

### DIFF
--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -1187,10 +1187,13 @@ wxHtmlLinkInfo *wxHtmlContainerCell::GetLink(int x, int y) const
 {
     wxHtmlCell *cell = FindCellByPos(x, y);
 
-    // VZ: I don't know if we should pass absolute or relative coords to
-    //     wxHtmlCell::GetLink()? As the base class version just ignores them
-    //     anyhow, it hardly matters right now but should still be clarified
-    return cell ? cell->GetLink(x, y) : nullptr;
+    if ( !cell )
+        return nullptr;
+
+    wxPoint relpos(x, y);
+    relpos -= cell->GetAbsPos(this);
+
+    return cell->GetLink(relpos.x, relpos.y);
 }
 
 
@@ -1366,7 +1369,11 @@ bool wxHtmlContainerCell::ProcessMouseClick(wxHtmlWindowInterface *window,
     bool retval = false;
     wxHtmlCell *cell = FindCellByPos(pos.x, pos.y);
     if ( cell )
-        retval = cell->ProcessMouseClick(window, pos, event);
+    {
+        wxPoint relpos(pos);
+        relpos -= cell->GetAbsPos(this);
+        retval = cell->ProcessMouseClick(window, relpos, event);
+    }
 
     return retval;
 }

--- a/src/html/htmlwin.cpp
+++ b/src/html/htmlwin.cpp
@@ -195,49 +195,46 @@ void wxHtmlWindowMouseHelper::HandleIdle(wxHtmlCell *rootCell,
                                          const wxPoint& pos)
 {
     wxHtmlCell *cell = rootCell ? rootCell->FindCellByPos(pos.x, pos.y) : nullptr;
+    wxHtmlLinkInfo *lnk = nullptr;
+    wxPoint relpos;
 
-    if (cell != m_tmpLastCell)
+    if ( cell )
     {
-        wxHtmlLinkInfo *lnk = nullptr;
-        if (cell)
-        {
-            // adjust the coordinates to be relative to this cell:
-            wxPoint relpos = pos - cell->GetAbsPos(rootCell);
-            lnk = cell->GetLink(relpos.x, relpos.y);
-        }
-
-        wxCursor cur;
-        if (cell)
-            cur = cell->GetMouseCursorAt(m_interface, pos);
-        else
-            cur = m_interface->GetHTMLCursor(
-                        wxHtmlWindowInterface::HTMLCursor_Default);
-
-        m_interface->GetHTMLWindow()->SetCursor(cur);
-
-        if (lnk != m_tmpLastLink)
-        {
-            if (lnk)
-                m_interface->SetHTMLStatusText(lnk->GetHref());
-            else
-                m_interface->SetHTMLStatusText(wxEmptyString);
-
-            m_tmpLastLink = lnk;
-        }
-
-        m_tmpLastCell = cell;
+        relpos = pos - cell->GetAbsPos(rootCell);
+        lnk = cell->GetLink(relpos.x, relpos.y);
     }
-    else // mouse moved but stayed in the same cell
+
+    wxCursor cur;
+    if ( cell )
+    {
+        cur = cell->GetMouseCursorAt(m_interface, relpos);
+    }
+    else
+    {
+        cur = m_interface->GetHTMLCursor(
+                    wxHtmlWindowInterface::HTMLCursor_Default);
+    }
+
+    m_interface->GetHTMLWindow()->SetCursor(cur);
+
+    if ( lnk != m_tmpLastLink )
+    {
+        if ( lnk )
+            m_interface->SetHTMLStatusText(lnk->GetHref());
+        else
+            m_interface->SetHTMLStatusText(wxEmptyString);
+
+        m_tmpLastLink = lnk;
+    }
+
+    if ( cell == m_tmpLastCell )
     {
         if ( cell )
-        {
-            // A single cell can have different cursors for different positions,
-            // so update cursor for this case as well.
-            wxCursor cur = cell->GetMouseCursorAt(m_interface, pos);
-            m_interface->GetHTMLWindow()->SetCursor(cur);
-
-            OnCellMouseHover(cell, pos.x, pos.y);
-        }
+            OnCellMouseHover(cell, relpos.x, relpos.y);
+    }
+    else
+    {
+        m_tmpLastCell = cell;
     }
 
     m_tmpMouseMoved = false;
@@ -1568,13 +1565,7 @@ void wxHtmlWindow::OnInternalIdle()
 
         // handle cursor and status bar text changes:
 
-        // NB: because we're passing in 'cell' and not 'm_Cell' (so that the
-        //     leaf cell lookup isn't done twice), we need to adjust the
-        //     position for the new root:
-        wxPoint posInCell(x, y);
-        if (cell)
-            posInCell -= cell->GetAbsPos();
-        wxHtmlWindowMouseHelper::HandleIdle(cell, posInCell);
+        wxHtmlWindowMouseHelper::HandleIdle(m_Cell, wxPoint(x, y));
     }
 }
 

--- a/tests/html/htmlwindow.cpp
+++ b/tests/html/htmlwindow.cpp
@@ -43,6 +43,7 @@ private:
         WXUISIM_TEST( CellClick );
         WXUISIM_TEST( LinkClick );
 #endif // wxUSE_UIACTIONSIMULATOR
+        CPPUNIT_TEST( ImageMapCoordinates );
         CPPUNIT_TEST( AppendToPage );
     CPPUNIT_TEST_SUITE_END();
 
@@ -50,6 +51,7 @@ private:
     void Title();
     void CellClick();
     void LinkClick();
+    void ImageMapCoordinates();
     void AppendToPage();
 
     wxHtmlWindow *m_win;
@@ -98,6 +100,44 @@ static const char *TEST_MARKUP_LINK =
 
 static const char *TEST_PLAIN_TEXT =
     "Title\nA longer line\nand the last line.";
+
+static const char *TEST_MARKUP_IMAGEMAP =
+    "<html><body>"
+    "Text<br>"
+    "<img src=\"missing.png\" width=\"100\" height=\"100\" usemap=\"#map\">"
+    "<map name=\"map\">"
+    "<area shape=\"rect\" coords=\"10,10,20,20\" href=\"hit\">"
+    "</map>"
+    "</body></html>";
+
+static wxHtmlCell *FindCellWithLink(wxHtmlCell *cell, wxPoint *pos)
+{
+    if ( !cell->GetFirstChild() )
+    {
+        for ( int y = 0; y < cell->GetHeight(); y++ )
+        {
+            for ( int x = 0; x < cell->GetWidth(); x++ )
+            {
+                if ( cell->GetLink(x, y) )
+                {
+                    *pos = wxPoint(x, y);
+                    return cell;
+                }
+            }
+        }
+    }
+
+    for ( wxHtmlCell *child = cell->GetFirstChild();
+          child;
+          child = child->GetNext() )
+    {
+        wxHtmlCell *found = FindCellWithLink(child, pos);
+        if ( found )
+            return found;
+    }
+
+    return nullptr;
+}
 
 void HtmlWindowTestCase::SelectionToText()
 {
@@ -155,6 +195,26 @@ void HtmlWindowTestCase::LinkClick()
     CPPUNIT_ASSERT_EQUAL(1, clicked.GetCount());
 }
 #endif // wxUSE_UIACTIONSIMULATOR
+
+void HtmlWindowTestCase::ImageMapCoordinates()
+{
+    m_win->SetBorders(0);
+    m_win->SetPage(TEST_MARKUP_IMAGEMAP);
+
+    wxHtmlContainerCell *root = m_win->GetInternalRepresentation();
+    wxPoint hitpos;
+    wxHtmlCell *image = FindCellWithLink(root, &hitpos);
+
+    CPPUNIT_ASSERT(image);
+
+    const wxPoint imgpos = image->GetAbsPos(root);
+    wxHtmlLinkInfo *link = root->GetLink(imgpos.x + hitpos.x,
+                                         imgpos.y + hitpos.y);
+
+    CPPUNIT_ASSERT(link);
+    CPPUNIT_ASSERT_EQUAL("hit", link->GetHref());
+    CPPUNIT_ASSERT(!root->GetLink(imgpos.x, imgpos.y));
+}
 
 void HtmlWindowTestCase::AppendToPage()
 {


### PR DESCRIPTION
Convert container and idle mouse positions to the target cell coordinate space before querying links, so wxHTML image map hit testing receives image-relative positions.

Add a wxHtmlWindow regression test covering a shifted image map.

Fixes #3163