### PR TITLE
Fix crash painting a combo editor pending deletion in wxPropertyGrid

### DIFF
--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -728,6 +728,28 @@ void wxPropertyGrid::OnComboItemPaint( const wxPGComboBox* pCb,
 {
     wxPGProperty* p = pCb->GetProperty();
 
+    // m_selProp (returned by GetProperty()) is set once at editor creation
+    // and never cleared, so a combo retired into m_deletedEditorObjects can
+    // hold a dangling (non-null) property pointer after the grid contents
+    // are rebuilt. HidePopup()'s focus-loss processing can re-fire
+    // OnMeasureItem()/OnComboItemPaint() on such a retired combo, and
+    // painting would then dereference the freed property and crash. A null
+    // check alone doesn't catch the dangling case, so first bail out if
+    // this combo is pending deletion.
+    for ( wxObject* o : m_deletedEditorObjects )
+    {
+        if ( o == pCb )
+        {
+            rect.height = 0;
+            return;
+        }
+    }
+    if ( !p )
+    {
+        rect.height = 0;
+        return;
+    }
+
     wxString text;
 
     const wxPGChoices& choices = p->GetChoices();


### PR DESCRIPTION
The property pointer held by `wxPGComboBox` (`m_selProp`, returned by `GetProperty()`) is set once when the editor is created and never cleared. When the grid contents are rebuilt while the editor is open, the combo is retired into `m_deletedEditorObjects` for delayed destruction, but `HidePopup()`'s focus-loss processing can still re-fire `OnMeasureItem()`/`OnComboItemPaint()` on the retired combo. Its property pointer now dangles, so painting dereferences the freed property and crashes. The existing null check doesn't help since the pointer is non-null, just stale.

Skip painting entirely for a combo that is pending deletion (and, for safety, for a null property).

This was one of the most frequent crash signatures reported from a large wxWidgets application making heavy use of wxPropertyGrid on macOS, and the guard eliminated it. Arguably the root cause is that `m_selProp` is never cleared when the editor is retired — happy to rework it that way instead if that's preferred, but clearing it at retirement time would make `GetProperty()` return null in paint callbacks that currently don't expect it, so the localized guard seemed the safer change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)