### PR TITLE
MSW: Fix dark mode themed border drawing for wxTextCtrl on old Windows

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2862,7 +2862,7 @@ bool wxTextCtrl::MSWShouldDrawDarkThemeBorder() const
     // We need to draw the border for rich edit and when we are not using
     // DarkMode_DarkTheme. The non-rich control draws a good themed border
     // with DarkMode_DarkTheme.
-    return IsRich() && !wxMSWDarkMode::HasDarkTheme();
+    return IsRich() || !wxMSWDarkMode::HasDarkTheme();
 }
 
 void wxTextCtrl::MSWDrawThemeBorder(WXHDC hdc)


### PR DESCRIPTION
Fix dark mode themed border drawing for `wxTextCtrl` when `DarkMode_DarkTheme` is not available.

See #26957.