### PR TITLE
Allow to use wxGTK with GTK+3.0 being initialized already

### DIFF
--- a/include/wx/gtk/app.h
+++ b/include/wx/gtk/app.h
@@ -46,13 +46,11 @@ public:
     // GTK-specific methods
     // -------------------
 
-#ifndef __WXGTK3__
     // this can be overridden to return a specific visual to be used for GTK+
     // instead of the default one (it's used by wxGLApp)
     //
     // must return XVisualInfo pointer (it is not freed by caller)
     virtual void *GetXVisualInfo() { return nullptr; }
-#endif // GTK < 3
 
     // Check if we're using a global menu. Currently this is only true when
     // running under Ubuntu Unity and global menu is not disabled.

--- a/include/wx/gtk/app.h
+++ b/include/wx/gtk/app.h
@@ -46,11 +46,13 @@ public:
     // GTK-specific methods
     // -------------------
 
+#ifndef __WXGTK3__
     // this can be overridden to return a specific visual to be used for GTK+
     // instead of the default one (it's used by wxGLApp)
     //
     // must return XVisualInfo pointer (it is not freed by caller)
     virtual void *GetXVisualInfo() { return nullptr; }
+#endif // GTK < 3
 
     // Check if we're using a global menu. Currently this is only true when
     // running under Ubuntu Unity and global menu is not disabled.
@@ -71,6 +73,9 @@ public:
     // calls g_log_set_writer_func() itself.
     static void GTKAllowDiagnosticsControl();
 
+    // Indicate that GTK+ already has been intialized by an
+    // external library and skip this in wxApp::Initialize()
+    static void GTKAlreadyInitialized( bool initialized );
 
     // implementation only from now on
     // -------------------------------

--- a/include/wx/gtk/app.h
+++ b/include/wx/gtk/app.h
@@ -73,7 +73,7 @@ public:
 
     // Indicate that GTK+ already has been intialized by an
     // external library and skip this in wxApp::Initialize()
-    static void GTKAlreadyInitialized( bool initialized );
+    static void GTKAlreadyInitialized();
 
     // implementation only from now on
     // -------------------------------

--- a/include/wx/gtk/app.h
+++ b/include/wx/gtk/app.h
@@ -71,10 +71,6 @@ public:
     // calls g_log_set_writer_func() itself.
     static void GTKAllowDiagnosticsControl();
 
-    // Indicate that GTK+ already has been intialized by an
-    // external library and skip this in wxApp::Initialize()
-    static void GTKAlreadyInitialized();
-
     // implementation only from now on
     // -------------------------------
 

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1306,16 +1306,6 @@ public:
      */
     static void GTKAllowDiagnosticsControl();
 
-    /**
-        Indicate that GTK+ already has been intialized by an
-        external library and skip this in wxApp::Initialize()
-
-        @onlyfor{wxgtk}
-
-        @since 3.3.4
-    */
-    static void GTKAlreadyInitialized();
-
     ///@}
 
     /**

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1306,6 +1306,16 @@ public:
      */
     static void GTKAllowDiagnosticsControl();
 
