### PR TITLE
Handle wxRichTextCtrl clipboard transfer failures

### DIFF
--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -8950,68 +8950,80 @@ bool wxRichTextBuffer::PasteFromClipboard(long position)
             if (wxTheClipboard->IsSupported(wxDataFormat(wxRichTextBufferDataObject::GetRichTextBufferFormatId())))
             {
                 wxRichTextBufferDataObject data;
-                wxTheClipboard->GetData(data);
-                wxRichTextBuffer* richTextBuffer = data.GetRichTextBuffer();
-                if (richTextBuffer)
+                if (wxTheClipboard->GetData(data))
                 {
-                    container->InsertParagraphsWithUndo(this, position+1, *richTextBuffer, GetRichTextCtrl(), 0);
-                    if (GetRichTextCtrl())
-                        GetRichTextCtrl()->ShowPosition(position + richTextBuffer->GetOwnRange().GetEnd());
-                    if (richTextBuffer->GetStyleSheet())
+                    wxRichTextBuffer* richTextBuffer = data.GetRichTextBuffer();
+                    if (richTextBuffer)
                     {
-                        delete richTextBuffer->GetStyleSheet();
-                        richTextBuffer->SetStyleSheet(nullptr);
+                        container->InsertParagraphsWithUndo(this, position+1, *richTextBuffer, GetRichTextCtrl(), 0);
+                        if (GetRichTextCtrl())
+                            GetRichTextCtrl()->ShowPosition(position + richTextBuffer->GetOwnRange().GetEnd());
+                        if (richTextBuffer->GetStyleSheet())
+                        {
+                            delete richTextBuffer->GetStyleSheet();
+                            richTextBuffer->SetStyleSheet(nullptr);
+                        }
+                        delete richTextBuffer;
+
+                        success = true;
                     }
-                    delete richTextBuffer;
                 }
             }
-            else if (wxTheClipboard->IsSupported(wxDF_TEXT)
+
+            // Fall back if advertised rich text couldn't be read.
+            if (!success && (wxTheClipboard->IsSupported(wxDF_TEXT)
                      || wxTheClipboard->IsSupported(wxDF_UNICODETEXT)
                     )
+               )
             {
                 wxTextDataObject data;
-                wxTheClipboard->GetData(data);
-                wxString text(data.GetText());
-#ifdef __WXMSW__
-                wxString text2;
-                text2.Alloc(text.length()+1);
-                for ( wxUniChar ch : text )
+                if (wxTheClipboard->GetData(data))
                 {
-                    if (ch != wxT('\r'))
-                        text2 += ch;
-                }
+                    wxString text(data.GetText());
+#ifdef __WXMSW__
+                    wxString text2;
+                    text2.Alloc(text.length()+1);
+                    for ( wxUniChar ch : text )
+                    {
+                        if (ch != wxT('\r'))
+                            text2 += ch;
+                    }
 #else
-                wxString text2 = text;
+                    wxString text2 = text;
 #endif
-                container->InsertTextWithUndo(this, position+1, text2, GetRichTextCtrl(), wxRICHTEXT_INSERT_WITH_PREVIOUS_PARAGRAPH_STYLE);
+                    container->InsertTextWithUndo(this, position+1, text2, GetRichTextCtrl(), wxRICHTEXT_INSERT_WITH_PREVIOUS_PARAGRAPH_STYLE);
 
-                if (GetRichTextCtrl())
-                    GetRichTextCtrl()->ShowPosition(position + text2.length());
+                    if (GetRichTextCtrl())
+                        GetRichTextCtrl()->ShowPosition(position + text2.length());
 
-                success = true;
+                    success = true;
+                }
             }
-            else if (wxTheClipboard->IsSupported(wxDF_BITMAP))
+
+            if (!success && wxTheClipboard->IsSupported(wxDF_BITMAP))
             {
                 wxBitmapDataObject data;
-                wxTheClipboard->GetData(data);
-                wxBitmap bitmap(data.GetBitmap());
-                wxImage image(bitmap.ConvertToImage());
+                if (wxTheClipboard->GetData(data))
+                {
+                    wxBitmap bitmap(data.GetBitmap());
+                    wxImage image(bitmap.ConvertToImage());
 
-                wxRichTextAction* action = new wxRichTextAction(nullptr, _("Insert Image"), wxRICHTEXT_INSERT, this, container, GetRichTextCtrl(), false);
+                    wxRichTextAction* action = new wxRichTextAction(nullptr, _("Insert Image"), wxRICHTEXT_INSERT, this, container, GetRichTextCtrl(), false);
 
-                action->GetNewParagraphs().AddImage(image);
+                    action->GetNewParagraphs().AddImage(image);
 
-                if (action->GetNewParagraphs().GetChildCount() == 1)
-                    action->GetNewParagraphs().SetPartialParagraph(true);
+                    if (action->GetNewParagraphs().GetChildCount() == 1)
+                        action->GetNewParagraphs().SetPartialParagraph(true);
 
-                action->SetPosition(position+1);
+                    action->SetPosition(position+1);
 
-                // Set the range we'll need to delete in Undo
-                action->SetRange(wxRichTextRange(position+1, position+1));
+                    // Set the range we'll need to delete in Undo
+                    action->SetRange(wxRichTextRange(position+1, position+1));
 
-                SubmitAction(action);
+                    SubmitAction(action);
 
-                success = true;
+                    success = true;
+                }
             }
             wxTheClipboard->Close();
         }

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -3489,11 +3489,13 @@ void wxRichTextCtrl::Cut()
     if (CanCut())
     {
         wxRichTextRange range = GetInternalSelectionRange();
-        GetBuffer().CopyToClipboard(range);
-
-        DeleteSelectedContent();
-        LayoutContent();
-        Refresh(false);
+        // Keep the selection if it couldn't be put on the clipboard.
+        if ( GetBuffer().CopyToClipboard(range) )
+        {
+            DeleteSelectedContent();
+            LayoutContent();
+            Refresh(false);
+        }
     }
 }
 

