### PR TITLE
fix use-after-free with duplicate names in the archive file system

### DIFF
--- a/src/common/fs_arc.cpp
+++ b/src/common/fs_arc.cpp
@@ -8,8 +8,6 @@
 
 #include "wx/wxprec.h"
 
-#include <memory>
-
 #if wxUSE_FS_ARCHIVE
 
 #include "wx/fs_arc.h"
@@ -34,8 +32,13 @@
 // version.
 //---------------------------------------------------------------------------
 
+// The hash is only a lookup index into the linked list below: the list nodes
+// own the wxArchiveEntry objects (see AddToCache() and the destructor). This
+// matters because an archive may contain several entries with the same
+// normalised name and the hash can only hold one pointer per name, so it must
+// not own them or it would free an entry still aliased by a list node.
 using wxArchiveFSEntryHash =
-    std::unordered_map<wxString, std::unique_ptr<wxArchiveEntry>>;
+    std::unordered_map<wxString, wxArchiveEntry*>;
 
 struct wxArchiveFSEntry
 {
@@ -107,6 +110,7 @@ wxArchiveFSCacheDataImpl::~wxArchiveFSCacheDataImpl()
     while (entry)
     {
         wxArchiveFSEntry *next = entry->next;
+        delete entry->entry;
         delete entry;
         entry = next;
     }
@@ -116,12 +120,17 @@ wxArchiveFSCacheDataImpl::~wxArchiveFSCacheDataImpl()
 
 wxArchiveFSEntry *wxArchiveFSCacheDataImpl::AddToCache(wxArchiveEntry *entry)
 {
-    m_hash[entry->GetName(wxPATH_UNIX)] = std::unique_ptr<wxArchiveEntry>(entry);
     wxArchiveFSEntry *fse = new wxArchiveFSEntry;
     *m_endptr = fse;
     (*m_endptr)->entry = entry;
     (*m_endptr)->next = nullptr;
     m_endptr = &(*m_endptr)->next;
+
+    // The list node created above owns "entry"; the hash only indexes it. If
+    // the archive contains a duplicate normalised name this just re-points the
+    // index at the newer entry without freeing the older one, which is still
+    // referenced by its own list node.
+    m_hash[entry->GetName(wxPATH_UNIX)] = entry;
     return fse;
 }
 
@@ -136,7 +145,7 @@ wxArchiveEntry *wxArchiveFSCacheDataImpl::Get(const wxString& name)
     const auto it = m_hash.find(name);
 
     if (it != m_hash.end())
-        return it->second.get();
+        return it->second;
 
     if (!m_archive)
         return nullptr;

--- a/tests/filesys/filesystest.cpp
+++ b/tests/filesys/filesystest.cpp
@@ -27,6 +27,12 @@
 #include "wx/fs_mem.h"
 #include "wx/sstream.h"
 
+#if wxUSE_FS_ARCHIVE && wxUSE_ZIPSTREAM
+    #include "wx/fs_arc.h"
+    #include "wx/mstream.h"
+    #include "wx/zipstrm.h"
+#endif
+
 #include <memory>
 
 // ----------------------------------------------------------------------------
@@ -313,5 +319,84 @@ TEST_CASE("wxFileSystem::MemoryFSHandler", "[filesys][memoryfshandler][find]")
     CHECK( fs.FindFirst(url) == url );
     CHECK( fs.FindNext() == "" );
 }
+
+#if wxUSE_FS_ARCHIVE && wxUSE_ZIPSTREAM
+
+// An archive may contain several entries with the same name. The archive file
+// system used to store the entries in a hash keyed by name that owned them,
+// while also keeping a separate list of raw aliases, so a duplicate name freed
+// the first entry while the list kept pointing at it. Re-enumerating the
+// (cached) archive then dereferenced the dangling pointer, see the discussion
+// in https://github.com/wxWidgets/wxWidgets/pull/26492 for the sibling class.
+TEST_CASE("wxFileSystem::ArchiveDuplicateNames", "[filesys][fs_arc][zip][find]")
+{
+    class AutoHandlers
+    {
+    public:
+        AutoHandlers()
+            : m_mem(new wxMemoryFSHandler()), m_arc(new wxArchiveFSHandler())
+        {
+            wxFileSystem::AddHandler(m_mem.get());
+            wxFileSystem::AddHandler(m_arc.get());
+        }
+
+        ~AutoHandlers()
+        {
+            wxFileSystem::RemoveHandler(m_arc.get());
+            wxFileSystem::RemoveHandler(m_mem.get());
+        }
+
+    private:
+        std::unique_ptr<wxMemoryFSHandler> const m_mem;
+        std::unique_ptr<wxArchiveFSHandler> const m_arc;
+    } autoHandlers;
+
+    // Build a zip with two entries sharing the same name.
+    wxMemoryOutputStream mos;
+    {
+        wxZipOutputStream zos(mos);
+        REQUIRE( zos.PutNextEntry("dup.txt") );
+        zos.Write("one", 3);
+        REQUIRE( zos.PutNextEntry("dup.txt") );
+        zos.Write("two", 3);
+        REQUIRE( zos.Close() );
+    }
+
+    const size_t zipLen = mos.GetSize();
+    std::unique_ptr<unsigned char[]> zipData(new unsigned char[zipLen]);
+    mos.CopyTo(zipData.get(), zipLen);
+    wxMemoryFSHandler::AddFile("dup.zip", zipData.get(), zipLen);
+
+    wxFileSystem fs;
+
+    // First enumeration reads and caches the whole archive; adding the second
+    // "dup.txt" is what used to free the first entry.
+    int firstCount = 0;
+    for ( wxString url = fs.FindFirst("memory:dup.zip#zip:*", wxFILE);
+          !url.empty();
+          url = fs.FindNext() )
+    {
+        firstCount++;
+    }
+    CHECK( firstCount == 2 );
+
+    // Second enumeration walks the cached list of entries: with the bug this
+    // reads the freed first entry (an ASAN use-after-free) and can return a
+    // bogus name; with the fix both entries are still alive.
+    int secondCount = 0;
+    for ( wxString url = fs.FindFirst("memory:dup.zip#zip:*", wxFILE);
+          !url.empty();
+          url = fs.FindNext() )
+    {
+        INFO("Found URL was: " << url);
+        CHECK( url.EndsWith("dup.txt") );
+        secondCount++;
+    }
+    CHECK( secondCount == 2 );
+
+    wxMemoryFSHandler::RemoveFile("dup.zip");
+}
+
+#endif // wxUSE_FS_ARCHIVE && wxUSE_ZIPSTREAM
 
 #endif // wxUSE_FILESYSTEM


### PR DESCRIPTION
the archive file system caches each entry in a hash keyed by name that owns the entry, alongside a parallel list holding raw pointers to those same entries. zip and tar both allow several members with the same name, and caching a duplicate overwrites the hash slot and frees the earlier entry while its list node still points at it, so re-enumerating the cached archive reads freed memory (an ASAN use-after-free in DoFind, reachable through wxFileSystem for a crafted archive). the fix moves ownership of the entries onto the list nodes and leaves the hash as a non-owning index, so a duplicate name only re-points the lookup and never frees an entry that is still referenced. added a regression test that enumerates a zip containing two identically named entries.