### PR TITLE
Don't call handlers unregistered during wxEpollDispatcher::Dispatch()

### DIFF
--- a/include/wx/unix/private/epolldispatcher.h
+++ b/include/wx/unix/private/epolldispatcher.h
@@ -16,6 +16,12 @@
 
 #include "wx/private/fdiodispatcher.h"
 
+#if wxUSE_THREADS
+    #include "wx/thread.h"
+#endif
+
+#include <vector>
+
 struct epoll_event;
 
 class WXDLLIMPEXP_BASE wxEpollDispatcher : public wxFDIODispatcher
@@ -44,8 +50,50 @@ private:
     // given timeout
     int DoPoll(epoll_event *events, int numEvents, int timeout) const;
 
+    // What epoll_event::data.ptr points at, instead of the handler itself.
+    //
+    // epoll_wait() copies data.ptr into the batch it returns before any
+    // handler runs, and dispatching one event of that batch can unregister,
+    // and in the code owning it destroy, the handler for a later one.
+    // Unregistering clears the handler here, which is how Dispatch() knows a
+    // registration is gone.
+    struct Entry
+    {
+        Entry() : handler(NULL) { }
+
+        wxFDIOHandler *handler;
+    };
+
+    // Return the entry for this descriptor, creating one if necessary.
+    Entry *GetEntry(int fd);
+
+    // Forget the handler corresponding to the given given descriptor, if any.
+    void ForgetEntry(int fd);
+
 
     int m_epollDescriptor;
+
+    // Indexed by descriptor, and only ever grown, never shrunk: an entry
+    // cannot be freed when its descriptor is unregistered because a batch
+    // being dispatched may still point at it, so they live as long as the
+    // dispatcher does.
+    //
+    // The lock guards this vector alone. Descriptors are registered and
+    // unregistered from worker threads -- wxSocketImpl does it from the thread
+    // performing the socket operation -- while Dispatch() runs on the thread
+    // with the event loop. Dispatch() never looks at the vector, reaching an
+    // entry through the pointer epoll_wait() gave back, so it takes no lock,
+    // and no lock is held across a call into a handler.
+    //
+    // Entry::handler itself is an ordinary pointer, written by whichever
+    // thread registers the descriptor and read by the dispatching one. That is
+    // the same cross-thread case as a handler destroyed by another thread
+    // while the loop is between finding it and calling it, which is racy here
+    // as it was before.
+    std::vector<Entry *> m_entries;
+#if wxUSE_THREADS
+    wxCriticalSection m_entriesCS;
+#endif // wxUSE_THREADS
 };
 
 #endif // wxUSE_EPOLL_DISPATCHER

--- a/src/unix/epolldispatcher.cpp
+++ b/src/unix/epolldispatcher.cpp
@@ -98,17 +98,66 @@ wxEpollDispatcher::wxEpollDispatcher(int epollDescriptor)
 
 wxEpollDispatcher::~wxEpollDispatcher()
 {
+    for ( size_t n = 0; n < m_entries.size(); ++n )
+        delete m_entries[n];
+
     if ( close(m_epollDescriptor) != 0 )
     {
         wxLogSysError(_("Error closing epoll descriptor"));
     }
 }
 
+wxEpollDispatcher::Entry *wxEpollDispatcher::GetEntry(int fd)
+{
+#if wxUSE_THREADS
+    wxCriticalSectionLocker lock(m_entriesCS);
+#endif
+
+    if ( static_cast<size_t>(fd) >= m_entries.size() )
+    {
+        m_entries.resize(fd + 1, NULL);
+    }
+
+    Entry *&entry = m_entries[fd];
+    if ( !entry )
+        entry = new Entry();
+
+    return entry;
+}
+
+void wxEpollDispatcher::ForgetEntry(int fd)
+{
+#if wxUSE_THREADS
+    wxCriticalSectionLocker lock(m_entriesCS);
+#endif
+
+    // This shouldn't happen because we always extend m_entries to the maximum
+    // FD seen so far.
+    wxCHECK_RET
+    (
+        static_cast<size_t>(fd) < m_entries.size(),
+        wxString::Format("Unregistering FD %d but max seen FD is %d",
+                         fd, static_cast<int>(m_entries.size()) - 1)
+    );
+
+    Entry * const entry = m_entries[fd];
+    wxCHECK_RET
+    (
+        entry,
+        wxString::Format("Unregistering not registered FD %d", fd)
+    );
+
+    entry->handler = NULL;
+}
+
 bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
 {
     epoll_event ev;
     ev.events = GetEpollMask(flags, fd);
-    ev.data.ptr = handler;
+
+    // The entry and not the handler: see Entry.
+    Entry * const entry = GetEntry(fd);
+    ev.data.ptr = entry;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_ADD, fd, &ev);
     if ( ret != 0 )
@@ -118,6 +167,8 @@ bool wxEpollDispatcher::RegisterFD(int fd, wxFDIOHandler* handler, int flags)
 
         return false;
     }
