### PR TITLE
wxQt: fix cross-thread CallAfter() not waking the event loop

### DIFF
--- a/src/qt/evtloop.cpp
+++ b/src/qt/evtloop.cpp
@@ -14,6 +14,7 @@
 #include "wx/private/eventloopsourcesmanager.h"
 
 #include <QtCore/QCoreApplication>
+#include <QtCore/QEvent>
 #include <QtCore/QAbstractEventDispatcher>
 #include <QtCore/QSocketNotifier>
 #include <QtCore/QTimer>
@@ -156,8 +157,27 @@ bool wxQtEventLoopBase::QtDispatch() const
 
 void wxQtEventLoopBase::WakeUp()
 {
-    QAbstractEventDispatcher *instance = QAbstractEventDispatcher::instance();
-    if ( instance )
+    // Post a no-op Qt event to the (main-thread) idle timer rather than only
+    // calling QAbstractEventDispatcher::wakeUp().
+    //
+    // wx pending events queued via wxEvtHandler::CallAfter() (including the
+    // cross-thread marshalling used by e.g. wxIPC worker threads) are processed
+    // by wxQtIdleTimer::idle() -> ProcessPendingEvents(), and that idle timer is
+    // (re)scheduled by the application-wide event filter, which only runs when a
+    // real Qt *event* is dispatched. Merely waking the dispatcher returns the
+    // blocked event loop from its wait but posts no event, so the filter never
+    // runs, the idle timer is never rescheduled, and the queued pending events
+    // are not processed until some unrelated Qt event happens to arrive. This
+    // stalled cross-thread CallAfter() indefinitely under wxQt.
+    //
+    // QCoreApplication::postEvent() is documented to be thread-safe; posting to
+    // the idle timer (which lives in the main thread) both wakes the loop and
+    // drives the event filter so the idle check, and thus the pending events,
+    // run promptly.
+    if ( m_qtIdleTimer )
+        QCoreApplication::postEvent(m_qtIdleTimer.get(), new QEvent(QEvent::User));
+    else if ( QAbstractEventDispatcher *instance =
+                  QAbstractEventDispatcher::instance() )
         instance->wakeUp();
 }
 

--- a/tests/events/evtlooptest.cpp
+++ b/tests/events/evtlooptest.cpp
@@ -17,6 +17,9 @@
 #include "wx/apptrait.h"
 #include "wx/evtloop.h"
 #include "wx/timer.h"
+#include "wx/app.h"
+#include "wx/evtloop.h"
+#include "wx/thread.h"
 
 #include <memory>
 
@@ -40,9 +43,15 @@ public:
 private:
     CPPUNIT_TEST_SUITE( EvtloopTestCase );
         CPPUNIT_TEST( TestExit );
+#if wxUSE_THREADS
+        CPPUNIT_TEST( TestCrossThreadCallAfter );
+#endif // wxUSE_THREADS
     CPPUNIT_TEST_SUITE_END();
 
     void TestExit();
+#if wxUSE_THREADS
+    void TestCrossThreadCallAfter();
+#endif // wxUSE_THREADS
 
     wxDECLARE_NO_COPY_CLASS(EvtloopTestCase);
 };
@@ -149,3 +158,63 @@ void EvtloopTestCase::TestExit()
     timerRun2.StartOnce(1);
     CPPUNIT_ASSERT_EQUAL( EXIT_CODE_OUTER_LOOP, loopOuter.Run() );
 }
