### PR TITLE
Fix file picker control with wxFLP_USE_TEXTCTRL on macOS Tahoe

### DIFF
--- a/src/common/pickerbase.cpp
+++ b/src/common/pickerbase.cpp
@@ -65,6 +65,9 @@ bool wxPickerBase::CreateBase(wxWindow *parent,
 
     if (HasFlag(wxPB_USE_TEXTCTRL))
     {
+#ifdef __WXOSX__
+        MacClipsToBounds(false);
+#endif
         // NOTE: the style of this class (wxPickerBase) and the style of the
         //       attached text control are different: GetTextCtrlStyle() extracts
         //       the styles related to the textctrl from the styles passed here


### PR DESCRIPTION
Before:
<img width="241" height="36" alt="image" src="https://github.com/user-attachments/assets/7f7e256b-1b48-40f4-a667-2ccf70535cc7" />

After:
<img width="241" height="37" alt="image" src="https://github.com/user-attachments/assets/da0ecebf-5a01-49bc-a104-7fcd75f5ac81" />
