### PR TITLE
Fix initial radiobox layout in wxMSW

### DIFF
--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -414,7 +414,9 @@ public:
 
         // A 'Smart' SetSize that will fill in default size values with 'best'
         // size.  Sets the minsize to what was passed in.
-    void SetInitialSize(const wxSize& size=wxDefaultSize);
+        //
+        // Returns true if the size was changed.
+    bool SetInitialSize(const wxSize& size = wxDefaultSize);
 
         // the generic centre function - centers the window on parent by`
         // default or on screen if it doesn't have parent or

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -1752,10 +1752,13 @@ public:
         Most controls will use this to set their initial size, and their min
         size to the passed in value (if any.)
 
+        @return @true if the size was changed (the return value is only
+            available in wxWidgets 3.3.4 or later)
+
         @see SetSize(), GetBestSize(), GetEffectiveMinSize(),
              @ref overview_windowsizing
     */
-    void SetInitialSize(const wxSize& size = wxDefaultSize);
+    bool SetInitialSize(const wxSize& size = wxDefaultSize);
 
     /**
         Sets the maximum client size of the window, to indicate to the sizer

--- a/src/common/pickerbase.cpp
+++ b/src/common/pickerbase.cpp
@@ -117,9 +117,11 @@ void wxPickerBase::PostCreation()
 
     SetSizer(m_sizer);
 
-    SetInitialSize( GetMinSize() );
-
-    Layout();
+    if ( !SetInitialSize( GetMinSize() ) )
+    {
+        // Layout if not already done by SetInitialSize() itself.
+        Layout();
+    }
 }
 
 #if wxUSE_TOOLTIPS

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -933,7 +933,7 @@ void wxWindowBase::SetMaxSize(const wxSize& maxSize)
     InvalidateBestSize();
 }
 
-void wxWindowBase::SetInitialSize(const wxSize& size)
+bool wxWindowBase::SetInitialSize(const wxSize& size)
 {
     // Set the min size to the size passed in.  This will usually either be
     // wxDefaultSize or the size passed to this window's ctor/Create function.
@@ -943,8 +943,12 @@ void wxWindowBase::SetInitialSize(const wxSize& size)
     wxSize best = GetEffectiveMinSize();
 
     // If the current size doesn't match then change it
-    if (GetSize() != best)
-        SetSize(best);
+    if ( GetSize() == best )
+        return false;
+
+    SetSize(best);
+
+    return true;
 }
 
 

--- a/src/msw/radiobox.cpp
+++ b/src/msw/radiobox.cpp
@@ -264,7 +264,11 @@ bool wxRadioBox::Create(wxWindow *parent,
         m_selectedButton = 0;
 
     // Now that we have items determine what is the best size and set it.
-    SetInitialSize(size);
+    if ( !SetInitialSize(size) )
+    {
+        // If the size didn't change, buttons were not laid out yet, do it now.
+        Layout();
+    }
 
     // The base wxStaticBox class never accepts focus, but we do because giving
     // focus to a wxRadioBox actually gives it to one of its buttons, which are


### PR DESCRIPTION
I ran into a bug in some legacy code not using sizers but using `wxRadioBox` — its radio buttons could all remain stuck in the top left corner because `Layout()` was never called. This fixes it.