### PR TITLE
Use a per-descriptor wrapper in wxEpollDispatcher instead of a map

### DIFF
--- a/include/wx/unix/private/epolldispatcher.h
+++ b/include/wx/unix/private/epolldispatcher.h
@@ -20,6 +20,8 @@
     #include "wx/thread.h"
 #endif
 
+#include <vector>
+
 struct epoll_event;
 
 class WXDLLIMPEXP_BASE wxEpollDispatcher : public wxFDIODispatcher
@@ -48,32 +50,47 @@ private:
     // given timeout
     int DoPoll(epoll_event *events, int numEvents, int timeout) const;
 
-    // Look up the handler currently registered for the given descriptor, or
-    // nullptr if there is none (any more).
-    wxFDIOHandler *FindHandler(int fd) const;
+    // What epoll_event::data.ptr points at, instead of the handler itself.
+    //
+    // epoll_wait() copies data.ptr into the batch it returns before any
+    // handler runs, and dispatching one event of that batch can unregister,
+    // and in the code owning it destroy, the handler for a later one.
+    // Unregistering clears the handler here, which is how Dispatch() knows a
+    // registration is gone.
+    struct Entry
+    {
+        explicit Entry(wxFDIOHandler *handler_) : handler(handler_) { }
 
-    // Record, replace or forget the handler for a descriptor. Kept separate
-    // from the epoll_ctl() calls so that the map is only updated once the
-    // kernel has accepted the change.
-    void StoreHandler(int fd, wxFDIOHandler *handler);
-    void ForgetHandler(int fd);
+        wxFDIOHandler *handler;
+    };
+
+    // Return the entry for this descriptor, creating one with no handler yet
+    // if it does not have any, or nullptr if it has none and none is wanted.
+    Entry *GetEntry(int fd, bool create);
 
 
     int m_epollDescriptor;
 
-    // Maps the descriptors we have registered to their handlers. Dispatch()
-    // needs this because epoll_event::data is a union: it holds the descriptor
-    // so that a handler unregistered while the batch is being processed can be
-    // detected, which means the handler pointer has to be found elsewhere.
+    // Indexed by descriptor, and only ever grown, never shrunk: an entry
+    // cannot be freed when its descriptor is unregistered because a batch
+    // being dispatched may still point at it, so they live as long as the
+    // dispatcher does.
     //
-    // Guarded because descriptors are registered and unregistered from worker
-    // threads -- wxSocketImpl does it from the thread performing the socket
-    // operation -- while Dispatch() reads the map from the thread running the
-    // event loop. epoll_ctl() itself is thread-safe, so nothing but this map
-    // needs the protection, and the lock is never held across a handler call.
-    wxFDIOHandlerMap m_handlers;
+    // The lock guards this vector alone. Descriptors are registered and
+    // unregistered from worker threads -- wxSocketImpl does it from the thread
+    // performing the socket operation -- while Dispatch() runs on the thread
+    // with the event loop. Dispatch() never looks at the vector, reaching an
+    // entry through the pointer epoll_wait() gave back, so it takes no lock,
+    // and no lock is held across a call into a handler.
+    //
+    // Entry::handler itself is an ordinary pointer, written by whichever
+    // thread registers the descriptor and read by the dispatching one. That is
+    // the same cross-thread case as a handler destroyed by another thread
+    // while the loop is between finding it and calling it, which is racy here
+    // as it was before.
+    std::vector<Entry *> m_entries;
 #if wxUSE_THREADS
-    mutable wxCriticalSection m_handlersCS;
+    wxCriticalSection m_entriesCS;
 #endif // wxUSE_THREADS
 };
 

--- a/include/wx/unix/private/epolldispatcher.h
+++ b/include/wx/unix/private/epolldispatcher.h
@@ -64,9 +64,11 @@ private:
         wxFDIOHandler *handler;
     };
 
-    // Return the entry for this descriptor, creating one with no handler yet
-    // if it does not have any, or nullptr if it has none and none is wanted.
-    Entry *GetEntry(int fd, bool create);
+    // Return the entry for this descriptor, creating one if necessary.
+    Entry *GetEntry(int fd);
+
+    // Forget the handler corresponding to the given given descriptor, if any.
+    void ForgetEntry(int fd);
 
 
     int m_epollDescriptor;

--- a/include/wx/unix/private/epolldispatcher.h
+++ b/include/wx/unix/private/epolldispatcher.h
@@ -20,6 +20,7 @@
     #include "wx/thread.h"
 #endif
 
+#include <memory>
 #include <vector>
 
 struct epoll_event;