+
+    entry->handler = handler;
     wxLogTrace(wxEpollDispatcher_Trace,
                wxT("Added fd %d (handler %p) to epoll %d"), fd, handler, m_epollDescriptor);
 
@@ -128,7 +179,9 @@ bool wxEpollDispatcher::ModifyFD(int fd, wxFDIOHandler* handler, int flags)
 {
     epoll_event ev;
     ev.events = GetEpollMask(flags, fd);
-    ev.data.ptr = handler;
+
+    Entry * const entry = GetEntry(fd);
+    ev.data.ptr = entry;
 
     const int ret = epoll_ctl(m_epollDescriptor, EPOLL_CTL_MOD, fd, &ev);
     if ( ret != 0 )
@@ -138,6 +191,8 @@ bool wxEpollDispatcher::ModifyFD(int fd, wxFDIOHandler* handler, int flags)
 
         return false;
     }
+
+    entry->handler = handler;
 
     wxLogTrace(wxEpollDispatcher_Trace,
                 wxT("Modified fd %d (handler: %p) on epoll %d"), fd, handler, m_epollDescriptor);
@@ -155,6 +210,12 @@ bool wxEpollDispatcher::UnregisterFD(int fd)
         wxLogSysError(_("Failed to unregister descriptor %d from epoll descriptor %d"),
                       fd, m_epollDescriptor);
     }
+
+    // Drop the handler even if epoll_ctl() above failed: the caller is done
+    // with it either way, and a stale handler here is exactly what Dispatch()
+    // must not find. The entry itself stays valid, see comment for Entry.
+    ForgetEntry(fd);
+
     wxLogTrace(wxEpollDispatcher_Trace,
                 wxT("removed fd %d from %d"), fd, m_epollDescriptor);
     return true;
