### PR TITLE
Grid: Fix MakeCellVisible with variable row heights

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -8783,26 +8783,17 @@ void wxGrid::MakeCellVisible( int row, int col )
         int ch;
         gridWindow->GetClientSize(nullptr, &ch);
 
-        if ( top < gridOffset.y )
+        // special handling for tall cells: show always top part of the cell!
+        if ( top < gridOffset.y || (bottom - top) >= ch )
         {
             ypos = r.GetTop() - gridOffset.y;
         }
         else if ( bottom > (ch + gridOffset.y) )
         {
-            int h = r.GetHeight();
-
-            ypos = r.GetTop() - gridOffset.y;
-
-            int i;
-            for ( i = row - 1; i >= 0; i-- )
-            {
-                int rowHeight = GetRowHeight(i);
-                if ( h + rowHeight > ch )
-                    break;
-
-                h += rowHeight;
-                ypos -= rowHeight;
-            }
+            // Position the view so that the cell is on the bottom.
+            int x0, y0;
+            CalcGridWindowUnscrolledPosition(0, 0, &x0, &y0, gridWindow);
+            ypos = y0 + (bottom - ch);
 
             // we divide it later by GRID_SCROLL_LINE, make sure that we don't
             // have rounding errors (this is important, because if we do,

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -1110,6 +1110,24 @@ TEST_CASE_METHOD(GridTestCase, "Grid::ScrollWhenSelect", "[grid]")
     CHECK( m_grid->IsVisible(9, 1) );
 }
 
+TEST_CASE_METHOD(GridTestCase, "Grid::MakeCellVisibleWithVariableRowHeights", "[grid]")
+{
+    m_grid->AppendRows(30);
+    m_grid->SetSize(240, 120);
+
+    for ( int row = 0; row < 30; ++row )
+    {
+        if ( row % 3 == 0 )
+            m_grid->SetRowSize(row, 50);
+    }
+
+    m_grid->SetRowSize(0, 57);
+    m_grid->SetRowSize(29, 20);
+
+    m_grid->MakeCellVisible(30, 0);
+    CHECK( m_grid->IsVisible(30, 0) );
+}
+
 TEST_CASE_METHOD(GridTestCase, "Grid::MoveGridCursorUsingEndKey", "[grid]")
 {
 #if wxUSE_UIACTIONSIMULATOR


### PR DESCRIPTION
Use the current unscrolled origin and the actual target-cell bottom when scrolling down, instead of rebuilding a position from preceding row heights. Add a grid regression test with mixed row heights.

Fixes #4371