### PR TITLE
Add KeyTips (keyboard accessibility) to Ribbon

### DIFF
--- a/docs/doxygen/groups/class_ribbon.h
+++ b/docs/doxygen/groups/class_ribbon.h
@@ -16,7 +16,9 @@ toolbar. At a more functional level, it is similar to the user interface
 present in recent versions of Microsoft Office.
 
 Since wxWidgets 3.3.4, the ribbon can also be driven from the keyboard using
-Office-style KeyTips, improving accessibility for users who cannot rely on a
+key tips, i.e. popup windows showing the key which can be used to activate
+the associated element, commonly used in other programs with ribbon interface,
+improving accessibility for users who cannot rely on a
 mouse. Pressing @c WXK_F10 (customizable, see
 wxRibbonBar::SetKeyTipsTriggerKey()) badges every element which was assigned
 one, and typing its letters activates that element. See

--- a/docs/doxygen/groups/class_ribbon.h
+++ b/docs/doxygen/groups/class_ribbon.h
@@ -16,8 +16,10 @@ toolbar. At a more functional level, it is similar to the user interface
 present in recent versions of Microsoft Office.
 
 Since wxWidgets 3.3.4, the ribbon can also be driven from the keyboard using
-Office-style keytips. Pressing @c WXK_F10 badges every element which was
-assigned one, and typing its letters activates that element. See
+Office-style KeyTips, improving accessibility for users who cannot rely on a
+mouse. Pressing @c WXK_F10 (customizable, see
+wxRibbonBar::SetKeyTipsTriggerKey()) badges every element which was assigned
+one, and typing its letters activates that element. See
 wxRibbonBar::ShowKeyTips() and wxRibbonBar::SetPageKeyTip().
 
 */

--- a/docs/doxygen/groups/class_ribbon.h
+++ b/docs/doxygen/groups/class_ribbon.h
@@ -15,4 +15,9 @@ At the most generic level, this is a combination of a tab control with a
 toolbar. At a more functional level, it is similar to the user interface
 present in recent versions of Microsoft Office.
 
+Since wxWidgets 3.3.4, the ribbon can also be driven from the keyboard using
+Office-style keytips. Pressing @c WXK_F10 badges every element which was
+assigned one, and typing its letters activates that element. See
+wxRibbonBar::ShowKeyTips() and wxRibbonBar::SetPageKeyTip().
+
 */

--- a/include/wx/ribbon/art.h
+++ b/include/wx/ribbon/art.h
@@ -327,6 +327,12 @@ public:
                         wxRibbonBar* wnd,
                         const wxRect& rect) = 0;
 
