### PR TITLE
Ignore non-tab panes in wxAuiNotebook manager walks

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -689,8 +689,14 @@ protected:
     }
 
 protected:
+    class wxAuiNotebookManager : public wxAuiManager
+    {
+    protected:
+        virtual bool CanAddPane(wxWindow* window,
+                                const wxAuiPaneInfo& paneInfo) const override;
+    };
 
-    wxAuiManager m_mgr;
+    wxAuiNotebookManager m_mgr;
 
     // Contains all pages in the insertion order.
     wxAuiTabContainer m_tabs;

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -573,6 +573,9 @@ protected:
 
     void DoFrameLayout();
 
+    virtual bool CanAddPane(wxWindow* window,
+                            const wxAuiPaneInfo& paneInfo) const;
+
     void LayoutAddPane(wxSizer* container,
                        wxAuiDockInfo& dock,
                        wxAuiPaneInfo& pane,

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2009,8 +2009,11 @@ public:
     wxRect m_tab_rect;
     wxAuiTabCtrl* const m_tabs;
     int m_tabCtrlHeight = 0;
+
+    wxDECLARE_CLASS(wxAuiTabFrame);
 };
 
+wxIMPLEMENT_CLASS(wxAuiTabFrame, wxWindow);
 
 const int wxAuiBaseTabCtrlId = 5380;
 
@@ -2055,6 +2058,22 @@ bool IsDummyPane(const wxAuiPaneInfo& pane)
 }
 
 } // anonymous namespace
+
+bool wxAuiNotebook::wxAuiNotebookManager::CanAddPane(
+    wxWindow* window, const wxAuiPaneInfo& paneInfo) const
+{
+    if ( !wxAuiManager::CanAddPane(window, paneInfo) )
+        return false;
+
+    // wxAuiNotebook creates a hidden dummy pane before any real tab frames.
+    if ( IsDummyPane(paneInfo) && m_panes.empty() )
+        return true;
+
+    wxCHECK_MSG(wxDynamicCast(window, wxAuiTabFrame), false,
+                wxT("Can't add non-tab panes to wxAuiNotebook's manager"));
+
+    return true;
+}
 
 void wxAuiNotebook::OnSysColourChanged(wxSysColourChangedEvent &event)
 {

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -683,6 +683,14 @@ bool wxAuiManager::CanDockPanel(const wxAuiPaneInfo & WXUNUSED(p))
     return !(wxGetKeyState(WXK_CONTROL) || wxGetKeyState(WXK_ALT));
 }
 
+bool wxAuiManager::CanAddPane(wxWindow* window,
+                              const wxAuiPaneInfo& WXUNUSED(paneInfo)) const
+{
+    wxCHECK_MSG(window, false, wxT("null window ptrs are not allowed"));
+
+    return true;
+}
+
 // GetPane() looks up a wxAuiPaneInfo structure based
 // on the supplied window pointer.  Upon failure, GetPane()
 // returns an empty wxAuiPaneInfo, a condition which can be checked
@@ -995,10 +1003,7 @@ void wxAuiManager::SetArtProvider(wxAuiDockArt* art_provider)
 
 bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
 {
-    wxASSERT_MSG(window, wxT("null window ptrs are not allowed"));
-
-    // check if the pane has a valid window
-    if (!window)
+    if ( !CanAddPane(window, paneInfo) )
         return false;
 
     // check if the window is already managed by us
@@ -1164,6 +1169,9 @@ bool wxAuiManager::InsertPane(wxWindow* window, const wxAuiPaneInfo& paneInfo,
                                 int insert_level)
 {
     wxASSERT_MSG(window, wxT("null window ptrs are not allowed"));
+
+    if ( !GetPane(window).IsOk() && !CanAddPane(window, paneInfo) )
+        return false;
 
     // shift the panes around, depending on the insert level
     switch (insert_level)

--- a/tests/controls/auitest.cpp
+++ b/tests/controls/auitest.cpp
@@ -220,6 +220,28 @@ TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::RTTI", "[aui][rtti]")
     CHECK( wxDynamicCast(nb.get(), wxBookCtrlBase) == book );
 }
 
+TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::NonTabPaneRejected",
+                 "[aui]")
+{
+    wxPanel *page = new wxPanel(nb.get());
+    REQUIRE( nb->AddPage(page, "Page") );
+
+    wxPanel *pane = new wxPanel(nb.get());
+    wxAuiManager* const mgr = wxAuiManager::GetManager(nb.get());
+    REQUIRE( mgr );
+
+    wxAuiPaneInfo paneInfo;
+    paneInfo.Name("plain-pane").Right().CaptionVisible(false);
+
+#if wxDEBUG_LEVEL
+    WX_ASSERT_FAILS_WITH_ASSERT( mgr->AddPane(pane, paneInfo) );
+#else
+    CHECK( !mgr->AddPane(pane, paneInfo) );
+#endif
+
+    CHECK( !mgr->GetPane("plain-pane").IsOk() );
+}
+
 TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::FindPage", "[aui]")
 {
     wxPanel *p1 = new wxPanel(nb.get());


### PR DESCRIPTION
Skip manager panes that are not wxAuiTabFrame instances before touching tab controls. This prevents foreign panes added to the notebook manager from being treated as tab frames during sizing, style, selection, hit-test, and layout walks.

Add an AUI regression test covering a plain manager pane alongside a notebook page.

Fixes #4771