### PR TITLE
MSW: Preserve printer duplex defaults

### DIFF
--- a/include/wx/cmndata.h
+++ b/include/wx/cmndata.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 class WXDLLIMPEXP_FWD_CORE wxPrintNativeDataBase;
+class WXDLLIMPEXP_FWD_CORE wxWindowsPrintNativeData;
 
 /*
  * wxPrintData
@@ -89,7 +90,11 @@ public:
 
     void SetPrinterName(const wxString& name) { m_printerName = name; }
     void SetColour(bool colour) { m_colour = colour; }
-    void SetDuplex(wxDuplexMode duplex) { m_duplexMode = duplex; }
+    void SetDuplex(wxDuplexMode duplex)
+    {
+        m_duplexMode = duplex;
+        m_duplexModeValid = true;
+    }
     void SetPaperId(wxPaperSize sizeId) { m_paperId = sizeId; }
     void SetPaperSize(const wxSize& sz) { m_paperSize = sz; }
     void SetQuality(wxPrintQuality quality) { m_printQuality = quality; }
@@ -115,6 +120,16 @@ public:
     wxPrintNativeDataBase *GetNativeData() const { return m_nativeData.get(); }
 
 private:
+    friend class wxWindowsPrintNativeData;
+
+    bool IsDuplexSpecified() const { return m_duplexModeValid; }
+
+    void ResetDuplex()
+    {
+        m_duplexMode = wxDUPLEX_SIMPLEX;
+        m_duplexModeValid = false;
+    }
+
     wxPrintBin      m_bin = wxPRINTBIN_DEFAULT;
     int             m_media = wxPRINTMEDIA_DEFAULT;
     wxPrintMode     m_printMode = wxPRINT_MODE_PRINTER;
@@ -127,6 +142,8 @@ private:
     wxString        m_printerName;
     bool            m_colour = true;
     wxDuplexMode    m_duplexMode = wxDUPLEX_SIMPLEX;
+    // False means leave DM_DUPLEX untouched to preserve the driver default.
+    bool            m_duplexModeValid = false;
     wxPrintQuality  m_printQuality = wxPRINT_QUALITY_HIGH;
 
     // we intentionally don't initialize paper id and size at all, like this

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -358,7 +358,7 @@ bool wxWindowsPrintNativeData::TransferTo( wxPrintData &data )
         }
     }
     else
-        data.SetDuplex( wxDUPLEX_SIMPLEX );
+        data.ResetDuplex();
 
     //// Quality
 
@@ -661,22 +661,25 @@ bool wxWindowsPrintNativeData::TransferFrom( const wxPrintData &data )
         }
 
         //// Duplex
-        short duplex;
-        switch (data.GetDuplex())
+        if ( data.IsDuplexSpecified() )
         {
-            case wxDUPLEX_HORIZONTAL:
-                duplex = DMDUP_HORIZONTAL;
-                break;
-            case wxDUPLEX_VERTICAL:
-                duplex = DMDUP_VERTICAL;
-                break;
-            default:
-            // in fact case wxDUPLEX_SIMPLEX:
-                duplex = DMDUP_SIMPLEX;
-                break;
+            short duplex;
+            switch ( data.GetDuplex() )
+            {
+                case wxDUPLEX_HORIZONTAL:
+                    duplex = DMDUP_HORIZONTAL;
+                    break;
+                case wxDUPLEX_VERTICAL:
+                    duplex = DMDUP_VERTICAL;
+                    break;
+                default:
+                // in fact case wxDUPLEX_SIMPLEX:
+                    duplex = DMDUP_SIMPLEX;
+                    break;
+            }
+            devMode->dmDuplex = duplex;
+            devMode->dmFields |= DM_DUPLEX;
         }
-        devMode->dmDuplex = duplex;
-        devMode->dmFields |= DM_DUPLEX;
 
         //// Quality
 

--- a/tests/misc/guifuncs.cpp
+++ b/tests/misc/guifuncs.cpp
@@ -26,6 +26,12 @@
 #include "wx/dataobj.h"
 #include "wx/panel.h"
 
+#if defined(__WXMSW__) && wxUSE_PRINTING_ARCHITECTURE
+    #include "wx/msw/wrapwin.h"
+    #include "wx/msw/private.h"
+    #include "wx/msw/printdlg.h"
+#endif
+
 #include "asserthelper.h"
 #include "waitfor.h"
 
@@ -173,6 +179,47 @@ TEST_CASE("GUI::ParseFileDialogFilter", "[guifuncs]")
         )
     );
 }
+
+#if defined(__WXMSW__) && wxUSE_PRINTING_ARCHITECTURE
+
+TEST_CASE("wxPrintData::MSWDuplexDefault", "[print][msw]")
+{
+    wxWindowsPrintNativeData nativeData;
+    GlobalPtr hDevMode(sizeof(DEVMODE), GMEM_FIXED | GMEM_ZEROINIT);
+    REQUIRE( static_cast<HGLOBAL>(hDevMode) );
+
+    DEVMODE * const devMode =
+        static_cast<DEVMODE *>(static_cast<HGLOBAL>(hDevMode));
+    devMode->dmSize = sizeof(DEVMODE);
+    devMode->dmFields = DM_DUPLEX;
+    devMode->dmDuplex = DMDUP_VERTICAL;
+
+    // wxWindowsPrintNativeData takes ownership and frees the handle.
+    nativeData.SetDevMode(hDevMode.Release());
+
+    SECTION("Default")
+    {
+        wxPrintData data;
+
+        REQUIRE( nativeData.TransferFrom(data) );
+
+        CHECK( (devMode->dmFields & DM_DUPLEX) != 0 );
+        CHECK( devMode->dmDuplex == DMDUP_VERTICAL );
+    }
+
+    SECTION("ExplicitSimplex")
+    {
+        wxPrintData data;
+        data.SetDuplex(wxDUPLEX_SIMPLEX);
+
+        REQUIRE( nativeData.TransferFrom(data) );
+
+        CHECK( (devMode->dmFields & DM_DUPLEX) != 0 );
+        CHECK( devMode->dmDuplex == DMDUP_SIMPLEX );
+    }
+}
+
+#endif // defined(__WXMSW__) && wxUSE_PRINTING_ARCHITECTURE
 
 TEST_CASE("GUI::ClientToScreen", "[guifuncs]")
 {


### PR DESCRIPTION
Keep wxPrintData's default duplex value unspecified internally so MSW print conversion leaves the native DEVMODE duplex setting alone. Still write DM_DUPLEX when SetDuplex() is used, including explicit simplex.

Fixes #4366