### PR TITLE
Resolve absolute wxHTML archive resource paths

### DIFF
--- a/include/wx/private/filesys.h
+++ b/include/wx/private/filesys.h
@@ -1,0 +1,49 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/filesys.h
+// Purpose:     wxFileSystem private helpers
+// Author:      wxWidgets team
+// Copyright:   (c) 2026 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_FILESYS_H_
+#define _WX_PRIVATE_FILESYS_H_
+
+#include "wx/wxcrt.h"
+
+// Return the start of the rightmost wxFileSystem location, ignoring anchors and
+// Windows drive colons embedded in file URLs.
+inline int wxFindFileSystemRightLocationStart(const wxString& location,
+                                              int *lenOut = nullptr)
+{
+    int len = location.length();
+
+    int i;
+    for ( i = len - 1; i >= 0; i-- )
+    {
+        if ( location[i] == wxT('#') )
+            len = i;
+
+        if ( location[i] != wxT(':') )
+            continue;
+
+        // C: on Windows.
+        if ( i == 1 )
+            continue;
+
+        if ( i >= 2 && wxIsalpha(location[i - 1]) &&
+             location[i - 2] == wxT('/') )
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    if ( lenOut )
+        *lenOut = len;
+
+    return i + 1;
+}
+
+#endif // _WX_PRIVATE_FILESYS_H_

--- a/src/common/filesys.cpp
+++ b/src/common/filesys.cpp
@@ -26,6 +26,7 @@
 #include "wx/filename.h"
 #include "wx/tokenzr.h"
 #include "wx/private/fileback.h"
+#include "wx/private/filesys.h"
 #include "wx/private/make_unique.h"
 #include "wx/utils.h"
 
@@ -184,23 +185,8 @@ wxString wxFileSystemHandler::GetLeftLocation(const wxString& location)
 /* static */
 wxString wxFileSystemHandler::GetRightLocation(const wxString& location)
 {
-    int i, len = location.length();
-    for (i = len-1; i >= 0; i--)
-    {
-        if (location[i] == wxT('#'))
-            len = i;
-        if (location[i] != wxT(':'))
-            continue;
-
-        // C: on Windows
-        if (i == 1)
-            continue;
-        if (i >= 2 && wxIsalpha(location[i-1]) && location[i-2] == wxT('/'))
-            continue;
-
-        // Could be the protocol
-        break;
-    }
+    int len;
+    int i = wxFindFileSystemRightLocationStart(location, &len) - 1;
     if (i == 0) return wxEmptyString;
 
     const static wxString protocol(wxT("file:"));

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -26,6 +26,7 @@
 #include "wx/fontmap.h"
 #include "wx/uri.h"
 
+#include "wx/private/filesys.h"
 #include "wx/private/hyperlink.h"
 
 //-----------------------------------------------------------------------------
@@ -258,46 +259,57 @@ wxObject* wxHtmlWinParser::GetProduct()
     return top;
 }
 
+static wxString wxResolveHtmlURL(const wxFileSystem *fs, const wxString& url)
+{
+    wxURI current(url);
+    wxString fullurl = current.BuildUnescapedURI();
+
+    if ( !current.IsRelative() || !fs )
+        return fullurl;
+
+    wxString basepath = fs->GetPath();
+    if ( basepath.empty() )
+        return fullurl;
+
+    if ( current.GetPath().StartsWith(wxT("/")) &&
+         basepath.Find(wxT('#')) != wxNOT_FOUND )
+    {
+        return basepath.Left(wxFindFileSystemRightLocationStart(basepath)) +
+               fullurl;
+    }
+
+    wxURI base(basepath);
+
+    if ( !base.IsReference() )
+    {
+        wxURI path(fullurl);
+        path.Resolve(base);
+        return path.BuildUnescapedURI();
+    }
+
+    // ... or force such addition if not included already
+    if ( !current.GetPath().Contains(base.GetPath()) )
+    {
+        basepath += fullurl;
+        wxURI connected(basepath);
+        fullurl = connected.BuildUnescapedURI();
+    }
+
+    return fullurl;
+}
+
 wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
                                    const wxString& url) const
 {
-    if ( !m_windowInterface )
-        return wxHtmlParser::OpenURL(type, url);
-
     wxString myurl(url);
-    wxHtmlOpeningStatus status;
+    wxString myfullurl;
+    wxHtmlOpeningStatus status = wxHTML_OPEN;
     for (;;)
     {
-        wxString myfullurl(myurl);
+        myfullurl = wxResolveHtmlURL(GetFS(), myurl);
 
-        // consider url as absolute path first
-        wxURI current(myurl);
-        myfullurl = current.BuildUnescapedURI();
-
-        // if not absolute then ...
-        if( current.IsRelative() )
-        {
-            wxString basepath = GetFS()->GetPath();
-            wxURI base(basepath);
-
-            // ... try to apply base path if valid ...
-            if( !base.IsReference() )
-            {
-                wxURI path(myfullurl);
-                path.Resolve( base );
-                myfullurl = path.BuildUnescapedURI();
-            }
-            else
-            {
-                // ... or force such addition if not included already
-                if( !current.GetPath().Contains(base.GetPath()) )
-                {
-                    basepath += myurl;
-                    wxURI connected( basepath );
-                    myfullurl = connected.BuildUnescapedURI();
-                }
-            }
-        }
+        if ( !m_windowInterface )
+            break;
 
         wxString redirect;
         status = m_windowInterface->OnHTMLOpeningURL(type, myfullurl, &redirect);
@@ -310,11 +322,7 @@ wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
     if ( status == wxHTML_BLOCK )
         return nullptr;
 
-    int flags = wxFS_READ;
-    if (type == wxHTML_URL_IMAGE)
-        flags |= wxFS_SEEKABLE;
-
-    return GetFS()->OpenFile(myurl, flags);
+    return wxHtmlParser::OpenURL(type, myfullurl);
 }
 
 static constexpr wxChar CUR_NBSP_VALUE = L'\xA0';

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -317,6 +317,8 @@ wxFSFile *wxHtmlWinParser::OpenURL(wxHtmlURLType type,
     return GetFS()->OpenFile(myurl, flags);
 }
 
+static constexpr wxChar CUR_NBSP_VALUE = L'\xA0';
+
 void wxHtmlWinParser::AddText(const wxString& txt)
 {
     if ( m_whitespaceMode == Whitespace_Normal )
@@ -361,6 +363,7 @@ void wxHtmlWinParser::AddText(const wxString& txt)
             if (x)
             {
                 m_tmpStrBuf.append(' ');
+                m_tmpStrBuf.Replace(CUR_NBSP_VALUE, ' ');
                 AddWord(m_tmpStrBuf);
                 m_tmpStrBuf.clear();
 
@@ -392,7 +395,18 @@ void wxHtmlWinParser::AddText(const wxString& txt)
     }
     else // m_whitespaceMode == Whitespace_Pre
     {
-        AddPreBlock(txt);
+        if ( txt.find(CUR_NBSP_VALUE) != wxString::npos )
+        {
+            // we need to substitute spaces for &nbsp; here just like we
+            // did in the Whitespace_Normal branch above
+            wxString txt2(txt);
+            txt2.Replace(CUR_NBSP_VALUE, ' ');
+            AddPreBlock(txt2);
+        }
+        else
+        {
+            AddPreBlock(txt);
+        }
 
         // don't eat any whitespace in <pre> block
         m_tmpLastWasSpace = false;

--- a/tests/html/htmlparser.cpp
+++ b/tests/html/htmlparser.cpp
@@ -23,6 +23,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/html/winpars.h"
+#include "wx/sstream.h"
 
 #include <memory>
 #include <vector>
@@ -197,6 +198,67 @@ TEST_CASE("wxHtmlEntitiesParser::StrokedD", "[html][parser][entity]")
     expected << wxUniChar(0x0110) << wxUniChar(0x0111);
 
     CHECK( p.Parse("&Dstrok;&dstrok;") == expected );
+}
+
+TEST_CASE("wxHtmlWinParser::OpenURLAbsoluteArchivePath",
+          "[html][parser][url]")
+{
+    class RecordingFSHandler : public wxFileSystemHandler
+    {
+    public:
+        bool CanOpen(const wxString& location) override
+        {
+            return !location.empty();
+        }
+
+        wxFSFile *OpenFile(wxFileSystem& WXUNUSED(fs),
+                           const wxString& location) override
+        {
+            m_location = location;
+            return new wxFSFile(new wxStringInputStream("data"),
+                                location,
+                                wxEmptyString,
+                                wxEmptyString
+#if wxUSE_DATETIME
+                                , wxDateTime::Now()
+#endif // wxUSE_DATETIME
+                                );
+        }
+
+        const wxString& GetLocation() const { return m_location; }
+
+    private:
+        wxString m_location;
+    };
+
+    class AutoFSHandler
+    {
+    public:
+        AutoFSHandler(RecordingFSHandler *handler) : m_handler(handler)
+            { wxFileSystem::AddHandler(m_handler); }
+        ~AutoFSHandler()
+            { wxFileSystem::RemoveHandler(m_handler); }
+
+    private:
+        RecordingFSHandler *m_handler;
+    };
+
+    RecordingFSHandler handler;
+    AutoFSHandler autoFSHandler(&handler);
+
+    wxFileSystem fs;
+    fs.ChangePathTo("file:doc.chm#xchm:/d/e/", true);
+
+    wxHtmlWinParser parser;
+    parser.SetFS(&fs);
+
+    const wxString expected("file:doc.chm#xchm:/a/b/c.jpg");
+    std::unique_ptr<wxFSFile> file(
+        parser.OpenURL(wxHTML_URL_IMAGE, "/a/b/c.jpg"));
+
+    REQUIRE(file);
+    CHECK(handler.GetLocation() == expected);
+    CHECK(file->GetLocation() == expected);
 }
 
 TEST_CASE("wxHtmlCell::Detach", "[html][cell]")


### PR DESCRIPTION
Keep slash-rooted resource paths inside the current stacked filesystem URL instead of resolving them under the current archive directory.

Add a wxHtmlWinParser regression test for CHM-style absolute resource paths.

Fixes #3350