### PR TITLE
Improve sizing-related code in the widgets sample

### DIFF
--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -273,7 +273,7 @@ wxSizer *BitmapComboBoxWidgetsPage::CreateSizerWithSmallTextAndLabel(const wxStr
     wxControl* control = new wxStaticText(parent ? parent : this, wxID_ANY, label);
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
     wxTextCtrl *text = new wxTextCtrl(parent ? parent : this, id, wxEmptyString,
-        wxDefaultPosition, wxSize(50,wxDefaultCoord), wxTE_PROCESS_ENTER);
+        wxDefaultPosition, wxSize(FromDIP(50), wxDefaultCoord), wxTE_PROCESS_ENTER);
 
     sizerRow->Add(control, wxSizerFlags().CentreVertical().Border(wxRIGHT));
     sizerRow->Add(text, wxSizerFlags(1).FixedMinSize().CentreVertical().Border(wxLEFT));
@@ -333,7 +333,7 @@ void BitmapComboBoxWidgetsPage::CreateContent()
                                                 BitmapComboBoxPage_ChangeHeight,
                                                 &m_textChangeHeight,
                                                 sizerOptions->GetStaticBox());
-    m_textChangeHeight->SetSize(20, wxDefaultCoord);
+    m_textChangeHeight->SetSize(FromDIP(20), wxDefaultCoord);
     sizerOptions->Add(sizerRow, wxSizerFlags().FixedMinSize().Border());
 
     sizerLeft->Add( sizerOptions, wxSizerFlags().Expand().Border(wxTOP, FromDIP(2)));
@@ -397,7 +397,7 @@ void BitmapComboBoxWidgetsPage::CreateContent()
 #endif
 
     sizerRight->Add(m_combobox, wxSizerFlags().Expand().Border());
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -266,7 +266,7 @@ void ButtonWidgetsPage::CreateContent()
         "Use wxBitmapButton", wxID_ANY, sizerLeftBox);
     m_chkUseBitmapClass->SetValue(true);
 
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     wxStaticBoxSizer *sizerUseLabels =
         new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox,
@@ -283,7 +283,7 @@ void ButtonWidgetsPage::CreateContent()
         "&Disabled (broken image icon)", wxID_ANY, sizerUseLabelsBox);
     sizerLeft->Add(sizerUseLabels, wxSizerFlags().Expand().Border());
 
-    sizerLeft->AddSpacer(10);
+    sizerLeft->AddSpacer(FromDIP(10));
 
     static const wxString dirs[] =
     {
@@ -314,7 +314,7 @@ void ButtonWidgetsPage::CreateContent()
     sizerImageMargins->Add(sizerImageMarginsRow, wxSizerFlags().Border().Centre());
     sizerLeft->Add(sizerImageMargins, wxSizerFlags().Expand().Border());
 
-    sizerLeft->AddSpacer(15);
+    sizerLeft->AddSpacer(FromDIP(15));
 
     // should be in sync with enums Button[HV]Align!
     static const wxString halign[] =
@@ -341,7 +341,7 @@ void ButtonWidgetsPage::CreateContent()
     sizerLeft->Add(m_radioHAlign, wxSizerFlags().Expand().Border());
     sizerLeft->Add(m_radioVAlign, wxSizerFlags().Expand().Border());
 
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     wxButton *btn = new wxButton(sizerLeftBox, ButtonPage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
@@ -375,7 +375,7 @@ void ButtonWidgetsPage::CreateContent()
 
     // the 3 panes panes compose the window
     sizerTop->Add(sizerLeft,
-                  wxSizerFlags(0).Expand().DoubleBorder(wxALL & ~wxLEFT));
+                  wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxLEFT));
     sizerTop->Add(sizerMiddle,
                   wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(m_sizerButton,

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -214,10 +214,10 @@ void CheckBoxWidgetsPage::CreateContent()
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxHORIZONTAL);
     m_checkbox = new wxCheckBox(this, CheckboxPage_Checkbox, "&Check me!");
-    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->AddStretchSpacer();
     sizerRight->Add(m_checkbox, wxSizerFlags(1).Centre());
-    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->AddStretchSpacer();
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerCheckbox = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
@@ -278,9 +278,9 @@ void CheckBoxWidgetsPage::CreateCheckbox()
 
     NotifyWidgetRecreation(m_checkbox);
 
-    m_sizerCheckbox->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerCheckbox->AddStretchSpacer();
     m_sizerCheckbox->Add(m_checkbox, wxSizerFlags(1).Centre());
-    m_sizerCheckbox->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerCheckbox->AddStretchSpacer();
     m_sizerCheckbox->Layout();
 }
 

