### PR TITLE
Fix wxQt/MSW build after recent wxPowerResource changes

### DIFF
--- a/src/msw/power.cpp
+++ b/src/msw/power.cpp
@@ -27,6 +27,10 @@
 #include "wx/msw/private.h"
 #include "wx/msw/private/power.h"
 
+#ifdef __WXQT__
+    #include <QWidget>
+#endif
+
 // ----------------------------------------------------------------------------
 // wxPowerResource
 // ----------------------------------------------------------------------------
@@ -143,7 +147,12 @@ bool wxMSWUpdateShutdownBlockReason()
 {
     for ( wxWindow* win : wxTopLevelWindows )
     {
+#ifdef __WXQT__
+        auto hwnd = reinterpret_cast<HWND>(win->GetHandle()->winId());
+#else
         HWND hwnd = GetHwndOf(win);
+#endif
+
         if ( g_powerResourceSystemRefCount > 0 )
         {
             ::ShutdownBlockReasonCreate(hwnd,


### PR DESCRIPTION
Make code retrieving HWND from wxWindow added in 46918b84db (Improve wxPowerResource in wxMSW to provide the block reason, 2026-08-17) work with wxQt too.

See #26874.