### PR TITLE
Use ShutdownBlockReasonCreate() in wxPowerResource in wxMSW (#25670)

### DIFF
--- a/include/wx/msw/private/power.h
+++ b/include/wx/msw/private/power.h
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/msw/private/power.h
+// Purpose:     Private helpers for MSW power resource blocker
+// Author:      merhoumTaki
+// Created:     2026-08-18
+// Copyright:   (c) 2026 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_MSW_PRIVATE_POWER_H_
+#define _WX_MSW_PRIVATE_POWER_H_
+
+// Updates shutdown block reason for top-level MSW windows.
+bool wxMSWUpdateShutdownBlockReason();
+
+// Returns true if a system power resource block is currently active.
+bool wxMSWPowerResourceIsSystemBlockActive();
+
+#endif // _WX_MSW_PRIVATE_POWER_H_

--- a/src/msw/power.cpp
+++ b/src/msw/power.cpp
@@ -25,6 +25,7 @@
 #include "wx/power.h"
 #include "wx/atomic.h"
 #include "wx/msw/private.h"
+#include "wx/msw/private/power.h"
 
 // ----------------------------------------------------------------------------
 // wxPowerResource
@@ -35,6 +36,7 @@ namespace
 
 wxAtomicInt g_powerResourceScreenRefCount = 0;
 wxAtomicInt g_powerResourceSystemRefCount = 0;
+wxString g_powerResourceSystemReason;
 
 bool UpdatePowerResourceExecutionState()
 {
@@ -58,7 +60,7 @@ bool UpdatePowerResourceExecutionState()
 
 bool
 wxPowerResource::Acquire(wxPowerResourceKind kind,
-                         const wxString& WXUNUSED(reason),
+                         const wxString& reason,
                          wxPowerBlockKind blockKind)
 {
     if ( blockKind == wxPOWER_DELAY )
@@ -75,6 +77,11 @@ wxPowerResource::Acquire(wxPowerResourceKind kind,
 
         case wxPOWER_RESOURCE_SYSTEM:
             wxAtomicInc(g_powerResourceSystemRefCount);
+            if ( !reason.empty() )
+            {
+                g_powerResourceSystemReason = reason;
+                wxMSWUpdateShutdownBlockReason();
+            }
             break;
     }
 
@@ -100,6 +107,11 @@ void wxPowerResource::Release(wxPowerResourceKind kind)
             if ( g_powerResourceSystemRefCount > 0 )
             {
                 wxAtomicDec(g_powerResourceSystemRefCount);
+                if ( g_powerResourceSystemRefCount == 0 )
+                {
+                    g_powerResourceSystemReason.clear();
+                    wxMSWUpdateShutdownBlockReason();
+                }
             }
             else
             {
@@ -125,6 +137,29 @@ static inline bool wxGetPowerStatus(SYSTEM_POWER_STATUS *sps)
     }
 
     return true;
+}
+
+bool wxMSWUpdateShutdownBlockReason()
+{
+    for ( wxWindow* win : wxTopLevelWindows )
+    {
+        HWND hwnd = GetHwndOf(win);
+        if ( g_powerResourceSystemRefCount > 0 )
+        {
+            ::ShutdownBlockReasonCreate(hwnd,
+                g_powerResourceSystemReason.wc_str());
+        }
+        else
+        {
+            ::ShutdownBlockReasonDestroy(hwnd);
+        }
+    }
+    return true;
+}
+
+bool wxMSWPowerResourceIsSystemBlockActive()
+{
+    return g_powerResourceSystemRefCount > 0;
 }
 
 // ============================================================================

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -79,6 +79,7 @@
 #include "wx/msw/private/keyboard.h"
 #include "wx/msw/private/metrics.h"
 #include "wx/msw/private/paint.h"
+#include "wx/msw/private/power.h"
 #include "wx/msw/private/winstyle.h"
 #include "wx/msw/dcclient.h"
 #include "wx/msw/seh.h"
@@ -4311,6 +4312,15 @@ bool wxWindowMSW::HandleQueryEndSession(long logOff, bool *mayEnd)
 {
     if ( gs_queryEndSession == QueryEndSession::Unknown )
     {
+        if ( (logOff & ENDSESSION_LOGOFF) == 0 &&
+             wxMSWPowerResourceIsSystemBlockActive() )
+        {
+            wxMSWUpdateShutdownBlockReason();
+            gs_queryEndSession = QueryEndSession::Veto;
+            *mayEnd = false;
+            return true;
+        }
+
         // Make sure we won't generate another wxEVT_QUERY_END_SESSION.
         gs_queryEndSession = QueryEndSession::Allow;
 


### PR DESCRIPTION
Fixes #25670

### Summary
This PR integrates `ShutdownBlockReasonCreate()` and `ShutdownBlockReasonDestroy()` into `wxPowerResource` on MSW to provide Windows with a human-readable reason when shutdown is prevented, and automatically vetoes session termination while system power resources are active.

### Changes
1. **`src/msw/power.cpp`**: 
   - Added `wxMSWUpdateShutdownBlockReason()` to call `ShutdownBlockReasonCreate()` or `ShutdownBlockReasonDestroy()` across `wxTopLevelWindows` when `wxPOWER_RESOURCE_SYSTEM` is acquired or released.
   -Create `g_powerResourceSystemReason` to stored the reason string passed to `wxPowerResource::Acquire()`.
2. **`src/msw/window.cpp`**:
   - Updated `wxWindowMSW::HandleQueryEndSession()` to automatically veto `WM_QUERYENDSESSION` if `wxMSWPowerResourceIsSystemBlockActive()` returns true and the session query is not a logoff `(logOff & ENDSESSION_LOGOFF) == 0`.
3. **`include/wx/msw/private.h`**:
   - Declared global MSW helper functions.

### Testing
Tested with `samples/power` on Windows. When starting a long-running task and attempting to shut down, Windows successfully displays the block reason UI with the string "Waiting for long task to finish".