--- a/samples/widgets/choice.cpp
+++ b/samples/widgets/choice.cpp
@@ -255,7 +255,7 @@ void ChoiceWidgetsPage::CreateContent()
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
     m_choice = new wxChoice(this, ChoicePage_Choice);
     sizerRight->Add(m_choice, wxSizerFlags().Border().Expand());
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerChoice = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -298,7 +298,7 @@ void ComboboxWidgetsPage::CreateContent()
 
     wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);
     sizerLeft->Add(sizerLeftTop);
-    sizerLeft->AddSpacer(10);
+    sizerLeft->AddSpacer(FromDIP(10));
     sizerLeft->Add(sizerLeftBottom, wxSizerFlags().Expand());
 
     // middle pane
@@ -393,11 +393,11 @@ void ComboboxWidgetsPage::CreateContent()
     m_combobox1 = new wxComboBox( this, ComboPage_Dynamic );
     m_combobox1->Append( "Dynamic ComboBox Test - Click me!" );
     m_combobox1->SetSelection( 0 );
-    sizerRight->Add( 20, 20, wxSizerFlags().Expand() );
+    sizerRight->AddSpacer(FromDIP(20));
     sizerRight->Add( m_combobox1, wxSizerFlags().Expand().Border());
     m_combobox1->Bind( wxEVT_COMBOBOX_DROPDOWN, &ComboboxWidgetsPage::OnPopup, this );
     m_combobox1->Bind( wxEVT_COMBOBOX_CLOSEUP, &ComboboxWidgetsPage::OnDismiss, this );
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -184,7 +184,7 @@ void DatePickerWidgetsPage::CreateContent()
 
     m_textCur->SetMinSize(m_textCur->GetSizeFromText("9999-99-99"));
 
-    sizerMiddle->AddSpacer(10);
+    sizerMiddle->AddSpacer(FromDIP(10));
 
     sizerMiddle->Add(CreateSizerWithTextAndLabel
                      (
@@ -203,7 +203,7 @@ void DatePickerWidgetsPage::CreateContent()
     sizerMiddle->Add(new wxButton(this, DatePickerPage_SetRange, "Set &range"),
                      wxSizerFlags().Centre().Border());
 
-    sizerMiddle->AddSpacer(10);
+    sizerMiddle->AddSpacer(FromDIP(10));
 
     sizerMiddle->Add(CreateSizerWithTextAndLabel
                      (
@@ -223,9 +223,9 @@ void DatePickerWidgetsPage::CreateContent()
 
     m_datePicker = new wxDatePickerCtrl(this, DatePickerPage_Picker);
 
-    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->AddStretchSpacer();
     sizerRight->Add(m_datePicker, wxSizerFlags(1).Centre());
-    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->AddStretchSpacer();
     m_sizerDatePicker = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
@@ -287,9 +287,9 @@ void DatePickerWidgetsPage::CreateDatePicker()
 
     NotifyWidgetRecreation(m_datePicker);
 
-    m_sizerDatePicker->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerDatePicker->AddStretchSpacer();
     m_sizerDatePicker->Add(m_datePicker, wxSizerFlags(1).Centre());
-    m_sizerDatePicker->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerDatePicker->AddStretchSpacer();
     m_sizerDatePicker->Layout();
 }
 

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -163,7 +163,7 @@ void DirPickerWidgetsPage::CreateContent()
                     &m_textInitialDir
                  ), wxSizerFlags().Expand().Border());
 
-    sizerLeft->AddSpacer(10);
+    sizerLeft->AddSpacer(FromDIP(10));
 
     sizerLeft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
                  wxSizerFlags().CentreHorizontal().TripleBorder());