+    virtual void DrawKeyTip(
+                        wxDC& dc,
+                        wxWindow* wnd,
+                        const wxRect& rect,
+                        const wxString& keytip) = 0;
+
     virtual void GetBarTabWidth(
                         wxReadOnlyDC& dc,
                         wxWindow* wnd,
@@ -545,6 +551,12 @@ public:
     void DrawHelpButton(wxDC& dc,
                         wxRibbonBar* wnd,
                         const wxRect& rect) override;
+
+    void DrawKeyTip(
+                    wxDC& dc,
+                    wxWindow* wnd,
+                    const wxRect& rect,
+                    const wxString& keytip) override;
 
     void GetBarTabWidth(
                         wxReadOnlyDC& dc,

--- a/include/wx/ribbon/art.h
+++ b/include/wx/ribbon/art.h
@@ -327,11 +327,15 @@ public:
                         wxRibbonBar* wnd,
                         const wxRect& rect) = 0;
 
-    virtual void DrawKeyTip(
-                        wxDC& dc,
-                        wxWindow* wnd,
-                        const wxRect& rect,
-                        const wxString& keytip) = 0;
+    // This one is not pure virtual for compatibility with the existing art
+    // providers: it returns false if it is not implemented, in which case a
+    // default key tip badge is drawn by the caller.
+    virtual bool DrawKeyTip(
+                        wxDC& WXUNUSED(dc),
+                        wxWindow* WXUNUSED(wnd),
+                        const wxRect& WXUNUSED(rect),
+                        const wxString& WXUNUSED(keytip))
+                        { return false; }
 
     virtual void GetBarTabWidth(
                         wxReadOnlyDC& dc,
@@ -552,7 +556,7 @@ public:
                         wxRibbonBar* wnd,
                         const wxRect& rect) override;
 
-    void DrawKeyTip(
+    bool DrawKeyTip(
                     wxDC& dc,
                     wxWindow* wnd,
                     const wxRect& rect,

--- a/include/wx/ribbon/art_internal.h
+++ b/include/wx/ribbon/art_internal.h
@@ -43,6 +43,16 @@ WXDLLIMPEXP_RIBBON wxBitmap wxRibbonLoadPixmap(
                                 const char* const* bits,
                                 wxColour fore);
 
+// Draw a key tip badge in the default style, used both by the standard art
+// providers and as a fallback for the providers not implementing
+// wxRibbonArtProvider::DrawKeyTip().
+WXDLLIMPEXP_RIBBON void wxRibbonDrawKeyTip(
+                                wxDC& dc,
+                                wxWindow* wnd,
+                                const wxRect& rect,
+                                const wxString& keytip,
+                                const wxFont& font);
+
 /*
    HSL colour class, using interface as discussed in wx-dev. Provided mainly
    for art providers to perform colour scheme calculations in the HSL colour

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -176,7 +176,7 @@ public:
     wxDEPRECATED_MSG("wxRibbonButtonBar now uses wxBitmapBundle for DPI support")
     wxImageList* GetButtonImageList(wxSize size, int initialCount = 1);
 
-    // KeyTips (Office-style keyboard access mode).
+    // Key tips (popup windows showing associated keys).
     void SetPageKeyTip(size_t page, const wxString& keytip);
     void SetPageKeyTip(wxRibbonPage* page, const wxString& keytip);
     void SetToggleButtonKeyTip(const wxString& keytip);
@@ -263,7 +263,7 @@ protected:
 
     wxVector<wxImageList*> m_image_lists;
 
-    // KeyTips (Office-style keyboard access mode) implementation.
+    // Key tips implementation.
 private:
     struct wxRibbonKeyTipInfo
     {

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -15,11 +15,18 @@
 #if wxUSE_RIBBON
 
 class WXDLLIMPEXP_FWD_CORE wxImageList;
+class WXDLLIMPEXP_FWD_CORE wxKeyEvent;
+class WXDLLIMPEXP_FWD_CORE wxActivateEvent;
+class WXDLLIMPEXP_FWD_CORE wxWindowDestroyEvent;
+class wxRibbonButtonBar;
+class wxRibbonToolBar;
 
 #include "wx/ribbon/control.h"
 #include "wx/ribbon/page.h"
 
 #include "wx/vector.h"
+
+#include <vector>
 
 enum wxRibbonBarOption
 {
@@ -91,6 +98,7 @@ public:
     bool hovered;
     bool highlight;
     bool shown;
+    wxString keytip;
 };
 
 // This must be a class because it's forward declared.
@@ -167,6 +175,37 @@ public:
     wxDEPRECATED_MSG("wxRibbonButtonBar now uses wxBitmapBundle for DPI support")
     wxImageList* GetButtonImageList(wxSize size, int initialCount = 1);
 
+    // KeyTips (Office-style keyboard access mode).
+    void SetPageKeyTip(size_t page, const wxString& keytip);
+    void SetPageKeyTip(wxRibbonPage* page, const wxString& keytip);
+    void SetToggleButtonKeyTip(const wxString& keytip);
+    void SetHelpButtonKeyTip(const wxString& keytip);
+
+    bool ShowKeyTips();
+    void HideKeyTips();
+    bool IsKeyTipsShown() const { return m_keyTipsActive; }
+
+    struct TriggerKey
+    {
+        int keyCode;
+        int modifiers;
+    };
+
+    // Replaces all trigger keys with just this one (default is WXK_F10).
+    void SetKeyTipsTriggerKey(int keyCode, int modifiers = wxMOD_NONE);
+    // Adds an additional trigger key (e.g., Ctrl+F10 alongside F10).
+    void AddKeyTipsTriggerKey(int keyCode, int modifiers = wxMOD_NONE);
+    void ClearKeyTipsTriggerKeys();
+    const std::vector<TriggerKey>& GetKeyTipsTriggerKeys() const { return m_keyTipsTriggerKeys; }
+
+    // Implementation only: badges for the keytip targets on 'window'.
+    struct KeyTipBadge
+    {
+        wxRect rect;
+        wxString text;
+    };
+    void GetKeyTipTargetsFor(wxWindow* window, std::vector<KeyTipBadge>* badges) const;
+
 protected:
     friend class wxRibbonPage;
 
@@ -227,6 +266,62 @@ protected:
 
     wxVector<wxImageList*> m_image_lists;
 
+    // KeyTips (Office-style keyboard access mode) implementation.
+private:
+    struct wxRibbonKeyTipInfo
+    {
+        enum Kind
+        {
+            KeyTip_PageTab,
+            KeyTip_ToggleButton,
+            KeyTip_HelpButton,
+            KeyTip_ExtButton,
+            KeyTip_MinimisedPanel,
+            KeyTip_ButtonBarItem,
+            KeyTip_ToolBarItem,
+            KeyTip_Gallery
+        };
+
+        wxString fullKeyTip;
+        wxString remaining;
+        wxRect rect;
+        wxWindow* window = nullptr;
+        Kind kind = KeyTip_PageTab;
+
+        // For KeyTip_ButtonBarItem/KeyTip_ToolBarItem: targets the item's
+        // dropdown arrow instead of its main click area.
+        bool dropdown = false;
+
+        // Data needed to activate this target. Only the member(s) matching
+        // 'kind' are used.
+        size_t pageIndex = 0;
+        wxRibbonPanel* panel = nullptr;
+        wxRibbonButtonBar* buttonBar = nullptr;
+        wxWindowID buttonBarItemId = wxID_ANY;
+        wxRibbonToolBar* toolBar = nullptr;
+        wxWindowID toolBarItemId = wxID_ANY;
+    };
+
+    void DoBuildKeyTipTargets();
+    void DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target);
+    bool IsKeyTipsTriggerKey(int keyCode, int modifiers) const;
+    void OnKeyTipsCharHook(wxKeyEvent& event);
+    void OnKeyTipsActivate(wxActivateEvent& event);
+    void OnKeyTipsWindowDestroy(wxWindowDestroyEvent& event);
+    void RefreshKeyTipTargetWindows();
+
+    bool m_keyTipsActive = false;
+    wxString m_keyTipsTypedPrefix;
+    std::vector<wxRibbonKeyTipInfo> m_keyTipsTargets;
+    // Every window with a badge this session, so a narrowed-away badge
+    // still gets its window refreshed once (to erase it).
+    std::vector<wxWindow*> m_keyTipsWindows;
+    wxWindow* m_keyTipsTopLevelParent = nullptr;
+    std::vector<TriggerKey> m_keyTipsTriggerKeys;
+    wxString m_toggleButtonKeyTip;
+    wxString m_helpButtonKeyTip;
+
+protected:
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonBar);
     wxDECLARE_EVENT_TABLE();

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -267,25 +267,25 @@ protected:
 private:
     struct wxRibbonKeyTipInfo
     {
-        enum Kind
+        enum class Kind
         {
-            KeyTip_PageTab,
-            KeyTip_ToggleButton,
-            KeyTip_HelpButton,
-            KeyTip_ExtButton,
-            KeyTip_MinimisedPanel,
-            KeyTip_ButtonBarItem,
-            KeyTip_ToolBarItem,
-            KeyTip_Gallery
+            PageTab,
+            ToggleButton,
+            HelpButton,
+            ExtButton,
+            MinimisedPanel,
+            ButtonBarItem,
+            ToolBarItem,
+            Gallery
         };
 
         wxString fullKeyTip;
         wxString remaining;
         wxRect rect;
         wxWindow* window = nullptr;
-        Kind kind = KeyTip_PageTab;
+        Kind kind = Kind::PageTab;
 
-        // For KeyTip_ButtonBarItem/KeyTip_ToolBarItem: targets the item's
+        // For Kind::ButtonBarItem/Kind::ToolBarItem: targets the item's
         // dropdown arrow instead of its main click area.
         bool dropdown = false;
 

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -162,6 +162,7 @@ public:
     void SetWindowStyleFlag(long style) override;
     long GetWindowStyleFlag() const override;
     virtual bool Realize() override;
+    bool Reparent(wxWindowBase* newParent) override;
 
     // Implementation only.
     bool IsToggleButtonHovered() const { return m_toggle_button_hovered; }

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -184,7 +184,7 @@ public:
 
     bool ShowKeyTips();
     void HideKeyTips();
-    bool IsKeyTipsShown() const { return m_keyTipsActive; }
+    bool AreKeyTipsShown() const { return m_keyTipsActive; }
 
     struct TriggerKey
     {

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -199,13 +199,9 @@ public:
     void ClearKeyTipsTriggerKeys();
     const std::vector<TriggerKey>& GetKeyTipsTriggerKeys() const { return m_keyTipsTriggerKeys; }
 
-    // Implementation only: badges for the keytip targets on 'window'.
-    struct KeyTipBadge
-    {
-        wxRect rect;
-        wxString text;
-    };
-    void GetKeyTipTargetsFor(wxWindow* window, std::vector<KeyTipBadge>* badges) const;
+    // Implementation only: draw the badges of the keytip targets on 'window',
+    // if any, using the given art provider.
+    void DrawKeyTipsFor(wxDC& dc, wxWindow* window, wxRibbonArtProvider* art) const;
 
 protected:
     friend class wxRibbonPage;

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -18,7 +18,7 @@
 #include "wx/dynarray.h"
 #include "wx/bmpbndl.h"
 
-#include <map>
+#include <unordered_map>
 
 class wxRibbonButtonBar;
 class wxRibbonButtonBarButtonBase;
@@ -238,8 +238,8 @@ protected:
 
 private:
     wxRibbonBar* m_ribbonBar = nullptr;
-    std::map<wxWindowID, wxString> m_keyTips;
-    std::map<wxWindowID, wxString> m_dropdownKeyTips;
+    std::unordered_map<wxWindowID, wxString> m_keyTips;
+    std::unordered_map<wxWindowID, wxString> m_dropdownKeyTips;
 
 
 #ifndef SWIG

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -238,6 +238,8 @@ protected:
 
 private:
     wxRibbonBar* m_ribbonBar = nullptr;
+    // The KeyTips are always stored in upper case, to allow case-insensitive
+    // matching.
     std::unordered_map<wxWindowID, wxString> m_keyTips;
     std::unordered_map<wxWindowID, wxString> m_dropdownKeyTips;
 

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -18,6 +18,8 @@
 #include "wx/dynarray.h"
 #include "wx/bmpbndl.h"
 
+#include <map>
+
 class wxRibbonButtonBar;
 class wxRibbonButtonBarButtonBase;
 class wxRibbonButtonBarLayout;
@@ -133,12 +135,14 @@ public:
     virtual wxRibbonButtonBarButtonBase *GetItemById(int id) const;
     virtual int GetItemId(wxRibbonButtonBarButtonBase *button) const;
     virtual wxRect GetItemRect(int button_id) const;
+    virtual wxRect GetItemDropdownRect(int button_id) const;
 
 
     virtual bool Realize() override;
     virtual void ClearButtons();
     virtual bool DeleteButton(int button_id);
     virtual void EnableButton(int button_id, bool enable = true);
+    virtual bool GetButtonEnabled(int button_id) const;
     virtual void ToggleButton(int button_id, bool checked);
 
     virtual void SetButtonIcon(
@@ -170,6 +174,19 @@ public:
 
     // Get bitmap for button (DPI-aware resolution)
     wxBitmap GetButtonBitmap(int imageIndex, bool large) const;
+
+    // KeyTips (Office-style keyboard access mode).
+    void SetKeyTip(wxWindowID button_id, const wxString& keytip);
+    wxString GetKeyTip(wxWindowID button_id) const;
+
+    // Assigns a keytip to a hybrid button's dropdown arrow, separate
+    // from its main click area.
+    void SetDropdownKeyTip(wxWindowID button_id, const wxString& keytip);
+    wxString GetDropdownKeyTip(wxWindowID button_id) const;
+
+    // Implementation only: fires a button's click event for keytip
+    // activation. If dropdown is true, fires the dropdown-clicked event.
+    void ActivateButton(wxRibbonButtonBarButtonBase* button, bool dropdown = false);
 
 protected:
     friend class wxRibbonButtonBarEvent;
@@ -221,6 +238,8 @@ protected:
 
 private:
     wxRibbonBar* m_ribbonBar = nullptr;
+    std::map<wxWindowID, wxString> m_keyTips;
+    std::map<wxWindowID, wxString> m_dropdownKeyTips;
 
 
 #ifndef SWIG

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -175,7 +175,7 @@ public:
     // Get bitmap for button (DPI-aware resolution)
     wxBitmap GetButtonBitmap(int imageIndex, bool large) const;
 
-    // KeyTips (Office-style keyboard access mode).
+    // KeyTips (keyboard access mode).
     void SetKeyTip(wxWindowID button_id, const wxString& keytip);
     wxString GetKeyTip(wxWindowID button_id) const;
 

--- a/include/wx/ribbon/control.h
+++ b/include/wx/ribbon/control.h
@@ -56,6 +56,9 @@ public:
 
     virtual wxRibbonBar* GetAncestorRibbonBar()const;
 
+    // Leaves the ancestor bar's keytip mode, if it is in it.
+    void DismissKeyTips();
+
     // Finds the best width and height given the parent's width and height
     virtual wxSize GetBestSizeForParentSize(const wxSize& WXUNUSED(parentSize)) const { return GetBestSize(); }
 

--- a/include/wx/ribbon/gallery.h
+++ b/include/wx/ribbon/gallery.h
@@ -71,6 +71,10 @@ public:
     bool ScrollPixels(int pixels);
     void EnsureVisible(const wxRibbonGalleryItem* item);
 
+    // KeyTips (Office-style keyboard access mode).
+    void SetKeyTip(const wxString& keytip) { m_keyTip = keytip.Upper(); }
+    wxString GetKeyTip() const { return m_keyTip; }
+
 protected:
     wxBorder GetDefaultBorder() const override { return wxBORDER_NONE; }
     void CommonInit(long style);
@@ -117,6 +121,7 @@ protected:
     wxRibbonGalleryButtonState m_down_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
     wxRibbonGalleryButtonState m_extension_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
     bool m_hovered = false;
+    wxString m_keyTip;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonGallery);

--- a/include/wx/ribbon/gallery.h
+++ b/include/wx/ribbon/gallery.h
@@ -121,6 +121,8 @@ protected:
     wxRibbonGalleryButtonState m_down_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
     wxRibbonGalleryButtonState m_extension_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
     bool m_hovered = false;
+
+    // Always stored in upper case, to allow case-insensitive matching.
     wxString m_keyTip;
 
 #ifndef SWIG

--- a/include/wx/ribbon/gallery.h
+++ b/include/wx/ribbon/gallery.h
@@ -71,7 +71,7 @@ public:
     bool ScrollPixels(int pixels);
     void EnsureVisible(const wxRibbonGalleryItem* item);
 
-    // KeyTips (Office-style keyboard access mode).
+    // KeyTips (keyboard access mode).
     void SetKeyTip(const wxString& keytip) { m_keyTip = keytip.Upper(); }
     wxString GetKeyTip() const { return m_keyTip; }
 

--- a/include/wx/ribbon/panel.h
+++ b/include/wx/ribbon/panel.h
@@ -84,7 +84,7 @@ public:
 
     void HideIfExpanded();
 
-    // KeyTips (Office-style keyboard access mode).
+    // KeyTips (keyboard access mode).
     void SetExtButtonKeyTip(const wxString& keytip) { m_extButtonKeyTip = keytip.Upper(); }
     wxString GetExtButtonKeyTip() const { return m_extButtonKeyTip; }
     wxRect GetExtButtonRect() const { return m_ext_button_rect; }

--- a/include/wx/ribbon/panel.h
+++ b/include/wx/ribbon/panel.h
@@ -142,6 +142,9 @@ protected:
     bool m_hovered = false;
     bool m_ext_button_hovered = false;
     wxRect m_ext_button_rect;
+
+    // Both are always stored in upper case, to allow case-insensitive
+    // matching.
     wxString m_extButtonKeyTip;
     wxString m_keyTip;
 

--- a/include/wx/ribbon/panel.h
+++ b/include/wx/ribbon/panel.h
@@ -84,6 +84,15 @@ public:
 
     void HideIfExpanded();
 
+    // KeyTips (Office-style keyboard access mode).
+    void SetExtButtonKeyTip(const wxString& keytip) { m_extButtonKeyTip = keytip.Upper(); }
+    wxString GetExtButtonKeyTip() const { return m_extButtonKeyTip; }
+    wxRect GetExtButtonRect() const { return m_ext_button_rect; }
+
+    // Used when the panel is minimised.
+    void SetKeyTip(const wxString& keytip) { m_keyTip = keytip.Upper(); }
+    wxString GetKeyTip() const { return m_keyTip; }
+
 protected:
     virtual wxSize DoGetBestSize() const override;
     virtual wxSize GetPanelSizerBestSize() const;
@@ -133,6 +142,8 @@ protected:
     bool m_hovered = false;
     bool m_ext_button_hovered = false;
     wxRect m_ext_button_rect;
+    wxString m_extButtonKeyTip;
+    wxString m_keyTip;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonPanel);

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -17,6 +17,8 @@
 #include "wx/ribbon/art.h"
 #include "wx/bmpbndl.h"
 
+#include <map>
+
 class wxRibbonToolBarToolBase;
 class wxRibbonToolBarToolGroup;
 WX_DEFINE_USER_EXPORTED_ARRAY_PTR(wxRibbonToolBarToolGroup*, wxArrayRibbonToolBarToolGroup, class WXDLLIMPEXP_RIBBON);
@@ -143,6 +145,7 @@ public:
     virtual wxRibbonButtonKind GetToolKind(int tool_id)const;
     virtual int GetToolPos(int tool_id)const;
     virtual wxRect GetToolRect(int tool_id)const;
+    virtual wxRect GetToolDropdownRect(int tool_id)const;
     virtual bool GetToolState(int tool_id)const;
 
     virtual bool Realize() override;
@@ -160,6 +163,19 @@ public:
 
     // Finds the best width and height given the parent's width and height
     virtual wxSize GetBestSizeForParentSize(const wxSize& parentSize) const override;
+
+    // KeyTips (Office-style keyboard access mode).
+    void SetKeyTip(wxWindowID tool_id, const wxString& keytip);
+    wxString GetKeyTip(wxWindowID tool_id) const;
+
+    // Assigns a keytip to a hybrid tool's dropdown arrow, separate
+    // from its main click area.
+    void SetDropdownKeyTip(wxWindowID tool_id, const wxString& keytip);
+    wxString GetDropdownKeyTip(wxWindowID tool_id) const;
+
+    // Implementation only: fires a tool's click event for keytip
+    // activation. If dropdown is true, fires the dropdown-clicked event.
+    void ActivateTool(wxRibbonToolBarToolBase* tool, bool dropdown = false);
 
 protected:
     friend class wxRibbonToolBarEvent;
@@ -195,6 +211,8 @@ protected:
     wxSize* m_sizes = nullptr;
     int m_nrows_min = 0;
     int m_nrows_max = 0;
+    std::map<wxWindowID, wxString> m_keyTips;
+    std::map<wxWindowID, wxString> m_dropdownKeyTips;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonToolBar);

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -164,7 +164,7 @@ public:
     // Finds the best width and height given the parent's width and height
     virtual wxSize GetBestSizeForParentSize(const wxSize& parentSize) const override;
 
-    // KeyTips (Office-style keyboard access mode).
+    // KeyTips (keyboard access mode).
     void SetKeyTip(wxWindowID tool_id, const wxString& keytip);
     wxString GetKeyTip(wxWindowID tool_id) const;
 

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -211,6 +211,8 @@ protected:
     wxSize* m_sizes = nullptr;
     int m_nrows_min = 0;
     int m_nrows_max = 0;
+    // The KeyTips are always stored in upper case, to allow case-insensitive
+    // matching.
     std::unordered_map<wxWindowID, wxString> m_keyTips;
     std::unordered_map<wxWindowID, wxString> m_dropdownKeyTips;
 

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -17,7 +17,7 @@
 #include "wx/ribbon/art.h"
 #include "wx/bmpbndl.h"
 
-#include <map>
+#include <unordered_map>
 
 class wxRibbonToolBarToolBase;
 class wxRibbonToolBarToolGroup;
@@ -211,8 +211,8 @@ protected:
     wxSize* m_sizes = nullptr;
     int m_nrows_min = 0;
     int m_nrows_max = 0;
-    std::map<wxWindowID, wxString> m_keyTips;
-    std::map<wxWindowID, wxString> m_dropdownKeyTips;
+    std::unordered_map<wxWindowID, wxString> m_keyTips;
+    std::unordered_map<wxWindowID, wxString> m_dropdownKeyTips;
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxRibbonToolBar);

--- a/interface/wx/ribbon/art.h
+++ b/interface/wx/ribbon/art.h
@@ -725,6 +725,34 @@ public:
                                 const wxRect& rect) = 0;
 
     /**
+        Draw a keytip badge over a ribbon element in keyboard access mode.
+
+        This should draw a small labelled badge which stands out against the
+        element beneath it, similar to the ones Office uses.
+
+        @param dc
+            The device context to draw onto.
+        @param wnd
+            The window which is being drawn onto, which is the window owning
+            the element the badge belongs to.
+        @param rect
+            The rectangle of the element the badge is for. The badge itself is
+            usually smaller and positioned relative to it, rather than filling
+            it.
+        @param keytip
+            The characters to draw, which are the ones still to be typed, rather
+            than the whole keytip if the user has already typed a prefix.
+
+        @see wxRibbonBar::ShowKeyTips()
+
+        @since 3.3.4
+    */
+    virtual void DrawKeyTip(wxDC& dc,
+                            wxWindow* wnd,
+                            const wxRect& rect,
+                            const wxString& keytip) = 0;
+
+    /**
         Calculate the ideal and minimum width (in pixels) of a tab in a ribbon
         bar.
 

--- a/interface/wx/ribbon/art.h
+++ b/interface/wx/ribbon/art.h
@@ -731,6 +731,11 @@ public:
         element beneath it, similar to the ones commonly used in programs using
         ribbon interface.
 
+        Unlike the other drawing functions, this one is not pure virtual, as it
+        was added after the other ones and so implementing it is optional: the
+        base class version simply returns @false and a default badge is drawn
+        instead.
+
         @param dc
             The device context to draw onto.
         @param wnd
@@ -744,14 +749,18 @@ public:
             The characters to draw, which are the ones still to be typed, rather
             than the whole KeyTip if the user has already typed a prefix.
 
+        @return
+            @true if the badge was drawn or @false to let the caller draw the
+            default badge instead.
+
         @see wxRibbonBar::ShowKeyTips()
 
         @since 3.3.4
     */
-    virtual void DrawKeyTip(wxDC& dc,
+    virtual bool DrawKeyTip(wxDC& dc,
                             wxWindow* wnd,
                             const wxRect& rect,
-                            const wxString& keytip) = 0;
+                            const wxString& keytip);
 
     /**
         Calculate the ideal and minimum width (in pixels) of a tab in a ribbon

--- a/interface/wx/ribbon/art.h
+++ b/interface/wx/ribbon/art.h
@@ -725,7 +725,7 @@ public:
                                 const wxRect& rect) = 0;
 
     /**
-        Draw a keytip badge over a ribbon element in keyboard access mode.
+        Draw a KeyTip badge over a ribbon element in keyboard access mode.
 
         This should draw a small labelled badge which stands out against the
         element beneath it, similar to the ones Office uses.
@@ -741,7 +741,7 @@ public:
             it.
         @param keytip
             The characters to draw, which are the ones still to be typed, rather
-            than the whole keytip if the user has already typed a prefix.
+            than the whole KeyTip if the user has already typed a prefix.
 
         @see wxRibbonBar::ShowKeyTips()
 

--- a/interface/wx/ribbon/art.h
+++ b/interface/wx/ribbon/art.h
@@ -728,7 +728,8 @@ public:
         Draw a KeyTip badge over a ribbon element in keyboard access mode.
 
         This should draw a small labelled badge which stands out against the
-        element beneath it, similar to the ones Office uses.
+        element beneath it, similar to the ones commonly used in programs using
+        ribbon interface.
 
         @param dc
             The device context to draw onto.

--- a/interface/wx/ribbon/bar.h
+++ b/interface/wx/ribbon/bar.h
@@ -109,6 +109,15 @@ public:
     bool hovered;
     bool highlight;
     bool shown;
+
+    /**
+        The keytip assigned to this tab, or an empty string.
+
+        Use wxRibbonBar::SetPageKeyTip() to set it.
+
+        @since 3.3.4
+    */
+    wxString keytip;
 };
 
 /**
@@ -141,6 +150,31 @@ class wxRibbonPageTabInfoArray : public std::vector<wxRibbonPageTabInfoArray>
 
     After all pages have been created, and all controls and panels placed on
     those pages, Realize() must be called.
+
+    @section ribbonbar_keytips KeyTips
+
+    Since wxWidgets 3.3.4 pressing @c WXK_F10 shows Office-style "keytips":
+    a badge over every element which has one, listing the letters to type to
+    activate it. Unlike mnemonics, keytips are not derived from labels: an
+    element only takes part if it was assigned one explicitly. See
+    SetPageKeyTip(), wxRibbonButtonBar::SetKeyTip() and the other
+    @c SetKeyTip() overloads.
+
+    Multi-character keytips are supported: typing the first character narrows
+    the badges down to the elements sharing it. A keytip must therefore not be
+    a strict prefix of another visible at the same time, or it could never
+    fire. This is not validated at run time.
+
+    @c WXK_ESCAPE backs out one character, or leaves the mode if nothing was
+    typed. Pressing the trigger key again, clicking the ribbon, or the frame
+    being deactivated also leave it. CTRL and ALT combinations are treated as
+    accelerators: the mode is left and the key passed on, so @c CTRL-S is not
+    consumed by a button with keytip @c "S". Activating a page tab is the one
+    case which stays in the mode, showing the new page's keytips.
+
+    The trigger key is configurable, see SetKeyTipsTriggerKey(). It is only
+    consumed if there is something to show, so applications using no keytips
+    keep their existing @c WXK_F10 handling.
 
     @see wxRibbonPage
     @see wxRibbonPanel
@@ -498,4 +532,116 @@ public:
         Also calls wxRibbonPage::Realize() on each child page.
     */
     virtual bool Realize();
+
+    /**
+        Assigns the keytip used to switch to the given page.
+
+        Pass an empty string to remove it. The keytip is stored uppercased.
+
+        @see @ref ribbonbar_keytips
+
+        @since 3.3.4
+    */
+    void SetPageKeyTip(size_t page, const wxString& keytip);
+
+    /**
+        @overload
+
+        @since 3.3.4
+    */
+    void SetPageKeyTip(wxRibbonPage* page, const wxString& keytip);
+
+    /**
+        Assigns the keytip used to activate the panel toggle button.
+
+        Only has an effect if the bar uses @c wxRIBBON_BAR_SHOW_TOGGLE_BUTTON.
+
+        @since 3.3.4
+    */
+    void SetToggleButtonKeyTip(const wxString& keytip);
+
+    /**
+        Assigns the keytip used to activate the help button.
+
+        Only has an effect if the bar uses @c wxRIBBON_BAR_SHOW_HELP_BUTTON.
+
+        @since 3.3.4
+    */
+    void SetHelpButtonKeyTip(const wxString& keytip);
+
+    /**
+        Enters keyboard access mode and shows the keytip badges.
+
+        @return @true if the mode was entered, @false if the bar isn't shown on
+            screen or no keytips are currently assigned to anything visible.
+
+        @see @ref ribbonbar_keytips
+
+        @since 3.3.4
+    */
+    bool ShowKeyTips();
+
+    /**
+        Leaves keyboard access mode and hides the keytip badges.
+
+        Does nothing if the mode isn't active.
+
+        @since 3.3.4
+    */
+    void HideKeyTips();
+
+    /**
+        Returns @true if keyboard access mode is currently active.
+
+        @since 3.3.4
+    */
+    bool IsKeyTipsShown() const;
+
+    /**
+        A key combination which shows the keytips.
+
+        @since 3.3.4
+    */
+    struct TriggerKey
+    {
+        /// The key code (e.g., @c WXK_F10).
+        int keyCode;
+
+        /// The modifiers (e.g., @c wxMOD_NONE or @c wxMOD_CONTROL).
+        int modifiers;
+    };
+
+    /**
+        Makes @a keyCode with @a modifiers the only key which shows keytips.
+
+        Replaces the default of @c WXK_F10 with no modifiers.
+
+        @see AddKeyTipsTriggerKey()
+
+        @since 3.3.4
+    */
+    void SetKeyTipsTriggerKey(int keyCode, int modifiers = wxMOD_NONE);
+
+    /**
+        Adds another key which shows keytips, keeping the existing ones.
+
+        @since 3.3.4
+    */
+    void AddKeyTipsTriggerKey(int keyCode, int modifiers = wxMOD_NONE);
+
+    /**
+        Removes all trigger keys, disabling keyboard access mode.
+
+        It can still be entered programmatically with ShowKeyTips().
+
+        @since 3.3.4
+    */
+    void ClearKeyTipsTriggerKeys();
+
+    /**
+        Returns the keys which show keytips.
+
+        @since 3.3.4
+    */
+    const std::vector<TriggerKey>& GetKeyTipsTriggerKeys() const;
 };

--- a/interface/wx/ribbon/bar.h
+++ b/interface/wx/ribbon/bar.h
@@ -111,7 +111,7 @@ public:
     bool shown;
 
     /**
-        The keytip assigned to this tab, or an empty string.
+        The KeyTip assigned to this tab, or an empty string.
 
         Use wxRibbonBar::SetPageKeyTip() to set it.
 
@@ -153,15 +153,15 @@ class wxRibbonPageTabInfoArray : public std::vector<wxRibbonPageTabInfoArray>
 
     @section ribbonbar_keytips KeyTips
 
-    Since wxWidgets 3.3.4 pressing @c WXK_F10 shows Office-style "keytips":
+    Since wxWidgets 3.3.4, pressing @c WXK_F10 shows Office-style "KeyTips":
     a badge over every element which has one, listing the letters to type to
-    activate it. Unlike mnemonics, keytips are not derived from labels: an
+    activate it. Unlike mnemonics, KeyTips are not derived from labels; an
     element only takes part if it was assigned one explicitly. See
     SetPageKeyTip(), wxRibbonButtonBar::SetKeyTip() and the other
     @c SetKeyTip() overloads.
 
-    Multi-character keytips are supported: typing the first character narrows
-    the badges down to the elements sharing it. A keytip must therefore not be
+    Multi-character KeyTips are supported; typing the first character narrows
+    the badges down to the elements sharing it. A KeyTip must therefore not be
     a strict prefix of another visible at the same time, or it could never
     fire. This is not validated at run time.
 
@@ -169,11 +169,11 @@ class wxRibbonPageTabInfoArray : public std::vector<wxRibbonPageTabInfoArray>
     typed. Pressing the trigger key again, clicking the ribbon, or the frame
     being deactivated also leave it. CTRL and ALT combinations are treated as
     accelerators: the mode is left and the key passed on, so @c CTRL-S is not
-    consumed by a button with keytip @c "S". Activating a page tab is the one
-    case which stays in the mode, showing the new page's keytips.
+    consumed by a button with KeyTip @c "S". Activating a page tab is the one
+    case which stays in the mode, showing the new page's KeyTips.
 
     The trigger key is configurable, see SetKeyTipsTriggerKey(). It is only
-    consumed if there is something to show, so applications using no keytips
+    consumed if there is something to show, so applications using no KeyTips
     keep their existing @c WXK_F10 handling.
 
     @see wxRibbonPage
@@ -181,13 +181,13 @@ class wxRibbonPageTabInfoArray : public std::vector<wxRibbonPageTabInfoArray>
 
     @beginStyleTable
     @style{wxRIBBON_BAR_DEFAULT_STYLE}
-        Defined as wxRIBBON_BAR_FLOW_HORIZONTAL |
+        Defined as `wxRIBBON_BAR_FLOW_HORIZONTAL |
         wxRIBBON_BAR_SHOW_PAGE_LABELS | wxRIBBON_BAR_SHOW_PANEL_EXT_BUTTONS |
-        wxRIBBON_BAR_SHOW_TOGGLE_BUTTON | wxRIBBON_BAR_SHOW_HELP_BUTTON.
+        wxRIBBON_BAR_SHOW_TOGGLE_BUTTON | wxRIBBON_BAR_SHOW_HELP_BUTTON`.
     @style{wxRIBBON_BAR_FOLDBAR_STYLE}
-        Defined as wxRIBBON_BAR_FLOW_VERTICAL | wxRIBBON_BAR_SHOW_PAGE_ICONS
+        Defined as `wxRIBBON_BAR_FLOW_VERTICAL | wxRIBBON_BAR_SHOW_PAGE_ICONS
         | wxRIBBON_BAR_SHOW_PANEL_EXT_BUTTONS |
-        wxRIBBON_BAR_SHOW_PANEL_MINIMISE_BUTTONS
+        wxRIBBON_BAR_SHOW_PANEL_MINIMISE_BUTTONS`.
     @style{wxRIBBON_BAR_SHOW_PAGE_LABELS}
         Causes labels to be shown on the tabs in the ribbon bar.
     @style{wxRIBBON_BAR_SHOW_PAGE_ICONS}
@@ -534,9 +534,9 @@ public:
     virtual bool Realize();
 
     /**
-        Assigns the keytip used to switch to the given page.
+        Assigns the KeyTip used to switch to the given page.
 
-        Pass an empty string to remove it. The keytip is stored uppercased.
+        Pass an empty string to remove it. The KeyTip is stored uppercased.
 
         @see @ref ribbonbar_keytips
 
@@ -552,7 +552,7 @@ public:
     void SetPageKeyTip(wxRibbonPage* page, const wxString& keytip);
 
     /**
-        Assigns the keytip used to activate the panel toggle button.
+        Assigns the KeyTip used to activate the panel toggle button.
 
         Only has an effect if the bar uses @c wxRIBBON_BAR_SHOW_TOGGLE_BUTTON.
 
@@ -561,7 +561,7 @@ public:
     void SetToggleButtonKeyTip(const wxString& keytip);
 
     /**
-        Assigns the keytip used to activate the help button.
+        Assigns the KeyTip used to activate the help button.
 
         Only has an effect if the bar uses @c wxRIBBON_BAR_SHOW_HELP_BUTTON.
 
@@ -570,10 +570,10 @@ public:
     void SetHelpButtonKeyTip(const wxString& keytip);
 
     /**
-        Enters keyboard access mode and shows the keytip badges.
+        Enters keyboard access mode and shows the KeyTip badges.
 
         @return @true if the mode was entered, @false if the bar isn't shown on
-            screen or no keytips are currently assigned to anything visible.
+            screen or no KeyTips are currently assigned to anything visible.
 
         @see @ref ribbonbar_keytips
 
@@ -582,7 +582,7 @@ public:
     bool ShowKeyTips();
 
     /**
-        Leaves keyboard access mode and hides the keytip badges.
+        Leaves keyboard access mode and hides the KeyTip badges.
 
         Does nothing if the mode isn't active.
 
@@ -598,7 +598,7 @@ public:
     bool IsKeyTipsShown() const;
 
     /**
-        A key combination which shows the keytips.
+        A key combination which shows the KeyTips.
 
         @since 3.3.4
     */
@@ -612,7 +612,7 @@ public:
     };
 
     /**
-        Makes @a keyCode with @a modifiers the only key which shows keytips.
+        Makes @a keyCode with @a modifiers the only key which shows KeyTips.
 
         Replaces the default of @c WXK_F10 with no modifiers.
 
@@ -623,7 +623,7 @@ public:
     void SetKeyTipsTriggerKey(int keyCode, int modifiers = wxMOD_NONE);
 
     /**
-        Adds another key which shows keytips, keeping the existing ones.
+        Adds another key which shows KeyTips, keeping the existing ones.
 
         @since 3.3.4
     */
