### PR TITLE
Fix crash in wxWebView Edge backend due to dangling callbacks

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -15,6 +15,7 @@
 #endif
 #include "wx/msw/private/comptr.h"
 
+#include <memory>
 #include <unordered_map>
 
 #include <WebView2.h>
@@ -76,6 +77,9 @@ public:
 
     wxWebViewEdge* m_ctrl;
     wxWebViewConfiguration m_config;
+
+    // set false in dtor, checked by pending creation callbacks, see #26491
+    std::shared_ptr<bool> m_alive{ std::make_shared<bool>(true) };
 
     wxCOMPtr<ICoreWebView2Environment> m_webViewEnvironment;
     wxCOMPtr<ICoreWebView2_2> m_webView;

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -32,7 +32,7 @@
 #include "wx/msw/private/webview_edge.h"
 #include "wx/msw/private/comstream.h"
 
-#include <utility>
+#include <algorithm>
 
 #ifdef __VISUALC__
 #include <wrl/event.h>
@@ -317,7 +317,7 @@ public:
     {
         if (!m_webViewEnvironment)
         {
-            m_webViewsWaitingForEnvironment.push_back({ impl->m_alive, impl });
+            m_webViewsWaitingForEnvironment.push_back(impl);
 
             // keep us alive until the completion handler below runs, see #26491
             wxWebViewConfiguration keepAlive = impl->m_config;
@@ -346,21 +346,37 @@ public:
         }
     }
 
+    // Called from wxWebViewEdgeImpl dtor to ensure that we don't try to use a
+    // WebView which had been destroyed while waiting for the environment
+    // creation to complete, see #26491.
+    void RemoveWaitingForEnvironment(wxWebViewEdgeImpl* impl)
+    {
+        m_webViewsWaitingForEnvironment.erase(
+            std::remove(
+                m_webViewsWaitingForEnvironment.begin(),
+                m_webViewsWaitingForEnvironment.end(),
+                impl
+            ),
+            m_webViewsWaitingForEnvironment.end()
+        );
+    }
+
     HRESULT OnEnvironmentCreated(HRESULT WXUNUSED(result), ICoreWebView2Environment* environment)
     {
         m_webViewEnvironment = environment;
-        for (auto& waiting : m_webViewsWaitingForEnvironment)
-        {
-            if (*waiting.first) // still alive?
-                waiting.second->EnvironmentAvailable(m_webViewEnvironment);
-        }
+
+        // Note that EnvironmentAvailable() doesn't run any user code and so
+        // can't destroy any of the WebViews here, i.e. it can't modify the
+        // vector we're iterating over.
+        for (auto impl : m_webViewsWaitingForEnvironment)
+            impl->EnvironmentAvailable(m_webViewEnvironment);
+
         m_webViewsWaitingForEnvironment.clear();
         return S_OK;
     }
 
     static wxString ms_browserExecutableDir;
-    std::vector<std::pair<std::shared_ptr<bool>, wxWebViewEdgeImpl*>>
-        m_webViewsWaitingForEnvironment;
+    std::vector<wxWebViewEdgeImpl*> m_webViewsWaitingForEnvironment;
     wxCOMPtr<ICoreWebView2EnvironmentOptions> m_webViewEnvironmentOptions;
     wxCOMPtr<ICoreWebView2Environment> m_webViewEnvironment;
     wxString m_dataPath;
