### PR TITLE
Make GetAsDOS independent of time_t range

### DIFF
--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -1416,34 +1416,33 @@ wxDateTime& wxDateTime::SetFromDOS(unsigned long ddt)
 
 unsigned long wxDateTime::GetAsDOS() const
 {
-    unsigned long ddt;
-    time_t ticks = GetTicks();
-    struct tm tmstruct;
-    struct tm *tm = wxLocaltime_r(&ticks, &tmstruct);
-    wxCHECK_MSG( tm, ULONG_MAX, wxT("time can't be represented in DOS format") );
+    const Tm tm = GetTm();
 
-    long year = tm->tm_year;
-    year -= 80;
+    const long yearOffset = tm.year - 1980;
+    wxCHECK_MSG( yearOffset >= 0 && yearOffset <= 127,
+                 ULONG_MAX,
+                 wxT("time can't be represented in DOS format") );
+
+    unsigned long year = static_cast<unsigned long>(yearOffset);
     year <<= 25;
 
-    long month = tm->tm_mon;
+    unsigned long month = static_cast<unsigned long>(tm.mon);
     month += 1;
     month <<= 21;
 
-    long day = tm->tm_mday;
+    unsigned long day = tm.mday;
     day <<= 16;
 
-    long hour = tm->tm_hour;
+    unsigned long hour = tm.hour;
     hour <<= 11;
 
-    long minute = tm->tm_min;
+    unsigned long minute = tm.min;
     minute <<= 5;
 
-    long second = tm->tm_sec;
+    unsigned long second = tm.sec;
     second /= 2;
 
-    ddt = year | month | day | hour | minute | second;
-    return ddt;
+    return year | month | day | hour | minute | second;
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1033,6 +1033,17 @@ TEST_CASE("wxDateTime::Ticks", "[datetime]")
     }
 }
 
+TEST_CASE("wxDateTime::DOS", "[datetime]")
+{
+    CHECK( wxDateTime(1, wxDateTime::Jan, 1980).GetAsDOS() == 0x00210000UL );
+
+    const wxDateTime dt(8, wxDateTime::Apr, 2079, 13, 24, 58);
+    CHECK( dt.GetAsDOS() == 0xC6886B1DUL );
+
+    const wxDateTime dtMax(31, wxDateTime::Dec, 2107, 23, 59, 58);
+    CHECK( dtMax.GetAsDOS() == 0xFF9FBF7DUL );
+}
+
 // test parsing dates in RFC822 format
 TEST_CASE("wxDateTime::ParseRFC822", "[datetime]")
 {


### PR DESCRIPTION
Compute the DOS date/time fields from wxDateTime::GetTm() instead of round-tripping through time_t. This lets representable DOS dates beyond the 32-bit time_t range, including 2079-04-08, pack correctly while still rejecting years outside the DOS 1980..2107 range.

Add focused datetime coverage for the DOS minimum, the reported 2079 date, and the DOS maximum.

Fixes #4393