### PR TITLE
Stabilize parallel CTest runs

### DIFF
--- a/build/cmake/tests/gui/CMakeLists.txt
+++ b/build/cmake/tests/gui/CMakeLists.txt
@@ -235,6 +235,13 @@ wx_add_test(test_gui ${APP_TYPE} ${TEST_GUI_SRC}
     DATA ${TEST_GUI_DATA}
     RES_BUNDLE ${TEST_GUI_RES_BUNDLE}
     )
+
+# wxUIActionSimulator uses global input state, so this test must not run
+# concurrently with other CTest processes.
+if(TEST test_gui)
+    set_tests_properties(test_gui PROPERTIES RUN_SERIAL TRUE)
+endif()
+
 if(wxUSE_AUI)
     wx_exe_link_libraries(test_gui wxaui)
 endif()

--- a/tests/archive/archivetest.cpp
+++ b/tests/archive/archivetest.cpp
@@ -302,7 +302,7 @@ private:
 ArchiveTempDir::ArchiveTempDir()
     : m_tmp(wxT("arctest-"))
 {
-    CHECK(m_tmp.IsOk());
+    m_tmp.RequireOk();
     m_original = wxGetCwd();
     CHECK(wxSetWorkingDirectory(m_tmp.GetName()));
 }

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -286,41 +286,105 @@ void TextCtrlTestCase::MaxLength()
 
     if ( m_style == wxTE_MULTILINE )
     {
-#if defined(__WXMSW__) || defined(__WXGTK3__) || defined(__WXQT__)
+#if wxUSE_CLIPBOARD && \
+        (defined(__WXMSW__) || defined(__WXGTK3__) || defined(__WXQT__))
         CreateText(wxTE_DONTWRAP);
         EventCounter maxlen(m_text.get(), wxEVT_TEXT_MAXLEN);
 
         m_text->SetMaxLength(250);
-        m_text->SetFocus();
-        wxYield();
+
+        auto clipboardContainsText = [](const wxString &text)
+        {
+            wxClipboardLocker lock;
+
+            if ( !lock )
+                return false;
+
+            wxTextDataObject data;
+            return wxTheClipboard->GetData(data) && data.GetText() == text;
+        };
+
+        auto setClipboardText = [&clipboardContainsText](const wxString &text)
+        {
+            REQUIRE(WaitFor("wxTextCtrl clipboard setup",
+                            [&]()
+                            {
+                                wxClipboardLocker lock;
+
+                                if ( !lock )
+                                    return false;
+
+                                wxTheClipboard->Clear();
+                                return wxTheClipboard->SetData(
+                                    new wxTextDataObject(text));
+                            }));
+            REQUIRE(WaitFor("wxTextCtrl clipboard update",
+                            [&]() { return clipboardContainsText(text); }));
+        };
+
+        auto waitForPaste =
+            [this](const char *what, const std::function<bool()> &pred)
+        {
+            const wxString valueBeforePaste = m_text->GetValue();
+            REQUIRE(WaitFor(what,
+                            [&]()
+                            {
+                                if ( pred() )
+                                    return true;
+
+                                if ( m_text->GetValue() == valueBeforePaste )
+                                    m_text->Paste();
+
+                                return pred();
+                            }));
+        };
 
         const wxString linePattern = MakeLinePattern();
 
         m_text->AppendText(linePattern);
-        m_text->SelectAll();
-        m_text->Copy();
+        setClipboardText(linePattern);
 
         m_text->SetInsertionPointEnd();
 
-        sim.Char(WXK_RETURN);
-        sim.Char('v', wxMOD_CONTROL); // Paste copied line.
-        wxYield();
+        // Use Paste() directly instead of simulating Ctrl+V: this still uses
+        // the native paste path, but avoids focus-dependent key delivery.
+        m_text->WriteText("\n");
+        waitForPaste("wxTextCtrl first paste",
+                     [&]()
+                     {
+                         return m_text->GetNumberOfLines() == 2 &&
+                                m_text->GetLineText(1) == linePattern;
+                     });
 
         CHECK(maxlen.GetCount() == 0);
 
         m_text->SetInsertionPointEnd();
 
-        sim.Char(WXK_RETURN);
+        m_text->WriteText("\n");
         wxYield();
 
-        sim.Char('v', wxMOD_CONTROL); // Paste copied line (2nd time).
-        WaitFor("wxTextCtrl update", [&]() { return maxlen.GetCount() != 0; });
+        waitForPaste("wxTextCtrl max length update",
+                     [&]()
+                     {
+                         if ( maxlen.GetCount() == 0 ||
+                              m_text->GetNumberOfLines() != 3 )
+                             return false;
+
+                         const int lineLength = m_text->GetLineText(2).length();
+                         return lineLength == 46 || lineLength == 48;
+                     });
 
         CHECK(maxlen.GetCount() == 1); // Maximum length reached.
         maxlen.Clear();
 
-        sim.Text("7"); // Should be rejected.
-        WaitFor("wxTextCtrl update", [&]() { return maxlen.GetCount() != 0; });
+        setClipboardText("7");
+        const wxString valueBeforeRejectedPaste = m_text->GetValue();
+        waitForPaste("wxTextCtrl rejected paste update",
+                     [&]()
+                     {
+                         return maxlen.GetCount() != 0 &&
+                                m_text->GetValue() == valueBeforeRejectedPaste;
+                     });
 
         CHECK(maxlen.GetCount() == 1);
         maxlen.Clear();
@@ -342,11 +406,20 @@ void TextCtrlTestCase::MaxLength()
 
         // Try to paste a long string into a shorter selection:
 
-        m_text->SetSelection(0, 20);  // selection is: 01234567890123456789
-        m_text->Copy();
+        // This test is about paste handling, so avoid depending on Copy().
+        setClipboardText(linePattern.Left(20));
         m_text->SetSelection(15, 21); // selection is: 567890
-        m_text->Paste(); // Only the first six characters can actually be pasted.
-        WaitFor("wxTextCtrl update", [&]() { return maxlen.GetCount() != 0; });
+        waitForPaste("wxTextCtrl selection paste update",
+                     [&]()
+                     {
+                         if ( maxlen.GetCount() == 0 )
+                             return false;
+
+                         const auto line = m_text->GetLineText(0);
+                         return line[15].GetValue() == '0' &&
+                                line[20].GetValue() == '5' &&
+                                line[21].GetValue() == '1';
+                     });
         const auto line = m_text->GetLineText(0);
         CHECK( (line[15].GetValue() == '0' &&
                          line[20].GetValue() == '5' &&
@@ -359,7 +432,7 @@ void TextCtrlTestCase::MaxLength()
         m_text->AppendText(wxString::Format("\n%s", linePattern));
         CHECK(m_text->GetNumberOfLines() == 4);
         CHECK(maxlen.GetCount() == 0);
-#endif // __WXMSW__ || __WXGTK3__ || __WXQT__
+#endif // wxUSE_CLIPBOARD && (__WXMSW__ || __WXGTK3__ || __WXQT__)
     }
     else // !wxTE_MULTILINE
     {

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -663,14 +663,14 @@ void TextCtrlTestCase::Url()
     m_text->AppendText("http://www.wxwidgets.org");
 
     wxUIActionSimulator sim;
-    sim.MouseMove(m_text->ClientToScreen(wxPoint(5, 5)));
+    REQUIRE(sim.MouseMove(m_text->ClientToScreen(wxPoint(5, 5))));
 
     EventCounter url(m_text.get(), wxEVT_TEXT_URL);
 
-    sim.MouseClick();
+    REQUIRE(sim.MouseClick());
     wxYield();
 
-    CHECK(url.GetCount() == 1);
+    CHECK(url.GetCount() >= 1);
 #endif
 }
 

--- a/tests/file/dir.cpp
+++ b/tests/file/dir.cpp
@@ -68,7 +68,7 @@ void DirTestCase::CreateTempFile(const wxString& path)
 DirTestCase::DirTestCase()
     : m_dirTestFolder("dirtest")
 {
-    CPPUNIT_ASSERT(m_dirTestFolder.IsOk());
+    m_dirTestFolder.RequireOk();
 
     const wxString& dirTestFolder = GetDirTestFolder();
 

--- a/tests/file/dir.cpp
+++ b/tests/file/dir.cpp
@@ -17,8 +17,9 @@
 #include "wx/filename.h"
 #include "wx/stdpaths.h"
 
-#define DIRTEST_FOLDER      wxString("dirTest_folder")
 #define SEP                 wxFileName::GetPathSeparator()
+
+#include "testfile.h"
 
 // We can't use wxFileSelectorDefaultWildcardStr from wxCore here, so define
 // our own.
@@ -46,6 +47,10 @@ protected:
                                int flags = wxDIR_DEFAULT,
                                const wxString& filespec = wxEmptyString);
 
+    const wxString& GetDirTestFolder() const { return m_dirTestFolder.GetName(); }
+
+    TempDir m_dirTestFolder;
+
     wxDECLARE_NO_COPY_CLASS(DirTestCase);
 };
 
@@ -61,26 +66,27 @@ void DirTestCase::CreateTempFile(const wxString& path)
 }
 
 DirTestCase::DirTestCase()