--- a/samples/widgets/editlbox.cpp
+++ b/samples/widgets/editlbox.cpp
@@ -147,7 +147,7 @@ void EditableListboxWidgetsPage::CreateContent()
                                     _("Match these wildcards:"),
                                     wxDefaultPosition, wxDefaultSize, 0);
     sizerRight->Add(m_lbox, wxSizerFlags(1).Expand().Border());
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerLbox = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -188,7 +188,7 @@ void FilePickerWidgetsPage::CreateContent()
                     &m_textInitialDir
                  ), wxSizerFlags().Expand().Border());
 
-    leftSizer->AddSpacer(10);
+    leftSizer->AddSpacer(FromDIP(10));
 
     leftSizer->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
                  wxSizerFlags().CentreHorizontal().TripleBorder());

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -250,7 +250,7 @@ void GaugeWidgetsPage::CreateContent()
     wxSizer *sizerRight = new wxBoxSizer(wxHORIZONTAL);
     m_gauge = new wxGauge(this, GaugePage_Gauge, m_range);
     sizerRight->Add(m_gauge, wxSizerFlags(1).Centre().Border());
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerGauge = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window

--- a/samples/widgets/headerctrl.cpp
+++ b/samples/widgets/headerctrl.cpp
@@ -158,7 +158,7 @@ void HeaderCtrlWidgetsPage::CreateContent()
                2, wxRA_SPECIFY_COLS);
         sizerCol->Add(m_colSettings[i].rbAlignments, wxSizerFlags().Expand().Border());
         ResetColumnStyle(i);
-        sizerTop->AddSpacer(15);
+        sizerTop->AddSpacer(FromDIP(15));
         sizerTop->Add(sizerCol, wxSizerFlags().Expand());
     }
 

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -213,12 +213,12 @@ void HyperlinkWidgetsPage::CreateContent()
 
     m_fun = new wxStaticText(this, wxID_ANY, " for fun!");
 
-    szHyperlink->Add(0, 0, wxSizerFlags(1).Centre());
+    szHyperlink->AddStretchSpacer();
     szHyperlink->Add(m_visit, wxSizerFlags().Centre());
     szHyperlink->Add(m_hyperlink, wxSizerFlags().Centre());
     szHyperlink->Add(m_fun, wxSizerFlags().Centre());
-    szHyperlink->Add(0, 0, wxSizerFlags(1).Centre());
-    szHyperlink->SetMinSize(150, 0);
+    szHyperlink->AddStretchSpacer();
+    szHyperlink->SetMinSize(FromDIP(150), 0);
 
     if (m_checkGeneric->IsChecked())
     {
@@ -235,11 +235,11 @@ void HyperlinkWidgetsPage::CreateContent()
                                               "www.wxwidgets.org");
     }
 
-    szHyperlinkLong->Add(0, 0, wxSizerFlags(1).Centre());
-    szHyperlinkLong->Add(szHyperlink, wxSizerFlags().Centre().Expand());
-    szHyperlinkLong->Add(0, 0, wxSizerFlags(1).Centre());
+    szHyperlinkLong->AddStretchSpacer();
+    szHyperlinkLong->Add(szHyperlink, wxSizerFlags().Centre());
+    szHyperlinkLong->AddStretchSpacer();
     szHyperlinkLong->Add(m_hyperlinkLong, wxSizerFlags().Expand());
-    szHyperlinkLong->Add(0, 0, wxSizerFlags(1).Centre());
+    szHyperlinkLong->AddStretchSpacer();
 
 
     // the 3 panes panes compose the window

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -394,7 +394,7 @@ void ListboxWidgetsPage::CreateContent()
                            0, nullptr,
                            wxLB_HSCROLL);
     sizerRight->Add(m_lbox, wxSizerFlags(1).Expand().Border());
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerLbox = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window

--- a/samples/widgets/native.cpp
+++ b/samples/widgets/native.cpp
@@ -87,7 +87,7 @@ public:
         // When creating the native window, we must specify the valid parent
         // and while we don't have to specify any position if it's going to be
         // laid out by sizers, we do need the size.
