### PR TITLE
Allow using system NanoSVG library in configure builds

### DIFF
--- a/build/cmake/lib/nanosvg.cmake
+++ b/build/cmake/lib/nanosvg.cmake
@@ -33,12 +33,21 @@ elseif(wxUSE_NANOSVG)
         get_target_property(svg_incl_dir ${TARGETNAME} INTERFACE_INCLUDE_DIRECTORIES)
         if(svg_incl_dir)
             list(APPEND NANOSVG_INCLUDE_DIRS ${svg_incl_dir})
+
+            # The headers are included as <nanosvg/nanosvg.h>, matching their
+            # installed location, so the parent directory has to be on the
+            # search path as well (it usually, but not always, already is).
+            get_filename_component(svg_incl_parent "${svg_incl_dir}" DIRECTORY)
+            if(svg_incl_parent)
+                list(APPEND NANOSVG_INCLUDE_DIRS ${svg_incl_parent})
+            endif()
         endif()
 
-        get_target_property(svg_lib_d ${TARGETNAME} IMPORTED_LOCATION_DEBUG)
-        get_target_property(svg_lib_r ${TARGETNAME} IMPORTED_LOCATION_RELEASE)
-        get_target_property(svg_lib   ${TARGETNAME} IMPORTED_LOCATION)
-        if(svg_lib_d OR svg_lib_r OR svg_lib)
+        # If the package provides a compiled library (rather than just an
+        # INTERFACE target carrying the headers), link with it instead of
+        # building the NanoSVG implementation into wxWidgets ourselves.
+        get_target_property(svg_target_type ${TARGETNAME} TYPE)
+        if(NOT svg_target_type STREQUAL "INTERFACE_LIBRARY")
             set(wxUSE_NANOSVG_EXTERNAL_ENABLE_IMPL FALSE)
         endif()
     endforeach()

--- a/configure
+++ b/configure
@@ -5275,28 +5275,35 @@ fi
           eval "$wx_cv_use_xtest"
 
 
-          withstring=
-          defaultval=$wxUSE_ALL_FEATURES
-          if test -z "$defaultval"; then
-              if test x"$withstring" = xwithout; then
-                  defaultval=yes
-              else
-                  defaultval=no
-              fi
-          fi
 
 # Check whether --with-nanosvg was given.
 if test "${with_nanosvg+set}" = set; then :
   withval=$with_nanosvg;
                         if test "$withval" = yes; then
                           wx_cv_use_nanosvg='wxUSE_NANOSVG=yes'
-                        else
+                        elif test "$withval" = no; then
                           wx_cv_use_nanosvg='wxUSE_NANOSVG=no'
+                        elif test "$withval" = sys; then
+                          wx_cv_use_nanosvg='wxUSE_NANOSVG=sys'
+                        elif test "$withval" = builtin; then
+                          wx_cv_use_nanosvg='wxUSE_NANOSVG=builtin'
+                        else
+                          as_fn_error $? "Invalid value for --with-nanosvg: should be yes, no, sys, or builtin" "$LINENO" 5
                         fi
 
 else
 
-                        wx_cv_use_nanosvg='wxUSE_NANOSVG=${'DEFAULT_wxUSE_NANOSVG":-$defaultval}"
+                        if test -n "${DEFAULT_wxUSE_NANOSVG}"; then
+                            value=${DEFAULT_wxUSE_NANOSVG}
+                        elif test "$wxUSE_ALL_FEATURES" = no; then
+                            value=no
+                        elif test "$wxUSE_SYS_LIBS" = no; then
+                            value=builtin
+                        else
+                            value=yes
+                        fi
+
+                        wx_cv_use_nanosvg="wxUSE_NANOSVG=$value"
 
 fi
 
@@ -27462,9 +27469,77 @@ else
 fi
 
 
-if test "$wxUSE_NANOSVG" = "yes"; then
+NANOSVG_LINK=
+if test "$wxUSE_NANOSVG" != "no" ; then
     $as_echo "#define wxUSE_NANOSVG 1" >>confdefs.h
 
