### PR TITLE
Add missing Dstrok HTML entity

### DIFF
--- a/src/html/htmlpars.cpp
+++ b/src/html/htmlpars.cpp
@@ -3,6 +3,7 @@
 // Purpose:     wxHtmlParser class (generic parser)
 // Author:      Vaclav Slavik
 // Copyright:   (c) 1999 Vaclav Slavik
+//              (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
@@ -555,6 +556,7 @@ wxChar wxHtmlEntitiesParser::GetEntityChar(const wxString& entity) const
             ENTITY("Chi", 935),
             ENTITY("Dagger", 8225),
             ENTITY("Delta", 916),
+            ENTITY("Dstrok", 272),
             ENTITY("ETH", 208),
             ENTITY("Eacute", 201),
             ENTITY("Ecirc", 202),
@@ -639,6 +641,7 @@ wxChar wxHtmlEntitiesParser::GetEntityChar(const wxString& entity) const
             ENTITY("delta", 948),
             ENTITY("diams", 9830),
             ENTITY("divide", 247),
+            ENTITY("dstrok", 273),
             ENTITY("eacute", 233),
             ENTITY("ecirc", 234),
             ENTITY("egrave", 232),

--- a/tests/html/htmlparser.cpp
+++ b/tests/html/htmlparser.cpp
@@ -190,6 +190,15 @@ TEST_CASE("wxHtmlParser::NBSPLineBreak", "[html][parser]")
     CHECK(cells[1]->GetAbsPos().y == cells[2]->GetAbsPos().y);
 }
 
+TEST_CASE("wxHtmlEntitiesParser::StrokedD", "[html][parser][entity]")
+{
+    wxHtmlEntitiesParser p;
+    wxString expected;
+    expected << wxUniChar(0x0110) << wxUniChar(0x0111);
+
+    CHECK( p.Parse("&Dstrok;&dstrok;") == expected );
+}
+
 TEST_CASE("wxHtmlCell::Detach", "[html][cell]")
 {
     wxMemoryDC dc;


### PR DESCRIPTION
Recognize the uppercase and lowercase stroked-D named entities in the HTML entity parser and cover them with a focused parser test.

Fixes #3996