@@ -639,7 +639,7 @@ public:
     void ClearKeyTipsTriggerKeys();
 
     /**
-        Returns the keys which show keytips.
+        Returns the keys which show KeyTips.
 
         @since 3.3.4
     */

--- a/interface/wx/ribbon/bar.h
+++ b/interface/wx/ribbon/bar.h
@@ -153,7 +153,7 @@ class wxRibbonPageTabInfoArray : public std::vector<wxRibbonPageTabInfoArray>
 
     @section ribbonbar_keytips KeyTips
 
-    Since wxWidgets 3.3.4, pressing @c WXK_F10 shows Office-style "KeyTips":
+    Since wxWidgets 3.3.4, pressing @c WXK_F10 shows "KeyTips":
     a badge over every element which has one, listing the letters to type to
     activate it. Unlike mnemonics, KeyTips are not derived from labels; an
     element only takes part if it was assigned one explicitly. See

--- a/interface/wx/ribbon/bar.h
+++ b/interface/wx/ribbon/bar.h
@@ -595,7 +595,7 @@ public:
 
         @since 3.3.4
     */
-    bool IsKeyTipsShown() const;
+    bool AreKeyTipsShown() const;
 
     /**
         A key combination which shows the KeyTips.

--- a/interface/wx/ribbon/buttonbar.h
+++ b/interface/wx/ribbon/buttonbar.h
@@ -659,10 +659,10 @@ public:
     bool GetShowToolTipsForDisabled() const;
 
     /**
-        Assigns the keytip used to click the given button.
+        Assigns the KeyTip used to click the given button.
 
-        Pass an empty string to remove it. The keytip is stored upper-cased.
-        Disabled buttons don't show a keytip.
+        Pass an empty string to remove it. The KeyTip is stored upper-cased.
+        Disabled buttons don't show a KeyTip.
 
         @see wxRibbonBar::ShowKeyTips()
 
@@ -671,16 +671,16 @@ public:
     void SetKeyTip(wxWindowID button_id, const wxString& keytip);
 
     /**
-        Returns the keytip of the given button, or an empty string.
+        Returns the KeyTip of the given button, or an empty string.
 
         @since 3.3.4
     */
     wxString GetKeyTip(wxWindowID button_id) const;
 
     /**
-        Assigns the keytip used to open a hybrid button's dropdown menu.
+        Assigns the KeyTip used to open a hybrid button's dropdown menu.
 
-        This is separate from the keytip of the button's main click area, set
+        This is separate from the KeyTip of the button's main click area, set
         by SetKeyTip(), and has no effect on non-hybrid buttons.
 
         @since 3.3.4
@@ -688,7 +688,7 @@ public:
     void SetDropdownKeyTip(wxWindowID button_id, const wxString& keytip);
 
     /**
-        Returns the dropdown keytip of the given button, or an empty string.
+        Returns the dropdown KeyTip of the given button, or an empty string.
 
         @since 3.3.4
     */

--- a/interface/wx/ribbon/buttonbar.h
+++ b/interface/wx/ribbon/buttonbar.h
@@ -658,6 +658,41 @@ public:
     */
     bool GetShowToolTipsForDisabled() const;
 
+    /**
+        Assigns the keytip used to click the given button.
+
+        Pass an empty string to remove it. The keytip is stored upper-cased.
+        Disabled buttons don't show a keytip.
+
+        @see wxRibbonBar::ShowKeyTips()
+
+        @since 3.3.4
+    */
+    void SetKeyTip(wxWindowID button_id, const wxString& keytip);
+
+    /**
+        Returns the keytip of the given button, or an empty string.
+
+        @since 3.3.4
+    */
+    wxString GetKeyTip(wxWindowID button_id) const;
+
+    /**
+        Assigns the keytip used to open a hybrid button's dropdown menu.
+
+        This is separate from the keytip of the button's main click area, set
+        by SetKeyTip(), and has no effect on non-hybrid buttons.
+
+        @since 3.3.4
+    */
+    void SetDropdownKeyTip(wxWindowID button_id, const wxString& keytip);
+
+    /**
+        Returns the dropdown keytip of the given button, or an empty string.
+
+        @since 3.3.4
+    */
+    wxString GetDropdownKeyTip(wxWindowID button_id) const;
 };
 
 /**

--- a/interface/wx/ribbon/control.h
+++ b/interface/wx/ribbon/control.h
@@ -161,6 +161,19 @@ public:
         Used to implement the wxRIBBON_PANEL_FLEXIBLE panel style.
     */
     virtual wxSize GetBestSizeForParentSize(const wxSize& parentSize) const;
+
+    /**
+        Leaves the ancestor ribbon bar's keyboard access mode (if it is in it).
+
+        Custom ribbon controls should call this when clicked, so that visible
+        keytips don't survive a mouse interaction.
+
+        @see wxRibbonBar::HideKeyTips()
+
+        @since 3.3.4
+    */
+    void DismissKeyTips();
+
 protected:
     /**
         Implementation of GetNextSmallerSize().

--- a/interface/wx/ribbon/control.h
+++ b/interface/wx/ribbon/control.h
@@ -166,7 +166,7 @@ public:
         Leaves the ancestor ribbon bar's keyboard access mode (if it is in it).
 
         Custom ribbon controls should call this when clicked, so that visible
-        keytips don't survive a mouse interaction.
+        KeyTips don't survive a mouse interaction.
 
         @see wxRibbonBar::HideKeyTips()
 

--- a/interface/wx/ribbon/gallery.h
+++ b/interface/wx/ribbon/gallery.h
@@ -255,6 +255,28 @@ public:
         Scroll the gallery to ensure that the given item is visible.
     */
     void EnsureVisible(const wxRibbonGalleryItem* item);
+
+    /**
+        Assigns the keytip used to reach this gallery.
+
+        The gallery is one keytip target as a whole, its items don't get their
+        own. Activating it gives the gallery focus, so that the arrow keys and
+        Enter can then be used to pick an item.
+
+        Pass an empty string to remove it. The keytip is stored upper-cased.
+
+        @see wxRibbonBar::ShowKeyTips()
+
+        @since 3.3.4
+    */
+    void SetKeyTip(const wxString& keytip);
+
+    /**
+        Returns the keytip of this gallery, or an empty string.
+
+        @since 3.3.4
+    */
+    wxString GetKeyTip() const;
 };
 
 /**

--- a/interface/wx/ribbon/gallery.h
+++ b/interface/wx/ribbon/gallery.h
@@ -257,13 +257,13 @@ public:
     void EnsureVisible(const wxRibbonGalleryItem* item);
 
     /**
-        Assigns the keytip used to reach this gallery.
+        Assigns the KeyTip used to reach this gallery.
 
-        The gallery is one keytip target as a whole, its items don't get their
+        The gallery is one KeyTip target as a whole, its items don't get their
         own. Activating it gives the gallery focus, so that the arrow keys and
         Enter can then be used to pick an item.
 
-        Pass an empty string to remove it. The keytip is stored upper-cased.
+        Pass an empty string to remove it. The KeyTip is stored upper-cased.
 
         @see wxRibbonBar::ShowKeyTips()
 
@@ -272,7 +272,7 @@ public:
     void SetKeyTip(const wxString& keytip);
 
     /**
-        Returns the keytip of this gallery, or an empty string.
+        Returns the KeyTip of this gallery, or an empty string.
 
         @since 3.3.4
     */

--- a/interface/wx/ribbon/panel.h
+++ b/interface/wx/ribbon/panel.h
@@ -310,9 +310,9 @@ public:
     wxRibbonPanel* GetExpandedPanel();
 
     /**
-        Assigns the keytip used to click this panel's extension button.
+        Assigns the KeyTip used to click this panel's extension button.
 
-        Pass an empty string to remove it. The keytip is stored uppercased.
+        Pass an empty string to remove it. The KeyTip is stored uppercased.
         Only has an effect if the panel uses @c wxRIBBON_PANEL_EXT_BUTTON.
 
         @see wxRibbonBar::ShowKeyTips()
@@ -322,27 +322,27 @@ public:
     void SetExtButtonKeyTip(const wxString& keytip);
 
     /**
-        Returns the extension button's keytip, or an empty string.
+        Returns the extension button's KeyTip, or an empty string.
 
         @since 3.3.4
     */
     wxString GetExtButtonKeyTip() const;
 
     /**
-        Assigns the keytip used to expand this panel while it is minimised.
+        Assigns the KeyTip used to expand this panel while it is minimised.
 
         A minimised panel is a single button, so its children can't be reached
-        by keytip until it is expanded. Activating this one expands the panel
+        by KeyTip until it is expanded. Activating this one expands the panel
         and leaves keyboard access mode.
 
-        Pass an empty string to remove it. The keytip is stored upper-cased.
+        Pass an empty string to remove it. The KeyTip is stored upper-cased.
 
         @since 3.3.4
     */
     void SetKeyTip(const wxString& keytip);
 
     /**
-        Returns the panel's own keytip, or an empty string.
+        Returns the panel's own KeyTip, or an empty string.
 
         @since 3.3.4
     */

--- a/interface/wx/ribbon/panel.h
+++ b/interface/wx/ribbon/panel.h
@@ -308,4 +308,43 @@ public:
         @see GetExpandedDummy()
     */
     wxRibbonPanel* GetExpandedPanel();
+
+    /**
+        Assigns the keytip used to click this panel's extension button.
+
+        Pass an empty string to remove it. The keytip is stored uppercased.
+        Only has an effect if the panel uses @c wxRIBBON_PANEL_EXT_BUTTON.
+
+        @see wxRibbonBar::ShowKeyTips()
+
+        @since 3.3.4
+    */
+    void SetExtButtonKeyTip(const wxString& keytip);
+
+    /**
+        Returns the extension button's keytip, or an empty string.
+
+        @since 3.3.4
+    */
+    wxString GetExtButtonKeyTip() const;
+
+    /**
+        Assigns the keytip used to expand this panel while it is minimised.
+
+        A minimised panel is a single button, so its children can't be reached
+        by keytip until it is expanded. Activating this one expands the panel
+        and leaves keyboard access mode.
+
+        Pass an empty string to remove it. The keytip is stored upper-cased.
+
+        @since 3.3.4
+    */
+    void SetKeyTip(const wxString& keytip);
+
+    /**
+        Returns the panel's own keytip, or an empty string.
+
+        @since 3.3.4
+    */
+    wxString GetKeyTip() const;
 };

--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -526,10 +526,10 @@ public:
     virtual void ToggleTool(int tool_id, bool checked);
 
     /**
-        Assigns the keytip used to click the given tool.
+        Assigns the KeyTip used to click the given tool.
 
-        Pass an empty string to remove it. The keytip is stored uppercased.
-        Disabled tools don't show a keytip.
+        Pass an empty string to remove it. The KeyTip is stored uppercased.
+        Disabled tools don't show a KeyTip.
 
         @see wxRibbonBar::ShowKeyTips()
 
@@ -538,16 +538,16 @@ public:
     void SetKeyTip(wxWindowID tool_id, const wxString& keytip);
 
     /**
-        Returns the keytip of the given tool, or an empty string.
+        Returns the KeyTip of the given tool, or an empty string.
 
         @since 3.3.4
     */
     wxString GetKeyTip(wxWindowID tool_id) const;
 
     /**
-        Assigns the keytip used to open a hybrid tool's dropdown menu.
+        Assigns the KeyTip used to open a hybrid tool's dropdown menu.
 
-        This is separate from the keytip of the tool's main click area, set by
+        This is separate from the KeyTip of the tool's main click area, set by
         SetKeyTip(), and has no effect on non-hybrid tools.
 
         @since 3.3.4
@@ -555,7 +555,7 @@ public:
     void SetDropdownKeyTip(wxWindowID tool_id, const wxString& keytip);
 
     /**
-        Returns the dropdown keytip of the given tool, or an empty string.
+        Returns the dropdown KeyTip of the given tool, or an empty string.
 
         @since 3.3.4
     */

--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -524,6 +524,42 @@ public:
         @since 2.9.4
     */
     virtual void ToggleTool(int tool_id, bool checked);
+
+    /**
+        Assigns the keytip used to click the given tool.
+
+        Pass an empty string to remove it. The keytip is stored uppercased.
+        Disabled tools don't show a keytip.
+
+        @see wxRibbonBar::ShowKeyTips()
+
+        @since 3.3.4
+    */
+    void SetKeyTip(wxWindowID tool_id, const wxString& keytip);
+
+    /**
+        Returns the keytip of the given tool, or an empty string.
+
+        @since 3.3.4
+    */
+    wxString GetKeyTip(wxWindowID tool_id) const;
+
+    /**
+        Assigns the keytip used to open a hybrid tool's dropdown menu.
+
+        This is separate from the keytip of the tool's main click area, set by
+        SetKeyTip(), and has no effect on non-hybrid tools.
+
+        @since 3.3.4
+    */
+    void SetDropdownKeyTip(wxWindowID tool_id, const wxString& keytip);
+
+    /**
+        Returns the dropdown keytip of the given tool, or an empty string.
+
+        @since 3.3.4
+    */
+    wxString GetDropdownKeyTip(wxWindowID tool_id) const;
 };
 
 

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -708,6 +708,8 @@ MyFrame::MyFrame()
         bar->AddButton(ID_REMOVE_PANEL, "Remove Panel", wxArtProvider::GetBitmap(wxART_DELETE, wxART_OTHER, wxSize(24, 24)));
         bar->AddButton(ID_HIDE_PAGES, "Hide Pages", ribbon_large);
         bar->AddButton(ID_SHOW_PAGES, "Show Pages", ribbon_large);
