### PR TITLE
Fix various tests when running on Fedora/Wayland/Gnome Shell

### DIFF
--- a/tests/controls/buttontest.cpp
+++ b/tests/controls/buttontest.cpp
@@ -51,6 +51,9 @@ ButtonTestCase::ButtonTestCase()
 
 TEST_CASE_METHOD(ButtonTestCase, "Button::Click", "[button]")
 {
+    if ( !EnableUITests() )
+        return;
+
     //We use the internal class EventCounter which handles connecting and
     //disconnecting the control to the wxTestableFrame
     EventCounter clicked(m_button.get(), wxEVT_BUTTON);
@@ -73,6 +76,9 @@ TEST_CASE_METHOD(ButtonTestCase, "Button::Click", "[button]")
 
 TEST_CASE_METHOD(ButtonTestCase, "Button::Disabled", "[button]")
 {
+    if ( !EnableUITests() )
+        return;
+
     wxUIActionSimulator sim;
 
     // In this test we disable the button and check events are not sent and we

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -498,6 +498,9 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellEditResize", "[grid]")
 TEST_CASE_METHOD(GridTestCase, "Grid::CellClick", "[grid]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     EventCounter lclick(m_grid, wxEVT_GRID_CELL_LEFT_CLICK);
     EventCounter ldclick(m_grid, wxEVT_GRID_CELL_LEFT_DCLICK);
     EventCounter rclick(m_grid, wxEVT_GRID_CELL_RIGHT_CLICK);
@@ -556,6 +559,9 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellClick", "[grid]")
 TEST_CASE_METHOD(GridTestCase, "Grid::ReorderedColumnsCellClick", "[grid]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     EventCounter click(m_grid, wxEVT_GRID_CELL_LEFT_CLICK);
 
     wxUIActionSimulator sim;
@@ -587,6 +593,9 @@ TEST_CASE_METHOD(GridTestCase, "Grid::ReorderedColumnsCellClick", "[grid]")
 TEST_CASE_METHOD(GridTestCase, "Grid::CellSelect", "[grid]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     EventCounter cell(m_grid, wxEVT_GRID_SELECT_CELL);
 
     wxUIActionSimulator sim;

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -2240,7 +2240,13 @@ public:
 // test below.
 inline void UpdateGrid(wxGrid* grid)
 {
-#ifndef __WXQT__
+#if defined(__WXGTK__)
+    // Update() is a no-op under GTK3/Wayland, so wait for the actual
+    // paint event instead of relying on it being synchronous.
+    WaitForPaint waitForPaint(grid);
+    grid->Refresh();
+    waitForPaint.YieldUntilPainted();
+#elif !defined(__WXQT__)
     grid->Refresh();
     grid->Update();
 #else

--- a/tests/controls/radiobuttontest.cpp
+++ b/tests/controls/radiobuttontest.cpp
@@ -50,6 +50,9 @@ TEST_CASE_METHOD(RadioButtonTestCase, "RadioButton::Click", "[radiobutton]")
 {
     // OS X doesn't support selecting a single radio button
 #if wxUSE_UIACTIONSIMULATOR && !defined(__WXOSX__)
+    if ( !EnableUITests() )
+        return;
+
     EventCounter selected(m_radio.get(), wxEVT_RADIOBUTTON);
 
     wxUIActionSimulator sim;

--- a/tests/controls/spinctrldbltest.cpp
+++ b/tests/controls/spinctrldbltest.cpp
@@ -70,6 +70,9 @@ TEST_CASE("SpinCtrlDouble::NoEventsInCtor", "[spinctrl][spinctrldouble]")
 TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
                  "SpinCtrlDouble::Arrows", "[spinctrl][spinctrldouble]")
 {
+    if ( !EnableUITests() )
+        return;
+
     EventCounter updated(m_spin.get(), wxEVT_SPINCTRLDOUBLE);
 
     wxUIActionSimulator sim;
@@ -94,6 +97,9 @@ TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
 TEST_CASE_METHOD(SpinCtrlDoubleTestCaseWrap,
                  "SpinCtrlDouble::Wrap", "[spinctrl][spinctrldouble]")
 {
+    if ( !EnableUITests() )
+        return;
+
     wxUIActionSimulator sim;
 
     m_spin->SetFocus();
@@ -196,6 +202,9 @@ TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
 TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
                  "SpinCtrlDouble::Increment", "[spinctrl][spinctrldouble]")
 {
+    if ( !EnableUITests() )
+        return;
+
     CHECK( m_spin->GetIncrement() == 1.0 );
 
     m_spin->SetDigits(1);

--- a/tests/controls/spinctrltest.cpp
+++ b/tests/controls/spinctrltest.cpp
@@ -143,6 +143,9 @@ TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::NoEventsInCtor", "[spinctrl]")
 TEST_CASE_METHOD(SpinCtrlTestCase2, "SpinCtrl::Arrows", "[spinctrl]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     EventCounter updated(m_spin.get(), wxEVT_SPINCTRL);
 
     wxUIActionSimulator sim;
@@ -170,6 +173,9 @@ TEST_CASE_METHOD(SpinCtrlTestCase2, "SpinCtrl::Arrows", "[spinctrl]")
 TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::Wrap", "[spinctrl]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     m_spin->Create(wxTheApp->GetTopWindow(), wxID_ANY, "",
                    wxDefaultPosition, wxDefaultSize,
                    wxSP_ARROW_KEYS | wxSP_WRAP);
@@ -337,6 +343,9 @@ TEST_CASE_METHOD(SpinCtrlTestCase2, "SpinCtrl::Base", "[spinctrl]")
 TEST_CASE_METHOD(SpinCtrlTestCase3, "SpinCtrl::SetValueInsideEventHandler", "[spinctrl]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     // A dummy control with which we change the focus.
     wxTextCtrl* text = new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY);
     text->Move(m_spin->GetSize().x, m_spin->GetSize().y * 3);
@@ -367,6 +376,9 @@ TEST_CASE_METHOD(SpinCtrlTestCase3, "SpinCtrl::SetValueInsideEventHandler", "[sp
 TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::Increment", "[spinctrl]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     m_spin->Create(wxTheApp->GetTopWindow(), wxID_ANY, "",
         wxDefaultPosition, wxDefaultSize,
         wxSP_ARROW_KEYS | wxSP_WRAP);

--- a/tests/controls/styledtextctrltest.cpp
+++ b/tests/controls/styledtextctrltest.cpp
@@ -62,6 +62,9 @@ TEST_CASE_METHOD(StcPopupWindowsTestCase,
                  "wxStyledTextCtrl::AutoComp",
                  "[wxStyledTextCtrl][focus]")
 {
+    if ( !EnableUITests() )
+        return;
+
     m_stc->SetFocus();
     m_focusAlwaysRetained = true;
     m_stc->AutoCompShow(0,"ability able about above abroad absence absent");
@@ -111,6 +114,9 @@ TEST_CASE_METHOD(StcPopupWindowsTestCase,
                  "wxStyledTextCtrl::Calltip",
                  "[wxStyledTextCtrl][focus]")
 {
+    if ( !EnableUITests() )
+        return;
+
     m_stc->SetFocus();
     m_calltipClickReceived = false;
     m_focusAlwaysRetained = true;

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -118,6 +118,8 @@ protected:
 
     std::unique_ptr<wxTextCtrl> m_text;
 
+    std::unique_ptr<wxWindow> m_dummySibling;
+
     const long m_style;
 
     wxDECLARE_NO_COPY_CLASS(TextCtrlTestCase);
@@ -197,6 +199,7 @@ void TextCtrlTestCase::CreateText(long extraStyles)
 {
     const long style = m_style | extraStyles;
     const int h = (style & wxTE_MULTILINE) ? TEXT_HEIGHT : -1;
+    m_dummySibling = make_unique<wxWindow>(wxTheApp->GetTopWindow(), wxID_ANY);
     m_text = make_unique<wxTextCtrl>(wxTheApp->GetTopWindow(), wxID_ANY, "",
                                      wxDefaultPosition, wxSize(400, h),
                                      style);

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -204,6 +204,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::DeleteAllItems", "[treectrl]")
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::ItemClick", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     EventCounter activated(m_tree.get(), wxEVT_TREE_ITEM_ACTIVATED);
     EventCounter rclick(m_tree.get(), wxEVT_TREE_ITEM_RIGHT_CLICK);
 
@@ -230,6 +233,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::ItemClick", "[treectrl]")
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::LabelEdit", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     EventCounter beginedit(m_tree.get(), wxEVT_TREE_BEGIN_LABEL_EDIT);
     EventCounter endedit(m_tree.get(), wxEVT_TREE_END_LABEL_EDIT);
 
@@ -256,6 +262,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::LabelEdit", "[treectrl]")
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::KeyDown", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     EventCounter keydown(m_tree.get(), wxEVT_TREE_KEY_DOWN);
 
     wxUIActionSimulator sim;
@@ -270,6 +279,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::KeyDown", "[treectrl]")
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::CollapseExpandEvents", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
 #ifdef __WXGTK__
     // Works locally, but not when run on Travis CI.
     if ( IsAutomaticTest() )
@@ -315,6 +327,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::CollapseExpandEvents", "[treectr
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::SelectionChange", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     m_tree->ExpandAll();
 
     // This is currently needed to work around a problem under wxMSW: clicking
@@ -400,6 +415,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::SelectionChange", "[treectrl]")
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::SelectItemMultiInteractive", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
 #if defined(__WXGTK__) && !defined(__WXGTK3__)
     // FIXME: This test fails on GitHub CI under wxGTK2 although works fine on
     //        development machine, no idea why though!
@@ -475,6 +493,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::SelectItemMultiInteractive", "[t
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::Menu", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     EventCounter menu(m_tree.get(), wxEVT_TREE_ITEM_MENU);
     wxUIActionSimulator sim;
 
@@ -495,6 +516,9 @@ TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::Menu", "[treectrl]")
 
 TEST_CASE_METHOD(TreeCtrlTestCase, "wxTreeCtrl::KeyNavigation", "[treectrl]")
 {
+    if ( !EnableUITests() )
+        return;
+
     wxUIActionSimulator sim;
 
     m_tree->CollapseAll();

--- a/tests/controls/windowtest.cpp
+++ b/tests/controls/windowtest.cpp
@@ -30,6 +30,10 @@
 #include "wx/tooltip.h"
 #include "wx/wupdlock.h"
 
+#ifdef __WXGTK__
+    #include "wx/gtk/private/backend.h"
+#endif // __WXGTK__
+
 
 class WindowTestCase
 {
@@ -627,9 +631,15 @@ TEST_CASE_METHOD(WindowTestCase, "Window::Refresh", "[window]")
     WaitFor("parent repaint", [&]() { return isParentPainted; }, 100);
 
     // child1 should be the only window not to receive the wxEVT_PAINT event
-    // because it does not intersect with the refreshed rectangle.
+    // because it does not intersect with the refreshed rectangle. However,
+    // GTK3 with a native Wayland backend doesn't support partial redraws at
+    // all: any invalidation anywhere ends up repainting every window with
+    // its own full bounds, so don't check this there.
+#ifdef __WXGTK3__
+    if ( wxGTKImpl::IsX11(nullptr) )
+#endif // __WXGTK3__
+        CHECK(isChild1Painted == false);
     CHECK(isParentPainted == true);
-    CHECK(isChild1Painted == false);
     CHECK(isChild2Painted == true);
     CHECK(isChild3Painted == true);
 }

--- a/tests/events/keyboard.cpp
+++ b/tests/events/keyboard.cpp
@@ -229,13 +229,13 @@ TEST_CASE_METHOD(KeyboardEventTestCase, "KeyboardEvent::NormalLetter",
     sim.Char('a');
     wxYield();
 
-    CHECK( m_win->GetKeyDownCount() == 1 );
+    REQUIRE( m_win->GetKeyDownCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(), 'A' );
 
-    CHECK( m_win->GetCharCount() == 1 );
+    REQUIRE( m_win->GetCharCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetCharEvent(), 'a' );
 
-    CHECK( m_win->GetKeyUpCount() == 1 );
+    REQUIRE( m_win->GetKeyUpCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(), 'A' );
 #endif
 }
@@ -250,13 +250,13 @@ TEST_CASE_METHOD(KeyboardEventTestCase, "KeyboardEvent::NormalSpecial",
     sim.Char(WXK_END);
     wxYield();
 
-    CHECK( m_win->GetKeyDownCount() == 1 );
+    REQUIRE( m_win->GetKeyDownCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(), WXK_END );
 
-    CHECK( m_win->GetCharCount() == 1 );
+    REQUIRE( m_win->GetCharCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetCharEvent(), WXK_END );
 
-    CHECK( m_win->GetKeyUpCount() == 1 );
+    REQUIRE( m_win->GetKeyUpCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(), WXK_END );
 }
 
@@ -273,17 +273,17 @@ TEST_CASE_METHOD(KeyboardEventTestCase, "KeyboardEvent::CtrlLetter",
     sim.Char('z', wxMOD_CONTROL);
     wxYield();
 
-    CHECK( m_win->GetKeyDownCount() == 2 );
+    REQUIRE( m_win->GetKeyDownCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(0),
                          ModKeyDown(WXK_CONTROL) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(1),
                          KeyDesc('Z', wxMOD_CONTROL) );
 
-    CHECK( m_win->GetCharCount() == 1 );
+    REQUIRE( m_win->GetCharCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetCharEvent(),
                          KeyDesc('\x1a', wxMOD_CONTROL) );
 
-    CHECK( m_win->GetKeyUpCount() == 2 );
+    REQUIRE( m_win->GetKeyUpCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(0),
                          KeyDesc('Z', wxMOD_CONTROL) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(1),
@@ -301,17 +301,17 @@ TEST_CASE_METHOD(KeyboardEventTestCase, "KeyboardEvent::CtrlSpecial",
     sim.Char(WXK_PAGEUP, wxMOD_CONTROL);
     wxYield();
 
-    CHECK( m_win->GetKeyDownCount() == 2 );
+    REQUIRE( m_win->GetKeyDownCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(0),
                          ModKeyDown(WXK_CONTROL) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(1),
                          KeyDesc(WXK_PAGEUP, wxMOD_CONTROL) );
 
-    CHECK( m_win->GetCharCount() == 1 );
+    REQUIRE( m_win->GetCharCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetCharEvent(),
                          KeyDesc(WXK_PAGEUP, wxMOD_CONTROL) );
 
-    CHECK( m_win->GetKeyUpCount() == 2 );
+    REQUIRE( m_win->GetKeyUpCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(0),
                          KeyDesc(WXK_PAGEUP, wxMOD_CONTROL) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(1),
@@ -328,17 +328,17 @@ TEST_CASE_METHOD(KeyboardEventTestCase, "KeyboardEvent::ShiftLetter",
     sim.Char('Q', wxMOD_SHIFT);
     wxYield();
 
-    CHECK( m_win->GetKeyDownCount() == 2 );
+    REQUIRE( m_win->GetKeyDownCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(0),
                          ModKeyDown(WXK_SHIFT) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(1),
                          KeyDesc('Q', wxMOD_SHIFT) );
 
-    CHECK( m_win->GetCharCount() == 1 );
+    REQUIRE( m_win->GetCharCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetCharEvent(),
                          KeyDesc('Q', wxMOD_SHIFT) );
 
-    CHECK( m_win->GetKeyUpCount() == 2 );
+    REQUIRE( m_win->GetKeyUpCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(0),
                          KeyDesc('Q', wxMOD_SHIFT) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(1),
@@ -355,17 +355,17 @@ TEST_CASE_METHOD(KeyboardEventTestCase, "KeyboardEvent::ShiftSpecial",
     sim.Char(WXK_F3, wxMOD_SHIFT);
     wxYield();
 
-    CHECK( m_win->GetKeyDownCount() == 2 );
+    REQUIRE( m_win->GetKeyDownCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(0),
                          ModKeyDown(WXK_SHIFT) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyDownEvent(1),
                          KeyDesc(WXK_F3, wxMOD_SHIFT) );
 
-    CHECK( m_win->GetCharCount() == 1 );
+    REQUIRE( m_win->GetCharCount() == 1 );
     ASSERT_KEY_EVENT_IS( m_win->GetCharEvent(),
                          KeyDesc(WXK_F3, wxMOD_SHIFT) );
 
-    CHECK( m_win->GetKeyUpCount() == 2 );
+    REQUIRE( m_win->GetKeyUpCount() == 2 );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(0),
                          KeyDesc(WXK_F3, wxMOD_SHIFT) );
     ASSERT_KEY_EVENT_IS( m_win->GetKeyUpEvent(1),

--- a/tests/events/propagation.cpp
+++ b/tests/events/propagation.cpp
@@ -187,8 +187,16 @@ public:
         g_str.clear();
 #endif // __WXGTK__ || __WXQT__
 
+#ifdef __WXGTK__
+        // Update() is a no-op under GTK3/Wayland, so wait for the actual
+        // paint event instead of relying on it being synchronous.
+        WaitForPaint waitForPaint(this);
+        Refresh();
+        waitForPaint.YieldUntilPainted();
+#else
         Refresh();
         Update();
+#endif
     }
 
     virtual void OnDraw(wxDC& WXUNUSED(dc)) override

--- a/tests/graphics/clippingbox.cpp
+++ b/tests/graphics/clippingbox.cpp
@@ -3972,10 +3972,12 @@ TEST_CASE("ClippingBoxTestCase::wxPaintDC", "[clip][dc][paintdc]")
     // Ensure window is shown and large enough for testing
     wxTheApp->GetTopWindow()->Raise();
     REQUIRE(wxTheApp->GetTopWindow()->IsShown());
-    wxSize winSize = wxTheApp->GetTopWindow()->GetSize();
+    // Use client, not outer, size: decorations can eat more than the fixed
+    // margin below leaves room for (e.g. GTK3 client-side decorations).
+    wxSize winSize = wxTheApp->GetTopWindow()->GetClientSize();
     winSize.x = wxMax(winSize.x, s_dcSize.x + 50);
     winSize.y = wxMax(winSize.y, s_dcSize.y + 50);
-    wxTheApp->GetTopWindow()->SetSize(winSize);
+    wxTheApp->GetTopWindow()->SetClientSize(winSize);
 #if defined(__WXGTK__)
     // Under wxGTK we need to have two children (at least) because if there
     // is one child its paint area is set to fill the whole parent frame.

--- a/tests/misc/dynamiclib.cpp
+++ b/tests/misc/dynamiclib.cpp
@@ -41,8 +41,8 @@ TEST_CASE("DynamicLibrary::Load", "[dynlib]")
     static const char* const candidateDirs[] =
     {
         "/lib/x86_64-linux-gnu",
-        "/lib",
         "/lib64",
+        "/lib",
         "/usr/lib",
     };
 

--- a/tests/persistence/tlw.cpp
+++ b/tests/persistence/tlw.cpp
@@ -23,6 +23,7 @@
 
 #ifdef __WXGTK__
     #include "waitfor.h"
+    #include "wx/gtk/private/backend.h"
 #endif // __WXGTK__
 
 // ----------------------------------------------------------------------------
@@ -52,6 +53,14 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
 {
     const wxPoint pos(100, 150);
     const wxSize size(450, 350);
+
+    // Wayland doesn't allow clients to position their own top-level windows
+    // at all, unlike X11, so don't check the restored position there.
+#ifdef __WXGTK3__
+    const bool checkPosition = wxGTKImpl::IsX11(nullptr);
+#else
+    const bool checkPosition = true;
+#endif
 
     // Save the frame geometry.
     {
@@ -96,8 +105,11 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
         // Test that the object was registered and restored.
         CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame));
 
-        CHECK(pos.x == frame->GetPosition().x);
-        CHECK(pos.y == frame->GetPosition().y);
+        if ( checkPosition )
+        {
+            CHECK(pos.x == frame->GetPosition().x);
+            CHECK(pos.y == frame->GetPosition().y);
+        }
         CHECK(size.x == frame->GetSize().GetWidth());
         CHECK(size.y == frame->GetSize().GetHeight());
         CHECK(!frame->IsMaximized());
@@ -152,8 +164,11 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
 
         frame->Restore();
 
-        CHECK(pos.x == frame->GetPosition().x);
-        CHECK(pos.y == frame->GetPosition().y);
+        if ( checkPosition )
+        {
+            CHECK(pos.x == frame->GetPosition().x);
+            CHECK(pos.y == frame->GetPosition().y);
+        }
         CHECK(size.x == frame->GetSize().GetWidth());
         CHECK(size.y == frame->GetSize().GetHeight());
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -43,6 +43,7 @@
 
 #ifdef __WXGTK__
     #include <glib.h>
+    #include "wx/gtk/private/backend.h"
 #endif // __WXGTK__
 #endif // wxUSE_GUI
 
@@ -571,6 +572,20 @@ bool EnableUITests()
 #else // !(__WXMSW__ || __WXGTK__ || __WXQT__)
             s_enabled = 0;
 #endif // (__WXMSW__ || __WXGTK__ || __WXQT__)
+
+#ifdef __WXGTK3__
+            // wxUIActionSimulator injects X11 events, which never reach a
+            // native Wayland client, so disable UI tests by default there
+            // (WX_UI_TESTS=1 above still overrides this).
+            if ( s_enabled == 1 && !wxGTKImpl::IsX11(nullptr) )
+            {
+                s_enabled = 0;
+                wxFprintf(stderr, wxASCII_STR(
+                    "Disabling UI tests: wxUIActionSimulator doesn't work "
+                    "when running as a native Wayland client (use "
+                    "WX_UI_TESTS=1 to force them anyway).\n"));
+            }
+#endif // __WXGTK3__
         }
     }
 

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -312,6 +312,9 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::SignSpace", "[valnum]")
 
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::Interactive", "[valnum]")
 {
+    if ( !EnableUITests() )
+        return;
+
     // Set a locale using comma as thousands separator character.
     wxLocale loc(wxLANGUAGE_ENGLISH_UK, wxLOCALE_DONT_LOAD_DEFAULT);
 

--- a/tests/window/clientsize.cpp
+++ b/tests/window/clientsize.cpp
@@ -60,12 +60,12 @@ TEST_CASE("wxWindow::MinClientSize", "[window][client-size]")
 
 TEST_CASE("wxWindow::SetClientSize", "[window][client-size]")
 {
-#if defined(__WXGTK__) && !defined(__WXGTK3__)
-    // Under wxGTK2 we need to have two children (at least) because if there
+#if defined(__WXGTK__)
+    // Under wxGTK we need to have two children (at least) because if there
     // is exactly one child its size is set to fill the whole parent frame
     // and the window cannot be resized - see wxTopLevelWindowBase::Layout().
     std::unique_ptr<wxWindow> w0(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
-#endif // wxGTK 2
+#endif // wxGTK
     std::unique_ptr<wxWindow> w(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
 
     wxRect reqSize = wxTheApp->GetTopWindow()->GetClientRect();


### PR DESCRIPTION
This fixes a number of test issues when running the tests on Fedora under Wayland/Gnome Shell.

There are still about 10 test cases that fail, but I haven't been able to sort out those yet (they're intermittent).