### PR TITLE
wxPopupWindow:  prevent stealing foreground

### DIFF
--- a/src/msw/popupwin.cpp
+++ b/src/msw/popupwin.cpp
@@ -170,7 +170,33 @@ bool wxPopupWindow::Show(bool show)
             }
 
             // and set it as the foreground window so the mouse can be captured
-            ::SetForegroundWindow(GetHwnd());
+            // But if another application is in the foreground,
+            // don't take the foreground away from the other application.
+            static const auto GetForegroundProcessId = []() -> DWORD
+            {
+                HWND hwnd = ::GetForegroundWindow();
+                if ( !hwnd )
+                {
+                    // Docs say !hwnd is not an error.
+                    // Since there is no current foreground process,
+                    // we'll report this process as current because
+                    // we won't be stealing the foreground state.
+                    return ::GetCurrentProcessId();
+                }
+                DWORD foregroundProcessId;
+                DWORD thread = ::GetWindowThreadProcessId(hwnd, &foregroundProcessId);
+                if ( !thread )
+                {
+                    wxLogLastError(wxT("GetWindowThreadProcessId"));
+                    return 0;
+                }
+                return foregroundProcessId;
+            };
+
+            if ( ::GetCurrentProcessId() == GetForegroundProcessId() )
+            {
+                ::SetForegroundWindow(GetHwnd());
+            }
         }
 
         return true;

--- a/src/msw/popupwin.cpp
+++ b/src/msw/popupwin.cpp
@@ -172,28 +172,30 @@ bool wxPopupWindow::Show(bool show)
             // and set it as the foreground window so the mouse can be captured
             // But if another application is in the foreground,
             // don't take the foreground away from the other application.
-            static const auto GetForegroundProcessId = []() -> DWORD
+            bool isForegroundProcess = false;
+            HWND hwnd = ::GetForegroundWindow();
+            if ( hwnd )
             {
-                HWND hwnd = ::GetForegroundWindow();
-                if ( !hwnd )
-                {
-                    // Docs say !hwnd is not an error.
-                    // Since there is no current foreground process,
-                    // we'll report this process as current because
-                    // we won't be stealing the foreground state.
-                    return ::GetCurrentProcessId();
-                }
                 DWORD foregroundProcessId;
                 DWORD thread = ::GetWindowThreadProcessId(hwnd, &foregroundProcessId);
-                if ( !thread )
+                if ( thread )
+                {
+                    isForegroundProcess = ::GetCurrentProcessId() == foregroundProcessId;
+                }
+                else
                 {
                     wxLogLastError(wxT("GetWindowThreadProcessId"));
-                    return 0;
                 }
-                return foregroundProcessId;
-            };
-
-            if ( ::GetCurrentProcessId() == GetForegroundProcessId() )
+            }
+            else
+            {
+                // Docs say !hwnd is not an error.
+                // Since there is no current foreground process,
+                // we'll treat this process as current because
+                // we won't be stealing the foreground state.
+                isForegroundProcess = true;
+            }
+            if ( isForegroundProcess )
             {
                 ::SetForegroundWindow(GetHwnd());
             }


### PR DESCRIPTION
It seems wrong that displaying a popup window,
which is never a wxTopLevelWindow, changes the
foreground process.

Fix #26740