### PR TITLE
Preserve leading wxHTML BR elements

### DIFF
--- a/src/html/m_layout.cpp
+++ b/src/html/m_layout.cpp
@@ -90,7 +90,31 @@ wxHtmlPageBreakCell::AdjustPagebreak(int* pagebreak, int pageHeight) const
     return false;
 }
 
+class wxHtmlLineBreakCell : public wxHtmlCell
+{
+public:
+    wxHtmlLineBreakCell(const wxHtmlTag& tag, int height) : wxHtmlCell(tag)
+        { m_Height = height; }
 
+    void Draw(wxDC& WXUNUSED(dc),
+              int WXUNUSED(x), int WXUNUSED(y),
+              int WXUNUSED(view_y1), int WXUNUSED(view_y2),
+              wxHtmlRenderingInfo& WXUNUSED(info)) override {}
+
+private:
+    wxDECLARE_NO_COPY_CLASS(wxHtmlLineBreakCell);
+};
+
+static bool HasLayoutContent(wxHtmlContainerCell *c)
+{
+    for ( wxHtmlCell *cell = c->GetFirstChild(); cell; cell = cell->GetNext() )
+    {
+        if ( !cell->IsTerminalCell() || !cell->IsFormattingCell() )
+            return true;
+    }
+
+    return false;
+}
 
 TAG_HANDLER_BEGIN(P, "P")
     TAG_HANDLER_CONSTR(P) { }
@@ -119,14 +143,29 @@ TAG_HANDLER_BEGIN(BR, "BR")
     TAG_HANDLER_PROC(tag)
     {
         int al = m_WParser->GetContainer()->GetAlignHor();
-        wxHtmlContainerCell *c;
+        wxHtmlContainerCell *c = m_WParser->GetContainer();
 
-        m_WParser->CloseContainer();
-        c = m_WParser->OpenContainer();
-        c->CopyId(tag);
+        if ( !HasLayoutContent(c) && !c->HasId() )
+        {
+            c->CopyId(tag);
+            c->SetAlignHor(al);
+            c->SetAlign(tag);
+            c->InsertCell(
+                new wxHtmlLineBreakCell(tag, m_WParser->GetCharHeight()));
+
+            m_WParser->CloseContainer();
+            c = m_WParser->OpenContainer();
+        }
+        else
+        {
+            m_WParser->CloseContainer();
+            c = m_WParser->OpenContainer();
+            c->CopyId(tag);
+            c->SetMinHeight(m_WParser->GetCharHeight());
+        }
+
         c->SetAlignHor(al);
         c->SetAlign(tag);
-        c->SetMinHeight(m_WParser->GetCharHeight());
         return false;
     }
 

--- a/tests/html/htmlwindow.cpp
+++ b/tests/html/htmlwindow.cpp
@@ -39,6 +39,7 @@ private:
     CPPUNIT_TEST_SUITE( HtmlWindowTestCase );
         CPPUNIT_TEST( SelectionToText );
         CPPUNIT_TEST( Title );
+        CPPUNIT_TEST( InitialLineBreak );
 #if wxUSE_UIACTIONSIMULATOR
         WXUISIM_TEST( CellClick );
         WXUISIM_TEST( LinkClick );
@@ -48,6 +49,7 @@ private:
 
     void SelectionToText();
     void Title();
+    void InitialLineBreak();
     void CellClick();
     void LinkClick();
     void AppendToPage();
@@ -114,6 +116,25 @@ void HtmlWindowTestCase::Title()
     m_win->SetPage(TEST_MARKUP);
 
     CPPUNIT_ASSERT_EQUAL("Page", m_win->GetOpenedPageTitle());
+}
+
+void HtmlWindowTestCase::InitialLineBreak()
+{
+    m_win->SetBorders(0);
+    m_win->SetPage("<html><body>TEXT</body></html>");
+
+    wxHtmlContainerCell *plainTextRoot = m_win->GetInternalRepresentation();
+
+    CPPUNIT_ASSERT(plainTextRoot);
+
+    int plainTextHeight = plainTextRoot->GetHeight();
+
+    m_win->SetPage("<html><body><br>TEXT</body></html>");
+
+    wxHtmlContainerCell *rootWithBreak = m_win->GetInternalRepresentation();
+
+    CPPUNIT_ASSERT(rootWithBreak);
+    CPPUNIT_ASSERT(rootWithBreak->GetHeight() > plainTextHeight);
 }
 
 #if wxUSE_UIACTIONSIMULATOR


### PR DESCRIPTION
Keep an initial BR element as a real blank line even when the current container only has formatting cells.

Add a wxHtmlWindow regression test covering text preceded by an initial BR element.

Fixes #3345