### PR TITLE
Life demo: repaint clicked cells instead of drawing on a wxClientDC

### DIFF
--- a/demos/life/life.cpp
+++ b/demos/life/life.cpp
@@ -754,15 +754,22 @@ void LifeCanvas::SetCellSize(int cellsize)
     Refresh(false);
 }
 
-// draw a cell
-void LifeCanvas::DrawCell(wxInt32 i, wxInt32 j, bool alive)
+// the area a cell occupies on screen
+wxRect LifeCanvas::CellRect(wxInt32 i, wxInt32 j) const
 {
-    wxClientDC dc(this);
+    return wxRect(CellToX(i), CellToY(j), m_cellsize, m_cellsize);
+}
 
-    dc.SetPen(alive? *wxBLACK_PEN : *wxWHITE_PEN);
-    dc.SetBrush(alive? *wxBLACK_BRUSH : *wxWHITE_BRUSH);
-
-    DrawCell(i, j, dc);
+// mark a cell as needing to be repainted
+//
+// Drawing on a wxClientDC outside a paint handler does not reach the screen on
+// every platform -- see wxClientDC::CanBeUsedForDrawing(), which reports false
+// under wxGTK on Wayland and on the macOS and Qt ports. Repainting from
+// OnPaint(), which already draws whatever the Life object says is alive in the
+// damaged area, works everywhere.
+void LifeCanvas::RefreshCell(wxInt32 i, wxInt32 j)
+{
+    RefreshRect(CellRect(i, j), false);
 }
 
 void LifeCanvas::DrawCell(wxInt32 i, wxInt32 j, wxDC &dc)
@@ -923,17 +930,18 @@ void LifeCanvas::OnMouse(wxMouseEvent& event)
         m_mi = i;
         m_mj = j;
         m_life->SetCell(i, j, m_status == MOUSE_DRAWING);
-        DrawCell(i, j, m_status == MOUSE_DRAWING);
+        RefreshCell(i, j);
     }
     else if ((m_mi != i) || (m_mj != j))
     {
         // no: continue ongoing action
         bool alive = (m_status == MOUSE_DRAWING);
 
-        // prepare DC and pen + brush to optimize drawing
-        wxClientDC dc(this);
-        dc.SetPen(alive? *wxBLACK_PEN : *wxWHITE_PEN);
-        dc.SetBrush(alive? *wxBLACK_BRUSH : *wxWHITE_BRUSH);
+        // Collect everything this segment touches and invalidate it in one
+        // go at the end. Repainting the whole enclosing rectangle costs a
+        // little more than the cells on the line, but the segment spans one
+        // mouse motion, and OnPaint() redraws any cell in it correctly.
+        wxRect damaged;
 
         // draw a line of cells using Bresenham's algorithm
         wxInt32 d, ii, jj, di, ai, si, dj, aj, sj;
@@ -955,7 +963,7 @@ void LifeCanvas::OnMouse(wxMouseEvent& event)
             while (ii != i)
             {
                 m_life->SetCell(ii, jj, alive);
-                DrawCell(ii, jj, dc);
+                damaged.Union(CellRect(ii, jj));
                 if (d >= 0)
                 {
                     jj += sj;
@@ -973,7 +981,7 @@ void LifeCanvas::OnMouse(wxMouseEvent& event)
             while (jj != j)
             {
                 m_life->SetCell(ii, jj, alive);
-                DrawCell(ii, jj, dc);
+                damaged.Union(CellRect(ii, jj));
                 if (d >= 0)
                 {
                     ii += si;
@@ -986,9 +994,11 @@ void LifeCanvas::OnMouse(wxMouseEvent& event)
 
         // last cell
         m_life->SetCell(ii, jj, alive);
-        DrawCell(ii, jj, dc);
+        damaged.Union(CellRect(ii, jj));
         m_mi = ii;
         m_mj = jj;
+
+        RefreshRect(damaged, false);
     }
 
     ((LifeFrame *) wxGetApp().GetTopWindow())->UpdateInfoText();

--- a/demos/life/life.h
+++ b/demos/life/life.h
@@ -36,7 +36,9 @@ public:
 
     // drawing
     void DrawChanged();
-    void DrawCell(wxInt32 i, wxInt32 j, bool alive);
+
+    // mark a cell as needing to be repainted from the Life object
+    void RefreshCell(wxInt32 i, wxInt32 j);
 
 private:
     // any class wishing to process wxWidgets events must use this macro
@@ -44,6 +46,9 @@ private:
 
     // draw a cell (parametrized by DC)
     void DrawCell(wxInt32 i, wxInt32 j, wxDC &dc);
+
+    // the area a cell occupies on screen
+    wxRect CellRect(wxInt32 i, wxInt32 j) const;
 
     // event handlers
     void OnPaint(wxPaintEvent& event);


### PR DESCRIPTION
When porting wxWidgets to GTK4 Claude reckons to have found 6 bugs in wxWidgets that hinder samples, example applications or tests from working. I currently push them as separate pull requests so they can be individually reviewed. In this case the review might be a good thing as everything points at this being the right solution but both claude and I might miss a thing and the repaint should be triggered by wxWidgets, after all.

Clicking or dragging in the Life canvas updated the Life object but drew the affected cells straight onto a wxClientDC. Where that does not work the population counter went up while the grid stayed unchanged, and the cells only appeared once something else forced a repaint -- resizing the window, for instance.

wxClientDC::CanBeUsedForDrawing() reports false under GTK+ 3 on Wayland, on the macOS port and under Qt, so this is not specific to any one platform; the demo simply never asked.

Refresh the affected cell's rectangle instead and let the existing paint handler draw it from the Life object, which is where every other update to the grid already comes from.

(cherry picked from commit de2465bf215d7c6f2ef8785fd9d36bf177e0dab3)