+        bar->SetKeyTip(ID_REMOVE_PAGE, "R");
+        bar->SetKeyTip(ID_REMOVE_PANEL, "P");
 
         panel = new wxRibbonPanel(page, wxID_ANY, "Button bar manipulation",
             ribbon_small);

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -475,6 +475,10 @@ MyFrame::MyFrame()
                                 | wxRIBBON_BAR_SHOW_HELP_BUTTON
                                 );
 
+    // Press F10 (the default trigger key) to try keyboard access mode.
+    m_ribbon->SetToggleButtonKeyTip("Q");
+    m_ribbon->SetHelpButtonKeyTip("H");
+
     // Reusable bitmap bundles for the generic ribbon and empty-page icons.
     const wxBitmapBundle ribbon_small = MakeSvgBundle(ribbon_svg, wxSize(16, 16));
     const wxBitmapBundle ribbon_large = MakeSvgBundle(ribbon_svg, wxSize(32, 32));
@@ -483,10 +487,12 @@ MyFrame::MyFrame()
     {
         wxRibbonPage* home = new wxRibbonPage(m_ribbon, wxID_ANY, "Examples",
             ribbon_small);
+        m_ribbon->SetPageKeyTip(home, "E");
         wxRibbonPanel *toolbar_panel = new wxRibbonPanel(home, wxID_ANY, "Toolbar",
                                             wxBitmapBundle(), wxDefaultPosition, wxDefaultSize,
                                             wxRIBBON_PANEL_NO_AUTO_MINIMISE |
                                             wxRIBBON_PANEL_EXT_BUTTON);
+        toolbar_panel->SetExtButtonKeyTip("X");
         wxRibbonToolBar *toolbar = new wxRibbonToolBar(toolbar_panel, ID_MAIN_TOOLBAR);
         toolbar->AddToggleTool(wxID_JUSTIFY_LEFT,
             MakeSvgBundle(align_left_svg, wxSize(16, 16)));
@@ -499,6 +505,9 @@ MyFrame::MyFrame()
         toolbar->AddTool(wxID_OPEN, wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_OTHER, wxSize(16, 15)), "Open something");
         toolbar->AddTool(wxID_SAVE, wxArtProvider::GetBitmap(wxART_FILE_SAVE, wxART_OTHER, wxSize(16, 15)), "Save something");
         toolbar->AddTool(wxID_SAVEAS, wxArtProvider::GetBitmap(wxART_FILE_SAVE_AS, wxART_OTHER, wxSize(16, 15)), "Save something as ...");
+        toolbar->SetKeyTip(wxID_OPEN, "O");
+        toolbar->SetKeyTip(wxID_SAVE, "SV");
+        toolbar->SetKeyTip(wxID_SAVEAS, "SA");
         toolbar->EnableTool(wxID_OPEN, false);
         toolbar->EnableTool(wxID_SAVE, false);
         toolbar->EnableTool(wxID_SAVEAS, false);
@@ -519,6 +528,10 @@ MyFrame::MyFrame()
         wxRibbonToolBarToolBase* print_tool;
         print_tool = toolbar->AddHybridTool(wxID_PRINT, wxArtProvider::GetBitmap(wxART_PRINT, wxART_OTHER, wxSize(16, 15)),
                                 "This is the Print button tooltip\ndemonstrating a tooltip");
+        toolbar->SetKeyTip(wxID_PRINT, "PT");
+        // "PO" reaches the dropdown arrow's menu, separate from "PT"'s main action.
+        // Neither is a prefix of the other, unlike "P"/"PM" would be.
+        toolbar->SetDropdownKeyTip(wxID_PRINT, "PO");
         toolbar->SetRows(2, 3);
 
         size_t tool_pos = toolbar->GetToolPos(wxID_PRINT);
@@ -542,6 +555,9 @@ MyFrame::MyFrame()
         wxBitmapBundle crop_bundle = MakeSvgBundle(auto_crop_selection_svg, wxSize(32, 32));
         selection->AddButton(ID_SELECTION_CONTRACT, "Contract",
             crop_bundle, crop_bundle);
+        selection->SetKeyTip(ID_SELECTION_EXPAND_V, "V");
+        selection->SetKeyTip(ID_SELECTION_EXPAND_H, "Z");
+        selection->SetKeyTip(ID_SELECTION_CONTRACT, "C");
 
         wxRibbonPanel *shapes_panel = new wxRibbonPanel(home, wxID_ANY, "Shapes",
             MakeSvgBundle(circle_svg, wxSize(16, 16)));
@@ -558,6 +574,14 @@ MyFrame::MyFrame()
             MakeSvgBundle(square_svg, wxSize(32, 32)), wxEmptyString);
         shapes->AddDropdownButton(ID_POLYGON, "Other Polygon",
             MakeSvgBundle(hexagon_svg, wxSize(32, 32)), wxEmptyString);
+        // Shared "S" prefix demonstrates keytip narrowing.
+        shapes->SetKeyTip(ID_CIRCLE, "SC");
+        shapes->SetKeyTip(ID_CROSS, "SX");
+        shapes->SetKeyTip(ID_TRIANGLE, "ST");
+        // "SD" reaches the dropdown arrow's menu, separate from "ST"'s main action.
+        shapes->SetDropdownKeyTip(ID_TRIANGLE, "SD");
+        shapes->SetKeyTip(ID_SQUARE, "SQ");
+        shapes->SetKeyTip(ID_POLYGON, "SP");
 
         wxRibbonPanel *sizer_panel = new wxRibbonPanel(home, wxID_ANY, "Panel with Sizer",
                                                     wxBitmapBundle(), wxDefaultPosition, wxDefaultSize,
@@ -587,6 +611,9 @@ MyFrame::MyFrame()
         // This prevents ribbon buttons in panels with sizer from collapsing.
         bar->SetButtonMinSizeClass(ID_BUTTON_XX, wxRIBBON_BUTTONBAR_BUTTON_LARGE);
         bar->SetButtonMinSizeClass(ID_BUTTON_XY, wxRIBBON_BUTTONBAR_BUTTON_LARGE);
+        // Digit keytips work too.
+        bar->SetKeyTip(ID_BUTTON_XX, "1");
+        bar->SetKeyTip(ID_BUTTON_XY, "2");
 
         wxSizer* sizer_panelsizer_h = new wxBoxSizer(wxHORIZONTAL);
         wxSizer* sizer_panelsizer_v = new wxBoxSizer(wxVERTICAL);
@@ -603,6 +630,7 @@ MyFrame::MyFrame()
 
         wxRibbonPage* scheme = new wxRibbonPage(m_ribbon, wxID_ANY, "Appearance",
             MakeSvgBundle(eye_svg, wxSize(16, 16)));
+        m_ribbon->SetPageKeyTip(scheme, "A");
         m_ribbon->GetArtProvider()->GetColourScheme(&m_default_primary,
             &m_default_secondary, &m_default_tertiary);
         wxRibbonPanel *provider_panel = new wxRibbonPanel(scheme, wxID_ANY,
@@ -617,20 +645,27 @@ MyFrame::MyFrame()
             MakeSvgBundle(msw_style_svg, wxSize(32, 32)));
         m_provider_bar->AddToggleButton(ID_MSW_FLAT_PROVIDER, "MSW Flat Provider",
             MakeSvgBundle(msw_flat_style_svg, wxSize(32, 32)));
+        m_provider_bar->SetKeyTip(ID_DEFAULT_PROVIDER, "D");
+        m_provider_bar->SetKeyTip(ID_AUI_PROVIDER, "I");
+        m_provider_bar->SetKeyTip(ID_MSW_PROVIDER, "M");
+        m_provider_bar->SetKeyTip(ID_MSW_FLAT_PROVIDER, "F");
 
         m_provider_bar->ToggleButton(ID_DEFAULT_PROVIDER, true);
         wxRibbonPanel *primary_panel = new wxRibbonPanel(scheme, wxID_ANY,
             "Primary Colour", MakeSvgBundle(colours_svg, wxSize(16, 16)));
         m_primary_gallery = PopulateColoursPanel(primary_panel,
             m_default_primary, ID_PRIMARY_COLOUR);
+        m_primary_gallery->SetKeyTip("P");
         wxRibbonPanel *secondary_panel = new wxRibbonPanel(scheme, wxID_ANY,
             "Secondary Colour", MakeSvgBundle(colours_svg, wxSize(16, 16)));
         m_secondary_gallery = PopulateColoursPanel(secondary_panel,
             m_default_secondary, ID_SECONDARY_COLOUR);
+        m_secondary_gallery->SetKeyTip("S");
     }
     {
         wxRibbonPage* page = new wxRibbonPage(m_ribbon, wxID_ANY, "UI Updated",
             ribbon_small);
+        m_ribbon->SetPageKeyTip(page, "U");
         wxRibbonPanel *panel = new wxRibbonPanel(page, wxID_ANY, "Enable/Disable",
             ribbon_small);
         wxRibbonButtonBar *bar = new wxRibbonButtonBar(panel, wxID_ANY);
@@ -661,9 +696,11 @@ MyFrame::MyFrame()
         artProvider->SetColor(wxRIBBON_ART_BUTTON_BAR_LABEL_DISABLED_COLOUR, tColour.MakeDisabled());
     }
     new wxRibbonPage(m_ribbon, wxID_ANY, "Empty Page", empty_small);
+    m_ribbon->SetPageKeyTip(m_ribbon->GetPageCount()-1, "T");
     {
         wxRibbonPage* page = new wxRibbonPage(m_ribbon, wxID_ANY, "Another Page",
             empty_small);
+        m_ribbon->SetPageKeyTip(page, "N");
         wxRibbonPanel *panel = new wxRibbonPanel(page, wxID_ANY, "Page manipulation",
             ribbon_small);
         wxRibbonButtonBar *bar = new wxRibbonButtonBar(panel, wxID_ANY);
@@ -698,10 +735,12 @@ MyFrame::MyFrame()
     }
     new wxRibbonPage(m_ribbon, wxID_ANY, "Highlight Page", empty_small);
     m_ribbon->AddPageHighlight(m_ribbon->GetPageCount()-1);
