### PR TITLE
Check for wayland-protocols availability before using it in configure

### DIFF
--- a/configure
+++ b/configure
@@ -28487,7 +28487,7 @@ if ${wx_cv_wayland_protocols_dir+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-                            wx_cv_wayland_protocols_dir=`$PKG_CONFIG --variable=pkgdatadir wayland-protocols`
+                            wx_cv_wayland_protocols_dir=`$PKG_CONFIG --variable=pkgdatadir wayland-protocols 2>/dev/null`
 
 
 fi
@@ -28495,8 +28495,15 @@ fi
 $as_echo "$wx_cv_wayland_protocols_dir" >&6; }
                     WAYLAND_PROTOCOLS_DIR=$wx_cv_wayland_protocols_dir
 
-                    $as_echo "#define wxHAVE_WAYLAND_SESSION_MANAGEMENT 1" >>confdefs.h
+                    if test -n "$WAYLAND_PROTOCOLS_DIR" -a \
+                            -f "$WAYLAND_PROTOCOLS_DIR/stable/xdg-shell/xdg-shell.xml"; then
+                        $as_echo "#define wxHAVE_WAYLAND_SESSION_MANAGEMENT 1" >>confdefs.h
 
+                    else
+                        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wayland-protocols package not found, Wayland session management support will be disabled" >&5
+$as_echo "$as_me: WARNING: wayland-protocols package not found, Wayland session management support will be disabled" >&2;}
+                        WAYLAND_SM_SUPPORT=':'
+                    fi
                 else
                                         WAYLAND_SM_SUPPORT=':'
                 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3134,18 +3134,24 @@ installed, where VER is 2, 3 or 4.
                 )
 
                 if test "$wx_cv_gtk_wayland_sm" = "yes"; then
-                    dnl We don't check for wayland-protocols being installed as
-                    dnl it's a dependency of libgtk-3-dev or similar, and so
-                    dnl should be available.
+                    dnl wayland-protocols is normally a dependency of
+                    dnl libgtk-3-dev or similar, but it's not always pulled in
+                    dnl automatically, so still check that it's really there.
                     AC_CACHE_CHECK([for wayland-protocols data directory],
                         wx_cv_wayland_protocols_dir,
                         [
-                            wx_cv_wayland_protocols_dir=`$PKG_CONFIG --variable=pkgdatadir wayland-protocols`
+                            wx_cv_wayland_protocols_dir=`$PKG_CONFIG --variable=pkgdatadir wayland-protocols 2>/dev/null`
                         ]
                     )
                     WAYLAND_PROTOCOLS_DIR=$wx_cv_wayland_protocols_dir
 
-                    AC_DEFINE(wxHAVE_WAYLAND_SESSION_MANAGEMENT)
+                    if test -n "$WAYLAND_PROTOCOLS_DIR" -a \
+                            -f "$WAYLAND_PROTOCOLS_DIR/stable/xdg-shell/xdg-shell.xml"; then
+                        AC_DEFINE(wxHAVE_WAYLAND_SESSION_MANAGEMENT)
+                    else
+                        AC_MSG_WARN([wayland-protocols package not found, Wayland session management support will be disabled])
+                        WAYLAND_SM_SUPPORT=':'
+                    fi
                 else
                     dnl Don't bother running wayland-scanner for this protocol.
                     WAYLAND_SM_SUPPORT=':'


### PR DESCRIPTION
wx_cv_wayland_protocols_dir could be empty if the wayland-protocols package wasn't installed, but wxHAVE_WAYLAND_SESSION_MANAGEMENT was still being defined unconditionally in this case, resulting in wayland.cpp trying to include the never-generated
xdg-shell-client-protocol.c and failing to compile.

Only define wxHAVE_WAYLAND_SESSION_MANAGEMENT if xdg-shell.xml is actually found under the wayland-protocols data directory, falling back to disabling session management support otherwise, just as is already done when GTK is too old to support it.