@@ -218,12 +279,19 @@ int wxEpollDispatcher::Dispatch(int timeout)
     int numEvents = 0;
     for ( epoll_event *p = events; p < events + rc; p++ )
     {
-        wxFDIOHandler * const handler = (wxFDIOHandler *)(p->data.ptr);
+        // Go through the entry instead of using a handler pointer recorded
+        // when the descriptor was registered: dispatching an earlier event of
+        // this batch may have unregistered, and in the code that owns it
+        // destroyed, the handler for a later one, and epoll_wait() filled this
+        // array in before any of that happened. Using the recorded pointer
+        // would then call a virtual function on a destroyed object.
+        //
+        // A cleared handler is therefore expected here rather than an error,
+        // and is simply skipped.
+        const Entry * const entry = static_cast<const Entry *>(p->data.ptr);
+        wxFDIOHandler * const handler = entry ? entry->handler : NULL;
         if ( !handler )
-        {
-            wxFAIL_MSG( wxT("NULL handler in epoll_event?") );
             continue;
-        }
 
         // note that for compatibility with wxSelectDispatcher we call
         // OnReadWaiting() on EPOLLHUP as this is what epoll_wait() returns

--- a/tests/events/evtsource.cpp
+++ b/tests/events/evtsource.cpp
@@ -1,9 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Name:        tests/events/evtsource.cpp
-// Purpose:     Test the event sources
-// Author:      Bartosz Bekier
-// Created:     2009-01-24
-// Copyright:   (c) 2009 Bartosz Bekier <bartosz.bekier@gmail.com>
+// Purpose:     Test wxFDIODispatcher under Unix
+// Created:     2026-08-26
+// Copyright:   (c) 2026 wxWidgets development team
 // Licence:     wxWindows licence
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -12,3 +11,136 @@
 // ----------------------------------------------------------------------------
 
 #include "testprec.h"
+
+#ifndef WX_PRECOMP
+#endif // WX_PRECOMP
+
+#ifdef __UNIX__
+
+#include "wx/private/fdiodispatcher.h"
+
+#include <unistd.h>
+
+// ----------------------------------------------------------------------------
+// a handler that unregisters another one from inside its own callback
+// ----------------------------------------------------------------------------
+
+namespace
+{
+
+// Both handlers below are registered for descriptors that are ready at the
+// same time, so a single Dispatch() call sees both of them in one batch. The
+// first one to run unregisters the other, which must then not be called: the
+// dispatcher has to notice that the registration is gone rather than reuse
+// whatever it recorded when the batch was collected.
+class UnregisteringHandler : public wxFDIOHandler
+{
+public:
+    explicit UnregisteringHandler(int fd)
+        : m_fd(fd), m_peer(NULL), m_registered(false), m_called(false) { }
+
+    void OnReadWaiting() wxOVERRIDE
+    {
+        m_called = true;
+
+        if ( m_peer && m_peer->m_registered )
+        {
+            wxFDIODispatcher::Get()->UnregisterFD(m_peer->m_fd);
+            m_peer->m_registered = false;
+        }
+    }
+
+    void OnWriteWaiting() wxOVERRIDE { }
+    void OnExceptionWaiting() wxOVERRIDE { }
+
+    int m_fd;
+    UnregisteringHandler *m_peer;
+    bool m_registered;
+    bool m_called;
+};
+
+// Pipe whose read end is already readable, so that registering it guarantees
+// the dispatcher reports it immediately.
+struct ReadablePipe
+{
+    ReadablePipe()
+    {
+        if ( pipe(m_fds) != 0 )
+        {
+            m_fds[0] =
+            m_fds[1] = -1;
+            return;
+        }
+
+        const char b = 'x';
+        if ( write(m_fds[1], &b, 1) != 1 )
+        {
+            // Leave the descriptors valid; the test below checks readiness.
+        }
+    }
+
+    ~ReadablePipe()
+    {
+        if ( IsOk() )
+        {
+            close(m_fds[0]);
+            close(m_fds[1]);
+        }
+    }
+
+    int ReadEnd() const { return m_fds[0]; }
+    bool IsOk() const { return m_fds[0] != -1; }
+
+    int m_fds[2];
+};
+
+} // anonymous namespace
+
+// ----------------------------------------------------------------------------
+// the test itself
+// ----------------------------------------------------------------------------
+
+// A descriptor unregistered while the dispatcher is still working through the
+// events it collected must not have its handler called afterwards.
+//
+// wxSelectDispatcher looks the handler up per ready descriptor and so has
+// always behaved this way. wxEpollDispatcher used to store the handler pointer
+// in the epoll_event itself and call through the copy taken before any handler
+// ran, which meant a handler unregistered - and, in real code, destroyed -
+// while servicing an earlier event of the same batch was still called, on
+// memory its owner had already released.
+TEST_CASE("EventSource::UnregisterDuringDispatch", "[fdiodispatcher]")
+{
+    wxFDIODispatcher * const dispatcher = wxFDIODispatcher::Get();
+    REQUIRE( dispatcher );
+
+    ReadablePipe pipe1, pipe2;
+    REQUIRE( pipe1.IsOk() );
+    REQUIRE( pipe2.IsOk() );
+
+    UnregisteringHandler handler1(pipe1.ReadEnd());
+    UnregisteringHandler handler2(pipe2.ReadEnd());
+    handler1.m_peer = &handler2;
+    handler2.m_peer = &handler1;
+
+    REQUIRE( dispatcher->RegisterFD(handler1.m_fd, &handler1, wxFDIO_INPUT) );
+    handler1.m_registered = true;
+    REQUIRE( dispatcher->RegisterFD(handler2.m_fd, &handler2, wxFDIO_INPUT) );
+    handler2.m_registered = true;
+
+    // Both descriptors are readable, so this collects both of them and then
+    // dispatches the first, which unregisters the second.
+    const int numEvents = dispatcher->Dispatch(0);
+
+    // Exactly one handler ran: the one that was unregistered before its turn
+    // came must have been skipped.
+    CHECK( handler1.m_called != handler2.m_called );
+    CHECK( numEvents == 1 );
+
+    if ( handler1.m_registered )
+        dispatcher->UnregisterFD(handler1.m_fd);
+    if ( handler2.m_registered )
+        dispatcher->UnregisterFD(handler2.m_fd);
+}
+
+#endif // __UNIX__


### PR DESCRIPTION
Backport of ddd1e72 and 44efecd to `3.2`, as discussed in #26930.

Derived from master's final state rather than replaying the map version first, since that would only be replaced again in the same PR.

## Adaptations

Three constructs are not available here, so:

| master | `3.2` |
|---|---|
| `std::vector<std::unique_ptr<Entry>>`, `std::make_unique` | `std::vector<Entry *>`, `new` / `delete` in the dtor |
| `Entry() = default;` with a default member initialiser | explicit `Entry() : handler(NULL) { }` |
| `fd >= wxSsize(m_entries)` | `static_cast<size_t>(fd) >= m_entries.size()` |

plus `nullptr` to `NULL` and `override` to `wxOVERRIDE`. Behaviour is otherwise identical, including both `wxCHECK_RET()`s in `ForgetEntry()`.

One incidental difference: comparing as `size_t` also rejects a negative descriptor, which the signed `wxSsize()` comparison on master does not.

## Verified

Linux/aarch64, GCC 15.2, ASan build of `3.2` at 81eae11 (`wx-config --version` 3.2.12), forced rebuild and relink on each side.

| | `tests/events/evtsource.cpp` | reproducer, 200 runs |
|---|---|---|
| stock `3.2` | fails, 2 assertions | 0 pass, 200 heap-use-after-free |
| this change | passes, 7 assertions | 200 pass, 0 failures |

Full test suite on the patched build: **321 test cases, all passed** (1286896 assertions), no failures.

The reproducer is the standalone one from #26924, unchanged. `tests/events/evtsource.cpp` was an empty stub on this branch too, and `tests/Makefile.in` already lists it, so no build system change is needed.

Not tested on x86_64.