+    m_ribbon->SetPageKeyTip(m_ribbon->GetPageCount()-1, "L");
 
     {
         wxRibbonPage* page = new wxRibbonPage(m_ribbon, wxID_ANY, "Advanced",
             empty_small);
+        m_ribbon->SetPageKeyTip(page, "B");
         wxRibbonPanel* panel = new wxRibbonPanel(page, wxID_ANY, "Button bar manipulation",
             ribbon_small);
         wxRibbonButtonBar* button_bar = new wxRibbonButtonBar(panel, wxID_ANY);

--- a/src/ribbon/art_internal.cpp
+++ b/src/ribbon/art_internal.cpp
@@ -157,9 +157,15 @@ void wxRibbonDrawKeyTip(wxDC& dc,
 
     wxRect badge_rect(pos, badge_size);
 
-    const bool dark = wxSystemSettings::GetAppearance().IsDark();
-    const wxColour badge_bg = dark ? wxColour{ 255, 214, 51 } : wxColour{ 97, 97, 97 };
-    const wxColour badge_fg = dark ? *wxBLACK : *wxWHITE;
+    // These colours match the ones used by other established ribbon
+    // implementations, and no system colour would give the same appearance.
+    const wxColour badge_bg_light(97, 97, 97);
+    const wxColour badge_bg_dark(255, 214, 51);
+
+    const wxColour badge_bg =
+        wxSystemSettings::SelectLightDark(badge_bg_light, badge_bg_dark);
+    const wxColour badge_fg =
+        wxSystemSettings::SelectLightDark(*wxWHITE, *wxBLACK);
 
     dc.SetPen(wxPen(badge_bg));
     dc.SetBrush(wxBrush(badge_bg));

--- a/src/ribbon/art_internal.cpp
+++ b/src/ribbon/art_internal.cpp
@@ -116,6 +116,59 @@ wxBitmap wxRibbonLoadPixmap(const char* const* bits, wxColour fore)
     return wxBitmap(xpm);
 }
 
+void wxRibbonDrawKeyTip(wxDC& dc,
+                        wxWindow* wnd,
+                        const wxRect& rect,
+                        const wxString& keytip,
+                        const wxFont& font)
+{
+    if ( keytip.empty() )
+        return;
+
+    dc.SetFont(font);
+    wxSize text_size = dc.GetTextExtent(keytip);
+
+    const int padding_x = 3;
+    const int padding_y = 2;
+    wxSize badge_size(text_size.GetWidth() + 2 * padding_x,
+                       text_size.GetHeight() + 2 * padding_y);
+
+    // Anchor inside the rect's bottom center if it fits.
+    // Otherwise (e.g., a panel's small ext button) drop the
+    // badge below the rect instead.
+    wxPoint pos;
+    if ( badge_size.GetHeight() <= rect.GetHeight() )
+    {
+        pos.x = rect.GetX() + (rect.GetWidth() - badge_size.GetWidth()) / 2;
+        pos.y = rect.GetBottom() - badge_size.GetHeight();
+    }
+    else
+    {
+        pos.x = rect.GetX() + (rect.GetWidth() - badge_size.GetWidth()) / 2;
+        pos.y = rect.GetBottom() + 2;
+    }
+
+    if ( wnd != nullptr )
+    {
+        wxSize client = wnd->GetClientSize();
+        pos.x = wxMax(0, wxMin(pos.x, client.GetWidth() - badge_size.GetWidth()));
+        pos.y = wxMax(0, wxMin(pos.y, client.GetHeight() - badge_size.GetHeight()));
+    }
+
+    wxRect badge_rect(pos, badge_size);
+
+    const bool dark = wxSystemSettings::GetAppearance().IsDark();
+    const wxColour badge_bg = dark ? wxColour{ 255, 214, 51 } : wxColour{ 97, 97, 97 };
+    const wxColour badge_fg = dark ? *wxBLACK : *wxWHITE;
+
+    dc.SetPen(wxPen(badge_bg));
+    dc.SetBrush(wxBrush(badge_bg));
+    dc.DrawRectangle(badge_rect);
+
+    dc.SetTextForeground(badge_fg);
+    dc.DrawText(keytip, badge_rect.GetX() + padding_x, badge_rect.GetY() + padding_y);
+}
+
 wxRibbonHSLColour::wxRibbonHSLColour(const wxColour& col)
 {
     float red = col.Red() / 255.0f;

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -2767,6 +2767,54 @@ void wxRibbonMSWArtProvider::DrawHelpButton(wxDC& dc,
                 rect.GetY() + (20 - sz.GetHeight()) / 2);
 }
 
+void wxRibbonMSWArtProvider::DrawKeyTip(wxDC& dc,
+                                       wxWindow* wnd,
+                                       const wxRect& rect,
+                                       const wxString& keytip)
+{
+    if ( keytip.empty() )
+        return;
+
+    dc.SetFont(m_tab_label_font);
+    wxSize text_size = dc.GetTextExtent(keytip);
+
+    const int padding_x = 3;
+    const int padding_y = 2;
+    wxSize badge_size(text_size.GetWidth() + 2 * padding_x,
+                       text_size.GetHeight() + 2 * padding_y);
+
+    // Anchor inside the rect's bottom center if it fits.
+    // Otherwise (e.g., a panel's small ext button) drop the
+    // badge below the rect instead.
+    wxPoint pos;
+    if ( badge_size.GetHeight() <= rect.GetHeight() )
+    {
+        pos.x = rect.GetX() + (rect.GetWidth() - badge_size.GetWidth()) / 2;
+        pos.y = rect.GetBottom() - badge_size.GetHeight();
+    }
+    else
+    {
+        pos.x = rect.GetX() + (rect.GetWidth() - badge_size.GetWidth()) / 2;
+        pos.y = rect.GetBottom() + 2;
+    }
+
+    if ( wnd != nullptr )
+    {
+        wxSize client = wnd->GetClientSize();
+        pos.x = wxMax(0, wxMin(pos.x, client.GetWidth() - badge_size.GetWidth()));
+        pos.y = wxMax(0, wxMin(pos.y, client.GetHeight() - badge_size.GetHeight()));
+    }
+
+    wxRect badge_rect(pos, badge_size);
+
+    dc.SetPen(wxPen(*wxBLACK));
+    dc.SetBrush(wxBrush(wxColour(255, 255, 225)));
+    dc.DrawRectangle(badge_rect);
+
+    dc.SetTextForeground(*wxBLACK);
+    dc.DrawText(keytip, badge_rect.GetX() + padding_x, badge_rect.GetY() + padding_y);
+}
+
 void wxRibbonMSWArtProvider::GetBarTabWidth(
                         wxReadOnlyDC& dc,
                         wxWindow* WXUNUSED(wnd),

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -2808,7 +2808,7 @@ void wxRibbonMSWArtProvider::DrawKeyTip(wxDC& dc,
     wxRect badge_rect(pos, badge_size);
 
     const bool dark = wxSystemSettings::GetAppearance().IsDark();
-    const wxColour badge_bg = dark ? wxColour{ 235, 235, 235 } : wxColour{ 97, 97, 97 };
+    const wxColour badge_bg = dark ? wxColour{ 255, 214, 51 } : wxColour{ 97, 97, 97 };
     const wxColour badge_fg = dark ? *wxBLACK : *wxWHITE;
 
     dc.SetPen(wxPen(badge_bg));

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -2808,7 +2808,7 @@ void wxRibbonMSWArtProvider::DrawKeyTip(wxDC& dc,
     wxRect badge_rect(pos, badge_size);
 
     const bool dark = wxSystemSettings::GetAppearance().IsDark();
-    const wxColour badge_bg = dark ? *wxWHITE : *wxBLACK;
+    const wxColour badge_bg = dark ? wxColour{ 235, 235, 235 } : wxColour{ 97, 97, 97 };
     const wxColour badge_fg = dark ? *wxBLACK : *wxWHITE;
 
     dc.SetPen(wxPen(badge_bg));

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -2767,56 +2767,14 @@ void wxRibbonMSWArtProvider::DrawHelpButton(wxDC& dc,
                 rect.GetY() + (20 - sz.GetHeight()) / 2);
 }
 
-void wxRibbonMSWArtProvider::DrawKeyTip(wxDC& dc,
+bool wxRibbonMSWArtProvider::DrawKeyTip(wxDC& dc,
                                        wxWindow* wnd,
                                        const wxRect& rect,
                                        const wxString& keytip)
 {
-    if ( keytip.empty() )
-        return;
+    wxRibbonDrawKeyTip(dc, wnd, rect, keytip, m_tab_label_font);
 
-    dc.SetFont(m_tab_label_font);
-    wxSize text_size = dc.GetTextExtent(keytip);
-
-    const int padding_x = 3;
-    const int padding_y = 2;
-    wxSize badge_size(text_size.GetWidth() + 2 * padding_x,
-                       text_size.GetHeight() + 2 * padding_y);
-
-    // Anchor inside the rect's bottom center if it fits.
-    // Otherwise (e.g., a panel's small ext button) drop the
-    // badge below the rect instead.
-    wxPoint pos;
-    if ( badge_size.GetHeight() <= rect.GetHeight() )
-    {
-        pos.x = rect.GetX() + (rect.GetWidth() - badge_size.GetWidth()) / 2;
-        pos.y = rect.GetBottom() - badge_size.GetHeight();
-    }
-    else
-    {
-        pos.x = rect.GetX() + (rect.GetWidth() - badge_size.GetWidth()) / 2;
-        pos.y = rect.GetBottom() + 2;
-    }
-
-    if ( wnd != nullptr )
-    {
-        wxSize client = wnd->GetClientSize();
-        pos.x = wxMax(0, wxMin(pos.x, client.GetWidth() - badge_size.GetWidth()));
-        pos.y = wxMax(0, wxMin(pos.y, client.GetHeight() - badge_size.GetHeight()));
-    }
-
-    wxRect badge_rect(pos, badge_size);
-
-    const bool dark = wxSystemSettings::GetAppearance().IsDark();
-    const wxColour badge_bg = dark ? wxColour{ 255, 214, 51 } : wxColour{ 97, 97, 97 };
-    const wxColour badge_fg = dark ? *wxBLACK : *wxWHITE;
-
-    dc.SetPen(wxPen(badge_bg));
-    dc.SetBrush(wxBrush(badge_bg));
-    dc.DrawRectangle(badge_rect);
-
-    dc.SetTextForeground(badge_fg);
-    dc.DrawText(keytip, badge_rect.GetX() + padding_x, badge_rect.GetY() + padding_y);
+    return true;
 }
 
 void wxRibbonMSWArtProvider::GetBarTabWidth(

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -2807,11 +2807,15 @@ void wxRibbonMSWArtProvider::DrawKeyTip(wxDC& dc,
 
     wxRect badge_rect(pos, badge_size);
 
-    dc.SetPen(wxPen(*wxBLACK));
-    dc.SetBrush(wxBrush(wxColour(255, 255, 225)));
+    const bool dark = wxSystemSettings::GetAppearance().IsDark();
+    const wxColour badge_bg = dark ? *wxWHITE : *wxBLACK;
+    const wxColour badge_fg = dark ? *wxBLACK : *wxWHITE;
+
+    dc.SetPen(wxPen(badge_bg));
+    dc.SetBrush(wxBrush(badge_bg));
     dc.DrawRectangle(badge_rect);
 
-    dc.SetTextForeground(*wxBLACK);
+    dc.SetTextForeground(badge_fg);
     dc.DrawText(keytip, badge_rect.GetX() + padding_x, badge_rect.GetY() + padding_y);
 }
 

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -760,12 +760,16 @@ wxRibbonBar::wxRibbonBar(wxWindow* parent,
 
 wxRibbonBar::~wxRibbonBar()
 {
-    if ( m_keyTipsTopLevelParent != nullptr )
+    if ( m_keyTipsActive )
+        HideKeyTips();
+
+    if ( m_keyTipsTopLevelParent != nullptr && !m_keyTipsTopLevelParent->IsBeingDeleted() )
     {
         m_keyTipsTopLevelParent->Unbind(wxEVT_CHAR_HOOK, &wxRibbonBar::OnKeyTipsCharHook, this);
         m_keyTipsTopLevelParent->Unbind(wxEVT_ACTIVATE, &wxRibbonBar::OnKeyTipsActivate, this);
         m_keyTipsTopLevelParent->Unbind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
     }
+    m_keyTipsTopLevelParent = nullptr;
 
     SetArtProvider(nullptr);
 
@@ -1448,7 +1452,16 @@ bool wxRibbonBar::ShowKeyTips()
 
     DoBuildKeyTipTargets();
     if ( m_keyTipsTargets.empty() )
+    {
+        m_keyTipsWindows.clear();
         return false;
+    }
+
+    for ( wxWindow* w : m_keyTipsWindows )
+    {
+        if ( w != this )
+            w->Bind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
+    }
 
     m_keyTipsActive = true;
     m_keyTipsTypedPrefix.clear();
@@ -1465,6 +1478,11 @@ void wxRibbonBar::HideKeyTips()
     RefreshKeyTipTargetWindows();
     m_keyTipsActive = false;
     m_keyTipsTypedPrefix.clear();
+    for ( wxWindow* w : m_keyTipsWindows )
+    {
+        if ( w != this && w != nullptr && !w->IsBeingDeleted() )
+            w->Unbind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
+    }
     m_keyTipsTargets.clear();
     m_keyTipsWindows.clear();
 }
@@ -1667,16 +1685,33 @@ void wxRibbonBar::DoBuildKeyTipTargets()
     for ( auto& target : m_keyTipsTargets )
         target.remaining = target.fullKeyTip;
 
-    m_keyTipsWindows.clear();
-    m_keyTipsWindows.push_back(this);
+    std::vector<wxWindow*> oldWindows;
+    if ( m_keyTipsActive )
+        oldWindows = m_keyTipsWindows;
+
+    std::vector<wxWindow*> newWindows;
+    newWindows.push_back(this);
     for ( const auto& target : m_keyTipsTargets )
     {
-        if ( std::find(m_keyTipsWindows.begin(), m_keyTipsWindows.end(), target.window) ==
-             m_keyTipsWindows.end() )
+        if ( std::find(newWindows.begin(), newWindows.end(), target.window) == newWindows.end() )
+            newWindows.push_back(target.window);
+    }
+
+    if ( m_keyTipsActive )
+    {
+        for ( wxWindow* w : oldWindows )
         {
-            m_keyTipsWindows.push_back(target.window);
+            if ( w != this && std::find(newWindows.begin(), newWindows.end(), w) == newWindows.end()
+                 && w != nullptr && !w->IsBeingDeleted() )
+                w->Unbind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
+        }
+        for ( wxWindow* w : newWindows )
+        {
+            if ( w != this && std::find(oldWindows.begin(), oldWindows.end(), w) == oldWindows.end() )
+                w->Bind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
         }
     }
+    m_keyTipsWindows = std::move(newWindows);
 }
 
 void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
@@ -1782,16 +1817,52 @@ void wxRibbonBar::GetKeyTipTargetsFor(wxWindow* window, std::vector<KeyTipBadge>
 void wxRibbonBar::OnKeyTipsWindowDestroy(wxWindowDestroyEvent& event)
 {
     event.Skip();
+    wxWindow* window = event.GetWindow();
+
+    if ( window == m_keyTipsTopLevelParent )
+    {
+        m_keyTipsTopLevelParent = nullptr;
+        if ( m_keyTipsActive )
+            HideKeyTips();
+        return;
+    }
+
     if ( !m_keyTipsActive )
         return;
 
-    // Drop the stale target pointers, but don't refresh the dying window.
-    wxWindow* window = event.GetWindow();
-    m_keyTipsWindows.erase(
-        std::remove(m_keyTipsWindows.begin(), m_keyTipsWindows.end(), window),
-        m_keyTipsWindows.end());
+    auto it = std::find(m_keyTipsWindows.begin(), m_keyTipsWindows.end(), window);
+    if ( it != m_keyTipsWindows.end() )
+    {
+        m_keyTipsWindows.erase(it);
+        HideKeyTips();
+    }
+}
 
-    HideKeyTips();
+bool wxRibbonBar::Reparent(wxWindowBase* newParent)
+{
+    if ( m_keyTipsActive )
+        HideKeyTips();
+
+    wxWindow* oldTLW = m_keyTipsTopLevelParent;
+    bool res = wxRibbonControl::Reparent(newParent);
+    wxWindow* newTLW = wxGetTopLevelParent(this);
+    if ( newTLW != oldTLW )
+    {
+        if ( oldTLW != nullptr && !oldTLW->IsBeingDeleted() )
+        {
+            oldTLW->Unbind(wxEVT_CHAR_HOOK, &wxRibbonBar::OnKeyTipsCharHook, this);
+            oldTLW->Unbind(wxEVT_ACTIVATE, &wxRibbonBar::OnKeyTipsActivate, this);
+            oldTLW->Unbind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
+        }
+        m_keyTipsTopLevelParent = newTLW;
+        if ( m_keyTipsTopLevelParent != nullptr )
+        {
+            m_keyTipsTopLevelParent->Bind(wxEVT_CHAR_HOOK, &wxRibbonBar::OnKeyTipsCharHook, this);
+            m_keyTipsTopLevelParent->Bind(wxEVT_ACTIVATE, &wxRibbonBar::OnKeyTipsActivate, this);
+            m_keyTipsTopLevelParent->Bind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
+        }
+    }
+    return res;
 }
 
 void wxRibbonBar::OnKeyTipsActivate(wxActivateEvent& event)
@@ -1869,6 +1940,8 @@ void wxRibbonBar::OnKeyTipsCharHook(wxKeyEvent& event)
             if ( target.remaining.empty() || target.remaining[0] != ch )
                 continue;
 
+            if ( target.window == nullptr || target.window->IsBeingDeleted() )
+                continue;
             // The window may have been hidden since the targets were built.
             if ( !target.window->IsShownOnScreen() )
                 continue;

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -1389,7 +1389,7 @@ void wxRibbonBar::OnKillFocus(wxFocusEvent& WXUNUSED(evt))
 }
 
 // ----------------------------------------------------------------------------
-// KeyTips (Office-style keyboard access mode)
+// KeyTips (keyboard access mode)
 // ----------------------------------------------------------------------------
 
 void wxRibbonBar::SetPageKeyTip(size_t page, const wxString& keytip)

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -1500,7 +1500,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
         info.fullKeyTip = tab.keytip;
         info.rect = tab.rect;
         info.window = this;
-        info.kind = wxRibbonKeyTipInfo::KeyTip_PageTab;
+        info.kind = wxRibbonKeyTipInfo::Kind::PageTab;
         info.pageIndex = i;
         m_keyTipsTargets.push_back(info);
     }
@@ -1511,7 +1511,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
         info.fullKeyTip = m_toggleButtonKeyTip;
         info.rect = m_toggle_button_rect;
         info.window = this;
-        info.kind = wxRibbonKeyTipInfo::KeyTip_ToggleButton;
+        info.kind = wxRibbonKeyTipInfo::Kind::ToggleButton;
         m_keyTipsTargets.push_back(info);
     }
 
@@ -1521,7 +1521,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
         info.fullKeyTip = m_helpButtonKeyTip;
         info.rect = m_help_button_rect;
         info.window = this;
-        info.kind = wxRibbonKeyTipInfo::KeyTip_HelpButton;
+        info.kind = wxRibbonKeyTipInfo::Kind::HelpButton;
         m_keyTipsTargets.push_back(info);
     }
 
@@ -1544,7 +1544,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
                     info.fullKeyTip = keytip;
                     info.rect = wxRect(wxPoint(0, 0), panel->GetSize());
                     info.window = panel;
-                    info.kind = wxRibbonKeyTipInfo::KeyTip_MinimisedPanel;
+                    info.kind = wxRibbonKeyTipInfo::Kind::MinimisedPanel;
                     info.panel = panel;
                     m_keyTipsTargets.push_back(info);
                 }
@@ -1560,7 +1560,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
                     info.fullKeyTip = keytip;
                     info.rect = panel->GetExtButtonRect();
                     info.window = panel;
-                    info.kind = wxRibbonKeyTipInfo::KeyTip_ExtButton;
+                    info.kind = wxRibbonKeyTipInfo::Kind::ExtButton;
                     info.panel = panel;
                     m_keyTipsTargets.push_back(info);
                 }
@@ -1598,7 +1598,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
                         info.fullKeyTip = keytip;
                         info.rect = rect;
                         info.window = bb;
-                        info.kind = wxRibbonKeyTipInfo::KeyTip_ButtonBarItem;
+                        info.kind = wxRibbonKeyTipInfo::Kind::ButtonBarItem;
                         info.buttonBar = bb;
                         info.buttonBarItemId = id;
                         m_keyTipsTargets.push_back(info);
@@ -1611,7 +1611,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
                             dropdownInfo.fullKeyTip = dropdownKeytip;
                             dropdownInfo.rect = dropdownRect;
                             dropdownInfo.window = bb;
-                            dropdownInfo.kind = wxRibbonKeyTipInfo::KeyTip_ButtonBarItem;
+                            dropdownInfo.kind = wxRibbonKeyTipInfo::Kind::ButtonBarItem;
                             dropdownInfo.buttonBar = bb;
                             dropdownInfo.buttonBarItemId = id;
                             dropdownInfo.dropdown = true;
@@ -1642,7 +1642,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
                         info.fullKeyTip = keytip;
                         info.rect = rect;
                         info.window = tb;
-                        info.kind = wxRibbonKeyTipInfo::KeyTip_ToolBarItem;
+                        info.kind = wxRibbonKeyTipInfo::Kind::ToolBarItem;
                         info.toolBar = tb;
                         info.toolBarItemId = id;
                         m_keyTipsTargets.push_back(info);
@@ -1655,7 +1655,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
                             dropdownInfo.fullKeyTip = dropdownKeytip;
                             dropdownInfo.rect = dropdownRect;
                             dropdownInfo.window = tb;
-                            dropdownInfo.kind = wxRibbonKeyTipInfo::KeyTip_ToolBarItem;
+                            dropdownInfo.kind = wxRibbonKeyTipInfo::Kind::ToolBarItem;
                             dropdownInfo.toolBar = tb;
                             dropdownInfo.toolBarItemId = id;
                             dropdownInfo.dropdown = true;
@@ -1672,7 +1672,7 @@ void wxRibbonBar::DoBuildKeyTipTargets()
                         info.fullKeyTip = keytip;
                         info.rect = wxRect(wxPoint(0, 0), gallery->GetSize());
                         info.window = gallery;
-                        info.kind = wxRibbonKeyTipInfo::KeyTip_Gallery;
+                        info.kind = wxRibbonKeyTipInfo::Kind::Gallery;
                         m_keyTipsTargets.push_back(info);
                     }
                 }
@@ -1716,7 +1716,7 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
 {
     switch ( target.kind )
     {
-        case wxRibbonKeyTipInfo::KeyTip_PageTab:
+        case wxRibbonKeyTipInfo::Kind::PageTab:
         {
             wxRibbonPageTabInfo& tab = m_pages.Item(target.pageIndex);
             if ( m_ribbon_state == wxRIBBON_BAR_MINIMIZED )
@@ -1742,7 +1742,7 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
             break;
         }
 
-        case wxRibbonKeyTipInfo::KeyTip_ToggleButton:
+        case wxRibbonKeyTipInfo::Kind::ToggleButton:
         {
             ShowPanels(ArePanelsShown() ? wxRIBBON_BAR_MINIMIZED : wxRIBBON_BAR_PINNED);
             wxRibbonBarEvent event(wxEVT_RIBBONBAR_TOGGLED, GetId());
@@ -1751,7 +1751,7 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
             break;
         }
 
-        case wxRibbonKeyTipInfo::KeyTip_HelpButton:
+        case wxRibbonKeyTipInfo::Kind::HelpButton:
         {
             wxRibbonBarEvent event(wxEVT_RIBBONBAR_HELP_CLICK, GetId());
             event.SetEventObject(this);
@@ -1759,7 +1759,7 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
             break;
         }
 
-        case wxRibbonKeyTipInfo::KeyTip_ExtButton:
+        case wxRibbonKeyTipInfo::Kind::ExtButton:
         {
             wxRibbonPanelEvent notification(wxEVT_RIBBONPANEL_EXTBUTTON_ACTIVATED, target.panel->GetId());
             notification.SetEventObject(target.panel);
@@ -1768,11 +1768,11 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
             break;
         }
 
-        case wxRibbonKeyTipInfo::KeyTip_MinimisedPanel:
+        case wxRibbonKeyTipInfo::Kind::MinimisedPanel:
             target.panel->ShowExpanded();
             break;
 
-        case wxRibbonKeyTipInfo::KeyTip_ButtonBarItem:
+        case wxRibbonKeyTipInfo::Kind::ButtonBarItem:
         {
             wxRibbonButtonBarButtonBase* button = target.buttonBar->GetItemById(target.buttonBarItemId);
             if ( button != nullptr )
@@ -1780,7 +1780,7 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
             break;
         }
 
-        case wxRibbonKeyTipInfo::KeyTip_ToolBarItem:
+        case wxRibbonKeyTipInfo::Kind::ToolBarItem:
         {
             wxRibbonToolBarToolBase* tool = target.toolBar->FindById(target.toolBarItemId);
             if ( tool != nullptr )
@@ -1788,7 +1788,7 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
             break;
         }
 
-        case wxRibbonKeyTipInfo::KeyTip_Gallery:
+        case wxRibbonKeyTipInfo::Kind::Gallery:
             target.window->SetFocus();
             break;
     }

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -14,6 +14,7 @@
 
 #include "wx/ribbon/bar.h"
 #include "wx/ribbon/art.h"
+#include "wx/ribbon/art_internal.h"
 #include "wx/ribbon/panel.h"
 #include "wx/ribbon/buttonbar.h"
 #include "wx/ribbon/toolbar.h"
@@ -971,10 +972,7 @@ void wxRibbonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
     {
         // The toggle and help buttons leave a clipping region set.
         dc.DestroyClippingRegion();
-        std::vector<KeyTipBadge> badges;
-        GetKeyTipTargetsFor(this, &badges);
-        for ( const auto& badge : badges )
-            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
+        DrawKeyTipsFor(dc, this, m_art);
     }
 }
 