@@ -59,9 +60,9 @@ private:
     // registration is gone.
     struct Entry
     {
-        explicit Entry(wxFDIOHandler *handler_) : handler(handler_) { }
+        Entry() = default;
 
-        wxFDIOHandler *handler;
+        wxFDIOHandler* handler = nullptr;
     };
 
     // Return the entry for this descriptor, creating one if necessary.
@@ -90,7 +91,7 @@ private:
     // the same cross-thread case as a handler destroyed by another thread
     // while the loop is between finding it and calling it, which is racy here
     // as it was before.
-    std::vector<Entry *> m_entries;
+    std::vector<std::unique_ptr<Entry>> m_entries;
 #if wxUSE_THREADS
     wxCriticalSection m_entriesCS;
 #endif // wxUSE_THREADS

--- a/src/unix/epolldispatcher.cpp
+++ b/src/unix/epolldispatcher.cpp
@@ -98,8 +98,7 @@ wxEpollDispatcher::wxEpollDispatcher(int epollDescriptor)
 
 wxEpollDispatcher::~wxEpollDispatcher()
 {
-    for ( size_t n = 0; n < m_entries.size(); ++n )
-        delete m_entries[n];
+    m_entries.clear();
 
     if ( close(m_epollDescriptor) != 0 )
     {
@@ -115,14 +114,14 @@ wxEpollDispatcher::Entry *wxEpollDispatcher::GetEntry(int fd)
 
     if ( fd >= wxSsize(m_entries) )
     {
-        m_entries.resize(fd + 1, nullptr);
+        m_entries.resize(fd + 1);
     }
 
-    Entry *&entry = m_entries[fd];
+    auto& entry = m_entries[fd];
     if ( !entry )
-        entry = new Entry(nullptr);
+        entry = std::make_unique<Entry>();
 
-    return entry;
+    return entry.get();
 }
 
 void wxEpollDispatcher::ForgetEntry(int fd)

--- a/src/unix/epolldispatcher.cpp
+++ b/src/unix/epolldispatcher.cpp
@@ -113,7 +113,7 @@ wxEpollDispatcher::Entry *wxEpollDispatcher::GetEntry(int fd)
     wxCriticalSectionLocker lock(m_entriesCS);
 #endif
 
-    if ( m_entries.size() <= static_cast<size_t>(fd) )
+    if ( fd >= wxSsize(m_entries) )
     {
         m_entries.resize(fd + 1, nullptr);
     }
@@ -135,7 +135,7 @@ void wxEpollDispatcher::ForgetEntry(int fd)
     // FD seen so far.
     wxCHECK_RET
     (
-        fd < static_cast<int>(m_entries.size()),
+        fd < wxSsize(m_entries),
         wxString::Format("Unregistering FD %d but max seen FD is %d",
                          fd, m_entries.size() - 1)
     );

--- a/src/unix/epolldispatcher.cpp
+++ b/src/unix/epolldispatcher.cpp
@@ -98,44 +98,34 @@ wxEpollDispatcher::wxEpollDispatcher(int epollDescriptor)
 
 wxEpollDispatcher::~wxEpollDispatcher()
 {
+    for ( size_t n = 0; n < m_entries.size(); ++n )
+        delete m_entries[n];
+
     if ( close(m_epollDescriptor) != 0 )
     {
         wxLogSysError(_("Error closing epoll descriptor"));
     }
 }
 
-wxFDIOHandler *wxEpollDispatcher::FindHandler(int fd) const
+wxEpollDispatcher::Entry *wxEpollDispatcher::GetEntry(int fd, bool create)
 {
 #if wxUSE_THREADS
-    wxCriticalSectionLocker lock(m_handlersCS);
+    wxCriticalSectionLocker lock(m_entriesCS);
 #endif
 
-    const wxFDIOHandlerMap::const_iterator it = m_handlers.find(fd);
+    if ( m_entries.size() <= static_cast<size_t>(fd) )
+    {
+        if ( !create )
+            return nullptr;
 
-    return it == m_handlers.end() ? nullptr : it->second.handler;
-}
+        m_entries.resize(fd + 1, nullptr);
+    }
 
-void wxEpollDispatcher::StoreHandler(int fd, wxFDIOHandler *handler)
-{
-#if wxUSE_THREADS
-    wxCriticalSectionLocker lock(m_handlersCS);
-#endif
+    Entry *&entry = m_entries[fd];
+    if ( !entry && create )
+        entry = new Entry(nullptr);
 
-    // Deliberately an unconditional assignment and not an insertion that
-    // complains about an existing entry: wxFDIOManagerUnix decides between
-    // RegisterFD() and ModifyFD() from the mask it keeps on the handler, not
-    // from what this dispatcher knows, so the two can legitimately disagree
-    // about whether a descriptor is already registered.
-    m_handlers[fd] = wxFDIOHandlerEntry(handler, 0);
-}
-
-void wxEpollDispatcher::ForgetHandler(int fd)
-{
-#if wxUSE_THREADS
-    wxCriticalSectionLocker lock(m_handlersCS);
-#endif
-
-    m_handlers.erase(fd);
+    return entry;
 }
 
 bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
@@ -143,8 +133,9 @@ bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
     epoll_event ev;
     ev.events = GetEpollMask(flags, fd);
 
-    // The descriptor and not the handler: see Dispatch() for why.
-    ev.data.fd = fd;
+    // The entry and not the handler: see Entry.
+    Entry * const entry = GetEntry(fd, true);
+    ev.data.ptr = entry;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_ADD, fd, &ev);
     if ( ret != 0 )
