### PR TITLE
Emit AUI page-changed event after removing last page

### DIFF
--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2444,6 +2444,7 @@ wxWindow* wxAuiNotebook::DoRemovePage(size_t page_idx)
     wxWindow* active_wnd = nullptr;
     if (m_curPage >= 0)
         active_wnd = m_tabs.GetWindowFromIdx(m_curPage);
+    const int old_curpage = m_curPage;
 
     // save pointer of window being deleted
     wxWindow* wnd = m_tabs.GetWindowFromIdx(page_idx);
@@ -2529,8 +2530,18 @@ wxWindow* wxAuiNotebook::DoRemovePage(size_t page_idx)
     m_curPage = wxNOT_FOUND;
 
     // set new active pane unless we're being destroyed anyhow
-    if (new_active && !m_isBeingDeleted)
+    if ( new_active && !m_isBeingDeleted )
+    {
         SetSelectionToWindow(new_active);
+    }
+    else if ( old_curpage != wxNOT_FOUND && !m_isBeingDeleted )
+    {
+        wxAuiNotebookEvent evt(wxEVT_AUINOTEBOOK_PAGE_CHANGED, m_windowId);
+        evt.SetSelection(wxNOT_FOUND);
+        evt.SetOldSelection(old_curpage);
+        evt.SetEventObject(this);
+        (void)ProcessWindowEvent(evt);
+    }
 
     return wnd;
 }

--- a/tests/controls/auitest.cpp
+++ b/tests/controls/auitest.cpp
@@ -169,6 +169,40 @@ TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::FindPage", "[aui]")
     CHECK( nb->FindPage(p3) == wxNOT_FOUND );
 }
 
+TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::RemoveLastPageEvent", "[aui]")
+{
+    wxPanel *p = new wxPanel(nb);
+    REQUIRE( nb->AddPage(p, "Page 1") );
+    CHECK( nb->GetSelection() == 0 );
+
+    int numChanged = 0;
+    int oldSelection = wxNOT_FOUND;
+    int selection = wxNOT_FOUND;
+
+    nb->Bind(wxEVT_AUINOTEBOOK_PAGE_CHANGED,
+             [&](wxAuiNotebookEvent& event)
+             {
+                 numChanged++;
+                 oldSelection = event.GetOldSelection();
+                 selection = event.GetSelection();
+             });
+
+    SECTION( "DeletePage" )
+    {
+        REQUIRE( nb->DeletePage(0) );
+    }
+
+    SECTION( "RemovePage" )
+    {
+        REQUIRE( nb->RemovePage(0) );
+    }
+
+    CHECK( nb->GetSelection() == wxNOT_FOUND );
+    CHECK( numChanged == 1 );
+    CHECK( oldSelection == 0 );
+    CHECK( selection == wxNOT_FOUND );
+}
+
 TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::Layout", "[aui]")
 {
     const auto addPage = [this](int n)


### PR DESCRIPTION
Send wxEVT_AUINOTEBOOK_PAGE_CHANGED when DeletePage() or RemovePage() removes the selected last wxAuiNotebook page and changes the selection to wxNOT_FOUND. Add coverage for both removal paths and keep programmatic removal from emitting page-close events.

Fixes #9920