+
+#if wxUSE_THREADS
+
+// Worker thread that, after giving the main thread time to enter and block in
+// its event loop, schedules a callback on the main thread via CallAfter().
+class ExitLoopFromThread : public wxThread
+{
+public:
+    ExitLoopFromThread(wxEventLoop& loop, int rc)
+        : wxThread(wxTHREAD_JOINABLE),
+          m_loop(loop),
+          m_rc(rc)
+    {
+    }
+
+protected:
+    virtual void *Entry() override
+    {
+        // Wait until the main thread is actually blocked waiting for events, so
+        // the CallAfter() below arrives while the loop is idle -- which is when
+        // it must still be able to wake the loop.
+        wxMilliSleep(250);
+
+        // wxEventLoop is not a wxEvtHandler, so route the deferred call through
+        // wxTheApp (which lives on, and runs the call on, the main thread).
+        wxEventLoop* const loop = &m_loop;
+        const int rc = m_rc;
+        wxTheApp->CallAfter([loop, rc] { loop->ScheduleExit(rc); });
+
+        return nullptr;
+    }
+
+private:
+    wxEventLoop& m_loop;
+    const int m_rc;
+
+    wxDECLARE_NO_COPY_CLASS(ExitLoopFromThread);
+};
+
+void EvtloopTestCase::TestCrossThreadCallAfter()
+{
+    // A CallAfter() issued from another thread must wake the main event loop and
+    // run there, even when the loop is otherwise idle. This is a regression test
+    // for wxQt, where wxQtEventLoopBase::WakeUp() woke the loop without posting a
+    // Qt event, so queued pending events (CallAfter) were never processed and the
+    // Run() below would block forever. See src/qt/evtloop.cpp.
+    wxEventLoop loop;
+
+    ExitLoopFromThread thread(loop, EXIT_CODE_OUTER_LOOP);
+    CPPUNIT_ASSERT_EQUAL( wxTHREAD_NO_ERROR, thread.Create() );
+    CPPUNIT_ASSERT_EQUAL( wxTHREAD_NO_ERROR, thread.Run() );
+
+    // If the cross-thread CallAfter() is delivered, the loop exits with the code
+    // the worker passed to ScheduleExit(); otherwise this hangs (the bug).
+    CPPUNIT_ASSERT_EQUAL( EXIT_CODE_OUTER_LOOP, loop.Run() );
+
+    thread.Wait();
+}
+
+#endif // wxUSE_THREADS

--- a/tests/net/ipc.cpp
+++ b/tests/net/ipc.cpp
@@ -17,18 +17,9 @@
 // here.
 //
 // This test requires wxUSE_THREADS==1 since it runs the test server concurrently
-// with the client. One build configuration is excluded: wxQt.
+// with the client.
 //
-// wxQt is excluded because of a bug in wxQt found during our testing:
-// wxIPC worker threads marshal their socket I/O to the main thread via
-// CallAfter(), but a cross-thread CallAfter() is not reliably processed by the
-// wxQt event loop. wxQtEventLoopBase::WakeUp() wakes the loop without posting a
-// Qt event, so the idle handler that runs pending events is never scheduled, and
-// server-pushed Advise() notifications stall. That is a wxQt event-loop bug, not
-// a wxIPC bug; it is fixed separately on branch
-// jpmattia/wxQT-CallAfter-wxWakeUpIdle, which will be a separate PR.
-//
-#if wxUSE_THREADS && !defined(__WXQT__)
+#if wxUSE_THREADS
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
@@ -1055,4 +1046,4 @@ TEST_CASE_METHOD(IPCFixture,
     CHECK( worker.m_error.empty() );
 }
 
-#endif // wxUSE_THREADS && !__WXQT__
+#endif // wxUSE_THREADS

--- a/tests/net/ipc_test_server.cpp
+++ b/tests/net/ipc_test_server.cpp
@@ -10,7 +10,7 @@
 
 // Match the guard in tests/net/ipc.cpp
 
-#if wxUSE_THREADS && !defined(__WXQT__)
+#if wxUSE_THREADS
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
@@ -715,4 +715,4 @@ void IPCServerThread::WaitForExit()
     launcher.DoStop();
 }
 
-#endif // wxUSE_THREADS && !__WXQT__
+#endif // wxUSE_THREADS

--- a/tests/net/ipc_test_server.h
+++ b/tests/net/ipc_test_server.h
@@ -15,7 +15,7 @@
 
 // Match the guard in tests/net/ipc.cpp and ipc_test_server.cpp: the IPC test is
 // excluded from wxQt, so its declarations must be too.
