### PR TITLE
Resize AUI MDI client with parent frame

### DIFF
--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -111,6 +111,7 @@ protected:
 
 private:
     void OnClose(wxCloseEvent& event);
+    void OnSize(wxSizeEvent& event);
 
     // close all children, return false if any of them vetoed it
     bool CloseAll();

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -52,6 +52,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxAuiMDIParentFrame, wxFrame);
 
 wxBEGIN_EVENT_TABLE(wxAuiMDIParentFrame, wxFrame)
     EVT_CLOSE(wxAuiMDIParentFrame::OnClose)
+    EVT_SIZE(wxAuiMDIParentFrame::OnSize)
 #if wxUSE_MENUS
     EVT_MENU (wxID_ANY, wxAuiMDIParentFrame::DoHandleMenu)
     EVT_UPDATE_UI (wxID_ANY, wxAuiMDIParentFrame::DoHandleUpdateUI)
@@ -115,6 +116,9 @@ bool wxAuiMDIParentFrame::Create(wxWindow *parent,
         return false;
 
     m_pClientWindow = OnCreateClient();
+    if ( m_pClientWindow )
+        m_pClientWindow->SetSize(GetClientSize());
+
     return m_pClientWindow != nullptr;
 }
 
@@ -245,6 +249,14 @@ void wxAuiMDIParentFrame::OnClose(wxCloseEvent& event)
         event.Veto();
     else
         event.Skip();
+}
+
+void wxAuiMDIParentFrame::OnSize(wxSizeEvent& event)
+{
+    if ( m_pClientWindow )
+        m_pClientWindow->SetSize(GetClientSize());
+
+    event.Skip();
 }
 
 bool wxAuiMDIParentFrame::CloseAll()

--- a/tests/controls/auitest.cpp
+++ b/tests/controls/auitest.cpp
@@ -21,11 +21,13 @@
 #endif // WX_PRECOMP
 
 #include "wx/panel.h"
+#include "wx/sizer.h"
 
 #include "wx/aui/auibar.h"
 #include "wx/aui/auibook.h"
 #include "wx/aui/framemanager.h"
 #include "wx/aui/serializer.h"
+#include "wx/aui/tabmdi.h"
 
 #include "asserthelper.h"
 
@@ -82,6 +84,24 @@ public:
     using wxAuiNotebook::OnTabRightUp;
 };
 
+#if wxUSE_MDI
+
+class AuiMDITestCase
+{
+public:
+    AuiMDITestCase()
+        : frame(new wxAuiMDIParentFrame(nullptr, wxID_ANY,
+              "wxAuiMDIParentFrame test"))
+    {
+        frame->Show();
+    }
+
+protected:
+    std::unique_ptr<wxAuiMDIParentFrame> frame;
+};
+
+#endif // wxUSE_MDI
+
 // ----------------------------------------------------------------------------
 // the tests themselves
 // ----------------------------------------------------------------------------
@@ -118,6 +138,38 @@ TEST_CASE_METHOD(AuiManagerTestCase, "wxAuiManager::AddPaneDockSize", "[aui]")
 
     CHECK( pane->GetSize().x == 180 );
 }
+
+#if wxUSE_MDI
+
+TEST_CASE_METHOD(AuiMDITestCase,
+                 "wxAuiMDIParentFrame::ChildWindowResize", "[aui][mdi]")
+{
+    wxAuiMDIClientWindow* const client = frame->GetClientWindow();
+    REQUIRE( client );
+
+    std::unique_ptr<wxAuiMDIChildFrame> child(
+        new wxAuiMDIChildFrame(frame.get(), wxID_ANY, "Child"));
+    wxPanel* const panel = new wxPanel(child.get());
+
+    wxBoxSizer* const sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(panel, wxSizerFlags(1).Expand());
+    child->SetSizer(sizer);
+    child->Show();
+
+    frame->SetSize(320, 240);
+    CHECK( client->GetSize() == frame->GetClientSize() );
+    const wxSize oldChildSize = child->GetSize();
+    const wxSize oldPanelSize = panel->GetSize();
+
+    frame->SetSize(480, 300);
+    CHECK( client->GetSize() == frame->GetClientSize() );
+    CHECK( child->GetSize().x > oldChildSize.x );
+    CHECK( child->GetSize().y > oldChildSize.y );
+    CHECK( panel->GetSize().x > oldPanelSize.x );
+    CHECK( panel->GetSize().y > oldPanelSize.y );
+}
+
+#endif // wxUSE_MDI
 
 TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::DoGetBestSize", "[aui]")
 {


### PR DESCRIPTION
Handle parent size events in wxAuiMDIParentFrame and resize the AUI MDI client window to the current frame client area. Also size the client window immediately after creation so child pages start from the frame's actual client size.

Add a regression test covering an AUI MDI child with expanding content while the parent frame is resized.

Fixes #9442