### PR TITLE
aui sample: don't assert on a null pane window before testing for it

### DIFF
--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1547,8 +1547,11 @@ void MyFrame::OnUpdateUI(wxUpdateUIEvent& event)
 
 void MyFrame::OnUpdateTabKindUI(wxUpdateUIEvent& event)
 {
+    // wxDynamicCast, not wxCheckCast: the pane's window is momentarily null
+    // while the pane is being floated or re-docked, and wxCheckCast asserts on
+    // null before the test below can run.
     auto* const book =
-        wxCheckCast<wxAuiNotebook>(m_mgr.GetPane("notebook_content").window);
+        wxDynamicCast(m_mgr.GetPane("notebook_content").window, wxAuiNotebook);
 
     if ( !book )
     {
@@ -1570,8 +1573,11 @@ void MyFrame::OnUpdateTabKindUI(wxUpdateUIEvent& event)
 
 void MyFrame::OnNotebookSetTabKind(wxCommandEvent& event)
 {
+    // wxDynamicCast, not wxCheckCast: the pane's window is momentarily null
+    // while the pane is being floated or re-docked, and wxCheckCast asserts on
+    // null before the test below can run.
     auto* const book =
-        wxCheckCast<wxAuiNotebook>(m_mgr.GetPane("notebook_content").window);
+        wxDynamicCast(m_mgr.GetPane("notebook_content").window, wxAuiNotebook);
 
     if ( !book )
         return;
@@ -1597,8 +1603,11 @@ void MyFrame::OnNotebookNextOrPrev(wxCommandEvent& evt)
 
 void MyFrame::OnNotebookSplit(wxCommandEvent& WXUNUSED(evt))
 {
+    // wxDynamicCast, not wxCheckCast: the pane's window is momentarily null
+    // while the pane is being floated or re-docked, and wxCheckCast asserts on
+    // null before the test below can run.
     auto* const book =
-        wxCheckCast<wxAuiNotebook>(m_mgr.GetPane("notebook_content").window);
+        wxDynamicCast(m_mgr.GetPane("notebook_content").window, wxAuiNotebook);
 
     if ( !book || book->GetPageCount() < 3 )
     {


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. To me as a casual outsider the patches look like actually resolving existing bugs. I currently push them as separate pull requests so they can be individually reviewed.

Three handlers in the sample fetch the notebook pane's window with wxCheckCast<wxAuiNotebook>() and then check the result against null:

    auto* const book =
        wxCheckCast<wxAuiNotebook>(m_mgr.GetPane("notebook_content").window);

    if ( !book )
        return;

but wxCheckCast asserts when given null, so the check below it can never be reached in the case it exists for. The pane's window really is null for a moment while the pane is being floated or re-docked, which is when these update-UI and command handlers can run.

Use wxDynamicCast, which returns null rather than asserting, and let the existing checks do their job.

(cherry picked from commit a977b00567350f7ccd59f5fb6a0e1f21d2dc4982)