+
+    if test "$wxUSE_NANOSVG" = "sys" -o "$wxUSE_NANOSVG" = "yes" ; then
+                                ac_fn_c_check_header_compile "$LINENO" "nanosvg/nanosvg.h" "ac_cv_header_nanosvg_nanosvg_h" "
+"
+if test "x$ac_cv_header_nanosvg_nanosvg_h" = xyes; then :
+  wx_found_nanosvg=yes
+else
+  wx_found_nanosvg=no
+fi
+
+
+
+        if test "$wx_found_nanosvg" = "yes" ; then
+            wxUSE_NANOSVG=sys
+            $as_echo "#define wxUSE_NANOSVG_EXTERNAL 1" >>confdefs.h
+
+
+                                                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nsvgCreateRasterizer in -lnanosvgrast" >&5
+$as_echo_n "checking for nsvgCreateRasterizer in -lnanosvgrast... " >&6; }
+if ${ac_cv_lib_nanosvgrast_nsvgCreateRasterizer+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lnanosvgrast -lnanosvg -lm $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char nsvgCreateRasterizer ();
+int
+main ()
+{
+return nsvgCreateRasterizer ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_nanosvgrast_nsvgCreateRasterizer=yes
+else
+  ac_cv_lib_nanosvgrast_nsvgCreateRasterizer=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nanosvgrast_nsvgCreateRasterizer" >&5
+$as_echo "$ac_cv_lib_nanosvgrast_nsvgCreateRasterizer" >&6; }
+if test "x$ac_cv_lib_nanosvgrast_nsvgCreateRasterizer" = xyes; then :
+  NANOSVG_LINK="-lnanosvgrast -lnanosvg"
+else
+  CXXFLAGS="$CXXFLAGS -DwxUSE_NANOSVG_EXTERNAL_ENABLE_IMPL"
+fi
+
+        elif test "$wxUSE_NANOSVG" = "sys" ; then
+            as_fn_error $? "system NanoSVG library not found! Use --with-nanosvg=builtin to use built-in version" "$LINENO" 5
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: system NanoSVG library not found, will use built-in instead" >&5
+$as_echo "$as_me: WARNING: system NanoSVG library not found, will use built-in instead" >&2;}
+            wxUSE_NANOSVG=builtin
+        fi
+    fi
 fi
 
 
@@ -42391,7 +42466,7 @@ EXTRALIBS_XML="$EXPAT_LINK"
 EXTRALIBS_HTML="$MSPACK_LINK"
 EXTRALIBS_MEDIA="$GST_LIBS"
 if test "$wxUSE_GUI" = "yes"; then
-    EXTRALIBS_GUI=`echo $GUI_TK_LIBRARY $SDL_LIBS $PNG_LINK $JPEG_LINK $TIFF_LINK $LZMA_LINK $JBIG_LINK $WEBP_LINK $WEBKIT_LINK`
+    EXTRALIBS_GUI=`echo $GUI_TK_LIBRARY $SDL_LIBS $PNG_LINK $JPEG_LINK $TIFF_LINK $LZMA_LINK $JBIG_LINK $WEBP_LINK $NANOSVG_LINK $WEBKIT_LINK`
 fi
 if test "$wxUSE_OPENGL" = "yes"; then
     EXTRALIBS_OPENGL="$LDFLAGS_GL $OPENGL_LIBS"
@@ -42434,6 +42509,9 @@ if test "$wxUSE_GUI" = "yes"; then
             WXCONFIG_LIBS="$WEBP_LINK $WXCONFIG_LIBS"
             ;;
     esac
+    if test "$wxUSE_NANOSVG" = "sys" -a -n "$NANOSVG_LINK" ; then
+        WXCONFIG_LIBS="$NANOSVG_LINK $WXCONFIG_LIBS"
+    fi
 fi
 case "$wxUSE_REGEX" in
     builtin)
