### PR TITLE
Avoid modal HTML help after missing topic

### DIFF
--- a/src/html/helpctrl.cpp
+++ b/src/html/helpctrl.cpp
@@ -405,7 +405,8 @@ bool wxHtmlHelpController::Display(const wxString& x)
 {
     CreateHelpWindow();
     bool success = m_helpWindow->Display(x);
-    MakeModalIfNeeded();
+    if ( success )
+        MakeModalIfNeeded();
     return success;
 }
 
@@ -413,7 +414,8 @@ bool wxHtmlHelpController::Display(int id)
 {
     CreateHelpWindow();
     bool success = m_helpWindow->Display(id);
-    MakeModalIfNeeded();
+    if ( success )
+        MakeModalIfNeeded();
     return success;
 }
 
@@ -421,7 +423,8 @@ bool wxHtmlHelpController::DisplayContents()
 {
     CreateHelpWindow();
     bool success = m_helpWindow->DisplayContents();
-    MakeModalIfNeeded();
+    if ( success )
+        MakeModalIfNeeded();
     return success;
 }
 
@@ -429,7 +432,8 @@ bool wxHtmlHelpController::DisplayIndex()
 {
     CreateHelpWindow();
     bool success = m_helpWindow->DisplayIndex();
-    MakeModalIfNeeded();
+    if ( success )
+        MakeModalIfNeeded();
     return success;
 }
 
@@ -438,7 +442,8 @@ bool wxHtmlHelpController::KeywordSearch(const wxString& keyword,
 {
     CreateHelpWindow();
     bool success = m_helpWindow->KeywordSearch(keyword, mode);
-    MakeModalIfNeeded();
+    if ( success )
+        MakeModalIfNeeded();
     return success;
 }
 

--- a/tests/html/htmlwindow.cpp
+++ b/tests/html/htmlwindow.cpp
@@ -17,8 +17,11 @@
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/timer.h"
 #endif // WX_PRECOMP
 
+#include "wx/html/helpctrl.h"
+#include "wx/html/helpdlg.h"
 #include "wx/html/htmlwin.h"
 #include "wx/uiaction.h"
 #include "testableframe.h"
@@ -43,6 +46,9 @@ private:
         WXUISIM_TEST( CellClick );
         WXUISIM_TEST( LinkClick );
 #endif // wxUSE_UIACTIONSIMULATOR
+#if wxUSE_WXHTML_HELP
+        CPPUNIT_TEST( DisplayMissingHelpTopic );
+#endif // wxUSE_WXHTML_HELP
         CPPUNIT_TEST( AppendToPage );
     CPPUNIT_TEST_SUITE_END();
 
@@ -50,6 +56,9 @@ private:
     void Title();
     void CellClick();
     void LinkClick();
+#if wxUSE_WXHTML_HELP
+    void DisplayMissingHelpTopic();
+#endif // wxUSE_WXHTML_HELP
     void AppendToPage();
 
     wxHtmlWindow *m_win;
@@ -98,6 +107,36 @@ static const char *TEST_MARKUP_LINK =
 
 static const char *TEST_PLAIN_TEXT =
     "Title\nA longer line\nand the last line.";
+
+#if wxUSE_WXHTML_HELP
+
+class CloseModalHelpDialogTimer : public wxTimer
+{
+public:
+    CloseModalHelpDialogTimer(wxHtmlHelpController& controller)
+        : m_controller(controller),
+          m_modalShown(false)
+    {
+    }
+
+    bool WasModalShown() const { return m_modalShown; }
+
+private:
+    virtual void Notify() override
+    {
+        wxHtmlHelpDialog *dialog = m_controller.GetDialog();
+        if ( dialog && dialog->IsModal() )
+        {
+            m_modalShown = true;
+            dialog->EndModal(wxID_CANCEL);
+        }
+    }
+
+    wxHtmlHelpController& m_controller;
+    bool m_modalShown;
+};
+
+#endif // wxUSE_WXHTML_HELP
 
 void HtmlWindowTestCase::SelectionToText()
 {
@@ -155,6 +194,25 @@ void HtmlWindowTestCase::LinkClick()
     CPPUNIT_ASSERT_EQUAL(1, clicked.GetCount());
 }
 #endif // wxUSE_UIACTIONSIMULATOR
+
+#if wxUSE_WXHTML_HELP
+void HtmlWindowTestCase::DisplayMissingHelpTopic()
+{
+    wxHtmlHelpController controller(
+        wxHF_DEFAULT_STYLE | wxHF_DIALOG | wxHF_MODAL,
+        wxTheApp->GetTopWindow());
+    CloseModalHelpDialogTimer timer(controller);
+
+    timer.StartOnce(50);
+
+    CPPUNIT_ASSERT(!controller.Display("missing topic"));
+
+    timer.Stop();
+
+    CPPUNIT_ASSERT(!timer.WasModalShown());
+    controller.Quit();
+}
+#endif // wxUSE_WXHTML_HELP
 
 void HtmlWindowTestCase::AppendToPage()
 {


### PR DESCRIPTION
Only modalize wxHtmlHelpController windows after a display operation succeeds, so a failed topic lookup can fall through to a fallback topic without showing a modal help frame.

Add a regression test covering a modal help dialog display request for a missing topic.

Fixes #3219