@@ -155,7 +146,7 @@ bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
         return false;
     }
 
-    StoreHandler(fd, handler);
+    entry->handler = handler;
     wxLogTrace(wxEpollDispatcher_Trace,
                wxT("Added fd %d (handler %p) to epoll %d"), fd, handler, m_epollDescriptor);
 
@@ -166,7 +157,9 @@ bool wxEpollDispatcher::ModifyFD(int fd, wxFDIOHandler* handler, int flags)
 {
     epoll_event ev;
     ev.events = GetEpollMask(flags, fd);
-    ev.data.fd = fd;
+
+    Entry * const entry = GetEntry(fd, true);
+    ev.data.ptr = entry;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_MOD, fd, &ev);
     if ( ret != 0 )
@@ -177,7 +170,7 @@ bool wxEpollDispatcher::ModifyFD(int fd, wxFDIOHandler* handler, int flags)
         return false;
     }
 
-    StoreHandler(fd, handler);
+    entry->handler = handler;
 
     wxLogTrace(wxEpollDispatcher_Trace,
                 wxT("Modified fd %d (handler: %p) on epoll %d"), fd, handler, m_epollDescriptor);
@@ -196,9 +189,10 @@ bool wxEpollDispatcher::UnregisterFD(int fd)
                       fd, m_epollDescriptor);
     }
     // Drop the handler even if epoll_ctl() above failed: the caller is done
-    // with it either way, and a stale entry here is exactly what Dispatch()
-    // must not find.
-    ForgetHandler(fd);
+    // with it either way, and a stale handler here is exactly what Dispatch()
+    // must not find. The entry itself stays, see Entry.
+    if ( Entry * const entry = GetEntry(fd, false) )
+        entry->handler = nullptr;
 
     wxLogTrace(wxEpollDispatcher_Trace,
                 wxT("removed fd %d from %d"), fd, m_epollDescriptor);
@@ -263,16 +257,17 @@ int wxEpollDispatcher::Dispatch(int timeout)
     int numEvents = 0;
     for ( epoll_event *p = events; p < events + rc; p++ )
     {
-        // Look the handler up now instead of using a pointer recorded when
-        // the descriptor was registered: dispatching an earlier event of this
-        // batch may have unregistered -- and, in the code that owns it,
-        // destroyed -- the handler for a later one, and epoll_wait() filled
-        // this array in before any of that happened. Using the recorded
-        // pointer would then call a virtual function on a destroyed object.
+        // Go through the entry instead of using a handler pointer recorded
+        // when the descriptor was registered: dispatching an earlier event of
+        // this batch may have unregistered, and in the code that owns it
+        // destroyed, the handler for a later one, and epoll_wait() filled this
+        // array in before any of that happened. Using the recorded pointer
+        // would then call a virtual function on a destroyed object.
         //
-        // A descriptor that is no longer registered is therefore expected here
-        // rather than an error, and is simply skipped.
-        wxFDIOHandler * const handler = FindHandler(p->data.fd);
+        // A cleared handler is therefore expected here rather than an error,
+        // and is simply skipped.
+        const Entry * const entry = static_cast<const Entry *>(p->data.ptr);
+        wxFDIOHandler * const handler = entry ? entry->handler : nullptr;
         if ( !handler )
             continue;
 

--- a/src/unix/epolldispatcher.cpp
+++ b/src/unix/epolldispatcher.cpp
@@ -107,7 +107,7 @@ wxEpollDispatcher::~wxEpollDispatcher()
     }
 }
 
