### PR TITLE
Parent wxDebugReportDialog's controls to their static boxes

### DIFF
--- a/src/generic/dbgrptg.cpp
+++ b/src/generic/dbgrptg.cpp
@@ -41,7 +41,9 @@
 #endif
 #include "wx/mimetype.h"
 
+#include "wx/statbox.h"
 #include "wx/statline.h"
+#include "wx/textwrapper.h"
 
 #ifdef __WXMSW__
     #include "wx/evtloop.h"     // for SetCriticalWindow()
@@ -329,23 +331,30 @@ wxDebugReportDialog::wxDebugReportDialog(wxDebugReport& dbgrpt)
     const wxSizerFlags flagsExpand(SizerFlags(1));
     const wxSizerFlags flagsExpand2(SizerFlags(2));
 
-    wxSizer *sizerPreview =
+    // Note that everything inside a wxStaticBoxSizer has to be created as a
+    // child of its wxStaticBox rather than of the dialog: using the box's own
+    // parent still works, for compatibility, but warns in a debug build.
+    wxStaticBoxSizer *sizerPreview =
         new wxStaticBoxSizer(wxVERTICAL, this, _("&Debug report preview:"));
-    sizerPreview->Add(CreateTextSizer(msg), wxSizerFlags().Centre().Border());
+    wxWindow * const boxPreview = sizerPreview->GetStaticBox();
+
+    wxTextSizerWrapper wrapperPreview(boxPreview);
+    sizerPreview->Add(CreateTextSizer(msg, wrapperPreview),
+                      wxSizerFlags().Centre().Border());
 
     // ... and the list of files in this debug report with buttons to view them
     wxSizer *sizerFileBtns = new wxBoxSizer(wxVERTICAL);
     sizerFileBtns->AddStretchSpacer();
-    sizerFileBtns->Add(new wxButton(this, wxID_VIEW_DETAILS, _("&View...")),
+    sizerFileBtns->Add(new wxButton(boxPreview, wxID_VIEW_DETAILS, _("&View...")),
                         wxSizerFlags().Border(wxBOTTOM));
-    sizerFileBtns->Add(new wxButton(this, wxID_OPEN, _("&Open...")),
+    sizerFileBtns->Add(new wxButton(boxPreview, wxID_OPEN, _("&Open...")),
                         wxSizerFlags().Border(wxTOP));
     sizerFileBtns->AddStretchSpacer();
 
 #if wxUSE_CHECKLISTBOX
-    m_checklst = new wxCheckListBox(this, wxID_ANY);
+    m_checklst = new wxCheckListBox(boxPreview, wxID_ANY);
 #else
-    m_checklst = new wxListBox(this, wxID_ANY);
+    m_checklst = new wxListBox(boxPreview, wxID_ANY);
 #endif
 
     wxSizer *sizerFiles = new wxBoxSizer(wxHORIZONTAL);
@@ -356,15 +365,18 @@ wxDebugReportDialog::wxDebugReportDialog(wxDebugReport& dbgrpt)
 
 
     // lower part of the dialog: notes field
-    wxSizer *sizerNotes = new wxStaticBoxSizer(wxVERTICAL, this, _("&Notes:"));
+    wxStaticBoxSizer *sizerNotes =
+        new wxStaticBoxSizer(wxVERTICAL, this, _("&Notes:"));
+    wxWindow * const boxNotes = sizerNotes->GetStaticBox();
 
     msg = _("If you have any additional information pertaining to this bug\nreport, please enter it here and it will be joined to it:");
 
-    m_notes = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+    m_notes = new wxTextCtrl(boxNotes, wxID_ANY, wxEmptyString,
                              wxDefaultPosition, wxDefaultSize,
                              wxTE_MULTILINE);
 
-    sizerNotes->Add(CreateTextSizer(msg), flagsFixed);
+    wxTextSizerWrapper wrapperNotes(boxNotes);
+    sizerNotes->Add(CreateTextSizer(msg, wrapperNotes), flagsFixed);
     sizerNotes->Add(m_notes, flagsExpand);
 
 


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. To me as a casual outsider the patches look like actually resolving existing bugs. I currently push them as separate pull requests so they can be individually reviewed.

The contents of the two wxStaticBoxSizers in the debug report dialog were created as children of the dialog rather than of the wxStaticBox.

That is the older convention, still supported, but wxStaticBoxSizer::CheckIfNonBoxChild() warns about it in a debug build, so simply raising a debug report produces warnings -- on every platform.

Create the buttons, the list of files, the notes field and the two explanatory texts with the box as their parent. The texts need CreateTextSizer() to be given a wxTextSizerWrapper for the box, since they are wrapped relative to their parent.

(cherry picked from commit 1536ea7478eb9d4e38f5841268437f7c5afb0517)