### PR TITLE
Drop unused parameters from wxWidgetIPhoneImpl::controlAction()

### DIFF
--- a/include/wx/osx/iphone/private.h
+++ b/include/wx/osx/iphone/private.h
@@ -128,7 +128,7 @@ public :
 
     // action
 
-    virtual void        controlAction(void* sender, wxUint32 controlEvent, WX_UIEvent rawEvent);
+    virtual void        controlAction(wxUint32 controlEvent);
     virtual void         controlTextDidChange();
 
     void*               GetController() { return m_controller; }

--- a/include/wx/osx/iphone/private/textimpl.h
+++ b/include/wx/osx/iphone/private/textimpl.h
@@ -41,7 +41,7 @@ public :
 
     virtual bool SetHint(const wxString& hint);
 
-    virtual void controlAction(WXWidget slf, void* _cmd, void *sender);
+    virtual void controlAction(wxUint32 controlEvent) override;
 protected :
     UITextField* m_textField;
     NSObject<UITextFieldDelegate>* m_delegate;

--- a/src/osx/iphone/slider.mm
+++ b/src/osx/iphone/slider.mm
@@ -46,12 +46,12 @@ public :
     {
     }
 
-    void controlAction(void* sender, wxUint32 controlEvent, WX_UIEvent rawEvent)
+    void controlAction(wxUint32 controlEvent) override
     {
         if ( controlEvent == UIControlEventValueChanged )
             GetWXPeer()->TriggerScrollEvent(wxEVT_SCROLL_THUMBTRACK);
         else
-            wxWidgetIPhoneImpl::controlAction(sender,controlEvent,rawEvent);
+            wxWidgetIPhoneImpl::controlAction(controlEvent);
     }
 
     void SetMaximum(wxInt32 m)

--- a/src/osx/iphone/textctrl.mm
+++ b/src/osx/iphone/textctrl.mm
@@ -685,8 +685,7 @@ void wxUITextFieldControl::WriteText(const wxString& str)
 #endif
 }
 
-void wxUITextFieldControl::controlAction(WXWidget WXUNUSED(slf),
-    void* WXUNUSED(_cmd), void *WXUNUSED(sender))
+void wxUITextFieldControl::controlAction(wxUint32 /*controlEvent*/)
 {
     wxWindow* wxpeer = (wxWindow*) GetWXPeer();
     if ( wxpeer && (wxpeer->GetWindowStyle() & wxTE_PROCESS_ENTER) )

--- a/src/osx/iphone/window.mm
+++ b/src/osx/iphone/window.mm
@@ -380,14 +380,14 @@ void wxOSXIPhoneClassAddWXMethods(Class c)
 {
     wxWidgetIPhoneImpl* impl = (wxWidgetIPhoneImpl* ) wxWidgetImpl::FindFromWXWidget( self );
     if (impl != nullptr)
-        impl->controlAction(sender, UIControlEventTouchUpInside, event);
+        impl->controlAction(UIControlEventTouchUpInside);
 }
 
 - (void) WX_valueChangedAction:(id)sender event:(UIEvent*)event
 {
     wxWidgetIPhoneImpl* impl = (wxWidgetIPhoneImpl* ) wxWidgetImpl::FindFromWXWidget( self );
     if (impl != nullptr)
-        impl->controlAction(sender, UIControlEventValueChanged, event);
+        impl->controlAction(UIControlEventValueChanged);
 }
 
 @end
@@ -964,7 +964,7 @@ void wxWidgetIPhoneImpl::touchEvent(NSSet* touches, UIEvent *event, WXWidget slf
     }
 }
 
-void wxWidgetIPhoneImpl::controlAction(void* sender, wxUint32 controlEvent, WX_UIEvent rawEvent)
+void wxWidgetIPhoneImpl::controlAction(wxUint32 controlEvent)
 {
     if ( controlEvent == UIControlEventTouchUpInside )
         GetWXPeer()->OSXHandleClicked(0);


### PR DESCRIPTION
And correct parameter type for wxUITextFieldControl override, which eliminates -Woverloaded-virtual warning.
```
warning: 'wxUITextFieldControl::controlAction' hides overloaded virtual function [-Woverloaded-virtual]
include/wx/osx/iphone/private.h:131:25: note: hidden overloaded virtual function 'wxWidgetIPhoneImpl::controlAction' declared here: type mismatch at 1st parameter ('void *' vs 'WXWidget' (aka 'UIView *'))
```