### PR TITLE
Clear m_windowSizer before destroying the old sizer in SetSizer()

### DIFF
--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -2402,8 +2402,16 @@ void wxWindowBase::SetSizer(wxSizer *sizer, bool deleteOld)
     {
         m_windowSizer->SetContainingWindow(nullptr);
 
+        // Stop pointing at the old sizer before destroying it, not after.
+        // Destroying a sizer tree detaches windows, which can reach the event
+        // loop, and anything that calls Layout() from there would otherwise
+        // find m_windowSizer still pointing into a tree that is halfway
+        // through being freed.
+        wxSizer* const oldSizer = m_windowSizer;
+        m_windowSizer = nullptr;
+
         if ( deleteOld )
-            delete m_windowSizer;
+            delete oldSizer;
     }
 
     m_windowSizer = sizer;


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. To me as a casual outsider the patches look like actually resolving existing bugs. I currently push them as separate pull requests so they can be individually reviewed.

wxWindowBase::SetSizer() destroyed the previously set sizer while m_windowSizer was still pointing at it, and only reassigned the member afterwards.

Destroying a sizer tree detaches the windows it manages, and detaching windows can reach the event loop. Anything that calls Layout() from there -- an idle handler, a size event, a paint -- finds m_windowSizer still pointing into a tree that is halfway through being freed.

Reset the member first and destroy through a local pointer, so the window is never observably associated with a sizer that is being destroyed.

(cherry picked from commit d70acbabc257d44fede5214f3b71ff1e3d7fabc0)