### PR TITLE
Respect AUI BestSize when adding panes

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -1103,6 +1103,27 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
         pinfo.best_size.IncTo(pinfo.min_size);
     }
 
+    if ( pinfo.dock_size == 0 && paneInfo.best_size != wxDefaultSize )
+    {
+        switch ( pinfo.dock_direction )
+        {
+            case wxAUI_DOCK_LEFT:
+            case wxAUI_DOCK_RIGHT:
+                if ( pinfo.best_size.x != wxDefaultCoord )
+                    pinfo.dock_size = pinfo.best_size.x;
+                break;
+
+            case wxAUI_DOCK_TOP:
+            case wxAUI_DOCK_BOTTOM:
+                if ( pinfo.best_size.y != wxDefaultCoord )
+                    pinfo.dock_size = pinfo.best_size.y;
+                break;
+
+            default:
+                break;
+        }
+    }
+
     AddPaneToMinDockIfNecessary(pinfo);
 
     return true;

--- a/tests/controls/auitest.cpp
+++ b/tests/controls/auitest.cpp
@@ -17,12 +17,14 @@
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/frame.h"
 #endif // WX_PRECOMP
 
 #include "wx/panel.h"
 
 #include "wx/aui/auibar.h"
 #include "wx/aui/auibook.h"
+#include "wx/aui/framemanager.h"
 #include "wx/aui/serializer.h"
 
 #include "asserthelper.h"
@@ -50,9 +52,62 @@ protected:
     wxAuiNotebook* const nb;
 };
 
+class AuiManagerTestCase
+{
+public:
+    AuiManagerTestCase()
+        : frame(new wxFrame(nullptr, wxID_ANY, "wxAuiManager test"))
+        , manager(frame.get())
+    {
+        frame->SetClientSize(800, 600);
+    }
+
+    ~AuiManagerTestCase()
+    {
+        manager.UnInit();
+    }
+
+protected:
+    std::unique_ptr<wxFrame> frame;
+    wxAuiManager manager;
+};
+
 // ----------------------------------------------------------------------------
 // the tests themselves
 // ----------------------------------------------------------------------------
+
+TEST_CASE_METHOD(AuiManagerTestCase, "wxAuiManager::AddPaneBestSize", "[aui]")
+{
+    wxWindow* const pane = new wxPanel(frame.get());
+    wxWindow* const center = new wxPanel(frame.get());
+
+    wxAuiPaneInfo paneInfo;
+    paneInfo.BestSize(320, 200).Left().CaptionVisible(false).PaneBorder(false);
+
+    REQUIRE( manager.AddPane(pane, paneInfo) );
+    REQUIRE( manager.AddPane(center, wxAuiPaneInfo().CenterPane()) );
+
+    manager.Update();
+
+    CHECK( pane->GetSize().x == 320 );
+}
+
+TEST_CASE_METHOD(AuiManagerTestCase, "wxAuiManager::AddPaneDockSize", "[aui]")
+{
+    wxWindow* const pane = new wxPanel(frame.get());
+    wxWindow* const center = new wxPanel(frame.get());
+
+    wxAuiPaneInfo paneInfo;
+    paneInfo.BestSize(320, 200).Left().CaptionVisible(false).PaneBorder(false);
+    paneInfo.dock_size = 180;
+
+    REQUIRE( manager.AddPane(pane, paneInfo) );
+    REQUIRE( manager.AddPane(center, wxAuiPaneInfo().CenterPane()) );
+
+    manager.Update();
+
+    CHECK( pane->GetSize().x == 180 );
+}
 
 TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::DoGetBestSize", "[aui]")
 {


### PR DESCRIPTION
Seed the initial dock size from an explicit wxAuiPaneInfo::BestSize() when no saved dock size is present. This lets AddPane() honor requested left/right or top/bottom pane sizes without making callers use MinSize() as a workaround, while preserved dock sizes from restored layouts still take precedence.

Add AUI manager tests for explicit BestSize() and saved dock_size precedence.

Fixes #4404