-        const wxSize size = FromDIP(wxSize(140, 30));
+        const wxSize size = FromDIP(FromDIP(wxSize(140, 30)));
 
         HWND hwnd = ::CreateWindow
                       (

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -396,7 +396,7 @@ void BookWidgetsPage::RecreateBook()
     }
 
     m_sizerBook->Add(m_book, wxSizerFlags(1).Expand().Border());
-    m_sizerBook->SetMinSize(150, 0);
+    m_sizerBook->SetMinSize(FromDIP(150), 0);
     m_sizerBook->Layout();
 }
 

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -336,7 +336,7 @@ void ODComboboxWidgetsPage::CreateContent()
     m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerStyle, "&Read only", wxID_ANY, sizerStyleBox);
     m_chkDclickcycles = CreateCheckBoxAndAddToSizer(sizerStyle, "&Double-click Cycles", wxID_ANY, sizerStyleBox);
 
-    sizerStyle->AddSpacer(4);
+    sizerStyle->AddSpacer(FromDIP(4));
 
     m_chkBitmapbutton = CreateCheckBoxAndAddToSizer(sizerStyle, "&Bitmap button", wxID_ANY, sizerStyleBox);
     m_chkStdbutton = CreateCheckBoxAndAddToSizer(sizerStyle, "B&lank button background", wxID_ANY, sizerStyleBox);
@@ -468,7 +468,7 @@ void ODComboboxWidgetsPage::CreateContent()
                        0, nullptr,
                        0);
     sizerRight->Add(m_combobox, wxSizerFlags().Expand().Border());
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -223,7 +223,7 @@ void RadioWidgetsPage::CreateContent()
     btn = new wxButton(sizerleftBox, RadioPage_Update, "&Update");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border());
 
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     btn = new wxButton(sizerleftBox, RadioPage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
@@ -277,11 +277,11 @@ void RadioWidgetsPage::CreateContent()
 
     // the 3 panes panes compose the window
     sizerTop->Add(sizerLeft,
-                  wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxLEFT)));
+                  wxSizerFlags().Expand().DoubleBorder((wxALL & ~wxLEFT)));
     sizerTop->Add(sizerMiddle,
                   wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(sizerRight,
-                  wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxRIGHT)));
+                  wxSizerFlags().Expand().DoubleBorder((wxALL & ~wxRIGHT)));
 
     // final initializations
     SetSizer(sizerTop);

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -307,7 +307,7 @@ void SliderWidgetsPage::CreateContent()
     m_chkSelectRange->SetToolTip("\"Select range\" is only supported \nin wxMSW");
 #endif // wxUSE_TOOLTIPS
 
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     wxButton *btn = new wxButton(sizerLeftBox, SliderPage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
@@ -403,7 +403,7 @@ void SliderWidgetsPage::CreateContent()
 
     // the 3 panes panes compose the window
     sizerTop->Add(sizerLeft,
-                  wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxLEFT)));
+                  wxSizerFlags().Expand().DoubleBorder((wxALL & ~wxLEFT)));
     sizerTop->Add(sizerMiddle,
                   wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(sizerRight,
@@ -522,7 +522,7 @@ void SliderWidgetsPage::CreateSlider()
     if ( m_slider->HasFlag(wxSL_VERTICAL) )
     {
         m_sizerSlider->AddStretchSpacer();
-        m_sizerSlider->Add(m_slider, wxSizerFlags(0).Expand().Border());
+        m_sizerSlider->Add(m_slider, wxSizerFlags().Expand().Border());
         m_sizerSlider->AddStretchSpacer();
     }
     else

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -333,7 +333,7 @@ void SpinBtnWidgetsPage::CreateContent()
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerSpin = sizerRight; // save it to modify it later
 
     Reset();

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -353,7 +353,7 @@ void StaticWidgetsPage::CreateContent()
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxHORIZONTAL);
-    sizerRight->SetMinSize(150, 0);
+    sizerRight->SetMinSize(FromDIP(150), 0);
     m_sizerStatic = sizerRight;
 
     CreateStatic();

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -426,7 +426,7 @@ void TextWidgetsPage::CreateContent()
                                       1, wxRA_SPECIFY_COLS);
 
     sizerLeft->Add(m_radioTextLines, wxSizerFlags().Expand().Border());
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     m_chkPassword = CreateCheckBoxAndAddToSizer(
                         sizerLeft, "&Password control", TextPage_Password, sizerLeftBox
@@ -448,7 +448,7 @@ void TextWidgetsPage::CreateContent()
                         TextPage_NoVertScrollbar, sizerLeftBox
                     );
     m_chkFilename->Disable(); // not implemented yet
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     static const wxString wrap[] =
     {
@@ -489,7 +489,7 @@ void TextWidgetsPage::CreateContent()
                                  WXSIZEOF(kinds), kinds,
                                  1, wxRA_SPECIFY_COLS);
 
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
     sizerLeft->Add(m_radioKind, wxSizerFlags().Expand().Border());
 #endif // __WXMSW__
 
