### PR TITLE
Fix removing views in wxView::OnUpdate()

### DIFF
--- a/build/cmake/tests/gui/CMakeLists.txt
+++ b/build/cmake/tests/gui/CMakeLists.txt
@@ -85,6 +85,7 @@ set(TEST_GUI_SRC
     controls/webtest.cpp
     controls/windowtest.cpp
     controls/dialogtest.cpp
+    docview/updateallviews.cpp
     events/clone.cpp
     events/enterleave.cpp
     # Duplicate this file here to test GUI event loops too.

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -624,13 +624,27 @@ void wxDocument::OnChangedViewList()
 
 void wxDocument::UpdateAllViews(wxView *sender, wxObject *hint)
 {
-    wxList::compatibility_iterator node = m_documentViews.GetFirst();
-    while (node)
+    // wxView::OnUpdate() may remove the view it's called on (relatively common)
+    // or, potentially, even another view from the document, so make a
+    // copy of the existing view container before starting to iterate
+    // over it.
+    const wxViewVector initialState = GetViewsVector();
+    for (wxView * const view : initialState)
     {
-        wxView *view = (wxView *)node->GetData();
         if (view != sender)
-            view->OnUpdate(sender, hint);
-        node = node->GetNext();
+        {
+            wxList::compatibility_iterator node = m_documentViews.GetFirst();
+            while (node)
+            {
+                wxView * const present = (wxView *)node->GetData();
+                if (present == view)
+                {
+                    view->OnUpdate(sender, hint);
+                    break;
+                }
+                node = node->GetNext();
+            }
+        }
     }
 }
 

--- a/src/msw/power.cpp
+++ b/src/msw/power.cpp
@@ -27,6 +27,10 @@
 #include "wx/msw/private.h"
 #include "wx/msw/private/power.h"
 
+#ifdef __WXQT__
+    #include <QWidget>
+#endif
+
 // ----------------------------------------------------------------------------
 // wxPowerResource
 // ----------------------------------------------------------------------------
@@ -143,7 +147,12 @@ bool wxMSWUpdateShutdownBlockReason()
 {
     for ( wxWindow* win : wxTopLevelWindows )
     {
+#ifdef __WXQT__
+        auto hwnd = reinterpret_cast<HWND>(win->GetHandle()->winId());
+#else
         HWND hwnd = GetHwndOf(win);
+#endif
+
         if ( g_powerResourceSystemRefCount > 0 )
         {
             ::ShutdownBlockReasonCreate(hwnd,

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -169,6 +169,7 @@ TEST_GUI_OBJECTS =  \
 	test_gui_asserthelper.o \
 	test_gui_test.o \
 	test_gui_testableframe.o \
+	test_gui_updateallviews.o \
 	test_gui_rect.o \
 	test_gui_size.o \
 	test_gui_point.o \
@@ -939,6 +940,9 @@ test_gui_test.o: $(srcdir)/test.cpp $(TEST_GUI_ODEP)
 
 test_gui_testableframe.o: $(srcdir)/testableframe.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/testableframe.cpp
+
+test_gui_updateallviews.o: $(srcdir)/docview/updateallviews.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/docview/updateallviews.cpp
 
 test_gui_rect.o: $(srcdir)/geometry/rect.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/geometry/rect.cpp

--- a/tests/docview/updateallviews.cpp
+++ b/tests/docview/updateallviews.cpp
@@ -1,0 +1,197 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/docview/doc-updateallviews.cpp
+// Purpose:     Unit test for wxDocument::UpdateAllViews()
+// Author:      Bill Su
+// Created:     2026-08-16
+// Copyright:   (c) 2026 Bill Su
+///////////////////////////////////////////////////////////////////////////////
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+#include "testprec.h"
+
+#if wxUSE_DOC_VIEW_ARCHITECTURE
+
+#include <memory>
+
+#include "asserthelper.h"
+
+#include "wx/docview.h"
+
+// ----------------------------------------------------------------------------
+// tests helpers
+// ----------------------------------------------------------------------------
+
+namespace
+{
+
+class MyDocument : public wxDocument
+{
+public:
+    virtual ~MyDocument() override;
+    virtual void OnChangedViewList() override;
+
+protected:
+};
+
+class MyView : public wxView
+{
+public:
+    explicit MyView(int serialNumber) : m_serialNumber(serialNumber) {}
+    virtual void OnUpdate(wxView* sender, wxObject* hint = nullptr) override;
+
+    virtual void OnDraw(wxDC* WXUNUSED(dc)) override { /* do nothing */ }
+
+private:
+    const int m_serialNumber;
+};
+
+MyDocument::~MyDocument()
+{
+    // avoid memory leak of views
+    DeleteAllViews();
+}
+
+void MyDocument::OnChangedViewList()
+{
+    // base class deletes this when no views remain,
+    // but dtor removes views, so base class version
+    // must not be called
+}
+
+struct Accum : public wxObject
+{
+    enum Command
+    {
+        SIMPLE,
+        SERNO_50_REMOVE_SELF,
+        SERNO_50_REMOVE_ODD,
+    };
+
+    Accum(Command c) : command(c) {}
+
+    const Command command;
+    wxVector<int> v;
+};
+
+void MyView::OnUpdate(wxView* WXUNUSED(sender), wxObject* hint /*= nullptr*/)
+{
+    Accum* const accum = static_cast<Accum*>(hint);
+    switch ( accum->command )
+    {
+        case Accum::SIMPLE:
+            accum->v.push_back(m_serialNumber);
+            break;
+
+        case Accum::SERNO_50_REMOVE_SELF:
+            if (m_serialNumber == 50)
+            {
+                GetDocument()->RemoveView(this);
+                delete this;
+            }
+            break;
+
+        case Accum::SERNO_50_REMOVE_ODD:
+            if (m_serialNumber == 50)
+            {
+                wxDocument* const doc = GetDocument();
+                const wxViewVector initialState = doc->GetViewsVector();
+                for (wxView* const view : initialState)
+                {
+                    MyView* const myView = static_cast<MyView*>(view);
+                    if (myView->m_serialNumber % 2 == 1)
+                    {
+                        doc->RemoveView(view);
+                        delete view;
+                    }
+                }
+            }
+            break;
+    }
+}
+
+} // anonymous namespace
+
+// ----------------------------------------------------------------------------
+// tests themselves
+// ----------------------------------------------------------------------------
+
+TEST_CASE("wxDocument::UpdateAllViews", "[docview]")
+{
+    const std::unique_ptr<wxDocument> doc(new MyDocument());
+    wxView* view50 = nullptr;
+    for (int i = 0; i < 100; ++i)
+    {
+        wxView* view = new MyView(i);
+        if (i == 50)
+        {
+            view50 = view;
+        }
+        doc->AddView(view);
+        view->SetDocument(doc.get());
+    }
+
+    // test UpdateAllViews() when not removing view(s)
+    SECTION("Simple")
+    {
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(nullptr, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 100 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v.back() == 99 );
+    }
+
+    // test UpdateAllViews() doesn't call sender
+    SECTION("SkipSender")
+    {
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(view50, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 99 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v[49] == 49 );
+        REQUIRE( accum.v[50] == 51 );
+        REQUIRE( accum.v.back() == 99 );
+    }
+
+    // test UpdateAllViews() when view removes (only) itself
+    SECTION("RemoveSelf")
+    {
+        {
+            Accum accum(Accum::SERNO_50_REMOVE_SELF);
+            doc->UpdateAllViews(nullptr, &accum);
+        }
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(nullptr, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 99 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v[49] == 49);
+        REQUIRE( accum.v[50] == 51 );
+        REQUIRE( accum.v.back() == 99 );
+    }
+
+    // test UpdateAllViews() when view removes many views
+    SECTION("RemoveOdd")
+    {
+        {
+            Accum accum(Accum::SERNO_50_REMOVE_ODD);
+            doc->UpdateAllViews(nullptr, &accum);
+        }
+        Accum accum(Accum::SIMPLE);
+        doc->UpdateAllViews(nullptr, &accum);
+        // order of wxView::OnUpdate() is not guaranteed
+        wxVectorSort(accum.v);
+        REQUIRE( accum.v.size() == 50 );
+        REQUIRE( accum.v.front() == 0 );
+        REQUIRE( accum.v.back() == 98 );
+    }
+}
+
+#endif // wxUSE_DOC_VIEW_ARCHITECTURE

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -144,6 +144,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_asserthelper.o \
 	$(OBJS)\test_gui_test.o \
 	$(OBJS)\test_gui_testableframe.o \
+	$(OBJS)\test_gui_updateallviews.o \
 	$(OBJS)\test_gui_rect.o \
 	$(OBJS)\test_gui_size.o \
 	$(OBJS)\test_gui_point.o \
@@ -879,6 +880,9 @@ $(OBJS)\test_gui_test.o: ./test.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_testableframe.o: ./testableframe.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_updateallviews.o: ./docview/updateallviews.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_rect.o: ./geometry/rect.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -157,6 +157,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_asserthelper.obj \
 	$(OBJS)\test_gui_test.obj \
 	$(OBJS)\test_gui_testableframe.obj \
+	$(OBJS)\test_gui_updateallviews.obj \
 	$(OBJS)\test_gui_rect.obj \
 	$(OBJS)\test_gui_size.obj \
 	$(OBJS)\test_gui_point.obj \
@@ -1169,6 +1170,9 @@ $(OBJS)\test_gui_test.obj: .\test.cpp
 
 $(OBJS)\test_gui_testableframe.obj: .\testableframe.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\testableframe.cpp
+
+$(OBJS)\test_gui_updateallviews.obj: .\docview\updateallviews.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\docview\updateallviews.cpp
 
 $(OBJS)\test_gui_rect.obj: .\geometry\rect.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\geometry\rect.cpp

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -174,6 +174,7 @@
             asserthelper.cpp
             test.cpp
             testableframe.cpp
+            docview/updateallviews.cpp
             geometry/rect.cpp
             geometry/size.cpp
             geometry/point.cpp


### PR DESCRIPTION
wxDocument::UpdateAllViews() could crash if some view removed itself or another view when its OnUpdate() was called.

Fix this by checking the view validity before using it in UpdateAllViews() and add a new unit test checking for this scenario.

Closes #26844.