### PR TITLE
Fix client size computation in wxGTK when using overlay scrollbars

### DIFF
--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -106,6 +106,7 @@ public:
     virtual int GetScrollPos( int orient ) const override;
     virtual int GetScrollThumb( int orient ) const override;
     virtual int GetScrollRange( int orient ) const override;
+    virtual int GetScrollbarSize( int orient ) const override;
     virtual void ScrollWindow( int dx, int dy,
                                const wxRect* rect = nullptr ) override;
     virtual bool ScrollLines(int lines) override;

--- a/include/wx/univ/scrolbar.h
+++ b/include/wx/univ/scrolbar.h
@@ -149,7 +149,7 @@ protected:
     wxRect GetScrollbarRect(wxScrollBar::Element elem, int thumbPos = -1) const;
 
     // returns the size of the scrollbar shaft excluding the arrows
-    wxCoord GetScrollbarSize() const;
+    wxCoord GetScrollbarBodySize() const;
 
     // translate the scrollbar position (in logical units) into physical
     // coordinate (in pixels) and the other way round

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -1443,6 +1443,11 @@ public:
         return false;
     }
 
+        // return the space taken by the scrollbar of the given orientation
+        // when it is shown in this window: this is 0 for the windows using
+        // overlay scrollbars, which don't take any space at all
+    virtual int GetScrollbarSize(int orient) const;
+
     // context-sensitive help
     // ----------------------
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -814,6 +814,31 @@ public:
     bool HasScrollbar(int orient) const;
 
     /**
+        Returns the space taken by the scrollbar of the given orientation when
+        it is shown in this window.
+
+        For a vertical scrollbar this is its width and for a horizontal one its
+        height, i.e. the amount by which showing the scrollbar reduces the
+        client size of the window in the corresponding direction.
+
+        This is normally the same as the value of the ::wxSYS_VSCROLL_X or
+        ::wxSYS_HSCROLL_Y system metric, but it is 0 for the windows using
+        overlay scrollbars, which are drawn on top of the window contents and
+        hence don't reduce its client area at all. Because of this, prefer
+        using this function rather than the system metrics directly when
+        computing the size required by a scrollable window.
+
+        Note that the returned value doesn't depend on whether the scrollbar is
+        currently shown, use HasScrollbar() to check for this.
+
+        @param orient
+            Orientation of the scrollbar, either wxHORIZONTAL or wxVERTICAL.
+
+        @since 3.3.4
+    */
+    virtual int GetScrollbarSize(int orient) const;
+
+    /**
         Return whether a scrollbar is always shown.
 
         @param orient

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -1131,6 +1131,13 @@ bool wxWindowBase::HasScrollbar(int orient) const
                                   : sizeVirt.y > sizeClient.y;
 }
 
+int wxWindowBase::GetScrollbarSize(int orient) const
+{
+    return wxSystemSettings::GetMetric(orient == wxHORIZONTAL ? wxSYS_HSCROLL_Y
+                                                              : wxSYS_VSCROLL_X,
+                                       AsWindow());
+}
+
 // ----------------------------------------------------------------------------
 // show/hide/enable/disable the window
 // ----------------------------------------------------------------------------

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -1651,10 +1651,10 @@ wxSize wxScrolledT_Helper::FilterBestSize(const wxWindow *win,
         wxSize minSize = win->GetMinSize();
 
         if ( ppuX > 0 )
-            best.x = minSize.x + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, win);
+            best.x = minSize.x + win->GetScrollbarSize(wxVERTICAL);
 
         if ( ppuY > 0 )
-            best.y = minSize.y + wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, win);
+            best.y = minSize.y + win->GetScrollbarSize(wxHORIZONTAL);
     }
 
     return best;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6962,6 +6962,18 @@ int wxWindowGTK::GetScrollRange( int orient ) const
     return wxRound(gtk_adjustment_get_upper(gtk_range_get_adjustment(sb)));
 }
 
+int wxWindowGTK::GetScrollbarSize( int orient ) const
+{
+#ifdef __WXGTK3__
+    // Overlay scrollbars are drawn on top of the window contents and so don't
+    // take any space in it.
+    if ( GTK_IS_SCROLLED_WINDOW(m_widget) && wxUsesOverlayScrollbars(m_widget) )
+        return 0;
+#endif // __WXGTK3__
+
+    return wxWindowBase::GetScrollbarSize(orient);
+}
+
 // Determine if increment is the same as +/-x, allowing for some small
 //   difference due to possible inexactness in floating point arithmetic
 static inline bool IsScrollIncrement(double increment, double x)

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4490,6 +4490,55 @@ void wxWindowGTK::DoSetClientSize( int width, int height )
     SetSize(width + (size.x - clientSize.x), height + (size.y - clientSize.y));
 }
 
+#ifdef __WXGTK3__
+
+// Check whether the given scrolled window uses overlay scrollbars, i.e. the
+// scrollbars drawn on top of its contents which, unlike the normal ones, don't
+// take any space in it.
+//
+// This replicates the logic of the private GTK function
+// gtk_scrolled_window_update_use_indicators() and must be kept in sync with it.
+static bool wxUsesOverlayScrollbars(GtkWidget* widget)
+{
+    // Overlay scrollbars only exist since GTK 3.16, where they're used by
+    // default, but this can be overridden in several different ways.
+    if ( !wx_is_at_least_gtk3(16) )
+        return false;
+
+#if GTK_CHECK_VERSION(3,16,0)
+    // The application may have disabled them for this particular window: we
+    // never call the corresponding setter ourselves, but it could do it.
+    if ( !gtk_scrolled_window_get_overlay_scrolling(GTK_SCROLLED_WINDOW(widget)) )
+        return false;
+#endif // GTK+ >= 3.16
+
+    // The user may have disabled them globally using the setting below, which
+    // only exists since GTK 3.24.9, so check that it's available before using
+    // it -- if it isn't, overlay scrollbars are used.
+    GtkSettings* const settings = gtk_widget_get_settings(widget);
+    if ( settings &&
+            g_object_class_find_property(G_OBJECT_GET_CLASS(settings),
+                                         "gtk-overlay-scrolling") )
+    {
+        gboolean enabled = TRUE;
+        g_object_get(settings, "gtk-overlay-scrolling", &enabled, nullptr);
+        if ( !enabled )
+            return false;
+    }
+
+    // Finally, this environment variable overrides everything else. Its value
+    // is not supposed to change during the program lifetime, so check it only
+    // once and cache the result, as this function is called often.
+    static const bool
+        disabledInEnv = g_strcmp0(getenv("GTK_OVERLAY_SCROLLING"), "0") == 0;
+    if ( disabledInEnv )
+        return false;
+
+    return true;
+}
+
+#endif // __WXGTK3__
+
 void wxWindowGTK::DoGetClientSize( int *width, int *height ) const
 {
     wxCHECK_RET( (m_widget != nullptr), wxT("invalid window") );
@@ -4506,8 +4555,14 @@ void wxWindowGTK::DoGetClientSize( int *width, int *height ) const
 
     if ( m_wxwindow )
     {
-        // if window is scrollable, account for scrollbars
-        if ( GTK_IS_SCROLLED_WINDOW(m_widget) )
+        // If the window is scrollable, account for its scrollbars -- but only
+        // if they're not the overlay ones, which are drawn on top of the
+        // window contents and so don't take any space in it.
+        if ( GTK_IS_SCROLLED_WINDOW(m_widget)
+#ifdef __WXGTK3__
+                && !wxUsesOverlayScrollbars(m_widget)
+#endif // __WXGTK3__
+           )
         {
             GtkPolicyType policy[ScrollDir_Max];
             gtk_scrolled_window_get_policy(GTK_SCROLLED_WINDOW(m_widget),

--- a/src/univ/scrolbar.cpp
+++ b/src/univ/scrolbar.cpp
@@ -510,7 +510,7 @@ wxRect wxScrollBar::GetScrollbarRect(wxScrollBar::Element elem,
     return rect;
 }
 
-wxCoord wxScrollBar::GetScrollbarSize() const
+wxCoord wxScrollBar::GetScrollbarBodySize() const
 {
     const wxSize sizeArrowSB = m_renderer->GetScrollbarArrowSize();
 
@@ -546,7 +546,7 @@ wxCoord wxScrollBar::ScrollbarToPixel(int thumbPos)
     }
 
     const wxSize sizeArrow = m_renderer->GetScrollbarArrowSize();
-    return (thumbPos * GetScrollbarSize()) / range
+    return (thumbPos * GetScrollbarBodySize()) / range
              + (IsVertical() ? sizeArrow.y : sizeArrow.x);
 }
 
@@ -554,7 +554,7 @@ int wxScrollBar::PixelToScrollbar(wxCoord coord)
 {
     const wxSize sizeArrow = m_renderer->GetScrollbarArrowSize();
     return ((coord - (IsVertical() ? sizeArrow.y : sizeArrow.x)) *
-               GetRange() ) / GetScrollbarSize();
+               GetRange() ) / GetScrollbarBodySize();
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/window/clientsize.cpp
+++ b/tests/window/clientsize.cpp
@@ -15,8 +15,13 @@
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/panel.h"
+    #include "wx/settings.h"
+    #include "wx/sizer.h"
     #include "wx/window.h"
 #endif // WX_PRECOMP
+
+#include "wx/scrolwin.h"
 
 #include <memory>
 
@@ -78,3 +83,106 @@ TEST_CASE("wxWindow::SetClientSize", "[window][client-size]")
     CHECK(r.width == reqSize.width);
     CHECK(r.height == reqSize.height);
 }
+
+// Check that the client size of a scrolled window accounts for the scrollbars
+// shown in it.
+//
+// All important checks below fails for wxQt currently, so disable the test for
+// it for now.
+#ifndef __WXQT__
+TEST_CASE("wxScrolled::ClientSize", "[window][client-size][scroll]")
+{
+    // Check that the borders, if any, are accounted for correctly too.
+    const long border = GENERATE(wxBORDER_NONE, wxBORDER_SIMPLE);
+    INFO("border style " << (border == wxBORDER_NONE ? "none" : "simple"));
+
+    // This window is not used for anything, but it must exist to prevent the
+    // test frame from resizing the panel created below to fill it entirely,
+    // which is what would happen if the panel were its unique child.
+    std::unique_ptr<wxWindow> const
+        sibling(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
+
+    // The scrolled window must be really laid out by its parent for the
+    // scrollbars to appear, so use a sizer in a panel of our own instead of
+    // just creating it as a child of the test frame.
+    std::unique_ptr<wxWindow> const
+        parent(new wxPanel(wxTheApp->GetTopWindow()));
+
+    // Make the panel big enough for the scrollbars to fit inside it.
+    parent->SetSize(wxSize(200, 200));
+
+    wxScrolledWindow* const
+        win = new wxScrolledWindow(parent.get(), wxID_ANY,
+                                   wxDefaultPosition, wxDefaultSize,
+                                   wxHSCROLL | wxVSCROLL | border);
+
+    // Using the scroll rate of 1 pixel makes it simpler to reason about the
+    // scroll positions below.
+    win->SetScrollRate(1, 1);
+
+    wxSizer* const sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(win, wxSizerFlags(1).Expand());
+    parent->SetSizer(sizer);
+    parent->Layout();
+
+    YieldForAWhile();
+
+    // Don't rely on the window having any particular size, we just need it to
+    // be big enough for the scrollbars to fit inside it.
+    const wxSize size = win->GetSize();
+    INFO("scrolled window size: " << size);
+    REQUIRE( size.x > 100 );
+    REQUIRE( size.y > 100 );
+
+    // Without any scrollbars the client size is just the total size without
+    // the borders.
+    const wxSize sizeClientNoScrollbars = win->GetClientSize();
+
+    // GetWindowBorderSize() seems to not return the correct result in wxOSX.
+#ifndef __WXOSX__
+    CHECK( sizeClientNoScrollbars == size - win->GetWindowBorderSize() );
+#endif
+
+    // Now make the virtual size big enough for both scrollbars to appear.
+    const wxSize sizeVirtual = 2*size;
+    win->SetVirtualSize(sizeVirtual);
+
+    YieldForAWhile();
+
+    REQUIRE( win->GetSize() == size );
+    CHECK( win->IsScrollbarShown(wxHORIZONTAL) );
+    CHECK( win->IsScrollbarShown(wxVERTICAL) );
+
+    const wxSize sizeClient = win->GetClientSize();
+    INFO("client size with scrollbars: " << sizeClient);
+
+    // The scrollbars either take place inside the window, reducing its client
+    // area by exactly their size, or are drawn on top of the window contents,
+    // in which case the client size doesn't change at all: this is the case of
+    // the overlay scrollbars used by default under macOS and also under GTK.
+    const wxSize sizeLost = sizeClientNoScrollbars - sizeClient;
+    INFO("client size lost to the scrollbars: " << sizeLost);
+
+    if ( sizeLost != wxSize(0, 0) )
+    {
+        const wxSize sizeScrollbar
+                     (
+                        wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, win),
+                        wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, win)
+                     );
+
+        // Allow for a small tolerance because the scrollbars may be separated
+        // from the window contents by a gap under some platforms.
+        CHECK( sizeLost.x == Approx(sizeScrollbar.x).margin(4) );
+        CHECK( sizeLost.y == Approx(sizeScrollbar.y).margin(4) );
+    }
+
+    // In any case, the client size must correspond to the part of the virtual
+    // area which is really visible, i.e. scrolling to the end must leave
+    // exactly the client size worth of pixels visible.
+    win->Scroll(sizeVirtual.x, sizeVirtual.y);
+
+    const wxSize sizeScrolled = sizeVirtual - sizeClient;
+    CHECK( win->GetViewStart() == wxPoint(sizeScrolled.x, sizeScrolled.y) );
+}
+#endif // !__WXQT__


### PR DESCRIPTION
While looking at #26097 I've finally decided to write a unit test checking that client size accounts for the scrollbars correctly and quickly discovered that it failed under wxGTK3. After investigating the reason for it, it became clear that wxGTK was accounting for the scrollbars over eagerly when overlay scrollbars were used (which is the case by default since years).

I've fixed this and the test passes now with wxGTK3. I am not at all sure if it passes with the other toolkits, but I think the first commit should be merged at any rate as it fixes a real bug.

@paulcor @RobertRoeb Please let me know what do you think.