@@ -474,6 +490,13 @@ wxWebViewEdgeImpl::wxWebViewEdgeImpl(wxWebViewEdge* webview) :
 wxWebViewEdgeImpl::~wxWebViewEdgeImpl()
 {
     *m_alive = false;
+
+    // If we're still waiting for the environment creation to complete, we must
+    // not be notified about it any more.
+    auto* const config =
+        static_cast<wxWebViewConfigurationImplEdge*>(m_config.GetImpl());
+    if (config)
+        config->RemoveWaitingForEnvironment(this);
 
     if (m_webView)
     {

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -32,6 +32,8 @@
 #include "wx/msw/private/webview_edge.h"
 #include "wx/msw/private/comstream.h"
 
+#include <utility>
+
 #ifdef __VISUALC__
 #include <wrl/event.h>
 using namespace Microsoft::WRL;
@@ -315,13 +317,20 @@ public:
     {
         if (!m_webViewEnvironment)
         {
-            m_webViewsWaitingForEnvironment.push_back(impl);
+            m_webViewsWaitingForEnvironment.push_back({ impl->m_alive, impl });
+
+            // keep us alive until the completion handler below runs, see #26491
+            wxWebViewConfiguration keepAlive = impl->m_config;
             HRESULT hr = wxCreateCoreWebView2EnvironmentWithOptions(
                 ms_browserExecutableDir.wc_str(),
                 GetDataPath().wc_str(),
                 m_webViewEnvironmentOptions,
-                Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(this,
-                    &wxWebViewConfigurationImplEdge::OnEnvironmentCreated).Get());
+                Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
+                    [this, keepAlive]
+                    (HRESULT result, ICoreWebView2Environment* env) -> HRESULT
+                    {
+                        return OnEnvironmentCreated(result, env);
+                    }).Get());
             if (FAILED(hr))
             {
                 wxLogApiError("CreateWebView2EnvironmentWithOptions", hr);
@@ -340,14 +349,18 @@ public:
     HRESULT OnEnvironmentCreated(HRESULT WXUNUSED(result), ICoreWebView2Environment* environment)
     {
         m_webViewEnvironment = environment;
-        for (auto impl : m_webViewsWaitingForEnvironment)
-            impl->EnvironmentAvailable(m_webViewEnvironment);
+        for (auto& waiting : m_webViewsWaitingForEnvironment)
+        {
+            if (*waiting.first) // still alive?
+                waiting.second->EnvironmentAvailable(m_webViewEnvironment);
+        }
         m_webViewsWaitingForEnvironment.clear();
         return S_OK;
     }
 
     static wxString ms_browserExecutableDir;
-    std::vector<wxWebViewEdgeImpl*> m_webViewsWaitingForEnvironment;
+    std::vector<std::pair<std::shared_ptr<bool>, wxWebViewEdgeImpl*>>
+        m_webViewsWaitingForEnvironment;
     wxCOMPtr<ICoreWebView2EnvironmentOptions> m_webViewEnvironmentOptions;
     wxCOMPtr<ICoreWebView2Environment> m_webViewEnvironment;
     wxString m_dataPath;
@@ -460,6 +473,8 @@ wxWebViewEdgeImpl::wxWebViewEdgeImpl(wxWebViewEdge* webview) :
 
 wxWebViewEdgeImpl::~wxWebViewEdgeImpl()
 {
+    *m_alive = false;
+
     if (m_webView)
     {
         m_webView->remove_NavigationCompleted(m_navigationCompletedToken);
@@ -498,6 +513,18 @@ void wxWebViewEdgeImpl::EnvironmentAvailable(ICoreWebView2Environment* environme
 {
     environment->QueryInterface(IID_PPV_ARGS(&m_webViewEnvironment));
     wxCOMPtr<ICoreWebView2Environment10> environment10;
+
+    // guard against completing after we're destroyed, see #26491
+    std::shared_ptr<bool> alive = m_alive;
+    auto onWebViewCreated =
+        [this, alive]
+        (HRESULT result, ICoreWebView2Controller* controller) -> HRESULT
+        {
+            if (!*alive)
+                return S_OK;
+            return OnWebViewCreated(result, controller);
+        };
+
     if (SUCCEEDED(m_webViewEnvironment->QueryInterface(IID_PPV_ARGS(&environment10))))
     {
         wxCOMPtr<ICoreWebView2ControllerOptions> controllerOptions;
@@ -510,14 +537,14 @@ void wxWebViewEdgeImpl::EnvironmentAvailable(ICoreWebView2Environment* environme
                 m_ctrl->GetHWND(),
                 controllerOptions.get(),
                 Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
-                    this, &wxWebViewEdgeImpl::OnWebViewCreated).Get());
+                    onWebViewCreated).Get());
         }
     }
     else
         m_webViewEnvironment->CreateCoreWebView2Controller(
             m_ctrl->GetHWND(),
             Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
-                this, &wxWebViewEdgeImpl::OnWebViewCreated).Get());
+                onWebViewCreated).Get());
 }
 
 bool wxWebViewEdgeImpl::Initialize()


### PR DESCRIPTION
The creation of wxWebView instances with the Edge backend involves async callbacks.  If a WebView instance is created and then destroyed before the callback completes, the callback is left with a dangling pointer. Fix this by using a std::shared_ptr<bool> to indicate whether the instance is still alive.  If it is not, abort the callback instead of crashing.

Fixes: https://github.com/wxWidgets/wxWidgets/issues/26491