### PR TITLE
Remove dead GTK block from wxCaretBase::SetBlinkTime()

### DIFF
--- a/src/generic/caret.cpp
+++ b/src/generic/caret.cpp
@@ -75,18 +75,19 @@ void wxCaretBase::SetBlinkTime(int milliseconds)
 {
     gs_blinkTime = milliseconds;
 
-#ifdef _WXGTK__
-    GtkSettings *settings = gtk_settings_get_default();
-    if (millseconds == 0)
-    {
-        gtk_settings_set_long_property(settings, "gtk-cursor-blink", gtk_false, nullptr);
-    }
-    else
-    {
-        gtk_settings_set_long_property(settings, "gtk-cursor-blink", gtk_true, nullptr);
-        gtk_settings_set_long_property(settings, "gtk-cursor-time", milliseconds, nullptr);
-    }
-#endif
+    // This used to be followed by a block passing the blink time on to
+    // GtkSettings, so that GTK's own text cursors would blink in step with
+    // wxCaret. It never ran: its guard was misspelled "_WXGTK__" with a single
+    // leading underscore, which nothing defines, and it could not have
+    // compiled if it had -- it misspelt its own parameter, and it passed
+    // gtk_false to gtk_settings_set_long_property(), which wants a glong.
+    // Removing it cannot change behaviour, for the same reason.
+    //
+    // Doing it for real is possible -- g_object_set() on "gtk-cursor-blink"
+    // and "gtk-cursor-blink-time" -- but it would reach past wxCaret into
+    // every native widget in the process, and GtkSettings is per display, so
+    // it is a decision about what this function is allowed to affect rather
+    // than a repair.
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. I currently push them as separate pull requests so they can be individually reviewed. In this case a review is needed as only that the code is dead and doesn't compile doesn't mean it isn't needed and nobody trusts it to actually be compiled in and work.

The block was guarded by

    #ifdef _WXGTK__

with a single leading underscore. Nothing defines that, so it has never been compiled, on any platform or in any configuration.

It could not have compiled if it had been, for two separate reasons. It refers to "millseconds" rather than to its parameter "milliseconds"; and it passes gtk_false, which is a function, where gtk_settings_set_long_ property() wants a glong:

    error: invalid conversion from 'gboolean (*)()' to 'glong'

That second one holds even against GTK+ 3, where the function still exists, deprecated since 3.16. GTK4 removed it altogether.

Removing the block therefore cannot change behaviour. A comment records what it was trying to do and why doing it properly is a design decision -- it would change the blink rate of every native widget in the process, and GtkSettings is per display -- rather than a straightforward repair.

(cherry picked from commit eee5661fd39da11ed272c4e9a86f07d0f84c8781)