### PR TITLE
Make wxComboBox ProcessEnter test independent of key focus

### DIFF
--- a/tests/controls/comboboxtest.cpp
+++ b/tests/controls/comboboxtest.cpp
@@ -249,6 +249,33 @@ TEST_CASE("wxComboBox::ProcessEnter", "[wxComboBox][enter]")
                                   WXSIZEOF(choices), choices,
                                   style);
         }
+
+        virtual void SimulateEnter(wxControl* control) const override
+        {
+#ifdef __WXMSW__
+            wxComboBox* const combo = wxDynamicCast(control, wxComboBox);
+            REQUIRE( combo );
+
+            if ( combo->HasFlag(wxTE_PROCESS_ENTER) )
+            {
+                // Exercise the same path used by the subclassed edit window:
+                // UIActionSimulator can send Return to the combo wrapper
+                // instead of the edit control on MSW.
+                REQUIRE( combo->MSWProcessEditMsg(WM_CHAR, VK_RETURN, 0) );
+                return;
+            }
+
+            wxControl* const button = wxDynamicCast(
+                combo->GetParent()->FindWindow(wxID_OK), wxControl);
+            REQUIRE( button );
+
+            wxCommandEvent event(wxEVT_BUTTON, wxID_OK);
+            event.SetEventObject(button);
+            button->Command(event);
+#else // !__WXMSW__
+            TextLikeControlCreator::SimulateEnter(control);
+#endif // __WXMSW__/!__WXMSW__
+        }
     };
 
     TestProcessEnter(ComboBoxCreator());

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -369,6 +369,28 @@ void TextEntryTestCase::UndoRedo()
 
 #if wxUSE_UIACTIONSIMULATOR
 
+void TextLikeControlCreator::SimulateEnter(wxControl* control) const
+{
+    wxUIActionSimulator sim;
+
+    // Calling SetFocus() is somehow not enough to give the focus to this
+    // window when running this test with wxGTK, apparently because the
+    // dialog itself needs to be raised to the front first, so simulate a
+    // click doing this.
+    sim.MouseMove(control->ClientToScreen(
+                      wxPoint(5, control->GetClientSize().y / 2)));
+    wxYield();
+    sim.MouseClick();
+    wxYield();
+
+    // Note that clicking it is still not enough to give it focus with
+    // wxGTK either, so we still need to call SetFocus() nevertheless: but
+    // now it works.
+    control->SetFocus();
+
+    sim.Char(WXK_RETURN);
+}
+
 namespace
 {
 
@@ -385,6 +407,7 @@ public:
     explicit TestDialog(const TextLikeControlCreator& controlCreator,
                         ProcessEnter processEnter)
         : wxDialog(wxTheApp->GetTopWindow(), wxID_ANY, "Test dialog"),
+          m_controlCreator(controlCreator),
           m_control
           (
               controlCreator.Create
@@ -458,26 +481,10 @@ private:
 
     void SimulateEnter()
     {
-        wxUIActionSimulator sim;
-
-        // Calling SetFocus() is somehow not enough to give the focus to this
-        // window when running this test with wxGTK, apparently because the
-        // dialog itself needs to be raised to the front first, so simulate a
-        // click doing this.
-        sim.MouseMove(m_control->ClientToScreen(
-                          wxPoint(5, m_control->GetClientSize().y / 2)));
-        wxYield();
-        sim.MouseClick();
-        wxYield();
-
-        // Note that clicking it is still not enough to give it focus with
-        // wxGTK either, so we still need to call SetFocus() nevertheless: but
-        // now it works.
-        m_control->SetFocus();
-
-        sim.Char(WXK_RETURN);
+        m_controlCreator.SimulateEnter(m_control);
     }
 
+    const TextLikeControlCreator& m_controlCreator;
     wxControl* const m_control;
     const ProcessEnter m_processEnter;
     wxTimer m_timer;
@@ -564,6 +571,10 @@ void TestProcessEnter(const TextLikeControlCreator& controlCreator)
 }
 
 #else // !wxUSE_UIACTIONSIMULATOR
+
+void TextLikeControlCreator::SimulateEnter(wxControl* WXUNUSED(control)) const
+{
+}
 
 void TestProcessEnter(const TextLikeControlCreator& WXUNUSED(controlCreator))
 {

--- a/tests/controls/textentrytest.h
+++ b/tests/controls/textentrytest.h
@@ -100,6 +100,9 @@ public:
     // Create the control of the right type using the given parent and style.
     virtual wxControl* Create(wxWindow* parent, int style) const = 0;
 
+    // Simulate pressing Enter in the control.
+    virtual void SimulateEnter(wxControl* control) const;
+
     // Return another creator similar to this one, but creating multiline
     // version of the control. If the returned pointer is non-null, it must be
     // deleted by the caller.


### PR DESCRIPTION
Allow text-like control creators to customize Enter simulation, and use this in the wxComboBox test on MSW.  This avoids relying on UIActionSimulator to deliver Return to the native edit child, which can time out even when key injection reports success.

Use the combo box MSW edit-message path for wxTE_PROCESS_ENTER, and invoke the dialog OK button directly for the no-style case.