@@ -46863,6 +46941,7 @@ echo "                                       png                ${wxUSE_LIBPNG-n
 echo "                                       regex              ${wxUSE_REGEX}"
 echo "                                       tiff               ${wxUSE_LIBTIFF-none}"
 echo "                                       webp               ${wxUSE_LIBWEBP-none}"
+echo "                                       nanosvg            ${wxUSE_NANOSVG-none}"
 if test "$wxUSE_X11" = 1; then
 echo "                                       xpm                ${wxUSE_LIBXPM-none}"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -547,7 +547,7 @@ WX_ARG_WITH(libnotify,     [  --with-libnotify        use libnotify for notifica
 WX_ARG_WITH(appindicator,  [  --with-appindicator     use AppIndicator (required for wxTaskBarIcon under Wayland)], wxUSE_APPINDICATOR)
 WX_ARG_WITH(opengl,        [  --with-opengl           use OpenGL (or Mesa)], wxUSE_OPENGL)
 WX_ARG_WITH(xtest,         [  --with-xtest            use XTest extension], wxUSE_XTEST)
-WX_ARG_WITH(nanosvg,       [  --with-nanosvg          use NanoSVG for rasterizing SVG], wxUSE_NANOSVG)
+WX_ARG_SYS_WITH(nanosvg,   [  --with-nanosvg          use NanoSVG for rasterizing SVG], wxUSE_NANOSVG)
 WX_ARG_WITH(lunasvg,       [  --with-lunasvg          use LunaSVG for rasterizing SVG], wxUSE_LUNASVG)
 
 if test "$wxUSE_GTK" = 1 -o "$wxUSE_X11" = 1; then
@@ -2767,8 +2767,35 @@ dnl ------------------------------------------------------------------------
 dnl Check for NanoSVG libraries
 dnl ------------------------------------------------------------------------
 
-if test "$wxUSE_NANOSVG" = "yes"; then
+NANOSVG_LINK=
+if test "$wxUSE_NANOSVG" != "no" ; then
     AC_DEFINE(wxUSE_NANOSVG)
+
+    if test "$wxUSE_NANOSVG" = "sys" -o "$wxUSE_NANOSVG" = "yes" ; then
+        dnl NanoSVG doesn't provide a pkg-config file, so just check for its
+        dnl header, which the system packages providing it (e.g. Debian,
+        dnl Fedora) install into a "nanosvg" subdirectory.
+        AC_CHECK_HEADER([nanosvg/nanosvg.h], [wx_found_nanosvg=yes],
+                        [wx_found_nanosvg=no], [ ])
+
+        if test "$wx_found_nanosvg" = "yes" ; then
+            wxUSE_NANOSVG=sys
+            AC_DEFINE(wxUSE_NANOSVG_EXTERNAL)
+
+            dnl Some distributions (e.g. Fedora) also build NanoSVG as a shared
+            dnl library: link with it if available, otherwise compile the
+            dnl header-only implementation into wxWidgets itself.
+            AC_CHECK_LIB(nanosvgrast, nsvgCreateRasterizer,
+                         [NANOSVG_LINK="-lnanosvgrast -lnanosvg"],
+                         [CXXFLAGS="$CXXFLAGS -DwxUSE_NANOSVG_EXTERNAL_ENABLE_IMPL"],
+                         [-lnanosvg -lm])
+        elif test "$wxUSE_NANOSVG" = "sys" ; then
+            AC_MSG_ERROR([system NanoSVG library not found! Use --with-nanosvg=builtin to use built-in version])
+        else
+            AC_MSG_WARN([system NanoSVG library not found, will use built-in instead])
+            wxUSE_NANOSVG=builtin
+        fi
+    fi
 fi
 
 dnl ------------------------------------------------------------------------
@@ -7953,7 +7980,7 @@ EXTRALIBS_XML="$EXPAT_LINK"
 EXTRALIBS_HTML="$MSPACK_LINK"
 EXTRALIBS_MEDIA="$GST_LIBS"
 if test "$wxUSE_GUI" = "yes"; then
-    EXTRALIBS_GUI=`echo $GUI_TK_LIBRARY $SDL_LIBS $PNG_LINK $JPEG_LINK $TIFF_LINK $LZMA_LINK $JBIG_LINK $WEBP_LINK $WEBKIT_LINK`
+    EXTRALIBS_GUI=`echo $GUI_TK_LIBRARY $SDL_LIBS $PNG_LINK $JPEG_LINK $TIFF_LINK $LZMA_LINK $JBIG_LINK $WEBP_LINK $NANOSVG_LINK $WEBKIT_LINK`
 fi
 if test "$wxUSE_OPENGL" = "yes"; then
     EXTRALIBS_OPENGL="$LDFLAGS_GL $OPENGL_LIBS"
@@ -8003,6 +8030,9 @@ if test "$wxUSE_GUI" = "yes"; then
             WXCONFIG_LIBS="$WEBP_LINK $WXCONFIG_LIBS"
             ;;
     esac
+    if test "$wxUSE_NANOSVG" = "sys" -a -n "$NANOSVG_LINK" ; then
+        WXCONFIG_LIBS="$NANOSVG_LINK $WXCONFIG_LIBS"
+    fi
 fi
 case "$wxUSE_REGEX" in
     builtin)
@@ -8602,6 +8632,7 @@ echo "                                       png                ${wxUSE_LIBPNG-n
 echo "                                       regex              ${wxUSE_REGEX}"
 echo "                                       tiff               ${wxUSE_LIBTIFF-none}"
 echo "                                       webp               ${wxUSE_LIBWEBP-none}"
+echo "                                       nanosvg            ${wxUSE_NANOSVG-none}"
 if test "$wxUSE_X11" = 1; then
 echo "                                       xpm                ${wxUSE_LIBXPM-none}"
 fi

--- a/docs/gtk/install.md
+++ b/docs/gtk/install.md
@@ -188,6 +188,10 @@ used to override this.
  * `--without-libwebp` \n
    Disables WebP image format code. Don't use libwebp.
 
+ * `--without-nanosvg` \n
+   Disables SVG rasterizing support in wxBitmapBundle. Use neither the system
+   nor the builtin copy of NanoSVG.
+
  * `--without-expat` \n
    Disable XML classes based on Expat parser. Don't use expat library.
 

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -279,8 +279,8 @@ wxGCC_WARNING_SUPPRESS(double-promotion)
 #endif
 
 #if wxUSE_NANOSVG_EXTERNAL
-    #include <nanosvg.h>
-    #include <nanosvgrast.h>
+    #include <nanosvg/nanosvg.h>
+    #include <nanosvg/nanosvgrast.h>
 #else
     #include "../../3rdparty/nanosvg/src/nanosvg.h"
     #include "../../3rdparty/nanosvg/src/nanosvgrast.h"


### PR DESCRIPTION
The CMake build already supported an external NanoSVG package, but the Autoconf build always required the bundled 3rdparty/nanosvg copy.

Make --with-nanosvg a WX_ARG_SYS_WITH option ("sys"/"builtin"/"yes"/"no") and, for the system case, check for <nanosvg/nanosvg.h> where the distribution packages (Debian, Fedora, ...) install it. If a compiled nanosvg library is also present, link with it; otherwise compile the header-only implementation into wxWidgets as was done before.

Include the headers as <nanosvg/nanosvg.h> to match their installed location, and add the parent of the package include directory in the CMake helper so this keeps working there for non-standard prefixes.

Also fix build/cmake/lib/nanosvg.cmake to decide whether a compiled library is available from the imported target type rather than from hardcoded IMPORTED_LOCATION_<CONFIG> properties: the latter misses packages that only set IMPORTED_LOCATION_NOCONFIG (e.g. Fedora's), which made it compile the implementation in and link the shared library at the same time.

With this it's possible to build against the system NanoSVG development package with 3rdparty/nanosvg removed entirely.