### PR TITLE
Don't call handlers unregistered during wxEpollDispatcher::Dispatch()

### DIFF
--- a/include/wx/unix/private/epolldispatcher.h
+++ b/include/wx/unix/private/epolldispatcher.h
@@ -16,6 +16,10 @@
 
 #include "wx/private/fdiodispatcher.h"
 
+#if wxUSE_THREADS
+    #include "wx/thread.h"
+#endif
+
 struct epoll_event;
 
 class WXDLLIMPEXP_BASE wxEpollDispatcher : public wxFDIODispatcher
@@ -44,8 +48,33 @@ private:
     // given timeout
     int DoPoll(epoll_event *events, int numEvents, int timeout) const;
 
+    // Look up the handler currently registered for the given descriptor, or
+    // nullptr if there is none (any more).
+    wxFDIOHandler *FindHandler(int fd) const;
+
+    // Record, replace or forget the handler for a descriptor. Kept separate
+    // from the epoll_ctl() calls so that the map is only updated once the
+    // kernel has accepted the change.
+    void StoreHandler(int fd, wxFDIOHandler *handler);
+    void ForgetHandler(int fd);
+
 
     int m_epollDescriptor;
+
+    // Maps the descriptors we have registered to their handlers. Dispatch()
+    // needs this because epoll_event::data is a union: it holds the descriptor
+    // so that a handler unregistered while the batch is being processed can be
+    // detected, which means the handler pointer has to be found elsewhere.
+    //
+    // Guarded because descriptors are registered and unregistered from worker
+    // threads -- wxSocketImpl does it from the thread performing the socket
+    // operation -- while Dispatch() reads the map from the thread running the
+    // event loop. epoll_ctl() itself is thread-safe, so nothing but this map
+    // needs the protection, and the lock is never held across a handler call.
+    wxFDIOHandlerMap m_handlers;
+#if wxUSE_THREADS
+    mutable wxCriticalSection m_handlersCS;
+#endif // wxUSE_THREADS
 };
 
 #endif // wxUSE_EPOLL_DISPATCHER

--- a/src/unix/epolldispatcher.cpp
+++ b/src/unix/epolldispatcher.cpp
@@ -104,11 +104,47 @@ wxEpollDispatcher::~wxEpollDispatcher()
     }
 }
 
+wxFDIOHandler *wxEpollDispatcher::FindHandler(int fd) const
+{
+#if wxUSE_THREADS
+    wxCriticalSectionLocker lock(m_handlersCS);
+#endif
+
+    const wxFDIOHandlerMap::const_iterator it = m_handlers.find(fd);
+
+    return it == m_handlers.end() ? nullptr : it->second.handler;
+}
+
+void wxEpollDispatcher::StoreHandler(int fd, wxFDIOHandler *handler)
+{
+#if wxUSE_THREADS
+    wxCriticalSectionLocker lock(m_handlersCS);
+#endif
+
+    // Deliberately an unconditional assignment and not an insertion that
+    // complains about an existing entry: wxFDIOManagerUnix decides between
+    // RegisterFD() and ModifyFD() from the mask it keeps on the handler, not
+    // from what this dispatcher knows, so the two can legitimately disagree
+    // about whether a descriptor is already registered.
+    m_handlers[fd] = wxFDIOHandlerEntry(handler, 0);
+}
+
+void wxEpollDispatcher::ForgetHandler(int fd)
+{
+#if wxUSE_THREADS
+    wxCriticalSectionLocker lock(m_handlersCS);
+#endif
+
+    m_handlers.erase(fd);
+}
+
 bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
 {
     epoll_event ev;
     ev.events = GetEpollMask(flags, fd);
-    ev.data.ptr = handler;
+
+    // The descriptor and not the handler: see Dispatch() for why.
+    ev.data.fd = fd;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_ADD, fd, &ev);
     if ( ret != 0 )
@@ -118,6 +154,8 @@ bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
 
         return false;
     }
+
+    StoreHandler(fd, handler);
     wxLogTrace(wxEpollDispatcher_Trace,
                wxT("Added fd %d (handler %p) to epoll %d"), fd, handler, m_epollDescriptor);
 
@@ -128,7 +166,7 @@ bool wxEpollDispatcher::ModifyFD(int fd, wxFDIOHandler* handler, int flags)
 {
     epoll_event ev;
     ev.events = GetEpollMask(flags, fd);
-    ev.data.ptr = handler;
+    ev.data.fd = fd;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_MOD, fd, &ev);
     if ( ret != 0 )
@@ -138,6 +176,8 @@ bool wxEpollDispatcher::ModifyFD(int fd, wxFDIOHandler* handler, int flags)
 
         return false;
     }
+
+    StoreHandler(fd, handler);
 
     wxLogTrace(wxEpollDispatcher_Trace,
                 wxT("Modified fd %d (handler: %p) on epoll %d"), fd, handler, m_epollDescriptor);
