### PR TITLE
Don't assert in wxHelpEvent::GuessOrigin() under Wayland

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -3468,7 +3468,7 @@ public:
                 Origin origin = Origin_Unknown)
         : wxCommandEvent(type, winid),
           m_pos(pt),
-          m_origin(GuessOrigin(origin))
+          m_origin(origin)
     { }
     wxHelpEvent(const wxHelpEvent& event)
         : wxCommandEvent(event),
@@ -3501,10 +3501,6 @@ protected:
     wxString  m_target;
     wxString  m_link;
     Origin    m_origin;
-
-    // we can try to guess the event origin ourselves, even if none is
-    // specified in the ctor
-    static Origin GuessOrigin(Origin origin);
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxHelpEvent);

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -972,23 +972,6 @@ wxChildFocusEvent::wxChildFocusEvent(wxWindow *win)
 }
 
 // ----------------------------------------------------------------------------
-// wxHelpEvent
-// ----------------------------------------------------------------------------
-
-/* static */
-wxHelpEvent::Origin wxHelpEvent::GuessOrigin(Origin origin)
-{
-    if ( origin == Origin_Unknown )
-    {
-        // assume that the event comes from the help button if it's not from
-        // keyboard and that pressing F1 always results in the help event
-        origin = wxGetKeyState(WXK_F1) ? Origin_Keyboard : Origin_HelpButton;
-    }
-
-    return origin;
-}
-
-// ----------------------------------------------------------------------------
 // wxDPIChangedEvent
 // ----------------------------------------------------------------------------
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3655,13 +3655,22 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
 
                 // WM_HELP doesn't use lParam under CE
                 HELPINFO* info = (HELPINFO*) lParam;
+
+                // WM_HELP is sent both when F1 is pressed and when the "?"
+                // title bar button is used, so check the key state to find out
+                // which one it was.
+                const wxHelpEvent::Origin origin = wxGetKeyState(WXK_F1)
+                                            ? wxHelpEvent::Origin_Keyboard
+                                            : wxHelpEvent::Origin_HelpButton;
+
                 if ( info->iContextType == HELPINFO_WINDOW )
                 {
                     wxHelpEvent helpEvent
                                 (
                                     wxEVT_HELP,
                                     GetId(),
-                                    wxPoint(info->MousePos.x, info->MousePos.y)
+                                    wxPoint(info->MousePos.x, info->MousePos.y),
+                                    origin
                                 );
 
                     helpEvent.SetEventObject(this);
@@ -3669,7 +3678,8 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                 }
                 else if ( info->iContextType == HELPINFO_MENUITEM )
                 {
-                    wxHelpEvent helpEvent(wxEVT_HELP, info->iCtrlId);
+                    wxHelpEvent helpEvent(wxEVT_HELP, info->iCtrlId,
+                                          wxDefaultPosition, origin);
                     helpEvent.SetEventObject(this);
                     HandleWindowEvent(helpEvent);
 


### PR DESCRIPTION
wxHelpEvent's ctor calls GuessOrigin(), which uses wxGetKeyState(WXK_F1) to tell keyboard-triggered help from help-button clicks. Under a non-X11 GTK backend (Wayland) wxGetKeyState() can't be used with non-modifier keys and asserts, which broke the EventClone test when it default- constructs a wxHelpEvent.

Skip the check and just return Origin_Unknown in this case, as we genuinely can't determine the origin then.