@@ -610,7 +610,7 @@ void TextWidgetsPage::CreateContent()
     m_sizerText = new wxStaticBoxSizer(wxHORIZONTAL, this, "&Text:");
     Reset();
     CreateText();
-    m_sizerText->SetMinSize(150, 0);
+    m_sizerText->SetMinSize(FromDIP(150), 0);
 
     // the 3 panes panes compose the upper part of the window
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);

--- a/samples/widgets/timepick.cpp
+++ b/samples/widgets/timepick.cpp
@@ -156,9 +156,9 @@ void TimePickerWidgetsPage::CreateContent()
 
     m_timePicker = new wxTimePickerCtrl(this, TimePickerPage_Picker);
 
-    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->AddStretchSpacer();
     sizerRight->Add(m_timePicker, wxSizerFlags(1).Centre());
-    sizerRight->Add(0, 0, wxSizerFlags(1).Centre());
+    sizerRight->AddStretchSpacer();
     m_sizerTimePicker = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
@@ -200,9 +200,9 @@ void TimePickerWidgetsPage::CreateTimePicker()
 
     NotifyWidgetRecreation(m_timePicker);
 
-    m_sizerTimePicker->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerTimePicker->AddStretchSpacer();
     m_sizerTimePicker->Add(m_timePicker, wxSizerFlags(1).Centre());
-    m_sizerTimePicker->Add(0, 0, wxSizerFlags(1).Centre());
+    m_sizerTimePicker->AddStretchSpacer();
     m_sizerTimePicker->Layout();
 }
 

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -241,7 +241,7 @@ void ToggleWidgetsPage::CreateContent()
     m_chkUseBitmapClass->SetValue(true);
 
 
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     wxStaticBoxSizer *sizerUseLabels =
         new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox,
@@ -258,7 +258,7 @@ void ToggleWidgetsPage::CreateContent()
         "&Disabled (broken image icon)", wxID_ANY, sizerUseLabelsBox);
     sizerLeft->Add(sizerUseLabels, wxSizerFlags().Expand().Border());
 
-    sizerLeft->AddSpacer(10);
+    sizerLeft->AddSpacer(FromDIP(10));
 
     static const wxString dirs[] =
     {
@@ -268,7 +268,7 @@ void ToggleWidgetsPage::CreateContent()
                                      wxDefaultPosition, wxDefaultSize,
                                      WXSIZEOF(dirs), dirs);
     sizerLeft->Add(m_radioImagePos, wxSizerFlags().Expand().Border());
-    sizerLeft->AddSpacer(15);
+    sizerLeft->AddSpacer(FromDIP(15));
 
     // should be in sync with enums Toggle[HV]Align!
     static const wxString halign[] =
@@ -296,7 +296,7 @@ void ToggleWidgetsPage::CreateContent()
     sizerLeft->Add(m_radioVAlign, wxSizerFlags().Expand().Border());
 #endif // wxHAS_BITMAPTOGGLEBUTTON
 
-    sizerLeft->AddSpacer(5);
+    sizerLeft->AddSpacer(FromDIP(5));
 
     wxButton *btn = new wxButton(sizerLeftBox, TogglePage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder());
