### PR TITLE
Fix ListCtrl::HitTest() on wxMSW not accounting for column header

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1988,6 +1988,16 @@ wxListCtrl::HitTest(const wxPoint& point, int& flags, long *ptrSubItem) const
     hitTestInfo.pt.x = (int) point.x;
     hitTestInfo.pt.y = (int) point.y;
 
+    // Firstly, check if the point is even on the list control itself since
+    // ListView_(Sub)ItemHitTest returns the topmost visible item when the
+    // point is over the column header control.
+    if ( ::ChildWindowFromPointEx(GetHwnd(), hitTestInfo.pt, CWP_SKIPINVISIBLE)
+           != GetHwnd() )
+    {
+        flags = wxLIST_HITTEST_NOWHERE;
+        return wxNOT_FOUND;
+    }
+
     long item;
 #ifdef LVM_SUBITEMHITTEST
     if ( ptrSubItem )


### PR DESCRIPTION
When the coordinates were on the column header, HitTest() unexpectedly returned the index of the topmost visible item instead of wxNOT_FOUND.

See #22239.

----

This was fixed thanks to @gix, who provided the solution in #22239. 

I am not closing #22239, since it also describes a similar problem on macOS, which, of course, may have been somehow fixed since but I cannot test it.