### PR TITLE
Don't let a page header or footer paint over the page body

### DIFF
--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -556,12 +556,16 @@ void wxHtmlPrintout::RenderPage(wxDC *dc, int page)
     if (!m_Headers[page % 2].empty())
     {
         m_RendererHdr.SetHtmlText(TranslateHeader(m_Headers[page % 2], page));
-        m_RendererHdr.Render((int) (ppmm_h * m_MarginLeft), (int) (ppmm_v * m_MarginTop));
+        m_RendererHdr.Render((int) (ppmm_h * m_MarginLeft),
+                             (int) (ppmm_v * m_MarginTop),
+                             0, m_HeaderHeight);
     }
     if (!m_Footers[page % 2].empty())
     {
         m_RendererHdr.SetHtmlText(TranslateHeader(m_Footers[page % 2], page));
-        m_RendererHdr.Render((int) (ppmm_h * m_MarginLeft), (int) (pageHeight - ppmm_v * m_MarginBottom - m_FooterHeight));
+        m_RendererHdr.Render((int) (ppmm_h * m_MarginLeft),
+                             (int) (pageHeight - ppmm_v * m_MarginBottom - m_FooterHeight),
+                             0, m_FooterHeight);
     }
 }
 

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -73,6 +73,40 @@ TEST_CASE("wxHtmlDCRenderer::BodyBgColour", "[html][print]")
     CHECK(actual == bg);
 }
 
+TEST_CASE("wxHtmlPrintout::HeaderDoesNotEraseBody", "[html][print]")
+{
+    // Mirror the dimensions and scaling used by print preview and verify that
+    // rendering the header after the body only affects the header area.
+    const wxColour bg(0x12, 0x34, 0x56);
+    wxBitmap bmp(560, 790);
+    {
+        wxMemoryDC dc(bmp);
+        dc.SetBackground(*wxWHITE_BRUSH);
+        dc.Clear();
+
+        wxHtmlPrintout pr;
+        pr.SetHtmlText("<body bgcolor=\"#123456\"><p>Body</p></body>");
+        pr.SetHeader("Header<hr>", wxPAGE_ALL);
+        REQUIRE( pr.SetUp(dc) );
+
+        pr.SetPPIScreen(96, 96);
+        pr.SetPPIPrinter(600, 600);
+        pr.SetPageSizePixels(4960, 7016);
+        pr.SetPageSizeMM(210, 297);
+        pr.SetPaperRectPixels(wxRect(0, 0, 4960, 7016));
+
+        REQUIRE_NOTHROW( pr.OnPreparePrinting() );
+        REQUIRE( pr.HasPage(1) );
+        REQUIRE( pr.OnPrintPage(1) );
+    }
+
+    const wxImage image = bmp.ConvertToImage();
+    const wxColour actual(image.GetRed(280, 395),
+                          image.GetGreen(280, 395),
+                          image.GetBlue(280, 395));
+    CHECK( actual == bg );
+}
+
 TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
 {
     wxHtmlPrintout pr;


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. To me as a casual outsider the patches look like actually resolving existing bugs. I currently push them as separate pull requests so they can be individually reviewed.

wxHtmlPrintout::RenderPage() renders the body first and then the header and footer through m_RendererHdr, calling

    m_RendererHdr.Render(x, y);

which leaves wxHtmlDCRenderer::Render()'s "to" parameter at its INT_MAX default. The header is therefore free to draw the full height of its HTML, not just the header area -- and an HTML background colour drawn by the header covers the body that was rendered underneath it.

Pass the header and footer heights, which RenderPage() already knows, as the bound.

The test renders a page with a body background colour and a header into a wxMemoryDC and checks that a pixel well inside the body still has the body's colour.

(cherry picked from commit 7775a7527eb84e5636329c2da248807f92737a67)