@@ -155,6 +195,11 @@ bool wxEpollDispatcher::UnregisterFD(int fd)
         wxLogSysError(_("Failed to unregister descriptor %d from epoll descriptor %d"),
                       fd, m_epollDescriptor);
     }
+    // Drop the handler even if epoll_ctl() above failed: the caller is done
+    // with it either way, and a stale entry here is exactly what Dispatch()
+    // must not find.
+    ForgetHandler(fd);
+
     wxLogTrace(wxEpollDispatcher_Trace,
                 wxT("removed fd %d from %d"), fd, m_epollDescriptor);
     return true;
@@ -218,12 +263,18 @@ int wxEpollDispatcher::Dispatch(int timeout)
     int numEvents = 0;
     for ( epoll_event *p = events; p < events + rc; p++ )
     {
-        wxFDIOHandler * const handler = (wxFDIOHandler *)(p->data.ptr);
+        // Look the handler up now instead of using a pointer recorded when
+        // the descriptor was registered: dispatching an earlier event of this
+        // batch may have unregistered -- and, in the code that owns it,
+        // destroyed -- the handler for a later one, and epoll_wait() filled
+        // this array in before any of that happened. Using the recorded
+        // pointer would then call a virtual function on a destroyed object.
+        //
+        // A descriptor that is no longer registered is therefore expected here
+        // rather than an error, and is simply skipped.
+        wxFDIOHandler * const handler = FindHandler(p->data.fd);
         if ( !handler )
-        {
-            wxFAIL_MSG( wxT("null handler in epoll_event?") );
             continue;
-        }
 
         // note that for compatibility with wxSelectDispatcher we call
         // OnReadWaiting() on EPOLLHUP as this is what epoll_wait() returns

--- a/tests/events/evtsource.cpp
+++ b/tests/events/evtsource.cpp
@@ -12,3 +12,133 @@
 // ----------------------------------------------------------------------------
 
 #include "testprec.h"
+
+#ifndef WX_PRECOMP
+#endif // WX_PRECOMP
+
+#include "wx/private/fdiodispatcher.h"
+
+#ifdef __UNIX__
+
+#include <unistd.h>
+
+// ----------------------------------------------------------------------------
+// a handler that unregisters another one from inside its own callback
+// ----------------------------------------------------------------------------
+
+namespace
+{
+
+// Both handlers below are registered for descriptors that are ready at the
+// same time, so a single Dispatch() call sees both of them in one batch. The
+// first one to run unregisters the other, which must then not be called: the
+// dispatcher has to notice that the registration is gone rather than reuse
+// whatever it recorded when the batch was collected.
+class UnregisteringHandler : public wxFDIOHandler
+{
+public:
+    explicit UnregisteringHandler(int fd) : m_fd(fd) { }
+
+    void OnReadWaiting() override
+    {
+        m_called = true;
+
+        if ( m_peer && m_peer->m_registered )
+        {
+            wxFDIODispatcher::Get()->UnregisterFD(m_peer->m_fd);
+            m_peer->m_registered = false;
+        }
+    }
+
+    void OnWriteWaiting() override { }
+    void OnExceptionWaiting() override { }
+
+    int m_fd;
+    UnregisteringHandler *m_peer = nullptr;
+    bool m_registered = false;
+    bool m_called = false;
+};
+
+// Pipe whose read end is already readable, so that registering it guarantees
+// the dispatcher reports it immediately.
+struct ReadablePipe
+{
+    ReadablePipe()
+    {
+        if ( pipe(m_fds) != 0 )
+        {
+            m_fds[0] = m_fds[1] = -1;
+            return;
+        }
+
+        const char b = 'x';
+        if ( write(m_fds[1], &b, 1) != 1 )
+        {
+            // Leave the descriptors valid; the test below checks readiness.
+        }
+    }
+
+    ~ReadablePipe()
+    {
+        if ( m_fds[0] != -1 )
+            close(m_fds[0]);
+        if ( m_fds[1] != -1 )
+            close(m_fds[1]);
+    }
+
+    int ReadEnd() const { return m_fds[0]; }
+    bool IsOk() const { return m_fds[0] != -1; }
+
+    int m_fds[2];
+};
+
+} // anonymous namespace
+
+// ----------------------------------------------------------------------------
+// the test itself
+// ----------------------------------------------------------------------------
+
+// A descriptor unregistered while the dispatcher is still working through the
+// events it collected must not have its handler called afterwards.
+//
+// wxSelectDispatcher looks the handler up per ready descriptor and so has
+// always behaved this way. wxEpollDispatcher used to store the handler pointer
+// in the epoll_event itself and call through the copy taken before any handler
+// ran, which meant a handler unregistered — and, in real code, destroyed —
+// while servicing an earlier event of the same batch was still called, on
+// memory its owner had already released.
+TEST_CASE("EventSource::UnregisterDuringDispatch", "[fdiodispatcher]")
+{
+    wxFDIODispatcher * const dispatcher = wxFDIODispatcher::Get();
+    REQUIRE( dispatcher );
+
+    ReadablePipe pipe1, pipe2;
+    REQUIRE( pipe1.IsOk() );
+    REQUIRE( pipe2.IsOk() );
+
+    UnregisteringHandler handler1(pipe1.ReadEnd());
+    UnregisteringHandler handler2(pipe2.ReadEnd());
+    handler1.m_peer = &handler2;
+    handler2.m_peer = &handler1;
+
+    REQUIRE( dispatcher->RegisterFD(handler1.m_fd, &handler1, wxFDIO_INPUT) );
+    handler1.m_registered = true;
+    REQUIRE( dispatcher->RegisterFD(handler2.m_fd, &handler2, wxFDIO_INPUT) );
+    handler2.m_registered = true;
+
+    // Both descriptors are readable, so this collects both of them and then
+    // dispatches the first, which unregisters the second.
+    const int numEvents = dispatcher->Dispatch(0);
+
+    // Exactly one handler ran: the one that was unregistered before its turn
+    // came must have been skipped.
+    CHECK( handler1.m_called != handler2.m_called );
+    CHECK( numEvents == 1 );
+
+    if ( handler1.m_registered )
+        dispatcher->UnregisterFD(handler1.m_fd);
+    if ( handler2.m_registered )
+        dispatcher->UnregisterFD(handler2.m_fd);
+}
+
+#endif // __UNIX__


### PR DESCRIPTION
Possibly related: #19118 — the same `wxWebSessionCURL` teardown path, reported there as `UnregisterFD()` errors on an already-closed descriptor rather than as a memory-safety problem.

`wxEpollDispatcher::Dispatch()` stores the `wxFDIOHandler` pointer in `epoll_event::data.ptr` and calls through the copy that `epoll_wait()` filled in before any handler ran:

```cpp
for ( epoll_event *p = events; p < events + rc; p++ )
{
    wxFDIOHandler * const handler = (wxFDIOHandler *)(p->data.ptr);
    ...
    handler->OnReadWaiting();
```

Servicing one event of a batch can unregister the descriptor belonging to a later event of the same batch — and, in real code, destroy its handler with it. `UnregisterFD()` removes the descriptor from the kernel's epoll set, but nothing scrubs the pointer already copied into the array, so the loop goes on to make a virtual call on released memory.

`wxSelectDispatcher` does not have this use-after-free: `ProcessSets()` calls `FindHandler(fd)` for each ready descriptor and skips the ones that are gone. This does the same for epoll — storing the descriptor in `epoll_event::data.fd` and resolving the handler when the event is actually processed, from a map held by `wxEpollDispatcher` itself and guarded, since descriptors are registered from worker threads while `Dispatch()` reads on the loop thread.

It deliberately does **not** derive from `wxMappedFDIODispatcher`: its `ModifyFD()` asserts the descriptor is already known, which `wxFDIOManagerUnix` legitimately violates, and its map has no lock.

A handler that is no longer registered is skipped silently rather than asserted on: after this change that is an expected outcome of the case above, not a programming error.

## Test

`tests/events/evtsource.cpp` was an empty stub. It now contains a test that does not depend on timing: two pipes that are both readable are collected in one `epoll_wait()` batch, and whichever handler runs first unregisters the other, which must then not be called.

| | events dispatched | unregistered handler | result |
|---|---|---|---|
| before | 2 | **called** | 2 assertions fail |
| after | 1 | skipped | passes |

It also passes on `wxSelectDispatcher`, which already behaves this way.

## Reproducing it

Nothing but the dispatcher: two pipes, no threads, no timing, no watchers. Both descriptors are readable, so one `epoll_wait()` collects both, and the handler dispatched first unregisters and **deletes** the other one, whose event is still pending in the batch being walked.

```cpp
// g++ -g -O1 -fsanitize=address epollrepro.cpp $(wx-config --cxxflags --libs base) -o epollrepro
#include "wx/init.h"
#include "wx/private/fdiodispatcher.h"

#include <cstdio>
#include <unistd.h>

namespace
{

class Peer;
Peer *g_a = nullptr;
Peer *g_b = nullptr;
int g_dispatched = 0;

class Peer : public wxFDIOHandler
{
public:
    explicit Peer(int fd) : m_fd(fd) { }

    void OnReadWaiting() override
    {
        ++g_dispatched;

        // Destroy the OTHER peer, which is still pending in this same batch.
        Peer *&other = (this == g_a) ? g_b : g_a;
        if ( other )
        {
            Peer *doomed = other;
            other = nullptr;
            wxFDIODispatcher::Get()->UnregisterFD(doomed->m_fd);
            delete doomed;
        }
    }

    void OnWriteWaiting() override { }
    void OnExceptionWaiting() override { }

    int m_fd;
};

// A pipe whose read end already has a byte in it, so it is reported ready.
bool MakeReadablePipe(int fds[2])
{
    if ( pipe(fds) != 0 )
        return false;

    const char b = 'x';
    return write(fds[1], &b, 1) == 1;
}

} // anonymous namespace

int main(int argc, char **argv)
{
    wxInitializer init(argc, argv);
    if ( !init.IsOk() )
    {
        fprintf(stderr, "failed to initialise wxWidgets\n");
        return 2;
    }

    int p1[2], p2[2];
    if ( !MakeReadablePipe(p1) || !MakeReadablePipe(p2) )
    {
        fprintf(stderr, "failed to create pipes\n");
        return 2;
    }

    wxFDIODispatcher *const dispatcher = wxFDIODispatcher::Get();
    if ( !dispatcher )
    {
        fprintf(stderr, "no FD dispatcher\n");
        return 2;
    }

    g_a = new Peer(p1[0]);
    g_b = new Peer(p2[0]);

    if ( !dispatcher->RegisterFD(g_a->m_fd, g_a, wxFDIO_INPUT) ||
         !dispatcher->RegisterFD(g_b->m_fd, g_b, wxFDIO_INPUT) )
    {
        fprintf(stderr, "failed to register descriptors\n");
        return 2;
    }

    // Collects both descriptors, dispatches the first, which frees the second.
    const int numEvents = dispatcher->Dispatch(0);

    printf("dispatched=%d handlers_run=%d\n", numEvents, g_dispatched);

    if ( g_dispatched != 1 )
    {
        printf("FAIL: the destroyed handler was called too\n");
        return 1;
    }

    // Whichever survived is still registered.
    Peer *survivor = g_a ? g_a : g_b;
    if ( survivor )
    {
        dispatcher->UnregisterFD(survivor->m_fd);
        delete survivor;
    }

    close(p1[0]); close(p1[1]);
    close(p2[0]); close(p2[1]);

    printf("OK\n");
    return 0;
}
```

Without this change, under ASan:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 at 0xf89afc5e5cf0 thread T0
  #0 wxEpollDispatcher::Dispatch(int)   src/unix/epolldispatcher.cpp:233
  #1 main                                epollrepro.cpp:102
freed by thread T0 here:
  #1 ~Peer          epollrepro.cpp:30
  #2 OnReadWaiting  epollrepro.cpp:46
```

`epolldispatcher.cpp:233` is the `handler->OnReadWaiting()` call, and the free happens one frame below `Dispatch()`, inside the other handler.

With this change: `dispatched=1 handlers_run=1`, then `OK`, exit 0.

## How it was found

Investigating a crash in aMule, where `wxWebRequest`'s curl backend destroys transfer event sources from inside curl callbacks that themselves run during `Dispatch()`. The diagnosis is @ngosang's, in [amule-org/amule#1136](https://github.com/amule-org/amule/issues/1136).

## Verified

Built and tested on Linux/aarch64 against master. `wx-config --version` 3.3.4, GCC 15.2, Ubuntu 26.04. Compiles warning-free under the project's own flags, full wxBase builds cleanly, and the before/after above was produced with a forced rebuild on each side.

I have not tested this on x86_64.

## Please consider backporting to 3.2

This crashes released builds, and 3.2 is the series users actually get. wxWidgets' own downloads page lists 3.3.3 as the *Development Release* and 3.2.11 as the *Latest Stable Release*, and distributions have followed that:

| | wx |
|---|---|
| Debian 13 trixie / 14 forky / sid | 3.2.8 / 3.2.11 / 3.2.11 |
| Ubuntu 24.04 LTS / 25.10 / 26.04 | 3.2.4 / 3.2.9 / 3.2.11 |
| Arch (rolling), Fedora Rawhide | 3.2.11, 3.2.11 |
| Alpine edge, Gentoo, FreeBSD ports | 3.2.9, 3.2.8.1, 3.2.8.1 |

No Linux distribution ships 3.3, and Debian has no `libwxgtk3.3` package in any suite. A fix that lands only on master therefore reaches approximately none of the affected users, and the reports it came from are on 3.2: the original crash is wx 3.2.8, and four independent cores were collected on 3.2.11.

I checked the `3.2` branch: `Dispatch()` there has the identical unguarded loop, and `wxMappedFDIODispatcher` with `FindHandler()` is already present, so the same approach works. This diff does not apply as-is — 3.2 predates the `nullptr` modernisation, so the context differs — but the adaptation is mechanical, and I am happy to prepare and test a 3.2 patch if that would help.