@@ -319,7 +319,7 @@ void ToggleWidgetsPage::CreateContent()
 
     // the 3 panes panes compose the window
     sizerTop->Add(sizerLeft,
-                  wxSizerFlags(0).Expand().DoubleBorder((wxALL & ~wxLEFT)));
+                  wxSizerFlags().Expand().DoubleBorder((wxALL & ~wxLEFT)));
     sizerTop->Add(sizerMiddle,
                   wxSizerFlags(1).Expand().DoubleBorder());
     sizerTop->Add(m_sizerToggle,
@@ -510,7 +510,7 @@ void ToggleWidgetsPage::AddButtonToSizer()
     if ( m_chkFit->GetValue() )
     {
         m_sizerToggle->AddStretchSpacer();
-        m_sizerToggle->Add(m_toggle, wxSizerFlags(0).Centre().Border());
+        m_sizerToggle->Add(m_toggle, wxSizerFlags().Centre().Border());
         m_sizerToggle->AddStretchSpacer();
     }
     else // take up the entire space

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -607,7 +607,7 @@ WidgetsFrame::WidgetsFrame(const wxString& title)
 
     m_lboxLog = new wxListBox(sizerDownBox, wxID_ANY);
     sizerDown->Add(m_lboxLog, wxSizerFlags(1).Expand().Border());
-    sizerDown->SetMinSize(100, 150);
+    sizerDown->SetMinSize(FromDIP(wxSize(100, 150)));
 #else
     wxSizer *sizerDown = new wxBoxSizer(wxVERTICAL);
 #endif // USE_LOG
@@ -617,7 +617,7 @@ WidgetsFrame::WidgetsFrame(const wxString& title)
 #if USE_LOG
     btn = new wxButton(sizerDownBox, Widgets_ClearLog, "Clear &log");
     sizerBtns->Add(btn);
-    sizerBtns->AddSpacer(10);
+    sizerBtns->AddSpacer(FromDIP(10));
 #endif // USE_LOG
     btn = new wxButton(sizerDownBox, Widgets_Quit, "E&xit");
     sizerBtns->Add(btn);
@@ -625,8 +625,8 @@ WidgetsFrame::WidgetsFrame(const wxString& title)
 
     // put everything together
     sizerTop->Add(m_book, wxSizerFlags(1).Expand().DoubleBorder(wxALL & ~(wxTOP | wxBOTTOM)));
-    sizerTop->AddSpacer(5);
-    sizerTop->Add(sizerDown, wxSizerFlags(0).Expand().DoubleBorder(wxALL & ~wxTOP));
+    sizerTop->AddSpacer(FromDIP(5));
+    sizerTop->Add(sizerDown, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxTOP));
 
     m_panel->SetSizer(sizerTop);
 
@@ -1514,7 +1514,7 @@ wxSizer *WidgetsPage::CreateSizerWithText(wxControl *control,
     wxTextCtrl *text = new wxTextCtrl(control->GetParent(), id, wxEmptyString,
         wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
 
-    sizerRow->Add(control, wxSizerFlags(0).Border(wxRIGHT).CentreVertical());
+    sizerRow->Add(control, wxSizerFlags().Border(wxRIGHT).CentreVertical());
     sizerRow->Add(text, wxSizerFlags(1).Border(wxLEFT).CentreVertical());
 
     if ( ppText )
@@ -1550,7 +1550,7 @@ wxCheckBox *WidgetsPage::CreateCheckBoxAndAddToSizer(wxSizer *sizer,
 {
     wxCheckBox *checkbox = new wxCheckBox(statBoxParent ? statBoxParent: this, id, label);
     sizer->Add(checkbox, wxSizerFlags().HorzBorder());
-    sizer->AddSpacer(2);
+    sizer->AddSpacer(FromDIP(2));
 
     return checkbox;
 }


### PR DESCRIPTION
Fix the invalid sizer flag combination on the hyperlink page.

Replace pattern "wxSizer::Add(0, 0, wxSizerFlags(1).Centre());" with more readable "wxSizer::AddStretchSpacer(1)".