### PR TITLE
Refresh visible page when wxPreferencesEditor window is shown or activated on macOS

### DIFF
--- a/src/osx/cocoa/preferences.mm
+++ b/src/osx/cocoa/preferences.mm
@@ -91,6 +91,7 @@ public:
         m_toolbar->Bind(wxEVT_TOOL,
                         &wxCocoaPrefsWindow::OnPageChanged, this);
         Bind(wxEVT_CLOSE_WINDOW, &wxCocoaPrefsWindow::OnClose, this);
+        Bind(wxEVT_ACTIVATE, &wxCocoaPrefsWindow::OnActivate, this);
     }
 
     void AddPage(wxPreferencesPage *page)
@@ -122,6 +123,13 @@ public:
             wxCHECK_MSG( first, false, "no preferences panels" );
             OnSelectPageForTool(first);
             m_toolbar->OSXSelectTool(first->GetId());
+        }
+        else if ( show && m_visiblePage )
+        {
+            // The window is being shown again after having been hidden: the
+            // settings may have been changed elsewhere in the application in
+            // the meantime, so refresh the visible page (see #22165).
+            RefreshVisiblePage();
         }
 
         return wxFrame::Show(show);
@@ -228,6 +236,29 @@ private:
         //
         //       We'll need to add wxPreferencesPage::IsResizable() virtual
         //       method to implement this.
+    }
+
+    // Re-fill the currently visible page with the (possibly updated) data
+    // and adapt its, and hence our, size to the updated contents.
+    void RefreshVisiblePage()
+    {
+        m_visiblePage->InitDialog();
+        FitPageWindow(m_visiblePage);
+        SetClientSize(m_visiblePage->GetSize());
+        m_visiblePage->Refresh();
+    }
+
+    void OnActivate(wxActivateEvent& event)
+    {
+        event.Skip();
+
+        // Refresh the page when the already shown window comes back to the
+        // foreground: the settings may have been changed from the other
+        // application windows while it was in the background (see #22165).
+        // Note that this also covers the window being re-shown, as showing
+        // it activates it.
+        if ( event.GetActive() && m_visiblePage && IsShownOnScreen() )
+            RefreshVisiblePage();
     }
 
     void OnPageChanged(wxCommandEvent& event)


### PR DESCRIPTION
The macOS implementation of wxPreferencesEditor only fills each page with data (via `wxEVT_INIT_DIALOG` / `TransferDataToWindow`) once, when the page window is first created. If settings are changed elsewhere in the application and the preferences window is then shown again, it keeps displaying the stale values.

Fixes #22165, reworked from #22169 along the lines discussed there: the refresh now happens when the window is *activated* (as suggested by @vslavik), which covers both re-showing it and bringing it back to the foreground after it was hidden behind other windows; `Show()` also refreshes directly in case the window is re-shown without becoming key. The refreshed page is re-fitted afterwards since the updated contents may change its best size.

Per @vadz's feedback on #22169, page switching is intentionally left unchanged: switching to another page and back does not re-run `TransferDataToWindow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)