-wxEpollDispatcher::Entry *wxEpollDispatcher::GetEntry(int fd, bool create)
+wxEpollDispatcher::Entry *wxEpollDispatcher::GetEntry(int fd)
 {
 #if wxUSE_THREADS
     wxCriticalSectionLocker lock(m_entriesCS);
@@ -115,17 +115,32 @@ wxEpollDispatcher::Entry *wxEpollDispatcher::GetEntry(int fd, bool create)
 
     if ( m_entries.size() <= static_cast<size_t>(fd) )
     {
-        if ( !create )
-            return nullptr;
-
         m_entries.resize(fd + 1, nullptr);
     }
 
     Entry *&entry = m_entries[fd];
-    if ( !entry && create )
+    if ( !entry )
         entry = new Entry(nullptr);
 
     return entry;
+}
+
+void wxEpollDispatcher::ForgetEntry(int fd)
+{
+#if wxUSE_THREADS
+    wxCriticalSectionLocker lock(m_entriesCS);
+#endif
+
+    // This shouldn't happen because we always extend m_entries to the maximum
+    // FD seen so far.
+    wxCHECK_RET
+    (
+        fd < static_cast<int>(m_entries.size()),
+        wxString::Format("Unregistering FD %d but max seen FD is %d",
+                         fd, m_entries.size() - 1)
+    );
+
+    m_entries[fd]->handler = nullptr;
 }
 
 bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
@@ -134,7 +149,7 @@ bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
     ev.events = GetEpollMask(flags, fd);
 
     // The entry and not the handler: see Entry.
-    Entry * const entry = GetEntry(fd, true);
+    Entry * const entry = GetEntry(fd);
     ev.data.ptr = entry;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_ADD, fd, &ev);
@@ -158,7 +173,7 @@ bool wxEpollDispatcher::ModifyFD(int fd, wxFDIOHandler* handler, int flags)
     epoll_event ev;
     ev.events = GetEpollMask(flags, fd);
 
-    Entry * const entry = GetEntry(fd, true);
+    Entry * const entry = GetEntry(fd);
     ev.data.ptr = entry;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_MOD, fd, &ev);
@@ -188,11 +203,11 @@ bool wxEpollDispatcher::UnregisterFD(int fd)
         wxLogSysError(_("Failed to unregister descriptor %d from epoll descriptor %d"),
                       fd, m_epollDescriptor);
     }
+
     // Drop the handler even if epoll_ctl() above failed: the caller is done
     // with it either way, and a stale handler here is exactly what Dispatch()
-    // must not find. The entry itself stays, see Entry.
-    if ( Entry * const entry = GetEntry(fd, false) )
-        entry->handler = nullptr;
+    // must not find. The entry itself stays valid, see comment for Entry.
+    ForgetEntry(fd);
 
     wxLogTrace(wxEpollDispatcher_Trace,
                 wxT("removed fd %d from %d"), fd, m_epollDescriptor);


### PR DESCRIPTION
Follow-up to ddd1e72, which fixed the use-after-free with a descriptor-keyed map. @vadz preferred a wrapper pointer, so this converts it to one.

## What changes

`Dispatch()` currently resolves the handler with `FindHandler(p->data.fd)`, taking the lock once per event dispatched, on the thread running the event loop.

This points `epoll_event::data.ptr` at a small dispatcher-owned `Entry` holding the handler instead. Unregistering clears the handler in the entry rather than freeing it, since a batch being dispatched may still point at one, so entries live as long as the dispatcher and are indexed by descriptor.

`Dispatch()` then reaches the handler through the pointer `epoll_wait()` gave back and never looks at the container, so it takes no lock at all. What remains guards only growth of the vector, from registrations made on worker threads.

It also makes the `RegisterFD()`/`ModifyFD()` disagreement documented in the map version a non-issue: an entry is created on demand by either path, so there is nothing to reconcile.

## One deliberate difference

`Entry::handler` is an ordinary pointer, written by whichever thread registers the descriptor and read without the lock by the dispatching one. That is the same cross-thread case ddd1e72's own message records as racy before and after it. If you would rather that read were synchronised, say so and I will change it.

## Verified

Linux/aarch64, GCC 15.2, Ubuntu 26.04, ASan build of master at fcc0fed.

- The test added with the map version passes unchanged, 7 assertions.
- Standalone reproducer from #26924: 200 runs, 200 clean.
- Full suite: 870 of 871 cases pass. The single failure, `WebRequest::Sync::PostAfterRedirect`, fails identically on unpatched master in this environment.

Not tested on x86_64.

This is a cleanup rather than a fix, so there is no hurry on it. The `3.2` backport is the part that still matters, and I will send whichever version you keep here.
