### PR TITLE
Remove unnecessary `#include "wx/settings.h"`

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -12,8 +12,6 @@
 #ifndef _WX_WINDOW_H_
 #define _WX_WINDOW_H_
 
-#include "wx/settings.h"        // solely for wxSystemColour
-
 class WXDLLIMPEXP_FWD_CORE wxButton;
 
 // if this is set to 1, we use deferred window sizing to reduce flicker when


### PR DESCRIPTION
"solely for wxSystemColour", but `wxSystemColour` is not used here anymore.

A side effect of this `#include` was that `wxSystemColour`, `wxSystemSettings`, etc. were available by #including nearly any wx header, but only on MSW. Someone's code may fail to compile by removing this, but again, such code would only have compiled on MSW.