### PR TITLE
Guard wxPreviewCanvas control-bar shortcuts

### DIFF
--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -66,6 +66,24 @@
 // at least use it here instead of hardcoding the number.
 static const int DEFAULT_MAX_PAGES = 32000;
 
+namespace
+{
+
+wxPreviewControlBar *GetPreviewControlBar(wxPrintPreviewBase *preview,
+                                          wxWindow *parent)
+{
+    wxPreviewFrame *frame = nullptr;
+    if ( preview )
+        frame = wxDynamicCast(preview->GetFrame(), wxPreviewFrame);
+
+    if ( !frame )
+        frame = wxDynamicCast(parent, wxPreviewFrame);
+
+    return frame ? frame->GetControlBar() : nullptr;
+}
+
+} // anonymous namespace
+
 //----------------------------------------------------------------------------
 // wxPrintFactory
 //----------------------------------------------------------------------------
@@ -1024,7 +1042,14 @@ void wxPreviewCanvas::OnSysColourChanged(wxSysColourChangedEvent& event)
 
 void wxPreviewCanvas::OnChar(wxKeyEvent &event)
 {
-    wxPreviewControlBar* controlBar = ((wxPreviewFrame*) GetParent())->GetControlBar();
+    wxPreviewControlBar * const
+        controlBar = GetPreviewControlBar(m_printPreview, GetParent());
+    if ( !controlBar )
+    {
+        event.Skip();
+        return;
+    }
+
     switch (event.GetKeyCode())
     {
         case WXK_RETURN:
@@ -1067,10 +1092,10 @@ void wxPreviewCanvas::OnChar(wxKeyEvent &event)
 
 void wxPreviewCanvas::OnMouseWheel(wxMouseEvent& event)
 {
-    wxPreviewControlBar *
-        controlBar = wxStaticCast(GetParent(), wxPreviewFrame)->GetControlBar();
+    wxPreviewControlBar * const
+        controlBar = GetPreviewControlBar(m_printPreview, GetParent());
 
-    if ( controlBar )
+    if ( controlBar && m_printPreview )
     {
         if ( event.ControlDown() && event.GetWheelRotation() != 0 )
         {


### PR DESCRIPTION
Avoid assuming that wxPreviewCanvas is parented directly by wxPreviewFrame when handling keyboard and mouse-wheel shortcuts. Look up the preview control bar only after confirming that the preview frame or parent really is a wxPreviewFrame, and skip the event when the canvas is embedded elsewhere.

Fixes #9822