@@ -1796,20 +1794,24 @@ void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
     }
 }
 
-void wxRibbonBar::GetKeyTipTargetsFor(wxWindow* window, std::vector<KeyTipBadge>* badges) const
+void wxRibbonBar::DrawKeyTipsFor(wxDC& dc,
+                                 wxWindow* window,
+                                 wxRibbonArtProvider* art) const
 {
-    badges->clear();
-    if ( !m_keyTipsActive )
+    if ( !m_keyTipsActive || art == nullptr )
         return;
 
     for ( const auto& target : m_keyTipsTargets )
     {
-        if ( target.window == window )
+        if ( target.window != window )
+            continue;
+
+        // Fall back to the default badge if the art provider doesn't
+        // implement DrawKeyTip() itself.
+        if ( !art->DrawKeyTip(dc, window, target.rect, target.remaining) )
         {
-            KeyTipBadge badge;
-            badge.rect = target.rect;
-            badge.text = target.remaining;
-            badges->push_back(badge);
+            wxRibbonDrawKeyTip(dc, window, target.rect, target.remaining,
+                               window->GetFont());
         }
     }
 }

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -160,6 +160,8 @@ long wxRibbonBar::GetWindowStyleFlag() const
 
 bool wxRibbonBar::Realize()
 {
+    HideKeyTips();
+
     bool status = true;
 
     wxInfoDC dcTemp(this);
@@ -352,6 +354,7 @@ void wxRibbonBar::ShowPage(size_t page, bool show)
     if(page >= m_pages.GetCount())
         return;
     m_pages.Item(page).shown = show;
+    HideKeyTips();
 }
 
 bool wxRibbonBar::IsPageHighlighted(size_t page) const
@@ -372,6 +375,8 @@ void wxRibbonBar::DeletePage(size_t n)
 {
     if(n < m_pages.GetCount())
     {
+        HideKeyTips();
+
         wxRibbonPage *page = m_pages.Item(n).page;
 
         // Schedule page object for destruction and not destroying directly
@@ -1861,8 +1866,14 @@ void wxRibbonBar::OnKeyTipsCharHook(wxKeyEvent& event)
         std::vector<wxRibbonKeyTipInfo> matches;
         for ( const auto& target : m_keyTipsTargets )
         {
-            if ( !target.remaining.empty() && target.remaining[0] == ch )
-                matches.push_back(target);
+            if ( target.remaining.empty() || target.remaining[0] != ch )
+                continue;
+
+            // The window may have been hidden since the targets were built.
+            if ( !target.window->IsShownOnScreen() )
+                continue;
+
+            matches.push_back(target);
         }
 
         if ( matches.empty() )

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -14,9 +14,16 @@
 
 #include "wx/ribbon/bar.h"
 #include "wx/ribbon/art.h"
+#include "wx/ribbon/panel.h"
+#include "wx/ribbon/buttonbar.h"
+#include "wx/ribbon/toolbar.h"
+#include "wx/ribbon/gallery.h"
 #include "wx/dcbuffer.h"
 #include "wx/app.h"
 #include "wx/vector.h"
+
+#include <algorithm>
+#include <vector>
 
 #ifndef WX_PRECOMP
 #endif
@@ -748,6 +755,13 @@ wxRibbonBar::wxRibbonBar(wxWindow* parent,
 
 wxRibbonBar::~wxRibbonBar()
 {
+    if ( m_keyTipsTopLevelParent != nullptr )
+    {
+        m_keyTipsTopLevelParent->Unbind(wxEVT_CHAR_HOOK, &wxRibbonBar::OnKeyTipsCharHook, this);
+        m_keyTipsTopLevelParent->Unbind(wxEVT_ACTIVATE, &wxRibbonBar::OnKeyTipsActivate, this);
+        m_keyTipsTopLevelParent->Unbind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
+    }
+
     SetArtProvider(nullptr);
 
     for ( auto* list : m_image_lists )
@@ -788,6 +802,20 @@ void wxRibbonBar::CommonInit(long style)
         SetArtProvider(new wxRibbonDefaultArtProvider);
     }
     SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+    if ( m_keyTipsTriggerKeys.empty() )
+        m_keyTipsTriggerKeys.push_back({ WXK_F10, wxMOD_NONE });
+
+    if ( m_keyTipsTopLevelParent == nullptr )
+    {
+        m_keyTipsTopLevelParent = wxGetTopLevelParent(this);
+        if ( m_keyTipsTopLevelParent != nullptr )
+        {
+            m_keyTipsTopLevelParent->Bind(wxEVT_CHAR_HOOK, &wxRibbonBar::OnKeyTipsCharHook, this);
+            m_keyTipsTopLevelParent->Bind(wxEVT_ACTIVATE, &wxRibbonBar::OnKeyTipsActivate, this);
+            m_keyTipsTopLevelParent->Bind(wxEVT_DESTROY, &wxRibbonBar::OnKeyTipsWindowDestroy, this);
+        }
+    }
 }
 
 wxImageList* wxRibbonBar::GetButtonImageList(wxSize size, int initialCount)
@@ -930,6 +958,15 @@ void wxRibbonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
     if ( m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON  )
         m_art->DrawToggleButton(dc, this, m_toggle_button_rect, m_ribbon_state);
 
+    if ( m_keyTipsActive )
+    {
+        // The toggle and help buttons leave a clipping region set.
+        dc.DestroyClippingRegion();
+        std::vector<KeyTipBadge> badges;
+        GetKeyTipTargetsFor(this, &badges);
+        for ( const auto& badge : badges )
+            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
+    }
 }
 
 void wxRibbonBar::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
@@ -946,6 +983,9 @@ void wxRibbonBar::DoEraseBackground(wxDC& dc)
 
 void wxRibbonBar::OnSize(wxSizeEvent& evt)
 {
+    if ( m_keyTipsActive )
+        HideKeyTips();
+
     RecalculateTabSizes();
     if(m_current_page != wxNOT_FOUND)
     {
@@ -1028,6 +1068,9 @@ wxRibbonPageTabInfo* wxRibbonBar::HitTestTabs(wxPoint position, int* index)
 
 void wxRibbonBar::OnMouseLeftDown(wxMouseEvent& evt)
 {
+    if ( m_keyTipsActive )
+        HideKeyTips();
+
     wxRibbonPageTabInfo *tab = HitTestTabs(evt.GetPosition());
     SetFocus();
     if ( tab )
@@ -1194,6 +1237,9 @@ void wxRibbonBar::RefreshTabBar()
 
 void wxRibbonBar::OnMouseMiddleDown(wxMouseEvent& evt)
 {
+    if ( m_keyTipsActive )
+        HideKeyTips();
+
     DoMouseButtonCommon(evt, wxEVT_RIBBONBAR_TAB_MIDDLE_DOWN);
 }
 
@@ -1204,6 +1250,9 @@ void wxRibbonBar::OnMouseMiddleUp(wxMouseEvent& evt)
 
 void wxRibbonBar::OnMouseRightDown(wxMouseEvent& evt)
 {
+    if ( m_keyTipsActive )
+        HideKeyTips();
+
     DoMouseButtonCommon(evt, wxEVT_RIBBONBAR_TAB_RIGHT_DOWN);
 }
 
@@ -1326,7 +1375,521 @@ void wxRibbonBar::HideIfExpanded()
 
 void wxRibbonBar::OnKillFocus(wxFocusEvent& WXUNUSED(evt))
 {
+    if ( m_keyTipsActive )
+        HideKeyTips();
+
     HideIfExpanded();
+}
+
+// ----------------------------------------------------------------------------
+// KeyTips (Office-style keyboard access mode)
+// ----------------------------------------------------------------------------
+
+void wxRibbonBar::SetPageKeyTip(size_t page, const wxString& keytip)
+{
+    if ( page >= m_pages.GetCount() )
+        return;
+    m_pages.Item(page).keytip = keytip.Upper();
+}
+
+void wxRibbonBar::SetPageKeyTip(wxRibbonPage* page, const wxString& keytip)
+{
+    int n = GetPageNumber(page);
+    if ( n != wxNOT_FOUND )
+        SetPageKeyTip((size_t)n, keytip);
+}
+
+void wxRibbonBar::SetToggleButtonKeyTip(const wxString& keytip)
+{
+    m_toggleButtonKeyTip = keytip.Upper();
+}
+
+void wxRibbonBar::SetHelpButtonKeyTip(const wxString& keytip)
+{
+    m_helpButtonKeyTip = keytip.Upper();
+}
+
+void wxRibbonBar::SetKeyTipsTriggerKey(int keyCode, int modifiers)
+{
+    m_keyTipsTriggerKeys.clear();
+    m_keyTipsTriggerKeys.push_back({ keyCode, modifiers });
+}
+
+void wxRibbonBar::AddKeyTipsTriggerKey(int keyCode, int modifiers)
+{
+    m_keyTipsTriggerKeys.push_back({ keyCode, modifiers });
+}
+
+void wxRibbonBar::ClearKeyTipsTriggerKeys()
+{
+    m_keyTipsTriggerKeys.clear();
+}
+
+void wxRibbonBar::RefreshKeyTipTargetWindows()
+{
+    // Refresh each window directly. Refreshing only an ancestor doesn't
+    // reliably repaint child windows.
+    for ( wxWindow* w : m_keyTipsWindows )
+        w->Refresh();
+}
+
+bool wxRibbonBar::ShowKeyTips()
+{
+    if ( m_keyTipsActive )
+        return true;
+
+    if ( !IsShownOnScreen() )
+        return false;
+
+    DoBuildKeyTipTargets();
+    if ( m_keyTipsTargets.empty() )
+        return false;
+
+    m_keyTipsActive = true;
+    m_keyTipsTypedPrefix.clear();
+    RefreshKeyTipTargetWindows();
+    return true;
+}
+
+void wxRibbonBar::HideKeyTips()
+{
+    if ( !m_keyTipsActive )
+        return;
+
+    // Refresh before clearing state, so each window still knows to repaint.
+    RefreshKeyTipTargetWindows();
+    m_keyTipsActive = false;
+    m_keyTipsTypedPrefix.clear();
+    m_keyTipsTargets.clear();
+    m_keyTipsWindows.clear();
+}
+
+void wxRibbonBar::DoBuildKeyTipTargets()
+{
+    m_keyTipsTargets.clear();
+
+    size_t numtabs = m_pages.GetCount();
+    for ( size_t i = 0; i < numtabs; ++i )
+    {
+        wxRibbonPageTabInfo& tab = m_pages.Item(i);
+        if ( !tab.shown || tab.keytip.empty() )
+            continue;
+
+        wxRibbonKeyTipInfo info;
+        info.fullKeyTip = tab.keytip;
+        info.rect = tab.rect;
+        info.window = this;
+        info.kind = wxRibbonKeyTipInfo::KeyTip_PageTab;
+        info.pageIndex = i;
+        m_keyTipsTargets.push_back(info);
+    }
+
+    if ( (m_flags & wxRIBBON_BAR_SHOW_TOGGLE_BUTTON) && !m_toggleButtonKeyTip.empty() )
+    {
+        wxRibbonKeyTipInfo info;
+        info.fullKeyTip = m_toggleButtonKeyTip;
+        info.rect = m_toggle_button_rect;
+        info.window = this;
+        info.kind = wxRibbonKeyTipInfo::KeyTip_ToggleButton;
+        m_keyTipsTargets.push_back(info);
+    }
+
+    if ( (m_flags & wxRIBBON_BAR_SHOW_HELP_BUTTON) && !m_helpButtonKeyTip.empty() )
+    {
+        wxRibbonKeyTipInfo info;
+        info.fullKeyTip = m_helpButtonKeyTip;
+        info.rect = m_help_button_rect;
+        info.window = this;
+        info.kind = wxRibbonKeyTipInfo::KeyTip_HelpButton;
+        m_keyTipsTargets.push_back(info);
+    }
+
+    if ( m_current_page != wxNOT_FOUND && m_arePanelsShown )
+    {
+        wxRibbonPage* page = m_pages.Item(m_current_page).page;
+        for ( wxWindowList::compatibility_iterator node = page->GetChildren().GetFirst();
+              node; node = node->GetNext() )
+        {
+            wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
+            if ( panel == nullptr || !panel->IsShown() )
+                continue;
+
+            if ( panel->IsMinimised() )
+            {
+                wxString keytip = panel->GetKeyTip();
+                if ( !keytip.empty() )
+                {
+                    wxRibbonKeyTipInfo info;
+                    info.fullKeyTip = keytip;
+                    info.rect = wxRect(wxPoint(0, 0), panel->GetSize());
+                    info.window = panel;
+                    info.kind = wxRibbonKeyTipInfo::KeyTip_MinimisedPanel;
+                    info.panel = panel;
+                    m_keyTipsTargets.push_back(info);
+                }
+                continue;
+            }
+
+            if ( panel->HasExtButton() )
+            {
+                wxString keytip = panel->GetExtButtonKeyTip();
+                if ( !keytip.empty() )
+                {
+                    wxRibbonKeyTipInfo info;
+                    info.fullKeyTip = keytip;
+                    info.rect = panel->GetExtButtonRect();
+                    info.window = panel;
+                    info.kind = wxRibbonKeyTipInfo::KeyTip_ExtButton;
+                    info.panel = panel;
+                    m_keyTipsTargets.push_back(info);
+                }
+            }
+
+            for ( wxWindowList::compatibility_iterator pnode = panel->GetChildren().GetFirst();
+                  pnode; pnode = pnode->GetNext() )
+            {
+                wxWindow* child = pnode->GetData();
+                if ( !child->IsShown() )
+                    continue;
+
+                wxRibbonButtonBar* bb = wxDynamicCast(child, wxRibbonButtonBar);
+                wxRibbonToolBar* tb = wxDynamicCast(child, wxRibbonToolBar);
+                wxRibbonGallery* gallery = wxDynamicCast(child, wxRibbonGallery);
+                if ( bb != nullptr )
+                {
+                    size_t count = bb->GetButtonCount();
+                    for ( size_t b = 0; b < count; ++b )
+                    {
+                        wxRibbonButtonBarButtonBase* button = bb->GetItem(b);
+                        int id = bb->GetItemId(button);
+                        if ( !bb->GetButtonEnabled(id) )
+                            continue;
+                        wxString keytip = bb->GetKeyTip(id);
+                        if ( keytip.empty() )
+                            continue;
+
+                        // Empty if the button isn't in the current layout.
+                        wxRect rect = bb->GetItemRect(id);
+                        if ( rect.IsEmpty() )
+                            continue;
+
+                        wxRibbonKeyTipInfo info;
+                        info.fullKeyTip = keytip;
+                        info.rect = rect;
+                        info.window = bb;
+                        info.kind = wxRibbonKeyTipInfo::KeyTip_ButtonBarItem;
+                        info.buttonBar = bb;
+                        info.buttonBarItemId = id;
+                        m_keyTipsTargets.push_back(info);
+
+                        wxString dropdownKeytip = bb->GetDropdownKeyTip(id);
+                        wxRect dropdownRect = bb->GetItemDropdownRect(id);
+                        if ( !dropdownKeytip.empty() && !dropdownRect.IsEmpty() )
+                        {
+                            wxRibbonKeyTipInfo dropdownInfo;
+                            dropdownInfo.fullKeyTip = dropdownKeytip;
+                            dropdownInfo.rect = dropdownRect;
+                            dropdownInfo.window = bb;
+                            dropdownInfo.kind = wxRibbonKeyTipInfo::KeyTip_ButtonBarItem;
+                            dropdownInfo.buttonBar = bb;
+                            dropdownInfo.buttonBarItemId = id;
+                            dropdownInfo.dropdown = true;
+                            m_keyTipsTargets.push_back(dropdownInfo);
+                        }
+                    }
+                }
+                else if ( tb != nullptr )
+                {
+                    size_t count = tb->GetToolCount();
+                    for ( size_t t = 0; t < count; ++t )
+                    {
+                        wxRibbonToolBarToolBase* tool = tb->GetToolByPos(t);
+                        if ( tool == nullptr )
+                            continue; // separator
+                        int id = tb->GetToolId(tool);
+                        if ( !tb->GetToolEnabled(id) )
+                            continue;
+                        wxString keytip = tb->GetKeyTip(id);
+                        if ( keytip.empty() )
+                            continue;
+
+                        wxRect rect = tb->GetToolRect(id);
+                        if ( rect.IsEmpty() )
+                            continue;
+
+                        wxRibbonKeyTipInfo info;
+                        info.fullKeyTip = keytip;
+                        info.rect = rect;
+                        info.window = tb;
+                        info.kind = wxRibbonKeyTipInfo::KeyTip_ToolBarItem;
+                        info.toolBar = tb;
+                        info.toolBarItemId = id;
+                        m_keyTipsTargets.push_back(info);
+
+                        wxString dropdownKeytip = tb->GetDropdownKeyTip(id);
+                        wxRect dropdownRect = tb->GetToolDropdownRect(id);
+                        if ( !dropdownKeytip.empty() && !dropdownRect.IsEmpty() )
+                        {
+                            wxRibbonKeyTipInfo dropdownInfo;
+                            dropdownInfo.fullKeyTip = dropdownKeytip;
+                            dropdownInfo.rect = dropdownRect;
+                            dropdownInfo.window = tb;
+                            dropdownInfo.kind = wxRibbonKeyTipInfo::KeyTip_ToolBarItem;
+                            dropdownInfo.toolBar = tb;
+                            dropdownInfo.toolBarItemId = id;
+                            dropdownInfo.dropdown = true;
+                            m_keyTipsTargets.push_back(dropdownInfo);
+                        }
+                    }
+                }
+                else if ( gallery != nullptr )
+                {
+                    wxString keytip = gallery->GetKeyTip();
+                    if ( !keytip.empty() )
+                    {
+                        wxRibbonKeyTipInfo info;
+                        info.fullKeyTip = keytip;
+                        info.rect = wxRect(wxPoint(0, 0), gallery->GetSize());
+                        info.window = gallery;
+                        info.kind = wxRibbonKeyTipInfo::KeyTip_Gallery;
+                        m_keyTipsTargets.push_back(info);
+                    }
+                }
+            }
+        }
+    }
+
+    for ( auto& target : m_keyTipsTargets )
+        target.remaining = target.fullKeyTip;
+
+    m_keyTipsWindows.clear();
+    m_keyTipsWindows.push_back(this);
+    for ( const auto& target : m_keyTipsTargets )
+    {
+        if ( std::find(m_keyTipsWindows.begin(), m_keyTipsWindows.end(), target.window) ==
+             m_keyTipsWindows.end() )
+        {
+            m_keyTipsWindows.push_back(target.window);
+        }
+    }
+}
+
+void wxRibbonBar::DoActivateKeyTipTarget(const wxRibbonKeyTipInfo& target)
+{
+    switch ( target.kind )
+    {
+        case wxRibbonKeyTipInfo::KeyTip_PageTab:
+        {
+            wxRibbonPageTabInfo& tab = m_pages.Item(target.pageIndex);
+            if ( m_ribbon_state == wxRIBBON_BAR_MINIMIZED )
+                ShowPanels(wxRIBBON_BAR_EXPANDED);
+            if ( (int)target.pageIndex != m_current_page )
+            {
+                wxRibbonBarEvent query(wxEVT_RIBBONBAR_PAGE_CHANGING, GetId(), tab.page);
+                query.SetEventObject(this);
+                ProcessWindowEvent(query);
+                if ( query.IsAllowed() )
+                {
+                    SetActivePage(query.GetPage());
+
+                    wxRibbonBarEvent notification(wxEVT_RIBBONBAR_PAGE_CHANGED, GetId(),
+                        m_pages.Item(m_current_page).page);
+                    notification.SetEventObject(this);
+                    ProcessWindowEvent(notification);
+                }
+            }
+            // Switching pages isn't a command, so stay in keytip mode and
+            // show the keytips of the page we just moved to.
+            ShowKeyTips();
+            break;
+        }
+
+        case wxRibbonKeyTipInfo::KeyTip_ToggleButton:
+        {
+            ShowPanels(ArePanelsShown() ? wxRIBBON_BAR_MINIMIZED : wxRIBBON_BAR_PINNED);
+            wxRibbonBarEvent event(wxEVT_RIBBONBAR_TOGGLED, GetId());
+            event.SetEventObject(this);
+            ProcessWindowEvent(event);
+            break;
+        }
+
+        case wxRibbonKeyTipInfo::KeyTip_HelpButton:
+        {
+            wxRibbonBarEvent event(wxEVT_RIBBONBAR_HELP_CLICK, GetId());
+            event.SetEventObject(this);
+            ProcessWindowEvent(event);
+            break;
+        }
+
+        case wxRibbonKeyTipInfo::KeyTip_ExtButton:
+        {
+            wxRibbonPanelEvent notification(wxEVT_RIBBONPANEL_EXTBUTTON_ACTIVATED, target.panel->GetId());
+            notification.SetEventObject(target.panel);
+            notification.SetPanel(target.panel);
+            target.panel->ProcessWindowEvent(notification);
+            break;
+        }
+
+        case wxRibbonKeyTipInfo::KeyTip_MinimisedPanel:
+            target.panel->ShowExpanded();
+            break;
+
+        case wxRibbonKeyTipInfo::KeyTip_ButtonBarItem:
+        {
+            wxRibbonButtonBarButtonBase* button = target.buttonBar->GetItemById(target.buttonBarItemId);
+            if ( button != nullptr )
+                target.buttonBar->ActivateButton(button, target.dropdown);
+            break;
+        }
+
+        case wxRibbonKeyTipInfo::KeyTip_ToolBarItem:
+        {
+            wxRibbonToolBarToolBase* tool = target.toolBar->FindById(target.toolBarItemId);
+            if ( tool != nullptr )
+                target.toolBar->ActivateTool(tool, target.dropdown);
+            break;
+        }
+
+        case wxRibbonKeyTipInfo::KeyTip_Gallery:
+            target.window->SetFocus();
+            break;
+    }
+}
+
+void wxRibbonBar::GetKeyTipTargetsFor(wxWindow* window, std::vector<KeyTipBadge>* badges) const
+{
+    badges->clear();
+    if ( !m_keyTipsActive )
+        return;
+
+    for ( const auto& target : m_keyTipsTargets )
+    {
+        if ( target.window == window )
+        {
+            KeyTipBadge badge;
+            badge.rect = target.rect;
+            badge.text = target.remaining;
+            badges->push_back(badge);
+        }
+    }
+}
+
+void wxRibbonBar::OnKeyTipsWindowDestroy(wxWindowDestroyEvent& event)
+{
+    event.Skip();
+    if ( !m_keyTipsActive )
+        return;
+
+    // Drop the stale target pointers, but don't refresh the dying window.
+    wxWindow* window = event.GetWindow();
+    m_keyTipsWindows.erase(
+        std::remove(m_keyTipsWindows.begin(), m_keyTipsWindows.end(), window),
+        m_keyTipsWindows.end());
+
+    HideKeyTips();
+}
+
+void wxRibbonBar::OnKeyTipsActivate(wxActivateEvent& event)
+{
+    event.Skip();
+    if ( m_keyTipsActive && !event.GetActive() )
+        HideKeyTips();
+}
+
+bool wxRibbonBar::IsKeyTipsTriggerKey(int keyCode, int modifiers) const
+{
+    for ( const auto& trigger : m_keyTipsTriggerKeys )
+    {
+        if ( keyCode == trigger.keyCode && modifiers == trigger.modifiers )
+            return true;
+    }
+    return false;
+}
+
+void wxRibbonBar::OnKeyTipsCharHook(wxKeyEvent& event)
+{
+    if ( !m_keyTipsActive )
+    {
+        // Only steal the trigger key if there's something to show, so
+        // ribbon bars with no keytips configured stay backward compatible.
+        if ( IsKeyTipsTriggerKey(event.GetKeyCode(), event.GetModifiers()) &&
+             ShowKeyTips() )
+        {
+            return;
+        }
+        event.Skip();
+        return;
+    }
+
+    // KeyTips mode is active.
+    int keycode = event.GetKeyCode();
+
+    if ( keycode == WXK_ESCAPE )
+    {
+        if ( !m_keyTipsTypedPrefix.empty() )
+        {
+            m_keyTipsTypedPrefix.clear();
+            DoBuildKeyTipTargets();
+            RefreshKeyTipTargetWindows();
+        }
+        else
+        {
+            HideKeyTips();
+        }
+        return;
+    }
+
+    if ( IsKeyTipsTriggerKey(keycode, event.GetModifiers()) )
+    {
+        HideKeyTips();
+        return;
+    }
+
+    // Accelerators aren't keytips: leave the mode and let the key through,
+    // otherwise Ctrl+S would fire the "S" keytip and Alt+F4 would be eaten.
+    if ( event.GetModifiers() & ~wxMOD_SHIFT )
+    {
+        HideKeyTips();
+        event.Skip();
+        return;
+    }
+
+    if ( keycode > WXK_SPACE && keycode <= 255 && wxIsalnum((wxChar)keycode) )
+    {
+        wxUniChar ch = wxToupper((wxChar)keycode);
+
+        std::vector<wxRibbonKeyTipInfo> matches;
+        for ( const auto& target : m_keyTipsTargets )
+        {
+            if ( !target.remaining.empty() && target.remaining[0] == ch )
+                matches.push_back(target);
+        }
+
+        if ( matches.empty() )
+        {
+            // No match: consume the key, but otherwise do nothing.
+            return;
+        }
+
+        for ( auto& target : matches )
+            target.remaining = target.remaining.Mid(1);
+
+        if ( matches.size() == 1 && matches[0].remaining.empty() )
+        {
+            wxRibbonKeyTipInfo activated = matches[0];
+            HideKeyTips();
+            DoActivateKeyTipTarget(activated);
+        }
+        else
+        {
+            m_keyTipsTargets = matches;
+            m_keyTipsTypedPrefix += ch;
+            RefreshKeyTipTargetWindows();
+        }
+        return;
+    }
+
+    // Any other key: swallow it while keytips are active.
 }
 
 #endif // wxUSE_RIBBON

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -1126,12 +1126,7 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
     wxRibbonBar* bar = GetAncestorRibbonBar();
     if ( bar != nullptr )
-    {
-        std::vector<wxRibbonBar::KeyTipBadge> badges;
-        bar->GetKeyTipTargetsFor(this, &badges);
-        for ( const auto& badge : badges )
-            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
-    }
+        bar->DrawKeyTipsFor(dc, this, m_art);
 }
 
 wxBitmap wxRibbonButtonBar::GetButtonBitmap(int imageIndex, bool large) const

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -14,6 +14,7 @@
 
 #include "wx/ribbon/panel.h"
 #include "wx/ribbon/buttonbar.h"
+#include "wx/ribbon/bar.h"
 #include "wx/ribbon/art.h"
 #include "wx/dcbuffer.h"
 #include "wx/imaglist.h"
@@ -563,6 +564,8 @@ void wxRibbonButtonBar::ClearButtons()
         delete button;
     }
     m_buttons.Clear();
+    m_keyTips.clear();
+    m_dropdownKeyTips.clear();
     m_hovered_button = nullptr;
     m_active_button = nullptr;
     Realize();
@@ -584,12 +587,95 @@ bool wxRibbonButtonBar::DeleteButton(int button_id)
             if (m_active_button  && m_active_button->base  == button)
                 m_active_button = nullptr;
             delete button;
+            m_keyTips.erase(button_id);
+            m_dropdownKeyTips.erase(button_id);
             Realize();
             Refresh();
             return true;
         }
     }
     return false;