--- a/tests/controls/richtextctrltest.cpp
+++ b/tests/controls/richtextctrltest.cpp
@@ -17,9 +17,16 @@
 
 #include "wx/richtext/richtextctrl.h"
 #include "wx/richtext/richtextstyles.h"
+#include "wx/uiaction.h"
+
+#if wxUSE_CLIPBOARD && wxUSE_DATAOBJ && !defined(__WXOSX__)
+    #include "wx/clipbrd.h"
+    #include "wx/dataobj.h"
+#endif // wxUSE_CLIPBOARD && wxUSE_DATAOBJ && !defined(__WXOSX__)
+
 #include "testableframe.h"
 #include "asserthelper.h"
-#include "wx/uiaction.h"
+#include "waitfor.h"
 
 class RichTextCtrlTestCase : public CppUnit::TestCase
 {
@@ -102,6 +109,37 @@ CPPUNIT_TEST_SUITE_REGISTRATION( RichTextCtrlTestCase );
 
 // also include in its own registry so that these tests can be run alone
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( RichTextCtrlTestCase, "RichTextCtrlTestCase" );
+
+#if wxUSE_CLIPBOARD && wxUSE_DATAOBJ && !defined(__WXOSX__)
+
+namespace
+{
+
+bool SetClipboardText(const wxString &text)
+{
+    wxClipboardLocker lock;
+
+    if ( !lock )
+        return false;
+
+    wxTheClipboard->Clear();
+    return wxTheClipboard->SetData(new wxTextDataObject(text));
+}
+
+bool ClipboardContainsText(const wxString &text)
+{
+    wxClipboardLocker lock;
+
+    if ( !lock )
+        return false;
+
+    wxTextDataObject data;
+    return wxTheClipboard->GetData(data) && data.GetText() == text;
+}
+
+} // anonymous namespace
+
+#endif // wxUSE_CLIPBOARD && wxUSE_DATAOBJ && !defined(__WXOSX__)
 
 void RichTextCtrlTestCase::setUp()
 {
@@ -258,33 +296,62 @@ void RichTextCtrlTestCase::TextEvent()
 
 void RichTextCtrlTestCase::CutCopyPaste()
 {
-#ifndef __WXOSX__
-    m_rich->AppendText("sometext");
+#if wxUSE_CLIPBOARD && wxUSE_DATAOBJ && !defined(__WXOSX__)
+    const wxString text("sometext");
+    const wxString sentinel("not sometext");
+
+    auto waitForPaste = [&]()
+    {
+        return WaitFor("wxRichTextCtrl paste clipboard update",
+                       [&]()
+                       {
+                           if ( m_rich->GetValue() == text )
+                               return true;
+
+                           m_rich->Paste();
+                           return m_rich->GetValue() == text;
+                       });
+    };
+
+    m_rich->AppendText(text);
     m_rich->SelectAll();
 
-    if(m_rich->CanCut() && m_rich->CanPaste())
+    REQUIRE(WaitFor("wxRichTextCtrl clipboard setup",
+                    [&]() { return SetClipboardText(sentinel); }));
+
+    if ( m_rich->CanCut() )
     {
-        m_rich->Cut();
+        REQUIRE(WaitFor("wxRichTextCtrl cut clipboard update",
+                        [&]()
+                        {
+                            m_rich->Cut();
+                            return m_rich->IsEmpty() &&
+                                   ClipboardContainsText(text);
+                        }));
         CPPUNIT_ASSERT(m_rich->IsEmpty());
 
-        wxYield();
-
-        m_rich->Paste();
-        CPPUNIT_ASSERT_EQUAL("sometext", m_rich->GetValue());
+        REQUIRE(waitForPaste());
+        CPPUNIT_ASSERT_EQUAL(text, m_rich->GetValue());
     }
 
     m_rich->SelectAll();
 
-    if(m_rich->CanCopy() && m_rich->CanPaste())
+    REQUIRE(WaitFor("wxRichTextCtrl clipboard setup",
+                    [&]() { return SetClipboardText(sentinel); }));
+
+    if ( m_rich->CanCopy() )
     {
-        m_rich->Copy();
+        REQUIRE(WaitFor("wxRichTextCtrl copy clipboard update",
+                        [&]()
+                        {
+                            m_rich->Copy();
+                            return ClipboardContainsText(text);
+                        }));
         m_rich->Clear();
         CPPUNIT_ASSERT(m_rich->IsEmpty());
 
-        wxYield();
-
-        m_rich->Paste();
-        CPPUNIT_ASSERT_EQUAL("sometext", m_rich->GetValue());
+        REQUIRE(waitForPaste());
+        CPPUNIT_ASSERT_EQUAL(text, m_rich->GetValue());
     }
 #endif
 }


### PR DESCRIPTION
Fall back to lower-priority clipboard formats if advertised rich text data can't actually be read, and only report paste success after data has been retrieved.

Also avoid deleting the selection from wxRichTextCtrl::Cut() unless it was successfully copied to the clipboard, and make the CutCopyPaste test verify clipboard contents before relying on them.

This *might* be a fix for the first issue, but the symptoms reported are slightly different.

Refs #18738
Refs #24120