### PR TITLE
Render SF Symbol based art at any requested size on macOS

### DIFF
--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -100,7 +100,7 @@ public:
     wxBitmap(const void* data, wxBitmapType type, int width, int height, int depth = 1);
 
     // creates an bitmap from the native image format
-    wxBitmap(CGImageRef image, double scale = 1.0);
+    wxBitmap(CGImageRef image, double scale = 1.0, bool isTemplate = false);
     wxBitmap(WXImage image);
     wxBitmap(CGContextRef bitmapcontext);
 
@@ -133,7 +133,7 @@ public:
         { return Create(sz.GetWidth(), sz.GetHeight(), depth); }
 
     bool Create(const void* data, wxBitmapType type, int width, int height, int depth = 1);
-    bool Create( CGImageRef image, double scale = 1.0 );
+    bool Create( CGImageRef image, double scale = 1.0, bool isTemplate = false );
     bool Create( WXImage image );
     bool Create( CGContextRef bitmapcontext);
 

--- a/include/wx/private/bmpbndl.h
+++ b/include/wx/private/bmpbndl.h
@@ -18,6 +18,10 @@
 
 WXImage WXDLLIMPEXP_CORE wxOSXGetImageFromBundle(const  wxBitmapBundle& bundle);
 wxBitmapBundle WXDLLIMPEXP_CORE wxOSXMakeBundleFromImage(WXImage image);
+// Create a bitmap bundle backed by a named SF symbol that regenerates the
+// underlying NSImage at any requested size. Returns an invalid bundle if the
+// name does not resolve to an SF symbol or if SF symbols are unavailable.
+wxBitmapBundle WXDLLIMPEXP_CORE wxOSXMakeBundleForSystemSymbol(const wxString& name, const wxSize& defaultSize);
 WXImage WXDLLIMPEXP_CORE wxOSXImageFromBitmap(const wxBitmap& bmp);
 #if wxOSX_USE_COCOA
 void WXDLLIMPEXP_CORE wxOSXAddBitmapToImage(WXImage image, const wxBitmap& bmp);

