### PR TITLE
MSW: Use GetBorderPen() rather than hard-coded color for dark mode border

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3931,9 +3931,8 @@ void wxWindowMSW::MSWDrawThemeBorder(WXHDC hdc)
     {
         // There does not seem to be a theme class that draws a good
         // border on all supported versions of Windows. Manually draw a
-        // 1-pixel thick border. Use the observed colour of the simple
-        // border, WS_BORDER.
-        AutoHBRUSH brushBorder(0x646464);
+        // 1-pixel thick border.
+        AutoHBRUSH brushBorder(wxMSWDarkMode::GetBorderPen().GetColour().GetPixel());
         ::FrameRect(hdc, &rcBorder, brushBorder);
         // Draw the background with consecutively smaller 1-pixel thick
         // rectangles.


### PR DESCRIPTION
Use `wxMSWDarkMode::GetBorderPen()` in `wxWindowMSW::MSWDrawThemeBorder()` rather than a hard-coded color. This respects end user customization when `GetBorderPen()` is overridden.