+}
+
+void wxRibbonButtonBar::SetKeyTip(wxWindowID button_id, const wxString& keytip)
+{
+    if ( keytip.empty() )
+        m_keyTips.erase(button_id);
+    else
+        m_keyTips[button_id] = keytip.Upper();
+}
+
+wxString wxRibbonButtonBar::GetKeyTip(wxWindowID button_id) const
+{
+    auto it = m_keyTips.find(button_id);
+    return it == m_keyTips.end() ? wxString() : it->second;
+}
+
+void wxRibbonButtonBar::SetDropdownKeyTip(wxWindowID button_id, const wxString& keytip)
+{
+    if ( keytip.empty() )
+        m_dropdownKeyTips.erase(button_id);
+    else
+        m_dropdownKeyTips[button_id] = keytip.Upper();
+}
+
+wxString wxRibbonButtonBar::GetDropdownKeyTip(wxWindowID button_id) const
+{
+    auto it = m_dropdownKeyTips.find(button_id);
+    return it == m_dropdownKeyTips.end() ? wxString() : it->second;
+}
+
+void wxRibbonButtonBar::ActivateButton(wxRibbonButtonBarButtonBase* button, bool dropdown)
+{
+    wxCHECK_RET(button, wxT("invalid button"));
+    if ( button->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED )
+        return;
+
+    wxEventType event_type = (dropdown || button->kind == wxRIBBON_BUTTON_DROPDOWN)
+        ? wxEVT_RIBBONBUTTONBAR_DROPDOWN_CLICKED
+        : wxEVT_RIBBONBUTTONBAR_CLICKED;
+
+    wxRibbonButtonBarEvent notification(event_type, button->id);
+    if ( !dropdown && button->kind == wxRIBBON_BUTTON_TOGGLE )
+    {
+        button->state ^= wxRIBBON_BUTTONBAR_BUTTON_TOGGLED;
+        notification.SetInt(button->state & wxRIBBON_BUTTONBAR_BUTTON_TOGGLED);
+    }
+    notification.SetEventObject(this);
+    notification.SetBar(this);
+    notification.SetButton(button);
+
+    // PopupMenu() positions the menu relative to m_active_button, so set
+    // it here too, otherwise a keytip-opened menu appears at the cursor.
+    wxRibbonButtonBarButtonInstance* const old_active = m_active_button;
+    if ( m_active_button == nullptr || m_active_button->base != button )
+    {
+        wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
+        for ( auto& instance : layout->buttons )
+        {
+            if ( instance.base == button )
+            {
+                m_active_button = &instance;
+                break;
+            }
+        }
+    }
+
+    // Keep OnMouseMove() from mutating the active state while a handler runs
+    // a nested event loop, e.g. for a popup menu.
+    m_lock_active_state = true;
+    ProcessWindowEvent(notification);
+    m_lock_active_state = false;
+
+    // The handler may have reset m_active_button, e.g. by deleting the button.
+    if ( m_active_button != nullptr )
+        m_active_button = old_active;
+
+    wxRibbonPanel* panel = wxDynamicCast(GetParent(), wxRibbonPanel);
+    if ( panel != nullptr )
+        panel->HideIfExpanded();
+
+    Refresh(false);
 }
 
 void wxRibbonButtonBar::EnableButton(int button_id, bool enable)
@@ -620,6 +706,18 @@ void wxRibbonButtonBar::EnableButton(int button_id, bool enable)
             return;
         }
     }
+}
+
+bool wxRibbonButtonBar::GetButtonEnabled(int button_id) const
+{
+    size_t count = m_buttons.GetCount();
+    for ( size_t i = 0; i < count; ++i )
+    {
+        wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
+        if ( button->id == button_id )
+            return (button->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0;
+    }
+    return false;
 }
 
 void wxRibbonButtonBar::ToggleButton(int button_id, bool checked)
@@ -1012,6 +1110,15 @@ void wxRibbonButtonBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
         m_art->DrawButtonBarButton(dc, this, rect, base->kind,
             base->state | button.size, base->label, bitmap, bitmap_small);
      }
+
+    wxRibbonBar* bar = GetAncestorRibbonBar();
+    if ( bar != nullptr )
+    {
+        std::vector<wxRibbonBar::KeyTipBadge> badges;
+        bar->GetKeyTipTargetsFor(this, &badges);
+        for ( const auto& badge : badges )
+            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
+    }
 }
 
 wxBitmap wxRibbonButtonBar::GetButtonBitmap(int imageIndex, bool large) const
@@ -1043,7 +1150,10 @@ void wxRibbonButtonBar::OnSize(wxSizeEvent& evt)
             break;
         }
     }
+    // Both point into the previous layout's instances, so remap them or they
+    // keep a stale position and size.
     m_hovered_button = m_layouts.Item(m_current_layout)->FindSimilarInstance(m_hovered_button);
+    m_active_button = m_layouts.Item(m_current_layout)->FindSimilarInstance(m_active_button);
     Refresh();
 }
 
