### PR TITLE
Expose test_base test cases to CTest

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -933,7 +933,7 @@ endfunction()
 
 function(wx_add name group)
     cmake_parse_arguments(APP
-        "CONSOLE;CONSOLE_GUI;DLL;IMPORTANT"
+        "CONSOLE;CONSOLE_GUI;DLL;IMPORTANT;NO_CTEST"
         "NAME;FOLDER"
         "DATA;DEFINITIONS;DEPENDS;LIBRARIES;RES;RES_BUNDLE;PLIST;CHARSET"
         ${ARGN}
@@ -1118,7 +1118,7 @@ function(wx_add name group)
         VS_DEBUGGER_WORKING_DIRECTORY "${wxOUTPUT_DIR}/${wxPLATFORM_LIB_DIR}"
         )
 
-    if(group STREQUAL Tests)
+    if(group STREQUAL Tests AND NOT APP_NO_CTEST)
         add_test(NAME ${target_name}
             COMMAND ${target_name}
             WORKING_DIRECTORY "${wxOUTPUT_DIR}/${wxPLATFORM_LIB_DIR}")

--- a/build/cmake/tests/base/CMakeLists.txt
+++ b/build/cmake/tests/base/CMakeLists.txt
@@ -122,7 +122,9 @@ set(TEST_DATA
     testdata.conf
     )
 
-wx_add_test(test_base CONSOLE ${TEST_SRC}
+# Register test_base through Catch to get one CTest entry per Catch test case
+# instead of the default aggregate executable test.
+wx_add_test(test_base CONSOLE NO_CTEST ${TEST_SRC}
     DATA ${TEST_DATA}
     )
 target_compile_definitions(test_base PRIVATE TEST_HAS_IPC_SERVER)
@@ -132,3 +134,18 @@ endif()
 if(wxUSE_XML)
     wx_exe_link_libraries(test_base wxxml)
 endif()
+
+include("${wxSOURCE_DIR}/3rdparty/catch/contrib/Catch.cmake")
+catch_discover_tests(test_base
+    TEST_SPEC "~[.]" "~[ipc]"
+    TEST_LIST test_base_NON_IPC_TESTS
+    WORKING_DIRECTORY "${wxOUTPUT_DIR}/${wxPLATFORM_LIB_DIR}"
+    )
+catch_discover_tests(test_base
+    TEST_SPEC "~[.]" "[ipc]"
+    TEST_LIST test_base_IPC_TESTS
+    PROPERTIES
+        RESOURCE_LOCK test_base_ipc
+        TIMEOUT 180
+    WORKING_DIRECTORY "${wxOUTPUT_DIR}/${wxPLATFORM_LIB_DIR}"
+    )

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -493,10 +493,10 @@ TEST_CASE_METHOD(RequestFixture,
 
     Create("status/200");
     CHECK( request.IsOk() );
-    CHECK( session.GetNativeHandle() );
 
     // Note that the request must be started to have a valid native handle.
     request.Start();
+    CHECK( session.GetNativeHandle() );
     CHECK( request.GetNativeHandle() );
     RunLoopWithTimeout();
     CHECK( request.GetState() == wxWebRequest::State_Completed );

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -709,6 +709,20 @@ static void ShowTestInformation()
          << std::endl;
 }
 
+static bool IsCatchListCommandLine(const wxCmdLineArgsArray& argv)
+{
+    const wxArrayString& args = argv.GetArguments();
+
+    for ( size_t n = 1; n < args.GetCount(); ++n )
+    {
+        if ( args[n] == "--list-test-names-only" ||
+             args[n] == "--list-reporters" )
+            return true;
+    }
+
+    return false;
+}
+
 // Init
 //
 bool TestApp::OnInit()
@@ -724,8 +738,9 @@ bool TestApp::OnInit()
     // Hack: don't call TestAppBase::OnInit() to let CATCH handle command line.
 
     // Output some important information about the test environment unless
-    // we're running as a helper IPC server process.
-    if ( !ShouldRunTestIPCServer() )
+    // we're running as a helper IPC server process or producing machine-readable
+    // Catch discovery output.
+    if ( !ShouldRunTestIPCServer() && !IsCatchListCommandLine(argv) )
         ShowTestInformation();
 
     // Optionally allow executing the tests in the locale specified by the


### PR DESCRIPTION
Let wx_add() accept a NO_CTEST flag and use it for test_base, so the target can still be built normally without registering the old single aggregate CTest entry.

Use Catch's catch_discover_tests() to register the base test binary as individual CTest tests. Split normal tests from IPC tests so the IPC subset can carry a shared resource lock and a longer timeout.

Suppress the wxWidgets test-environment banner when Catch is listing test names or reporters. This keeps discovery output machine-readable while preserving the banner for real test runs.

---

Not sure how you feel about this one, so I've made it an isolated commit.  If we do this, then the tests in test_base can run in parallel and it reduces the total time to run all the tests.  It also helped me diagnose a bunch of race conditions that I've fixed (another PR coming for those isolated fixes) because I could get ctest to run specific tests with the ctest arguments and rerun failed tests directly from `ctest --rerun-failed --preset ....`

I only did this for test_base where it would be safe to run the tests in parallel; it's not practical to run the test_gui tests in parallel via ctest.  (This would launch one process per test case and they would all fight over the focus, clipboard, etc.)

I find this useful, but I'm not the one making the rules here `:)`.  No hard feelings if you don't want to use this approach.