### PR TITLE
Install the scrolled window's sizer after reparenting its controls

### DIFF
--- a/src/generic/wizard.cpp
+++ b/src/generic/wizard.cpp
@@ -936,9 +936,9 @@ bool wxWizard::DoLayoutAdaptation()
 
                         page->SetSizer(newSizer, false /* don't delete the old sizer */);
 
-                        scrolledWindow->SetSizer(oldSizer);
-
                         wxStandardDialogLayoutAdapter::DoReparentControls(page, scrolledWindow);
+
+                        scrolledWindow->SetSizer(oldSizer);
 
                         pages.Append(page);
                         windows.Append(scrolledWindow);


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. To me as a casual outsider the patches look like actually resolving existing bugs. I currently push them as separate pull requests so they can be individually reviewed.

wxWizard::DoLayoutAdaptation() moves a page's controls into a scrolled window, and did it in this order:

    page->SetSizer(newSizer, false);
    scrolledWindow->SetSizer(oldSizer);
    wxStandardDialogLayoutAdapter::DoReparentControls(page, scrolledWindow);

so the scrolled window was given a sizer managing controls that were, at that moment, still children of the page. The controls only became its children on the next line.

Reparent first and set the sizer afterwards, so that the sizer is installed on a window that already owns everything it lays out.

(cherry picked from commit dc4d5c6eba3fb9e2e6b7687207cd16b36995d919)