--- a/src/osx/artmac.cpp
+++ b/src/osx/artmac.cpp
@@ -124,11 +124,25 @@ wxIconBundle wxMacArtProvider::CreateIconBundle(const wxArtID& id, const wxArtCl
 #define ART_BITMAP(artId, symbolname) \
     if ( id == artId ) \
     { \
-        return wxOSXCreateSystemBitmapBundle(symbolname, size); \
+        return wxOSXCreateSystemBitmapBundle(symbolname, defSize); \
     }
 
-static wxBitmapBundle wxMacArtProvider_CreateBitmapBundle(const wxArtID& id, const wxSize& size)
+static wxBitmapBundle wxMacArtProvider_CreateBitmapBundle(const wxArtID& id, const wxArtClient& client, const wxSize& size)
 {
+    // SF symbols used below have a tiny intrinsic size (roughly the
+    // system font point size), which would leave them rendering as a small
+    // glyph inside whatever container the caller places them into.  Pick a
+    // reasonable default size based on the client hint so the bundle
+    // reports a size comparable to the other art provider icons.
+    wxSize defSize = size;
+    if ( defSize == wxDefaultSize )
+    {
+        defSize = wxArtProvider::GetNativeDIPSizeHint(client);
+        if ( defSize == wxDefaultSize )
+            defSize = wxSize(32, 32);
+    }
+
+
     ART_BITMAP(wxART_ERROR,         "xmark.circle" )
     ART_BITMAP(wxART_INFORMATION,   "info.circle" )
     ART_BITMAP(wxART_WARNING,       "exclamationmark.triangle" )
@@ -169,9 +183,9 @@ wxBitmapBundle wxMacArtProvider::CreateBitmapBundle(const wxArtID& id, const wxA
     // On the Mac folders in lists are always drawn closed, so if an open
     // folder icon is asked for we will ask for a closed one in its place
     if ( client == wxART_LIST && id == wxART_FOLDER_OPEN )
-        return wxMacArtProvider_CreateBitmapBundle(wxART_FOLDER, size);
+        return wxMacArtProvider_CreateBitmapBundle(wxART_FOLDER, client, size);
 
-    return wxMacArtProvider_CreateBitmapBundle(id, size);
+    return wxMacArtProvider_CreateBitmapBundle(id, client, size);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/osx/artmac.cpp
+++ b/src/osx/artmac.cpp
@@ -142,7 +142,6 @@ static wxBitmapBundle wxMacArtProvider_CreateBitmapBundle(const wxArtID& id, con
             defSize = wxSize(32, 32);
     }
 
-
     ART_BITMAP(wxART_ERROR,         "xmark.circle" )
     ART_BITMAP(wxART_INFORMATION,   "info.circle" )
     ART_BITMAP(wxART_WARNING,       "exclamationmark.triangle" )

--- a/src/osx/artmac.cpp
+++ b/src/osx/artmac.cpp
@@ -160,6 +160,9 @@ static wxBitmapBundle wxMacArtProvider_CreateBitmapBundle(const wxArtID& id, con
 
     ART_BITMAP(wxART_DELETE,         "minus.circle")
 
+    ART_BITMAP(wxART_TICK_MARK,      "checkmark")
+    ART_BITMAP(wxART_CROSS_MARK,     "xmark")
+
     ART_BITMAP(wxART_GO_BACK,        "arrow.backward.circle")
     ART_BITMAP(wxART_GO_FORWARD,     "arrow.forward.circle")
     ART_BITMAP(wxART_GO_UP,          "arrow.up.circle")

--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -195,6 +195,22 @@ WXImage wxOSXGetSystemImage(const wxString& name)
 
 wxBitmapBundle wxOSXCreateSystemBitmapBundle(const wxString& name, const wxSize& size)
 {
+#if wxOSX_USE_COCOA
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    // SF symbols need to be wrapped in a dedicated bundle implementation so
+    // they can be regenerated at any requested size and retain their
+    // template flag for light/dark mode tinting. Only attempt this on
+    // macOS 11+ where the SF symbol API is actually available; older
+    // systems fall through to the legacy named-image path below.
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        wxBitmapBundle symbolBundle = wxOSXMakeBundleForSystemSymbol(name, size);
+        if ( symbolBundle.IsOk() )
+            return symbolBundle;
+    }
+#endif
+#endif
+
     WXImage nsimage = wxOSXGetSystemImage(name);
     if ( nsimage )
     {

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -57,7 +57,7 @@ class WXDLLEXPORT wxBitmapRefData: public wxGDIRefData
 public:
     wxBitmapRefData(int width , int height , int depth, double logicalscale = 1.0);
     wxBitmapRefData(CGContextRef context);
-    wxBitmapRefData(CGImageRef image, double scale);
+    wxBitmapRefData(CGImageRef image, double scale, bool isTemplate = false);
     wxBitmapRefData(WXImage image);
     wxBitmapRefData();
     wxBitmapRefData(const wxBitmapRefData &tocopy);
@@ -201,10 +201,11 @@ wxBitmapRefData::wxBitmapRefData(CGContextRef context)
     Create( context );
 }
 
-wxBitmapRefData::wxBitmapRefData(CGImageRef image, double scale)
+wxBitmapRefData::wxBitmapRefData(CGImageRef image, double scale, bool isTemplate)
 {
     Init();
     Create( image, scale );
+    m_isTemplate = isTemplate;
 }
 
 wxBitmapRefData::wxBitmapRefData(WXImage image)
@@ -860,9 +861,9 @@ wxBitmap::wxBitmap(const wxString& filename, wxBitmapType type)
     LoadFile(filename, type);
 }
 
-wxBitmap::wxBitmap(CGImageRef image, double scale)
+wxBitmap::wxBitmap(CGImageRef image, double scale, bool isTemplate)
 {
-    (void) Create(image,scale);
+    (void) Create(image, scale, isTemplate);
 }
 
 wxGDIRefData* wxBitmap::CreateGDIRefData() const
@@ -1067,11 +1068,11 @@ bool wxBitmap::DoCreate(const wxSize& size, double scale, int d)
     return GetBitmapData()->IsOk() ;
 }
 
-bool wxBitmap::Create(CGImageRef image, double scale)
+bool wxBitmap::Create(CGImageRef image, double scale, bool isTemplate)
 {
     UnRef();
 
-    m_refData = new wxBitmapRefData( image, scale );
+    m_refData = new wxBitmapRefData( image, scale, isTemplate );
 
     return GetBitmapData()->IsOk() ;
 }

--- a/src/osx/core/bmpbndl.mm
+++ b/src/osx/core/bmpbndl.mm
@@ -28,6 +28,7 @@
 #include "wx/private/bmpbndl.h"
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 #include <algorithm>
 #include <unordered_map>
@@ -154,6 +155,125 @@ wxBitmap wxOSXImageBundleImpl::GetBitmap(const wxSize& WXUNUSED(size))
 wxBitmapBundle wxOSXMakeBundleFromImage( WXImage img)
 {
     return wxBitmapBundle::FromImpl( new wxOSXImageBundleImpl(img) );
+}
+
+// ============================================================================
+// wxOSXSFSymbolBundleImpl
+// ============================================================================
+//
+// Bundle implementation for macOS SF Symbols. Unlike wxOSXImageBundleImpl,
+// this keeps the symbol name around so we can regenerate the underlying
+// NSImage at any requested size.  SF symbols are effectively vector images,
+// so regenerating produces crisp output for every display scale.  The native
+// image cache is pre-populated with the symbol at the bundle's default size,
+// ensuring widgets retrieving the bundle's native NSImage still receive a
+// proper template image that adapts to light/dark appearance.
+
+#if wxOSX_USE_COCOA
+
+namespace
+{
+
+class wxOSXSFSymbolBundleImpl : public wxBitmapBundleImpl
+{
+public:
+    wxOSXSFSymbolBundleImpl(const wxString& symbolName, const wxSize& defaultSize)
+        : m_symbolName(symbolName), m_defaultSize(defaultSize)
+    {
+        // Pre-populate the native image cache so widget code paths that
+        // retrieve the NSImage directly (via wxOSXGetImageFromBundle) get
+        // the SF symbol image with its template flag intact.
+        WXImage image = CreateSymbolImage(defaultSize);
+        if ( image )
+            wxOSXSetImageForBundleImpl(this, image);
+    }
+
+    virtual wxSize GetDefaultSize() const override { return m_defaultSize; }
+
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const override
+    {
+        return m_defaultSize * scale;
+    }
+
+    virtual wxBitmap GetBitmap(const wxSize& size) override
+    {
+        const wxSize sz = (size == wxDefaultSize) ? m_defaultSize : size;
+        WXImage image = CreateSymbolImage(sz);
+        if ( image )
+            return wxBitmap(image);
+        return wxNullBitmap;
+    }
+
+private:
+    WXImage CreateSymbolImage(const wxSize& size) const
+    {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+        if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+        {
+            wxCFStringRef cfname(m_symbolName);
+            NSImage* symbol =
+                [NSImage imageWithSystemSymbolName:cfname.AsNSString()
+                          accessibilityDescription:nil];
+            if ( symbol )
+            {
+                // Configure the symbol at a point size matching the
+                // requested dimension so the stroke weight is appropriate
+                // for the rendered size.
+                NSImageSymbolConfiguration* config =
+                    [NSImageSymbolConfiguration
+                        configurationWithPointSize:size.GetHeight()
+                                            weight:NSFontWeightRegular];
+                NSImage* configured =
+                    [symbol imageWithSymbolConfiguration:config];
+                if ( configured )
+                    symbol = configured;
+
+                [symbol setSize:NSMakeSize(size.x, size.y)];
+                // SF symbols are template images; ensure the flag is set
+                // so AppKit tints them for the current light/dark mode.
+                [symbol setTemplate:YES];
+                return symbol;
+            }
+        }
+#else
+        wxUnusedVar(size);
+#endif
+        return nullptr;
+    }
+
+    const wxString m_symbolName;
+    const wxSize   m_defaultSize;
+};
+
+} // anonymous namespace
+
+#endif // wxOSX_USE_COCOA
+
+wxBitmapBundle wxOSXMakeBundleForSystemSymbol(const wxString& name, const wxSize& defaultSize)
+{
+#if wxOSX_USE_COCOA
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        wxCFStringRef cfname(name);
+        NSImage* probe =
+            [NSImage imageWithSystemSymbolName:cfname.AsNSString()
+                      accessibilityDescription:nil];
+        if ( probe )
+        {
+            wxSize sz = defaultSize;
+            if ( sz == wxDefaultSize )
+                sz = wxSize(32, 32);
+            return wxBitmapBundle::FromImpl(
+                new wxOSXSFSymbolBundleImpl(name, sz));
+        }
+    }
+#endif
+#else
+    wxUnusedVar(name);
+    wxUnusedVar(defaultSize);
+#endif
+    return wxBitmapBundle();
 }
 
 // ============================================================================

--- a/src/osx/core/bmpbndl.mm
+++ b/src/osx/core/bmpbndl.mm
@@ -192,17 +192,67 @@ public:
 
     virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const override
     {
-        return m_defaultSize * scale;
+        return wxSize(wxRound(m_defaultSize.x * scale),
+                      wxRound(m_defaultSize.y * scale));
     }
 
     virtual wxBitmap GetBitmap(const wxSize& size) override
     {
         const wxSize sz = (size == wxDefaultSize) ? m_defaultSize : size;
+
+        if ( m_cachedBitmap.IsOk() && m_cachedBitmap.GetSize() == sz )
+            return m_cachedBitmap;
+
+        // The requested size is in pixels, while NSImage sizes are in
+        // points, so we can't simply wrap an NSImage of this size in
+        // wxBitmap: it would be rasterized using the main screen scale
+        // factor and end up e.g. twice as big as requested on a Retina
+        // display. Instead, rasterize the symbol ourselves at exactly the
+        // requested pixel size, just as the SVG-based bundle implementation
+        // does, and let wxBitmapBundle::GetBitmap() adjust the scale factor
+        // of the returned bitmap if needed.
+        wxBitmap bmp;
         WXImage image = CreateSymbolImage(sz);
         if ( image )
-            return wxBitmap(image);
-        return wxNullBitmap;
+        {
+            CGContextRef context = CGBitmapContextCreate(
+                nullptr, sz.x, sz.y, 8, 0,
+                wxMacGetGenericRGBColorSpace(),
+                kCGImageAlphaPremultipliedFirst);
+            if ( context )
+            {
+                CGContextClearRect(context, CGRectMake(0, 0, sz.x, sz.y));
+
+                NSGraphicsContext* const previous = NSGraphicsContext.currentContext;
+                NSGraphicsContext.currentContext =
+                    [NSGraphicsContext graphicsContextWithCGContext:context
+                                                            flipped:NO];
+                [image drawInRect:NSMakeRect(0, 0, sz.x, sz.y)
+                         fromRect:NSZeroRect
+                        operation:NSCompositingOperationSourceOver
+                         fraction:1.0];
+                NSGraphicsContext.currentContext = previous;
+
+                CGImageRef cgImage = CGBitmapContextCreateImage(context);
+                if ( cgImage )
+                {
+                    bmp = wxBitmap(cgImage, 1.0);
+                    CGImageRelease(cgImage);
+                }
+                CGContextRelease(context);
+            }
+        }
+
+        // Cache only the last used bitmap, as the SVG implementation does,
+        // to avoid unbounded growth while still helping the common case of
+        // the same size being requested repeatedly.
+        m_cachedBitmap = bmp;
+
+        return bmp;
     }
+
+    // Return true if the symbol name resolved to an actual SF symbol.
+    bool IsOk() const { return wxOSXGetImageFromBundleImpl(this) != nullptr; }
 
 private:
     WXImage CreateSymbolImage(const wxSize& size) const
@@ -217,8 +267,9 @@ private:
             if ( symbol )
             {
                 // Configure the symbol at a point size matching the
-                // requested dimension so the stroke weight is appropriate
-                // for the rendered size.
+                // requested height (symbols are laid out relative to the cap
+                // height, so the height, and not the width, determines the
+                // appropriate stroke weight for the rendered size).
                 NSImageSymbolConfiguration* config =
                     [NSImageSymbolConfiguration
                         configurationWithPointSize:size.GetHeight()
@@ -243,6 +294,9 @@ private:
 
     const wxString m_symbolName;
     const wxSize   m_defaultSize;
+
+    // Last returned bitmap, see GetBitmap().
+    wxBitmap       m_cachedBitmap;
 };
 
 } // anonymous namespace
@@ -255,18 +309,19 @@ wxBitmapBundle wxOSXMakeBundleForSystemSymbol(const wxString& name, const wxSize
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
     if ( WX_IS_MACOS_AVAILABLE(11, 0) )
     {
-        wxCFStringRef cfname(name);
-        NSImage* probe =
-            [NSImage imageWithSystemSymbolName:cfname.AsNSString()
-                      accessibilityDescription:nil];
-        if ( probe )
-        {
-            wxSize sz = defaultSize;
-            if ( sz == wxDefaultSize )
-                sz = wxSize(32, 32);
-            return wxBitmapBundle::FromImpl(
-                new wxOSXSFSymbolBundleImpl(name, sz));
-        }
+        wxSize sz = defaultSize;
+        if ( sz == wxDefaultSize )
+            sz = wxSize(32, 32);
+
+        // The ctor tries to create the symbol image to pre-populate the
+        // native image cache, so it also serves as the existence check for
+        // the symbol name, without requiring a separate lookup here.
+        wxOSXSFSymbolBundleImpl* const impl =
+            new wxOSXSFSymbolBundleImpl(name, sz);
+        if ( impl->IsOk() )
+            return wxBitmapBundle::FromImpl(impl);
+
+        impl->DecRef();
     }
 #endif
 #else

--- a/src/osx/core/bmpbndl.mm
+++ b/src/osx/core/bmpbndl.mm
@@ -200,7 +200,9 @@ public:
     {
         const wxSize sz = (size == wxDefaultSize) ? m_defaultSize : size;
 
-        if ( m_cachedBitmap.IsOk() && m_cachedBitmap.GetSize() == sz )
+        const bool darkTint = IsDarkDrawingAppearance();
+        if ( m_cachedBitmap.IsOk() && m_cachedBitmap.GetSize() == sz &&
+                m_cachedForDark == darkTint )
             return m_cachedBitmap;
 
         // The requested size is in pixels, while NSImage sizes are in
@@ -231,12 +233,27 @@ public:
                          fromRect:NSZeroRect
                         operation:NSCompositingOperationSourceOver
                          fraction:1.0];
+
+                // When AppKit draws a symbol image, it renders it using the
+                // label color of the current appearance (e.g. light in dark
+                // mode). The rasterized bitmap loses that machinery, so
+                // bake the label color in here, keeping the alpha channel as
+                // the symbol shape.
+                CGContextSetBlendMode(context, kCGBlendModeSourceIn);
+                CGContextSetFillColorWithColor(context,
+                                               NSColor.labelColor.CGColor);
+                CGContextFillRect(context, CGRectMake(0, 0, sz.x, sz.y));
+
                 NSGraphicsContext.currentContext = previous;
 
                 CGImageRef cgImage = CGBitmapContextCreateImage(context);
                 if ( cgImage )
                 {
-                    bmp = wxBitmap(cgImage, 1.0);
+                    // Mark the bitmap as a template so that, when it is
+                    // drawn, it is tinted for the current (light or dark)
+                    // appearance just as the SF symbol NSImage itself
+                    // would be.
+                    bmp = wxBitmap(cgImage, 1.0, true /* template */);
                     CGImageRelease(cgImage);
                 }
                 CGContextRelease(context);
@@ -247,12 +264,30 @@ public:
         // to avoid unbounded growth while still helping the common case of
         // the same size being requested repeatedly.
         m_cachedBitmap = bmp;
+        m_cachedForDark = darkTint;
 
         return bmp;
     }
 
     // Return true if the symbol name resolved to an actual SF symbol.
     bool IsOk() const { return wxOSXGetImageFromBundleImpl(this) != nullptr; }
+
+    // Return true if the current drawing appearance is a dark one, i.e. if
+    // the label color used for tinting resolves to a light color.
+    static bool IsDarkDrawingAppearance()
+    {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+        if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+        {
+            NSAppearance* const appearance =
+                NSAppearance.currentDrawingAppearance;
+            return [appearance bestMatchFromAppearancesWithNames:
+                        @[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]]
+                    == NSAppearanceNameDarkAqua;
+        }
+#endif
+        return false;
+    }
 
 private:
     WXImage CreateSymbolImage(const wxSize& size) const
@@ -295,8 +330,10 @@ private:
     const wxString m_symbolName;
     const wxSize   m_defaultSize;
 
-    // Last returned bitmap, see GetBitmap().
+    // Last returned bitmap and the appearance it was tinted for, see
+    // GetBitmap().
     wxBitmap       m_cachedBitmap;
+    bool           m_cachedForDark = false;
 };
 
 } // anonymous namespace


### PR DESCRIPTION
SF Symbols returned by `+[NSImage imageWithSystemSymbolName:]` have a tiny intrinsic size (roughly the system font point size), so bitmap bundles created from them render as a small glyph scaled up, or centered, in whatever size the consumer requests — giving blurry or undersized icons for `wxArtProvider` art and other SF Symbol based bitmaps.

This adds a dedicated `wxBitmapBundleImpl` for SF Symbols that keeps the symbol name and regenerates the underlying `NSImage` at each requested size using `NSImageSymbolConfiguration` (so the stroke weight matches the rendered size). Since the symbols are effectively vector images, this produces crisp output at every size and display scale. The template flag is preserved so AppKit continues to tint the symbols correctly for light/dark appearance, and the native image cache is pre-populated so code paths retrieving the bundle's NSImage directly still get a proper template image.

`wxMacArtProvider` now also picks a reasonable default size from the art client hint instead of the symbol's intrinsic size, so SF Symbol based art reports sizes comparable to the other art provider icons.

Only active on macOS 11+ where the SF Symbol APIs exist; older systems fall through to the existing named-image path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)