-#if wxUSE_THREADS && !defined(__WXQT__)
+#if wxUSE_THREADS
 
 #include <memory>
 
@@ -57,6 +57,6 @@ inline void WaitForThreadWithDispatch(wxThread& thread)
     thread.Wait();
 }
 
-#endif // wxUSE_THREADS && !__WXQT__
+#endif // wxUSE_THREADS
 
 #endif // _WX_TESTS_NET_IPC_TEST_SERVER_H_

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -55,11 +55,7 @@ std::string wxTheCurrentTestClass, wxTheCurrentTestMethod;
 #include "wx/socket.h"
 #include "wx/evtloop.h"
 
-// __WXQT__ guard: see the longer note in tests/net/ipc.cpp. The IPC test (and
-// its server) is excluded from wxQt (cross-thread CallAfter() not processed by
-// the wxQt event loop, fixed separately on branch
-// jpmattia/wxQT-CallAfter-wxWakeUpIdle).
-#if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER) && !defined(__WXQT__)
+#if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER)
     #define wxHAS_TEST_IPC_SERVER
 
     #include "net/ipc_test_server.h"
@@ -364,8 +360,7 @@ public:
 #ifdef wxHAS_TEST_IPC_SERVER
         // The IPC test re-executes this same binary as its server (with
         // WX_IPC_TEST_SERVER set), so test_gui must run the server here too,
-        // exactly as the console test does in the non-GUI OnRun() below. See the
-        // note there and tests/net/ipc.cpp for the wxQt exclusion.
+        // exactly as the console test does in the non-GUI OnRun() below.
         if ( ShouldRunTestIPCServer() )
         {
             // Suppress the idle-driven test runner: RunIPCServerUntilStopped()


### PR DESCRIPTION

This fixes a wxQt event-loop bug found while testing the IPC work in #24858: a CallAfter() issued from a worker thread is not reliably processed by an idle main loop.

**The bug.** wxQtEventLoopBase::WakeUp() only calls QAbstractEventDispatcher::wakeUp(). That returns a blocked event loop from its wait, but posts no Qt event. On wxQt, wx pending events (everything queued via wxEvtHandler::CallAfter(), including cross-thread marshalling) are run by wxQtIdleTimer::idle() -> ProcessPendingEvents(), and that idle timer is only rescheduled by the application-wide event filter, which fires when a Qt event is dispatched. So a cross-thread CallAfter() into an idle loop wakes the loop but its work is never run until some unrelated Qt event happens to arrive. It works on wxGTK because GLib's wakeup targets the shared main context regardless of the calling thread.

**The fix.** WakeUp() now posts a no-op Qt event to the main-thread idle timer. QCoreApplication::postEvent() is documented thread-safe; posting both wakes the loop and drives the event filter, so the idle check, and with it the queued pending events, run promptly. It falls back to the dispatcher wakeUp() if the idle timer does not exist yet.

**The tests.** The second commit adds a regression test to evtlooptest.cpp that runs on all ports: a worker thread waits for the main loop to go idle, then exits it via wxTheApp->CallAfter(). Without the fix it hangs on wxQt. One validation note: the hang only reproduces reliably when the loop can go truly idle, e.g. under QT_QPA_PLATFORM=offscreen; with a real X server connected, X-connection traffic keeps rescheduling the idle timer and can mask the bug.

The third commit removes the wxQt exclusion from the IPC tests, which existed only because of this bug (wxIPC worker threads marshal their socket I/O to the main thread via CallAfter()); the test commit in #24858 noted the underlying bug would be fixed separately, which is this PR. All 10 [ipc] cases now pass on wxQt, in both the console and GUI test binaries, under X11 and offscreen. Beyond restoring coverage, this exercises the fix under a sustained multithreaded CallAfter() load.

Validated locally against Qt 5.15 on Linux; CI on my fork is green on all lanes, including wxQt with Qt 5.15 and 6.10 on MSW and Ubuntu.