+    /**
+        Indicate that GTK+ already has been intialized by an
+        external library and skip this in wxApp::Initialize()
+
+        @onlyfor{wxgtk}
+
+        @since 3.3.4
+    */
+    static void GTKAlreadyInitialized();
+
     ///@}
 
     /**

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -441,12 +441,6 @@ bool wxApp::OnInitGui()
     return true;
 }
 
-static bool gs_gtkAlreadyInitialized = false;
-void wxApp::GTKAlreadyInitialized()
-{
-    gs_gtkAlreadyInitialized = true;
-}
-
 // use unusual names for the parameters to avoid conflict with wxApp::arg[cv]
 bool wxApp::Initialize(int& argc_, wxChar **argv_)
 {
@@ -527,10 +521,9 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
         );
     }
 
-    if (!gs_gtkAlreadyInitialized)
+    // Test if GTK+ has already been initalized
+    if (!g_type_class_peek(GTK_TYPE_WIDGET))
     {
-        gs_gtkAlreadyInitialized = true;
-
         bool init_result;
 
         // Prevent gtk_init_check() from changing the locale automatically for

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -441,10 +441,10 @@ bool wxApp::OnInitGui()
     return true;
 }
 
-bool s_gtkAlreadyInitialized = false;
-void wxApp::GTKAlreadyInitialized( bool initialized )
+static bool gs_gtkAlreadyInitialized = false;
+void wxApp::GTKAlreadyInitialized()
 {
-    s_gtkAlreadyInitialized = initialized;
+    gs_gtkAlreadyInitialized = true;
 }
 
 // use unusual names for the parameters to avoid conflict with wxApp::arg[cv]
@@ -527,8 +527,10 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
         );
     }
 
-    if (!s_gtkAlreadyInitialized)
+    if (!gs_gtkAlreadyInitialized)
     {
+        gs_gtkAlreadyInitialized = true;
+
         bool init_result;
 
         // Prevent gtk_init_check() from changing the locale automatically for
@@ -537,12 +539,7 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
         //
         // Note that this function generates a warning if it's called more than
         // once, so avoid them.
-        static bool s_gtkLocalDisabled = false;
-        if ( !s_gtkLocalDisabled )
-        {
-            s_gtkLocalDisabled = true;
-            gtk_disable_setlocale();
-        }
+        gtk_disable_setlocale();
 
 #if defined(__WXGTK4__)
         init_result = gtk_init_check() != 0;

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -441,6 +441,12 @@ bool wxApp::OnInitGui()
     return true;
 }
 
+bool s_gtkAlreadyInitialized = false;
+void wxApp::GTKAlreadyInitialized( bool initialized )
+{
+    s_gtkAlreadyInitialized = initialized;
+}
+
 // use unusual names for the parameters to avoid conflict with wxApp::arg[cv]
 bool wxApp::Initialize(int& argc_, wxChar **argv_)
 {
@@ -521,54 +527,57 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
         );
     }
 
-    bool init_result;
-
-    // Prevent gtk_init_check() from changing the locale automatically for
-    // consistency with the other ports that don't do it. If necessary,
-    // wxApp::SetCLocale() may be explicitly called.
-    //
-    // Note that this function generates a warning if it's called more than
-    // once, so avoid them.
-    static bool s_gtkLocalDisabled = false;
-    if ( !s_gtkLocalDisabled )
+    if (!s_gtkAlreadyInitialized)
     {
-        s_gtkLocalDisabled = true;
-        gtk_disable_setlocale();
-    }
+        bool init_result;
 
-#if defined(__WXGTK4__)
-    init_result = gtk_init_check() != 0;
-#else
-    auto argvA = wxInitData::Get().argvA;
-
-    int argcGTK = argc_;
-    init_result = gtk_init_check( &argcGTK, &argvA ) != 0;
-
-    if ( argcGTK != argc_ )
-    {
-        // we have to drop the parameters which were consumed by GTK+
-        for ( int i = 0; i < argcGTK; i++ )
+        // Prevent gtk_init_check() from changing the locale automatically for
+        // consistency with the other ports that don't do it. If necessary,
+        // wxApp::SetCLocale() may be explicitly called.
+        //
+        // Note that this function generates a warning if it's called more than
+        // once, so avoid them.
+        static bool s_gtkLocalDisabled = false;
+        if ( !s_gtkLocalDisabled )
         {
-            while ( strcmp(wxConvUTF8.cWX2MB(argv_[i]), argvA[i]) != 0 )
-            {
-                free(argv_[i]);
-                memmove(argv_ + i, argv_ + i + 1, (argc_ - i)*sizeof(*argv_));
-            }
+            s_gtkLocalDisabled = true;
+            gtk_disable_setlocale();
         }
 
-        argc_ = argcGTK;
-        argv_[argc_] = nullptr;
+#if defined(__WXGTK4__)
+        init_result = gtk_init_check() != 0;
+#else
+        auto argvA = wxInitData::Get().argvA;
 
-        this->argc = argc_;
-        this->argv.Init(argc_, argv_);
-    }
-    //else: gtk_init() didn't modify our parameters
+        int argcGTK = argc_;
+        init_result = gtk_init_check( &argcGTK, &argvA ) != 0;
+
+        if ( argcGTK != argc_ )
+        {
+            // we have to drop the parameters which were consumed by GTK+
+            for ( int i = 0; i < argcGTK; i++ )
+            {
+                while ( strcmp(wxConvUTF8.cWX2MB(argv_[i]), argvA[i]) != 0 )
+                {
+                    free(argv_[i]);
+                    memmove(argv_ + i, argv_ + i + 1, (argc_ - i)*sizeof(*argv_));
+                }
+            }
+
+            argc_ = argcGTK;
+            argv_[argc_] = nullptr;
+
+            this->argc = argc_;
+            this->argv.Init(argc_, argv_);
+        }
+        //else: gtk_init() didn't modify our parameters
 #endif
 
-    if ( !init_result )
-    {
-        wxLogError(_("Unable to initialize GTK+, is DISPLAY set properly?"));
-        return false;
+        if ( !init_result )
+        {
+            wxLogError(_("Unable to initialize GTK+, is DISPLAY set properly?"));
+            return false;
+        }
     }
 
 #if wxUSE_MIMETYPE


### PR DESCRIPTION
I have the rare situation where I need to run wxGTK when GTK+ already has been intialized in the same process. I  propose to add a static function to wxApp that needs to be called before calling wxEntry() (which then calls wxApp::Initialize()) is called. I will add documentation if naming and approach are accepted. 

[I don't know why the `#ifdef __WXGTK3__` in app.h is in the commit, I didn't add that, will remove again]