### PR TITLE
except sample: catch the string type that is actually thrown

### DIFF
--- a/samples/except/except.cpp
+++ b/samples/except/except.cpp
@@ -481,9 +481,10 @@ bool MyFrame::ProcessEvent(wxEvent& event)
     {
         return wxFrame::ProcessEvent(event);
     }
-    catch ( const wxChar *msg )
+    catch ( const char *msg )
     {
-        wxLogMessage("Caught a string \"%s\" in MyFrame", msg);
+        wxLogMessage("Caught a string \"%s\" in MyFrame",
+                     wxString::FromUTF8(msg));
 
         return true;
     }
@@ -675,4 +676,3 @@ void MyDialog::OnCrash(wxCommandEvent& WXUNUSED(event))
 {
     DoCrash();
 }
-


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. To me as a casual outsider the patches look like actually resolving existing bugs. I currently push them as separate pull requests so they can be individually reviewed.

This pull request resolves the issue that trying to issue a string-type exception in the exception sample causes an assert about an unknown string type.

MyFrame::ProcessEvent() catches

    catch ( const wxChar *msg )

but the string thrown by the sample is a const char*, so in a build where wxChar is wchar_t the handler never matches and the exception escapes to the outer handler instead of demonstrating what it is there to demonstrate.

Catch const char* and convert explicitly for the log message.

(cherry picked from commit 8511f2f7abd52cbf00d0b6a338f597e3b555e6e8)