@@ -1430,6 +1540,8 @@ void wxRibbonButtonBar::OnMouseMove(wxMouseEvent& evt)
 
 void wxRibbonButtonBar::OnMouseDown(wxMouseEvent& evt)
 {
+    DismissKeyTips();
+
     wxPoint cursor(evt.GetPosition());
     m_active_button = nullptr;
 
@@ -1477,34 +1589,12 @@ void wxRibbonButtonBar::OnMouseUp(wxMouseEvent& evt)
         btn_rect.SetSize(size.size);
         if(btn_rect.Contains(cursor))
         {
-            int id = m_active_button->base->id;
             cursor -= btn_rect.GetTopLeft();
-            wxEventType event_type;
-            do
-            {
-                if(size.normal_region.Contains(cursor))
-                    event_type = wxEVT_RIBBONBUTTONBAR_CLICKED;
-                else if(size.dropdown_region.Contains(cursor))
-                    event_type = wxEVT_RIBBONBUTTONBAR_DROPDOWN_CLICKED;
-                else
-                    break;
-                wxRibbonButtonBarEvent notification(event_type, id);
-                if(m_active_button->base->kind == wxRIBBON_BUTTON_TOGGLE)
-                {
-                    m_active_button->base->state ^=
-                        wxRIBBON_BUTTONBAR_BUTTON_TOGGLED;
-                    notification.SetInt(m_active_button->base->state &
-                        wxRIBBON_BUTTONBAR_BUTTON_TOGGLED);
-                }
-                notification.SetEventObject(this);
-                notification.SetBar(this);
-                notification.SetButton(m_active_button->base);
-                m_lock_active_state = true;
-                ProcessWindowEvent(notification);
-                m_lock_active_state = false;
+            if(size.normal_region.Contains(cursor))
+                ActivateButton(m_active_button->base, false);
+            else if(size.dropdown_region.Contains(cursor))
+                ActivateButton(m_active_button->base, true);
 
-                wxStaticCast(m_parent, wxRibbonPanel)->HideIfExpanded();
-            } while(false);
             if(m_active_button) // may have been NULLed by event handler
             {
                 m_active_button->base->state &= ~wxRIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK;
@@ -1595,6 +1685,27 @@ wxRect wxRibbonButtonBar::GetItemRect(int button_id)const
             btn_rect.SetSize(size.size);
 
             return btn_rect;
+        }
+    }
+    return wxRect();
+}
+
+wxRect wxRibbonButtonBar::GetItemDropdownRect(int button_id) const
+{
+    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
+    for ( auto& instance : layout->buttons )
+    {
+        wxRibbonButtonBarButtonBase* button = instance.base;
+
+        if ( button->id == button_id )
+        {
+            wxRibbonButtonBarButtonSizeInfo& size = button->sizes[instance.size];
+            if ( size.dropdown_region.IsEmpty() )
+                return wxRect();
+
+            wxRect dropdown_rect = size.dropdown_region;
+            dropdown_rect.Offset(m_layout_offset + instance.position);
+            return dropdown_rect;
         }
     }
     return wxRect();

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -198,9 +198,21 @@ public:
         {
             return nullptr;
         }
+        return FindInstanceForBase(inst->base);
+    }
+
+    // Takes the stable button object directly, rather than an instance
+    // pointer, which may be dangling.
+    wxRibbonButtonBarButtonInstance* FindInstanceForBase(
+        wxRibbonButtonBarButtonBase* base)
+    {
+        if(base == nullptr)
+        {
+            return nullptr;
+        }
         for ( auto& instance : buttons )
         {
-            if(instance.base == inst->base)
+            if ( instance.base == base )
             {
                 return &instance;
             }
@@ -647,19 +659,12 @@ void wxRibbonButtonBar::ActivateButton(wxRibbonButtonBarButtonBase* button, bool
 
     // PopupMenu() positions the menu relative to m_active_button, so set
     // it here too, otherwise a keytip-opened menu appears at the cursor.
-    wxRibbonButtonBarButtonInstance* const old_active = m_active_button;
     if ( m_active_button == nullptr || m_active_button->base != button )
-    {
-        wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
-        for ( auto& instance : layout->buttons )
-        {
-            if ( instance.base == button )
-            {
-                m_active_button = &instance;
-                break;
-            }
-        }
-    }
+        m_active_button = m_layouts.Item(m_current_layout)->FindInstanceForBase(button);
+
+    // Track the id, not the instance pointer, since Realize() may rebuild
+    // the layout mid-handler and invalidate it.
+    const int old_active_id = m_active_button != nullptr ? m_active_button->base->id : wxID_ANY;
 
     // Keep OnMouseMove() from mutating the active state while a handler runs
     // a nested event loop, e.g. for a popup menu.
@@ -667,9 +672,17 @@ void wxRibbonButtonBar::ActivateButton(wxRibbonButtonBarButtonBase* button, bool
     ProcessWindowEvent(notification);
     m_lock_active_state = false;
 
-    // The handler may have reset m_active_button, e.g. by deleting the button.
-    if ( m_active_button != nullptr )
-        m_active_button = old_active;
+    // Re-resolve from the id instead of trusting m_active_button.
+    m_active_button = nullptr;
+    if ( old_active_id != wxID_ANY )
+    {
+        wxRibbonButtonBarButtonBase* old_active_base = GetItemById(old_active_id);
+        if ( old_active_base != nullptr )
+        {
+            m_active_button =
+                m_layouts.Item(m_current_layout)->FindInstanceForBase(old_active_base);
+        }
+    }
 
     wxRibbonPanel* panel = wxDynamicCast(GetParent(), wxRibbonPanel);
     if ( panel != nullptr )

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -212,7 +212,7 @@ public:
         }
         for ( auto& instance : buttons )
         {
-            if ( instance.base == base )
+            if(instance.base == base)
             {
                 return &instance;
             }

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -723,10 +723,8 @@ void wxRibbonButtonBar::EnableButton(int button_id, bool enable)
 
 bool wxRibbonButtonBar::GetButtonEnabled(int button_id) const
 {
-    size_t count = m_buttons.GetCount();
-    for ( size_t i = 0; i < count; ++i )
+    for ( auto const* button : m_buttons )
     {
-        wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
         if ( button->id == button_id )
             return (button->state & wxRIBBON_BUTTONBAR_BUTTON_DISABLED) == 0;
     }
@@ -735,11 +733,8 @@ bool wxRibbonButtonBar::GetButtonEnabled(int button_id) const
 
 void wxRibbonButtonBar::ToggleButton(int button_id, bool checked)
 {
-    size_t count = m_buttons.GetCount();
-    size_t i;
-    for(i = 0; i < count; ++i)
+    for ( auto* button : m_buttons )
     {
-        wxRibbonButtonBarButtonBase* button = m_buttons.Item(i);
         if(button->id == button_id)
         {
             if(checked)

--- a/src/ribbon/control.cpp
+++ b/src/ribbon/control.cpp
@@ -117,4 +117,10 @@ wxRibbonBar* wxRibbonControl::GetAncestorRibbonBar()const
     return nullptr;
 }
 
+void wxRibbonControl::DismissKeyTips()
+{
+    if ( wxRibbonBar* bar = GetAncestorRibbonBar() )
+        bar->HideKeyTips();
+}
+
 #endif // wxUSE_RIBBON

--- a/src/ribbon/gallery.cpp
+++ b/src/ribbon/gallery.cpp
@@ -534,12 +534,7 @@ void wxRibbonGallery::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
     wxRibbonBar* bar = GetAncestorRibbonBar();
     if ( bar != nullptr )
-    {
-        std::vector<wxRibbonBar::KeyTipBadge> badges;
-        bar->GetKeyTipTargetsFor(this, &badges);
-        for ( const auto& badge : badges )
-            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
-    }
+        bar->DrawKeyTipsFor(dc, this, m_art);
 }
 
 void wxRibbonGallery::OnSize(wxSizeEvent& WXUNUSED(evt))

--- a/src/ribbon/gallery.cpp
+++ b/src/ribbon/gallery.cpp
@@ -255,6 +255,8 @@ void wxRibbonGallery::OnMouseLeave(wxMouseEvent& WXUNUSED(evt))
 
 void wxRibbonGallery::OnMouseDown(wxMouseEvent& evt)
 {
+    DismissKeyTips();
+
     wxPoint pos = evt.GetPosition();
     m_mouse_active_rect = nullptr;
     if(m_client_rect.Contains(pos))
@@ -526,6 +528,17 @@ void wxRibbonGallery::OnPaint(wxPaintEvent& WXUNUSED(evt))
         if (bmp.IsOk())
             dc.DrawBitmap(bmp, offset_pos.GetLeft() + padding_left,
                 offset_pos.GetTop() + padding_top);
+    }
+
+    dc.DestroyClippingRegion();
+
+    wxRibbonBar* bar = GetAncestorRibbonBar();
+    if ( bar != nullptr )
+    {
+        std::vector<wxRibbonBar::KeyTipBadge> badges;
+        bar->GetKeyTipTargetsFor(this, &badges);
+        for ( const auto& badge : badges )
+            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
     }
 }
 

--- a/src/ribbon/panel.cpp
+++ b/src/ribbon/panel.cpp
@@ -339,6 +339,15 @@ void wxRibbonPanel::OnPaint(wxPaintEvent& WXUNUSED(evt))
         {
             m_art->DrawPanelBackground(dc, this, GetSize());
         }
+
+        wxRibbonBar* bar = GetAncestorRibbonBar();
+        if ( bar != nullptr )
+        {
+            std::vector<wxRibbonBar::KeyTipBadge> badges;
+            bar->GetKeyTipTargetsFor(this, &badges);
+            for ( const auto& badge : badges )
+                m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
+        }
     }
 }
 
@@ -783,6 +792,8 @@ bool wxRibbonPanel::Layout()
 
 void wxRibbonPanel::OnMouseClick(wxMouseEvent& WXUNUSED(evt))
 {
+    DismissKeyTips();
+
     if(IsMinimised())
     {
         if(m_expanded_panel != nullptr)
@@ -844,6 +855,8 @@ bool wxRibbonPanel::ShowExpanded()
 
     m_expanded_panel->SetArtProvider(m_art);
     m_expanded_panel->m_expanded_dummy = this;
+    m_expanded_panel->m_extButtonKeyTip = m_extButtonKeyTip;
+    m_expanded_panel->m_keyTip = m_keyTip;
 
     // Move all children to the new panel.
     // Conceptually it might be simpler to reparent this entire panel to the
@@ -976,6 +989,10 @@ bool wxRibbonPanel::HideExpanded()
             return false;
         }
     }
+
+    // Keep any keytips set while the panel was expanded.
+    m_expanded_dummy->m_extButtonKeyTip = m_extButtonKeyTip;
+    m_expanded_dummy->m_keyTip = m_keyTip;
 
     // Move children back to original panel
     // NB: Children iterators not used as behaviour is not well defined

--- a/src/ribbon/panel.cpp
+++ b/src/ribbon/panel.cpp
@@ -342,12 +342,7 @@ void wxRibbonPanel::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
         wxRibbonBar* bar = GetAncestorRibbonBar();
         if ( bar != nullptr )
-        {
-            std::vector<wxRibbonBar::KeyTipBadge> badges;
-            bar->GetKeyTipTargetsFor(this, &badges);
-            for ( const auto& badge : badges )
-                m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
-        }
+            bar->DrawKeyTipsFor(dc, this, m_art);
     }
 }
 

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -341,6 +341,8 @@ void wxRibbonToolBar::ClearTools()
 
     m_hover_tool = nullptr;
     m_active_tool = nullptr;
+    m_keyTips.clear();
+    m_dropdownKeyTips.clear();
 
     // at least one group should be available
     AppendGroup();
@@ -365,11 +367,76 @@ bool wxRibbonToolBar::DeleteTool(int tool_id)
                 if ( tool == m_active_tool )
                     m_active_tool = nullptr;
                 delete tool;
+                m_keyTips.erase(tool_id);
+                m_dropdownKeyTips.erase(tool_id);
                 return true;
             }
         }
     }
     return false;
+}
+
+void wxRibbonToolBar::SetKeyTip(wxWindowID tool_id, const wxString& keytip)
+{
+    if ( keytip.empty() )
+        m_keyTips.erase(tool_id);
+    else
+        m_keyTips[tool_id] = keytip.Upper();
+}
+
+wxString wxRibbonToolBar::GetKeyTip(wxWindowID tool_id) const
+{
+    auto it = m_keyTips.find(tool_id);
+    return it == m_keyTips.end() ? wxString() : it->second;
+}
+
+void wxRibbonToolBar::SetDropdownKeyTip(wxWindowID tool_id, const wxString& keytip)
+{
+    if ( keytip.empty() )
+        m_dropdownKeyTips.erase(tool_id);
+    else
+        m_dropdownKeyTips[tool_id] = keytip.Upper();
+}
+
+wxString wxRibbonToolBar::GetDropdownKeyTip(wxWindowID tool_id) const
+{
+    auto it = m_dropdownKeyTips.find(tool_id);
+    return it == m_dropdownKeyTips.end() ? wxString() : it->second;
+}
+
+void wxRibbonToolBar::ActivateTool(wxRibbonToolBarToolBase* tool, bool dropdown)
+{
+    wxCHECK_RET(tool, wxT("invalid tool"));
+    if ( tool->state & wxRIBBON_TOOLBAR_TOOL_DISABLED )
+        return;
+
+    wxEventType evt_type = (dropdown || tool->kind == wxRIBBON_BUTTON_DROPDOWN)
+        ? wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED
+        : wxEVT_RIBBONTOOLBAR_CLICKED;
+
+    wxRibbonToolBarEvent notification(evt_type, tool->id);
+    if ( !dropdown && tool->kind == wxRIBBON_BUTTON_TOGGLE )
+    {
+        tool->state ^= wxRIBBON_TOOLBAR_TOOL_TOGGLED;
+        notification.SetInt(tool->state & wxRIBBON_TOOLBAR_TOOL_TOGGLED);
+    }
+    notification.SetEventObject(this);
+    notification.SetBar(this);
+
+    // PopupMenu() positions the menu relative to m_active_tool, so set
+    // it here too, otherwise a keytip-opened menu appears at the cursor.
+    wxRibbonToolBarToolBase* const old_active = m_active_tool;
+    m_active_tool = tool;
+    ProcessEvent(notification);
+    // The handler may have reset m_active_tool, e.g. by deleting the tool.
+    if ( m_active_tool == tool )
+        m_active_tool = old_active;
+
+    wxRibbonPanel* panel = wxDynamicCast(GetParent(), wxRibbonPanel);
+    if ( panel != nullptr )
+        panel->HideIfExpanded();
+
+    Refresh(false);
 }
 
 bool wxRibbonToolBar::DeleteToolByPos(size_t pos)
@@ -389,6 +456,8 @@ bool wxRibbonToolBar::DeleteToolByPos(size_t pos)
                 m_hover_tool = nullptr;
             if ( tool == m_active_tool )
                 m_active_tool = nullptr;
+            m_keyTips.erase(tool->id);
+            m_dropdownKeyTips.erase(tool->id);
             delete tool;
             return true;
         }
@@ -563,6 +632,32 @@ wxRect wxRibbonToolBar::GetToolRect(int tool_id)const
             if (tool->id == tool_id)
             {
                 return wxRect(group->position + tool->position, tool->size);
+            }
+        }
+    }
+    return wxRect();
+}
+
+wxRect wxRibbonToolBar::GetToolDropdownRect(int tool_id)const
+{
+    size_t group_count = m_groups.GetCount();
+    size_t g, t;
+
+    for ( g = 0; g < group_count; ++g )
+    {
+        wxRibbonToolBarToolGroup* group = m_groups.Item(g);
+        size_t tool_count = group->tools.GetCount();
+        for ( t = 0; t < tool_count; ++t )
+        {
+            wxRibbonToolBarToolBase* tool = group->tools.Item(t);
+            if ( tool->id == tool_id )
+            {
+                if ( tool->dropdown.IsEmpty() )
+                    return wxRect();
+
+                wxRect dropdown_rect = tool->dropdown;
+                dropdown_rect.Offset(group->position + tool->position);
+                return dropdown_rect;
             }
         }
     }
@@ -1083,6 +1178,15 @@ void wxRibbonToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
             }
         }
     }
+
+    wxRibbonBar* bar = GetAncestorRibbonBar();
+    if ( bar != nullptr )
+    {
+        std::vector<wxRibbonBar::KeyTipBadge> badges;
+        bar->GetKeyTipTargetsFor(this, &badges);
+        for ( const auto& badge : badges )
+            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
+    }
 }
 
 void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
@@ -1178,6 +1282,8 @@ void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
 
 void wxRibbonToolBar::OnMouseDown(wxMouseEvent& evt)
 {
+    DismissKeyTips();
+
     OnMouseMove(evt);
     if(m_hover_tool)
     {
@@ -1205,23 +1311,8 @@ void wxRibbonToolBar::OnMouseUp(wxMouseEvent& WXUNUSED(evt))
     {
         if(m_active_tool->state & wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK)
         {
-            wxEventType evt_type = wxEVT_RIBBONTOOLBAR_CLICKED;
-            if(m_active_tool->state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE)
-                evt_type = wxEVT_RIBBONTOOLBAR_DROPDOWN_CLICKED;
-            wxRibbonToolBarEvent notification(evt_type, m_active_tool->id);
-            if(m_active_tool->kind == wxRIBBON_BUTTON_TOGGLE)
-            {
-                m_active_tool->state ^=
-                    wxRIBBON_TOOLBAR_TOOL_TOGGLED;
-                notification.SetInt(m_active_tool->state &
-                    wxRIBBON_TOOLBAR_TOOL_TOGGLED);
-            }
-            notification.SetEventObject(this);
-            notification.SetBar(this);
-            ProcessEvent(notification);
-
-            if (auto* const panel = wxCheckedStaticCast<wxRibbonPanel>(GetParent()))
-                panel->HideIfExpanded();
+            ActivateTool(m_active_tool,
+                (m_active_tool->state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE) != 0);
         }
 
         // Notice that m_active_tool could have been reset by the event handler

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -425,12 +425,12 @@ void wxRibbonToolBar::ActivateTool(wxRibbonToolBarToolBase* tool, bool dropdown)
 
     // PopupMenu() positions the menu relative to m_active_tool, so set
     // it here too, otherwise a keytip-opened menu appears at the cursor.
-    wxRibbonToolBarToolBase* const old_active = m_active_tool;
+    const int old_active_id = m_active_tool ? m_active_tool->id : wxID_ANY;
     m_active_tool = tool;
     ProcessEvent(notification);
-    // The handler may have reset m_active_tool, e.g. by deleting the tool.
-    if ( m_active_tool == tool )
-        m_active_tool = old_active;
+    m_active_tool = nullptr;
+    if ( old_active_id != wxID_ANY )
+        m_active_tool = FindById(old_active_id);
 
     wxRibbonPanel* panel = wxDynamicCast(GetParent(), wxRibbonPanel);
     if ( panel != nullptr )

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -1181,12 +1181,7 @@ void wxRibbonToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
     wxRibbonBar* bar = GetAncestorRibbonBar();
     if ( bar != nullptr )
-    {
-        std::vector<wxRibbonBar::KeyTipBadge> badges;
-        bar->GetKeyTipTargetsFor(this, &badges);
-        for ( const auto& badge : badges )
-            m_art->DrawKeyTip(dc, this, badge.rect, badge.text);
-    }
+        bar->DrawKeyTipsFor(dc, this, m_art);
 }
 
 void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)


### PR DESCRIPTION
Adds ability to connect and show keyboard shortcuts for buttons (regular, dropdown, hybrid), tabs, and other controls on ribbons. By default, `F10` activates this (like Office), but can be customized. (I chose to not use `ALT` for this like Office out of concern for compatibility).

<img width="777" height="139" alt="Screenshot 2026-08-27 174139" src="https://github.com/user-attachments/assets/789c69d3-7c99-46b7-84f3-deb92fbf9447" />

(In dark mode, KeyTips are yellow backgrounds and black text.)

Supports most of the functionality mentioned here:

https://support.microsoft.com/en-us/accessibility/windows/use-the-keyboard-to-work-with-the-ribbon

Tested on MSW, Linux Mint, and macOS.