+    : m_dirTestFolder("dirtest")
 {
-    // create a test directory hierarchy
-    wxDir::Make(DIRTEST_FOLDER + SEP + "folder1" + SEP + "subfolder1", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-    wxDir::Make(DIRTEST_FOLDER + SEP + "folder1" + SEP + "subfolder2", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-    wxDir::Make(DIRTEST_FOLDER + SEP + "folder2", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-    wxDir::Make(DIRTEST_FOLDER + SEP + "folder3" + SEP + "subfolder1", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    CPPUNIT_ASSERT(m_dirTestFolder.IsOk());
 
-    CreateTempFile(DIRTEST_FOLDER + SEP + "folder1" + SEP + "subfolder2" + SEP + "dummy");
-    CreateTempFile(DIRTEST_FOLDER + SEP + "dummy");
-    CreateTempFile(DIRTEST_FOLDER + SEP + "folder3" + SEP + "subfolder1" + SEP + "dummy.foo");
-    CreateTempFile(DIRTEST_FOLDER + SEP + "folder3" + SEP + "subfolder1" + SEP + "dummy.foo.bar");
+    const wxString& dirTestFolder = GetDirTestFolder();
+
+    // create a test directory hierarchy
+    wxDir::Make(dirTestFolder + SEP + "folder1" + SEP + "subfolder1", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    wxDir::Make(dirTestFolder + SEP + "folder1" + SEP + "subfolder2", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    wxDir::Make(dirTestFolder + SEP + "folder2", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    wxDir::Make(dirTestFolder + SEP + "folder3" + SEP + "subfolder1", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+    CreateTempFile(dirTestFolder + SEP + "folder1" + SEP + "subfolder2" + SEP + "dummy");
+    CreateTempFile(dirTestFolder + SEP + "dummy");
+    CreateTempFile(dirTestFolder + SEP + "folder3" + SEP + "subfolder1" + SEP + "dummy.foo");
+    CreateTempFile(dirTestFolder + SEP + "folder3" + SEP + "subfolder1" + SEP + "dummy.foo.bar");
 }
 
 DirTestCase::~DirTestCase()
 {
-    wxRemove(DIRTEST_FOLDER + SEP + "folder1" + SEP + "subfolder2" + SEP + "dummy");
-    wxRemove(DIRTEST_FOLDER + SEP + "dummy");
-    wxRemove(DIRTEST_FOLDER + SEP + "folder3" + SEP + "subfolder1" + SEP + "dummy.foo");
-    wxRemove(DIRTEST_FOLDER + SEP + "folder3" + SEP + "subfolder1" + SEP + "dummy.foo.bar");
-    wxDir::Remove(DIRTEST_FOLDER, wxPATH_RMDIR_RECURSIVE);
+    m_dirTestFolder.Remove();
 }
 
 wxArrayString DirTestCase::DirEnumHelper(wxDir& dir,
@@ -107,7 +113,7 @@ wxArrayString DirTestCase::DirEnumHelper(wxDir& dir,
 
 TEST_CASE_METHOD(DirTestCase, "Dir::Enum", "[dir]")
 {
-    wxDir dir(DIRTEST_FOLDER);
+    wxDir dir(GetDirTestFolder());
     CHECK( dir.IsOpened() );
 
     // enumerating everything in test directory
@@ -151,30 +157,32 @@ public:
 
 TEST_CASE_METHOD(DirTestCase, "Dir::Traverse", "[dir]")
 {
+    const wxString& dirTestFolder = GetDirTestFolder();
+
     // enum all files
     wxArrayString files;
-    CHECK( wxDir::GetAllFiles(DIRTEST_FOLDER, &files) == 4 );
+    CHECK( wxDir::GetAllFiles(dirTestFolder, &files) == 4 );
 
     // enum all files using an explicit wildcard
-    CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, WILDCARD_ALL) == 4);
+    CHECK(wxDir::GetAllFiles(dirTestFolder, &files, WILDCARD_ALL) == 4);
 
     // enum all files using an explicit wildcard different from WILDCARD_ALL
     //
     // broken under Wine, see https://bugs.winehq.org/show_bug.cgi?id=55677
     if ( !wxIsRunningUnderWine() )
     {
-        CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "d" + WILDCARD_ALL) == 4);
+        CHECK(wxDir::GetAllFiles(dirTestFolder, &files, "d" + WILDCARD_ALL) == 4);
     }
-    else if (wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "d" + WILDCARD_ALL) == 4)
+    else if (wxDir::GetAllFiles(dirTestFolder, &files, "d" + WILDCARD_ALL) == 4)
     {
         WARN("PathMatchSpec() seems to work under Wine now");
     }
 
     // enum all files according to the filter
-    CHECK( wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "*.foo") == 1 );
+    CHECK( wxDir::GetAllFiles(dirTestFolder, &files, "*.foo") == 1 );
 
     // enum again with custom traverser
-    wxDir dir(DIRTEST_FOLDER);
+    wxDir dir(dirTestFolder);
     TestDirTraverser traverser;
     dir.Traverse(traverser, wxEmptyString, wxDIR_DIRS | wxDIR_HIDDEN);
     CHECK( traverser.dirs.size() == 6 );

--- a/tests/file/filefn.cpp
+++ b/tests/file/filefn.cpp
@@ -19,6 +19,7 @@
 #include "wx/filefn.h"
 #include "wx/textfile.h"
 #include "wx/filesys.h"
+#include "wx/utils.h"
 
 #include "testfile.h"
 
@@ -45,6 +46,7 @@ protected:
                       const wxString& filePath2,
                       const wxString& destFilePath);
 
+    TempDir m_tempDir;
     wxString m_fileNameASCII;
     wxString m_fileNameNonASCII;
     wxString m_fileNameWork;
@@ -56,37 +58,35 @@ protected:
 // test fixture implementation
 // ----------------------------------------------------------------------------
 
-FileFunctionsTestCase::FileFunctionsTestCase()
+static wxString GetFileFunctionsTempDirPrefix()
 {
+    // Put the varying part first because MSW uses the leading prefix
+    // characters for temporary names.
+    return wxString::Format("%03lx-filefn", wxGetProcessId() & 0xfff);
+}
+
+FileFunctionsTestCase::FileFunctionsTestCase()
+    : m_tempDir(GetFileFunctionsTempDirPrefix())
+{
+    CPPUNIT_ASSERT(m_tempDir.IsOk());
+
     // Initialize local data
 
-    wxFileName fn1(wxFileName::GetTempDir(), wxT("wx_file_mask.txt"));
+    wxFileName fn1(m_tempDir.GetName(), "wx_file_mask.txt");
     m_fileNameASCII = fn1.GetFullPath();
 
     // This file name is 'wx_file_mask.txt' in Russian.
-    wxFileName fn2(wxFileName::GetTempDir(),
+    wxFileName fn2(m_tempDir.GetName(),
       wxT("wx_\u043C\u0430\u0441\u043A\u0430_\u0444\u0430\u0439\u043B\u0430.txt"));
     m_fileNameNonASCII = fn2.GetFullPath();
 
-    wxFileName fn3(wxFileName::GetTempDir(), wxT("wx_test_copy"));
+    wxFileName fn3(m_tempDir.GetName(), "wx_test_copy");
     m_fileNameWork = fn3.GetFullPath();
 }
 
 FileFunctionsTestCase::~FileFunctionsTestCase()
 {
-    // Remove all remaining temporary files
-    if ( wxFileExists(m_fileNameASCII) )
-    {
-        wxRemoveFile(m_fileNameASCII);
-    }
-    if ( wxFileExists(m_fileNameNonASCII) )
-    {
-        wxRemoveFile(m_fileNameNonASCII);
-    }
-    if ( wxFileExists(m_fileNameWork) )
-    {
-        wxRemoveFile(m_fileNameWork);
-    }
+    m_tempDir.Remove();
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/file/filefn.cpp
+++ b/tests/file/filefn.cpp
@@ -68,7 +68,7 @@ static wxString GetFileFunctionsTempDirPrefix()
 FileFunctionsTestCase::FileFunctionsTestCase()
     : m_tempDir(GetFileFunctionsTempDirPrefix())
 {
-    CPPUNIT_ASSERT(m_tempDir.IsOk());
+    m_tempDir.RequireOk();
 
     // Initialize local data
 

--- a/tests/file/filetest.cpp
+++ b/tests/file/filetest.cpp
@@ -16,6 +16,9 @@
 #if wxUSE_FILE
 
 #include "wx/file.h"
+#include "wx/filefn.h"
+#include "wx/filename.h"
+#include "wx/scopeguard.h"
 
 #include "testfile.h"
 
@@ -100,6 +103,17 @@ static void CheckFileContents(const wxString& name, const wxString& data)
     CHECK( s == data );
 }
 
+static bool RemoveTempPath(const wxString& path)
+{
+    if ( wxDirExists(path) )
+        return wxFileName::Rmdir(path, wxPATH_RMDIR_RECURSIVE);
+
+    if ( wxFileExists(path) )
+        return wxRemoveFile(path);
+
+    return true;
+}
+
 TEST_CASE("wxTempFile", "[file][temp]")
 {
     constexpr const char* name = "wxtemp_test";
@@ -151,6 +165,88 @@ TEST_CASE("wxTempFile", "[file][temp]")
     CHECK( tmpFile.Commit() );
 
     CheckFileContents(name, dataNew);
+}
+
+TEST_CASE("TempDir", "[file][temp]")
+{
+    SECTION("Create")
+    {
+        TempDir dir("wxtest-tempdir");
+        dir.RequireOk();
+        CHECK( wxDirExists(dir.GetName()) );
+        CHECK( dir.GetError().empty() );
+    }
+
+    SECTION("RetryExistingFile")
+    {
+        const wxString prefix = "wxtest-tempdir-file";
+        const unsigned long nameId = TempDir::ReserveNameId();
+        const wxString firstPath = TempDir::GetCandidateName(prefix, nameId, 0);
+        const wxString secondPath =
+            TempDir::GetCandidateName(prefix, nameId, 1);
+
+        REQUIRE( RemoveTempPath(firstPath) );
+        REQUIRE( RemoveTempPath(secondPath) );
+        wxON_BLOCK_EXIT1(RemoveTempPath, firstPath);
+        wxON_BLOCK_EXIT1(RemoveTempPath, secondPath);
+
+        {
+            wxFile file(firstPath, wxFile::write);
+            REQUIRE( file.IsOpened() );
+            REQUIRE( file.Close() );
+        }
+
+        TempDir dir(prefix, nameId);
+        dir.RequireOk();
+        CHECK( dir.GetName() == secondPath );
+        CHECK( wxFileExists(firstPath) );
+        CHECK( wxDirExists(secondPath) );
+        CHECK( dir.GetError().empty() );
+    }
+
+    SECTION("RetryExistingDir")
+    {
+        const wxString prefix = "wxtest-tempdir-dir";
+        const unsigned long nameId = TempDir::ReserveNameId();
+        const wxString firstPath = TempDir::GetCandidateName(prefix, nameId, 0);
+        const wxString secondPath =
+            TempDir::GetCandidateName(prefix, nameId, 1);
+
+        REQUIRE( RemoveTempPath(firstPath) );
+        REQUIRE( RemoveTempPath(secondPath) );
+        wxON_BLOCK_EXIT1(RemoveTempPath, firstPath);
+        wxON_BLOCK_EXIT1(RemoveTempPath, secondPath);
+
+        REQUIRE( wxMkdir(firstPath) );
+
+        TempDir dir(prefix, nameId);
+        dir.RequireOk();
+        CHECK( dir.GetName() == secondPath );
+        CHECK( wxDirExists(firstPath) );
+        CHECK( wxDirExists(secondPath) );
+        CHECK( dir.GetError().empty() );
+    }
+
+    SECTION("BadParent")
+    {
+        TempDir parent("wxtest-tempdir-parent");
+        parent.RequireOk();
+
+        const wxString parentFile =
+            wxFileName(parent.GetName(), "file").GetFullPath();
+
+        {
+            wxFile file(parentFile, wxFile::write);
+            REQUIRE( file.IsOpened() );
+            REQUIRE( file.Close() );
+        }
+
+        TempDir dir(wxFileName(parentFile, "child").GetFullPath());
+        CHECK_FALSE( dir.IsOk() );
+        CHECK( dir.GetName().empty() );
+        CHECK( dir.GetError().Contains("wxMkdir failed for") );
+        CHECK( dir.GetError().Contains(parentFile) );
+    }
 }
 
 #ifdef __LINUX__

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -747,7 +747,7 @@ TEST_CASE("wxFileName::Exists", "[filename]")
 #endif // __LINUX__
 #ifndef __VMS
     TempDir socktempdir("socktmpdir");
-    REQUIRE(socktempdir.IsOk());
+    socktempdir.RequireOk();
     wxFileName sockfilename(socktempdir.GetName(), "socket");
     wxString sockfile = sockfilename.GetFullPath();
     wxTCPServer server;
@@ -892,7 +892,7 @@ TEST_CASE("wxFileName::SameAs", "[filename]")
 
 #if defined(__UNIX__)
     TempDir tempdir("wxfn");
-    REQUIRE(tempdir.IsOk());
+    tempdir.RequireOk();
 
     wxFileName tempdir1fn;
     tempdir1fn.AssignDir(tempdir.GetName());
@@ -927,7 +927,7 @@ TEST_CASE("wxFileName::SameAs", "[filename]")
 TEST_CASE("wxFileName::Symlinks", "[filename]")
 {
     TempDir tempdirRoot("filenametest");
-    REQUIRE(tempdirRoot.IsOk());
+    tempdirRoot.RequireOk();
 
     const wxString tmpdir(wxFileName::GetTempDir());
     wxFileName tmpfn(wxFileName::DirName(tmpdir));

--- a/tests/fswatcher/fswatchertest.cpp
+++ b/tests/fswatcher/fswatchertest.cpp
@@ -133,7 +133,7 @@ public:
             return ms_watchDir;
 
         ms_watchDirData.reset(new TempDir("fswatcher_test"));
-        REQUIRE(ms_watchDirData->IsOk());
+        ms_watchDirData->RequireOk();
 
         TestLogEnabler enableLogs;
         ms_watchDir.AssignDir(ms_watchDirData->GetName());

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -247,7 +247,7 @@ public:
     TranslationsTestCatalogs()
         : m_prefix("wxintltest-")
     {
-        REQUIRE(m_prefix.IsOk());
+        m_prefix.RequireOk();
 
         CopyCatalog("en_GB");
         CopyCatalog("fr");

--- a/tests/testfile.h
+++ b/tests/testfile.h
@@ -12,7 +12,10 @@
 #include "wx/file.h"
 #include "wx/filefn.h"
 #include "wx/filename.h"
+#include "wx/log.h"
+#include "wx/utils.h"
 
+#include <atomic>
 #include <ostream>
 
 // define stream inserter for wxFileName to use it in Catch assertions
@@ -78,14 +81,72 @@ private:
 class TempDir
 {
 public:
-    explicit TempDir(const wxString& prefix = wxT("wxtest"))
+    static unsigned long ReserveNameId()
     {
-        m_name = wxFileName::CreateTempFileName(prefix);
-        if ( !m_name.empty() )
+        // Keep each TempDir construction on a distinct name sequence.
+        static std::atomic<unsigned long> s_nextId(0);
+        return s_nextId.fetch_add(1) + 1;
+    }
+
+    static wxString GetCandidateName(const wxString& prefix,
+                                     unsigned long nameId, unsigned int num)
+    {
+        wxString dir;
+        wxString name;
+        wxString ext;
+        wxFileName::SplitPath(prefix, &dir, &name, &ext);
+
+        if ( dir.empty() )
+            dir = wxFileName::GetTempDir();
+
+        if ( name.empty() )
+            name = wxT("wxtest");
+
+        if ( !ext.empty() )
+            name << "." << ext;
+
+        const wxString candidateName = wxString::Format(
+            "%s%lx-%lx-%03u", name, wxGetProcessId(), nameId, num);
+        return wxFileName(dir, candidateName).GetFullPath();
+    }
+
+    explicit TempDir(const wxString& prefix = wxT("wxtest"))
+        : TempDir(prefix, ReserveNameId())
+    {
+    }
+
+    TempDir(const wxString& prefix, unsigned long nameId)
+    {
+        // Make directory creation itself reserve the name.  Creating a temp
+        // file and replacing it with a directory opens a race after deletion.
+        static const unsigned int maxTries = 1000;
+        for ( unsigned int n = 0; n < maxTries; ++n )
         {
-            if ( !wxRemoveFile(m_name) || !wxMkdir(m_name) )
-                m_name.clear();
+            m_name = GetCandidateName(prefix, nameId, n);
+
+            unsigned long err;
+            {
+                wxLogNull noLog;
+                if ( wxMkdir(m_name) )
+                {
+                    m_error.clear();
+                    return;
+                }
+
+                // Capture the failure before Exists() below can change it.
+                err = wxSysErrorCode();
+            }
+
+            SetMkdirError(m_name, err);
+
+            if ( wxFileName::Exists(m_name) )
+                continue;
+
+            m_name.clear();
+            return;
         }
+
+        m_name.clear();
     }
 
     ~TempDir() { Remove(); }
@@ -95,7 +156,20 @@ public:
         return !m_name.empty();
     }
 
+    void RequireOk() const
+    {
+        if ( !IsOk() )
+        {
+            const wxString msg =
+                m_error.empty() ? wxString("TempDir creation failed") : m_error;
+            UNSCOPED_INFO(msg);
+        }
+
+        REQUIRE(IsOk());
+    }
+
     const wxString& GetName() const { return m_name; }
+    const wxString& GetError() const { return m_error; }
 
     bool Remove()
     {
@@ -112,7 +186,15 @@ public:
     void Dismiss() { m_name.clear(); }
 
 private:
+    void SetMkdirError(const wxString& path, unsigned long err)
+    {
+        m_error = wxString::Format("wxMkdir failed for \"%s\": %s",
+                                   path,
+                                   wxSysErrorMsgStr(err));
+    }
+
     wxString m_name;
+    wxString m_error;
 
     wxDECLARE_NO_COPY_CLASS(TempDir);
 };


### PR DESCRIPTION
## Summary

- Run `test_gui` serially under CTest because `wxUIActionSimulator` can use global input state.
- Give wxDir and FileFunctions tests per-test temporary workspaces to avoid collisions after Catch test-case discovery.
- Make the test `TempDir` helper create directories atomically with `wxMkdir()` instead of replacing a temporary file.
- Stabilize wxTextCtrl MaxLength and URL tests by avoiding focus-sensitive synthetic paste timing and accepting multiple rich edit URL events.

## Notes

No open issue appears to be directly fixed by this branch. Issue #16370 is related to temporary directory creation, but this branch only fixes the private test helper.