### PR TITLE
GTK4 1/18: the changes outside the GTK backend

### DIFF
--- a/include/wx/access.h
+++ b/include/wx/access.h
@@ -368,6 +368,8 @@ private:
 
 #if defined(__WXMSW__)
     #include "wx/msw/ole/access.h"
+#elif defined(__WXGTK4__)
+    #include "wx/gtk/access.h"
 #endif
 
 #endif // wxUSE_ACCESSIBILITY

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -732,6 +732,17 @@ private:
     // minimized, in which case we postpone updating it until it is restored.
     bool m_updateOnRestore = false;
 
+    // How many DoFrameLayout() walks over the frame's sizer are in progress.
+    // OnMotion() must not act while any of them is inside it: handling a
+    // motion goes on to call Update(), which replaces that sizer and deletes
+    // the old one underneath the walk. GTK4 dispatches input from within a
+    // layout, so such a motion really does arrive there.
+    //
+    // This is a count and not a flag because DoFrameLayout() nests, and an
+    // inner walk finishing would otherwise clear the state the outer one
+    // still needs.
+    int m_frameLayoutDepth = 0;
+
     // Toolbars used to show minimized panes. Some, or all, of them can be null.
     //
     // This is indexed by wxAUI_DOCK_TOP, wxAUI_DOCK_BOTTOM, wxAUI_DOCK_RIGHT

--- a/include/wx/bmpcbox.h
+++ b/include/wx/bmpcbox.h
@@ -24,7 +24,13 @@ class WXDLLIMPEXP_FWD_CORE wxItemContainer;
 // Define wxBITMAPCOMBOBOX_OWNERDRAWN_BASED for platforms which
 // wxBitmapComboBox implementation utilizes ownerdrawn combobox
 // (either native or generic).
-#if !defined(__WXGTK__) || defined(__WXUNIVERSAL__)
+//
+// GTK4 is among them: the native implementation is built on GtkComboBox,
+// which is deprecated there and has no replacement that can show a bitmap
+// beside each entry. The generic one is wxOwnerDrawnComboBox, which every
+// platform without a native version already uses and which GTK4 builds and
+// passes the tests for today.
+#if !defined(__WXGTK__) || defined(__WXUNIVERSAL__) || defined(__WXGTK4__)
     #define wxBITMAPCOMBOBOX_OWNERDRAWN_BASED
 
 class WXDLLIMPEXP_FWD_CORE wxDC;
@@ -113,7 +119,7 @@ private:
     #include "wx/generic/bmpcbox.h"
 #elif defined(__WXMSW__)
     #include "wx/msw/bmpcbox.h"
-#elif defined(__WXGTK__)
+#elif defined(__WXGTK__) && !defined(__WXGTK4__)
     #include "wx/gtk/bmpcbox.h"
 #else
     #include "wx/generic/bmpcbox.h"

--- a/include/wx/chkconf.h
+++ b/include/wx/chkconf.h
@@ -1505,9 +1505,19 @@
  */
 #if wxUSE_GUI
 
+/*
+   wxGTK implements this for GTK4 only, and only from GTK 4.10, which is where
+   an accessible object stopped having to be a widget -- without that a
+   wxAccessible cannot describe anything that has no window of its own, which
+   is what the whole API is for. The GTK version cannot be tested here, as no
+   GTK header has been seen yet at this point, so configure refuses
+   --enable-accessibility against an older GTK instead.
+ */
 #if wxUSE_ACCESSIBILITY && !defined(__WXMSW__)
-#   ifdef wxABORT_ON_CONFIG_ERROR
-#       error "wxUSE_ACCESSIBILITY is currently only supported under wxMSW"
+#   if defined(__WXGTK4__)
+        /* supported */
+#   elif defined(wxABORT_ON_CONFIG_ERROR)
+#       error "wxUSE_ACCESSIBILITY is only supported under wxMSW and wxGTK4"
 #   else
 #       undef wxUSE_ACCESSIBILITY
 #       define wxUSE_ACCESSIBILITY 0

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -34,7 +34,7 @@ class wxItemAttr;
 class WXDLLIMPEXP_FWD_CORE wxHeaderCtrl;
 
 #if wxUSE_NATIVE_DATAVIEWCTRL && !defined(__WXUNIVERSAL__)
-    #if defined(__WXGTK__) || defined(__WXOSX__)
+    #if (defined(__WXGTK__) && !defined(__WXGTK4__)) || defined(__WXOSX__)
         #define wxHAS_NATIVE_DATAVIEWCTRL
     #endif
 #endif

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -2978,6 +2978,27 @@ typedef struct _GtkTextBuffer     GtkTextBuffer;
 typedef struct _GtkRange          GtkRange;
 typedef struct _GtkCellRenderer   GtkCellRenderer;
 
+#ifdef __WXGTK4__
+/*
+   Stand-ins for the GTK4 and GLib types used by the menu classes: GTK4 builds
+   menus from a GMenu model and GActions rather than from widgets, and its
+   accelerators are shortcuts held by a controller, see
+   docs/gtk/gtk4-phase-menu-design.md.
+ */
+typedef struct _GMenu                 GMenu;
+typedef struct _GActionGroup          GActionGroup;
+typedef struct _GSimpleActionGroup    GSimpleActionGroup;
+typedef struct _GMainLoop             GMainLoop;
+typedef struct _GtkEventController    GtkEventController;
+typedef struct _GtkShortcutController GtkShortcutController;
+typedef struct _GdkSurface            GdkSurface;
+typedef struct _GdkDrop               GdkDrop;
+typedef struct _GdkDrag               GdkDrag;
+typedef struct _GdkContentFormats     GdkContentFormats;
+typedef struct _GdkClipboard          GdkClipboard;
+typedef struct _GdkContentProvider    GdkContentProvider;
+#endif /* __WXGTK4__ */
+
 typedef GtkWidget *WXWidget;
 
 #endif /*  __WXGTK__ */

--- a/include/wx/dirdlg.h
+++ b/include/wx/dirdlg.h
@@ -115,6 +115,17 @@ protected:
     #define wxDirDialog wxGenericDirDialog
 #elif defined(__WXMSW__) || (defined(__WXQT__) && defined(__WINDOWS__))
     #include "wx/msw/dirdlg.h"  // Native MSW or Qt under MSW
+#elif defined(__WXGTK4__)
+    // GTK4's own folder chooser, GtkFileDialog, does not open at all on a
+    // machine whose portal never produces a dialog: it builds its window and
+    // never shows it, with no error and no timeout, so ShowModal() does not
+    // return. Measured in docs/gtk/probes/gtk4-filedialog-portal-hang.c.
+    //
+    // wx has a folder chooser of its own, which every port without a native
+    // one already uses, so wxGTK4 uses that rather than a dialog that can
+    // hang the application.
+    #include "wx/generic/dirdlgg.h"
+    #define wxDirDialog wxGenericDirDialog
 #elif defined(__WXGTK__)
     #include "wx/gtk/dirdlg.h"  // Native GTK for gtk2.4
 #elif defined(__WXMAC__)

--- a/include/wx/filectrl.h
+++ b/include/wx/filectrl.h
@@ -66,7 +66,13 @@ void wxGenerateFolderChangedEvent( wxFileCtrlBase *fileCtrl, wxWindow *wnd );
 void wxGenerateSelectionChangedEvent( wxFileCtrlBase *fileCtrl, wxWindow *wnd );
 void wxGenerateFileActivatedEvent( wxFileCtrlBase *fileCtrl, wxWindow *wnd, const wxString& filename = wxEmptyString );
 
-#if defined(__WXGTK__) && !defined(__WXUNIVERSAL__)
+// Not under GTK4: wxGtkFileCtrl is a GtkFileChooserWidget, which GTK 4.10
+// deprecated and GTK4 gives nothing to replace it with -- GtkFileDialog and
+// GtkFileLauncher are controller objects, not widgets, and there is no
+// embeddable file chooser at all any more. wxWidgets has its own, which every
+// platform without a native one already uses, so use that rather than carry a
+// control that stops compiling at GTK5.
+#if defined(__WXGTK__) && !defined(__WXUNIVERSAL__) && !defined(__WXGTK4__)
     #define wxFileCtrl wxGtkFileCtrl
     #include "wx/gtk/filectrl.h"
 #else

--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -271,7 +271,16 @@ wxSaveFileSelector(const wxString& what,
                    wxWindow *parent = nullptr);
 
 
-#if defined (__WXUNIVERSAL__)
+#if defined (__WXUNIVERSAL__) || defined(__WXGTK4__)
+    // GTK4 too: the GtkFileChooser interface the native version is built on is
+    // deprecated, and its replacement GtkFileDialog does not reliably open at
+    // all -- it builds its window and never shows it on a machine whose portal
+    // produces no dialog, with no error and no timeout, so ShowModal() does
+    // not return. Measured in
+    // docs/gtk/probes/gtk4-filedialog-portal-hang.c; wxDirDialog moved for the
+    // same reason. The generic dialog is the one every port without a native
+    // version already uses, and it supports the extra control that the GTK4
+    // native one had to give up.
     #define wxHAS_GENERIC_FILEDIALOG
     #include "wx/generic/filedlgg.h"
 #elif defined(__WXMSW__) || (defined(__WXQT__) && defined(__WINDOWS__))

--- a/include/wx/generic/caret.h
+++ b/include/wx/generic/caret.h
@@ -14,6 +14,18 @@
 #include "wx/dc.h"
 #include "wx/overlay.h"
 
+#ifdef __WXGTK4__
+    // Under GTK4 wxOverlay::Create() always returns a native implementation,
+    // so the caret is always drawn in an overlay widget of its own and never
+    // draws on the window it belongs to. Hiding it around drawing is then not
+    // merely unnecessary but actively harmful: hiding and showing it again
+    // restarts the blink timer, and each of them queues a draw of the overlay,
+    // which invalidates its parent too and so arrives back here as another
+    // paint event -- with the result that the timer was restarted before it
+    // could ever expire and the caret stayed permanently on.
+    #define wxHAS_CARET_USING_OVERLAYS
+#endif
+
 class WXDLLIMPEXP_FWD_CORE wxCaret;
 
 class WXDLLIMPEXP_CORE wxCaretTimer : public wxTimer

--- a/include/wx/generic/statusbr.h
+++ b/include/wx/generic/statusbr.h
@@ -63,8 +63,12 @@ protected:
     void OnPaint(wxPaintEvent& event);
     void OnSize(wxSizeEvent& event);
 
+    // These only exist to drag the size grip, which isn't shown under GTK4,
+    // see wxStatusBarGeneric::ShowsSizeGrip().
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
     void OnLeftDown(wxMouseEvent& event);
     void OnRightDown(wxMouseEvent& event);
+#endif
 
     // Responds to colour changes
     void OnSysColourChanged(wxSysColourChangedEvent& event);

--- a/include/wx/html/htmlwin.h
+++ b/include/wx/html/htmlwin.h
@@ -594,11 +594,15 @@ public:
     wxNODISCARD virtual wxEvent *Clone() const override { return new wxHtmlCellEvent(*this); }
 
 private:
-    wxHtmlCell *m_cell;
+    // The default ctor exists for the dynamic event creation machinery and
+    // leaves these to their initializers here: without them, reading either
+    // one from a default-constructed event is undefined behaviour, which is
+    // what UBSAN reports as "load of value 93 ... for type 'bool'".
+    wxHtmlCell *m_cell = nullptr;
     wxMouseEvent m_mouseEvent;
     wxPoint m_pt;
 
-    bool m_bLinkWasClicked;
+    bool m_bLinkWasClicked = false;
 
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxHtmlCellEvent);
 };

--- a/include/wx/infobar.h
+++ b/include/wx/infobar.h
@@ -56,7 +56,13 @@ private:
 };
 
 // currently only GTK+ has a native implementation
-#if defined(__WXGTK218__) && !defined(__WXUNIVERSAL__)
+//
+// Not under GTK4: GtkInfoBar is deprecated there with no replacement at all --
+// GTK's own advice is to build the banner yourself, which is exactly what
+// wxInfoBarGeneric already is, and what every other platform uses. Keeping the
+// native one would mean carrying four deprecated calls for a widget that goes
+// away in GTK5 regardless.
+#if defined(__WXGTK218__) && !defined(__WXUNIVERSAL__) && !defined(__WXGTK4__)
     #include "wx/gtk/infobar.h"
     #define wxHAS_NATIVE_INFOBAR
 #endif // wxGTK2

--- a/include/wx/nativewin.h
+++ b/include/wx/nativewin.h
@@ -38,13 +38,22 @@
     typedef HWND wxNativeContainerWindowHandle;
     typedef HWND wxNativeWindowHandle;
 #elif defined(__WXGTK__)
-    // GdkNativeWindow is guint32 under GDK/X11 and gpointer under GDK/WIN32
-    #ifdef __UNIX__
-        typedef unsigned long wxNativeContainerWindowId;
+    #ifdef __WXGTK4__
+        // GTK 4 removed GdkWindow entirely, along with any way to reparent
+        // an arbitrary foreign native window into a GTK widget hierarchy
+        // (the mechanism wxNativeContainerWindow relies on), and has no
+        // replacement for it, so this class can't be implemented for this
+        // port any more.
+        #undef wxHAS_NATIVE_CONTAINER_WINDOW
     #else
-        typedef void *wxNativeContainerWindowId;
+        // GdkNativeWindow is guint32 under GDK/X11 and gpointer under GDK/WIN32
+        #ifdef __UNIX__
+            typedef unsigned long wxNativeContainerWindowId;
+        #else
+            typedef void *wxNativeContainerWindowId;
+        #endif
+        typedef GdkWindow *wxNativeContainerWindowHandle;
     #endif
-    typedef GdkWindow *wxNativeContainerWindowHandle;
     typedef GtkWidget *wxNativeWindowHandle;
 #elif defined(__WXOSX_COCOA__)
     typedef NSView *wxNativeWindowHandle;

--- a/include/wx/popupwin.h
+++ b/include/wx/popupwin.h
@@ -170,6 +170,12 @@ public:
     // Overridden to grab the input on some platforms
     virtual bool Show( bool show = true ) override;
 
+#ifdef __WXGTK4__
+    // Called from the GtkPopover "closed" handler, which is how GTK4 reports
+    // the click-outside dismissal a grab used to give us, see popupcmn.cpp.
+    void GTKOnPopoverClosed() { DismissAndNotify(); }
+#endif // __WXGTK4__
+
 protected:
     // common part of all ctors
     void Init();
@@ -199,6 +205,13 @@ protected:
     // the handlers we created, may be null (if not, must be deleted)
     wxPopupWindowHandler *m_handlerPopup;
     wxPopupFocusHandler  *m_handlerFocus;
+
+#ifdef __WXGTK4__
+    // Id of the GtkPopover "closed" handler, or 0 if not connected yet: GTK4
+    // reports the click-outside dismissal there rather than through a grab,
+    // see src/common/popupcmn.cpp.
+    unsigned long m_gtkClosedHandler = 0;
+#endif // __WXGTK4__
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_DYNAMIC_CLASS(wxPopupTransientWindow);

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -5004,6 +5004,15 @@ public:
     windows in all ports, but are not generated for the child windows in
     wxGTK.
 
+    Under Wayland a client may neither position its own top level window nor
+    learn where the compositor has put it. In wxGTK built against GTK 4 this
+    means no @c wxEVT_MOVE is sent for a wxWindow::Move() call, because the
+    move does not happen, and none is sent when the user drags the window,
+    because the application is never told. Code that has to follow a top
+    level window's position cannot be made to work on that platform; note
+    that wxWindow::GetPosition() still answers with the position that was
+    last requested, which is not where the window is.
+
     @beginEventTable{wxMoveEvent}
     @event{EVT_MOVE(func)}
         Process a @c wxEVT_MOVE event, which is generated when a window is moved.

--- a/interface/wx/msgdlg.h
+++ b/interface/wx/msgdlg.h
@@ -23,6 +23,14 @@ const char wxMessageBoxCaptionStr[] = "Message";
     in the message dialogs while macOS does use an icon, but it uses the
     application icon for the informational dialogs.
 
+    @note Under GTK4 this dialog is a @c GtkAlertDialog, which GTK gives no
+        title and no icon, and whose message text cannot be selected. So the
+        @a caption is not shown, the icon styles have no effect, and the user
+        cannot copy the message out of the dialog. This is not a limitation of
+        wxWidgets: GTK4 removed the deprecated @c GtkMessageDialog, which had
+        all three, and its replacement offers a message, an optional detail
+        line and a row of buttons and nothing else.
+
     @beginStyleTable
     @style{wxOK}
         Puts an Ok button in the message box. May be combined with @c wxCANCEL.

--- a/interface/wx/nativewin.h
+++ b/interface/wx/nativewin.h
@@ -95,3 +95,51 @@ public:
      */
     void Disown();
 };
+
+/**
+    @class wxNativeContainerWindow
+
+    Wraps an existing native top-level window so that it can be used as
+    the parent of other wxWidgets windows.
+
+    This is the counterpart of wxNativeWindow: while that class lets you
+    embed a native control inside a wxWidgets window, this one lets you
+    use an existing native top-level window as a container for wxWidgets
+    windows, e.g. when wxWidgets is used to implement a plugin hosted in
+    a native application.
+
+    @note Check whether @c wxHAS_NATIVE_CONTAINER_WINDOW is defined before
+        using this class as it is not available under all platforms. In
+        particular, it is @b not available when using wxGTK built against
+        GTK+ 4: this class relies on reparenting an arbitrary foreign
+        native window into a GTK widget hierarchy, and GTK 4 removed both
+        @c GdkWindow and this reparenting capability with no replacement,
+        so there is currently no way to implement this class for that
+        port.
+
+    @since 3.1.0
+
+    @library{wxcore}
+    @category{managedwnd}
+ */
+class wxNativeContainerWindow : public wxTopLevelWindow
+{
+public:
+    /**
+        Default ctor, Create() must be called later to really create the window.
+     */
+    wxNativeContainerWindow();
+
+    /**
+        Create a window from an existing native window handle.
+
+        Use GetHandle() to check if the creation was successful, it will
+        return 0 if the handle was invalid.
+     */
+    wxNativeContainerWindow(wxNativeContainerWindowHandle handle);
+
+    /**
+        Same as the non-default constructor, but with a return code.
+     */
+    bool Create(wxNativeContainerWindowHandle handle);
+};

--- a/interface/wx/popupwin.h
+++ b/interface/wx/popupwin.h
@@ -26,6 +26,13 @@
         wxWidgets 3.1.3).
     @endStyleTable
 
+    @note In wxGTK built against GTK 4 a popup window must have a parent:
+        creating one without a parent fails. GTK 4 removed @c GTK_WINDOW_POPUP,
+        and the only widget left that still gets a surface of its own which may
+        extend past the edges of its top level window is @c GtkPopover, which
+        is anchored to a rectangle inside a parent widget. There is nothing to
+        anchor a parentless popup to.
+
     @library{wxcore}
     @category{managedwnd}
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -2045,12 +2045,18 @@ public:
         Returns the window position in screen coordinates, whether the window is a
         child window or a top level one.
 
+        @note Under Wayland these are not screen coordinates; see
+            ClientToScreen() for what they are and what may be done with them.
+
         @see GetPosition()
     */
     wxPoint GetScreenPosition() const;
 
     /**
         Returns the position and size of the window on the screen as a wxRect object.
+
+        @note Under Wayland these are not screen coordinates; see
+            ClientToScreen() for what they are and what may be done with them.
 
         @see GetRect()
     */
@@ -2145,6 +2151,16 @@ public:
 
         @param pt
             The client position for the second form of the function.
+
+        @note Under Wayland these are not screen coordinates. A client is not
+            told where the compositor placed its window, so wxGTK can only
+            map as far as the top level window and the coordinates it returns
+            are relative to that. Converting one way and back is consistent,
+            and so is comparing such a value with another obtained the same
+            way -- including wxGetMousePosition(), which answers in the same
+            space while the pointer is over that window. What does not work
+            is mixing one with a coordinate from anywhere else: a second top
+            level window, wxDisplay, or the compositor.
     */
     wxPoint ClientToScreen(const wxPoint& pt) const;
 
@@ -2208,6 +2224,9 @@ public:
 
         @param pt
             The screen position.
+
+        @note Under Wayland these are not screen coordinates; see
+            ClientToScreen() for what they are and what may be done with them.
     */
     wxPoint ScreenToClient(const wxPoint& pt) const;
 

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -558,7 +558,31 @@ void wxAuiDefaultDockArt::DrawSash(wxDC& dc, wxWindow *window, int orientation, 
     if (!window->m_wxwindow) return;
     if (!gtk_widget_is_drawable(window->m_wxwindow)) return;
 
-#ifdef __WXGTK3__
+#if defined(__WXGTK4__)
+    // gtk_render_handle() and the style context it wants are deprecated, and
+    // what replaces them -- snapshotting a real GtkPaned separator -- is
+    // already behind wxRendererNative, which is where wxSplitterWindow gets
+    // the same sash from. Going through it keeps one implementation of "what
+    // a sash looks like" rather than two.
+    //
+    // It draws a sash that runs the length of the window, since that is what a
+    // splitter's does, so the drawing is clipped to the piece this call is
+    // about.
+    {
+        wxDCClipper clip(dc, rect);
+
+        const bool isVert = orientation == wxVERTICAL;
+
+        wxRendererNative::Get().DrawSplitterSash
+        (
+            window,
+            dc,
+            wxSize(rect.x + rect.width, rect.y + rect.height),
+            isVert ? rect.x : rect.y,
+            isVert ? wxVERTICAL : wxHORIZONTAL
+        );
+    }
+#elif defined(__WXGTK3__)
     cairo_t* cr = static_cast<cairo_t*>(dc.GetGraphicsContext()->GetNativeContext());
     // invert orientation for widget (horizontal GtkPaned has a vertical splitter)
     wxOrientation orient = orientation == wxVERTICAL ? wxHORIZONTAL : wxVERTICAL;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -68,6 +68,16 @@ wxDEFINE_EVENT( wxEVT_AUI_FIND_MANAGER, wxAuiManagerEvent );
 #include <memory>
 #include <unordered_map>
 
+// Where the pointer was, in the managed frame's client coordinates, the last
+// time a motion event arrived while a floating pane was being dragged.
+//
+// A file static rather than a member because only one pane can be dragged at a
+// time -- the drag holds the mouse capture -- and because adding a member to
+// wxAuiManager would change its size, which is not a reasonable price for a bug
+// fix. wxGTK keeps g_lastMouseEvent the same way and for the same reason.
+static wxPoint gs_dragClientPos;
+static bool gs_hasDragClientPos = false;
+
 wxIMPLEMENT_DYNAMIC_CLASS(wxAuiManagerEvent, wxEvent);
 wxIMPLEMENT_CLASS(wxAuiManager, wxEvtHandler);
 
@@ -4092,6 +4102,7 @@ void wxAuiManager::StartPaneDrag(wxWindow* pane_window,
     else
     {
         m_action = actionDragFloatingPane;
+        gs_hasDragClientPos = false;
     }
 
     m_actionWindow = pane_window;
@@ -4224,6 +4235,27 @@ void wxAuiManager::UpdateHint(const wxRect& rect)
      }
 }
 
+// Where the pointer is, in the managed frame's client coordinates.
+//
+// While a floating pane is being dragged this comes from that drag's own
+// motion events rather than from wxGetMousePosition(), which cannot answer it
+// everywhere: under Wayland it reports coordinates relative to whichever
+// surface the pointer is over, and during a drag that is the floating pane,
+// not the frame the pane might be dropped onto. Asking there returns a
+// position inside the wrong window, and ScreenToClient() cannot correct it
+// because a Wayland toplevel does not know where it is either.
+//
+// Everywhere else the two agree, so this is not a special case for one
+// platform: it is using the position the drag already reported instead of
+// asking the windowing system to reconstruct it.
+static wxPoint wxAuiGetDragClientPosition(wxWindow* frame)
+{
+    if ( gs_hasDragClientPos )
+        return gs_dragClientPos;
+
+    return frame->ScreenToClient(::wxGetMousePosition());
+}
+
 void wxAuiManager::OnFloatingPaneMoveStart(wxWindow* wnd)
 {
     // try to find the pane
@@ -4284,7 +4316,7 @@ void wxAuiManager::OnFloatingPaneMoving(wxWindow* wnd, wxDirection dir)
     wxUnusedVar(dir);
 #endif
 
-    wxPoint client_pt = m_frame->ScreenToClient(pt);
+    wxPoint client_pt = wxAuiGetDragClientPosition(m_frame);
 
     // calculate the offset from the upper left-hand corner
     // of the frame to the mouse pointer
@@ -4387,7 +4419,7 @@ void wxAuiManager::OnFloatingPaneMoved(wxWindow* wnd, wxDirection dir)
     wxUnusedVar(dir);
 #endif
 
-    wxPoint client_pt = m_frame->ScreenToClient(pt);
+    wxPoint client_pt = wxAuiGetDragClientPosition(m_frame);
 
     // calculate the offset from the upper left-hand corner
     // of the frame to the mouse pointer
@@ -5245,6 +5277,7 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
                     paneInfo->IsFloatable())
                 {
                     m_action = actionDragFloatingPane;
+                    gs_hasDragClientPos = false;
 
                     // set initial float position
                     wxPoint pt = m_frame->ClientToScreen(event.GetPosition());
@@ -5291,6 +5324,13 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
     }
     else if (m_action == actionDragFloatingPane)
     {
+        // Remember where the pointer is while we still have an event saying
+        // so: OnFloatingPaneMoving() and OnFloatingPaneMoved() decide from it
+        // and cannot ask for it themselves everywhere. See
+        // wxAuiGetDragClientPosition().
+        gs_dragClientPos = event.GetPosition();
+        gs_hasDragClientPos = true;
+
         if (m_actionWindow)
         {
             // We can't move the child window so we need to get the frame that
@@ -5365,6 +5405,7 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
         {
             pane.state &= ~wxAuiPaneInfo::actionPane;
             m_action = actionDragFloatingPane;
+            gs_hasDragClientPos = false;
             m_actionWindow = pane.frame;
         }
     }

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3375,7 +3375,26 @@ void wxAuiManager::Update()
 
 void wxAuiManager::DoFrameLayout()
 {
-    m_frame->Layout();
+    // Nothing may replace the frame's sizer while this walk is inside it.
+    // Counted rather than flagged, and unwound even if Layout() throws --
+    // leaving the count raised would make OnMotion() ignore the mouse for
+    // good.
+    class LayoutDepth
+    {
+    public:
+        explicit LayoutDepth(int& depth) : m_depth(depth) { ++m_depth; }
+        ~LayoutDepth() { --m_depth; }
+
+    private:
+        int& m_depth;
+
+        wxDECLARE_NO_COPY_CLASS(LayoutDepth);
+    };
+
+    {
+        LayoutDepth inLayout(m_frameLayoutDepth);
+        m_frame->Layout();
+    }
 
     for ( auto& part : m_uiParts )
     {
@@ -5154,6 +5173,15 @@ void wxAuiManager::OnLeftUp(wxMouseEvent& event)
 
 void wxAuiManager::OnMotion(wxMouseEvent& event)
 {
+    // GTK4 dispatches input from inside a layout, so this can arrive while
+    // DoFrameLayout() is still walking the frame's sizer. Acting on it goes
+    // back into Update(), which replaces and deletes that sizer underneath the
+    // walk. Dropping the motion is safe -- another one follows immediately --
+    // and it is the only place that covers every route back in, rather than
+    // guarding Update() itself, which some callers need to run synchronously.
+    if ( m_frameLayoutDepth > 0 )
+        return;
+
     // sometimes when Update() is called from inside this method,
     // a spurious mouse move event is generated; this check will make
     // sure that only real mouse moves will get anywhere in this method;

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -1229,7 +1229,15 @@ wxSize wxComboCtrlBase::DoGetSizeFromTextSize(int xlen, int ylen) const
     }
     else
     {
+#ifdef __WXGTK4__
+        // Measure a text control rather than a wxComboBox. GTK4 has no native
+        // combo box, so wxComboBox is itself a wxComboCtrl there -- creating
+        // one here to ask its height would ask this same function again, and
+        // not stop. A text entry is the part whose height is wanted anyway.
+        wxTextCtrl* cb = new wxTextCtrl;
+#else
         wxComboBox* cb = new wxComboBox;
+#endif
 #ifndef __WXGTK3__
         // GTK3 returns zero for the preferred size of a hidden widget
         cb->Hide();

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -1650,9 +1650,19 @@ void wxComboCtrlBase::OnTextCtrlEvent(wxCommandEvent& event)
     wxCommandEvent evt2(event);
     evt2.SetId(GetId());
     evt2.SetEventObject(this);
-    HandleWindowEvent(evt2);
+    const bool handled = HandleWindowEvent(evt2);
 
+    // The re-sent event is the one that propagates, so stop this one either
+    // way: letting both travel would deliver two to every parent.
     event.StopPropagation();
+
+    // Say so when nobody handled the re-sent event, so that the text
+    // control's own handling of this one carries on. For Enter that is what
+    // activates the dialog's default button: wxTextCtrl::OnChar() only calls
+    // ClickDefaultButtonIfPossible() if its wxEVT_TEXT_ENTER came back
+    // unhandled, and this handler is inside that call.
+    if ( !handled )
+        event.Skip();
 }
 
 // call if cursor is on button area or mouse is captured for the button

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -68,7 +68,17 @@ wxFLAGS_MEMBER(wxCB_DROPDOWN)
 
 wxEND_FLAGS( wxComboBoxStyle )
 
+#ifdef __WXGTK4__
+// wxComboBox is the generic, wxOwnerDrawnComboBox-based one there, and the
+// runtime base has to say so: wxVListBoxComboPopup asks
+// wxDynamicCast(combo, wxOwnerDrawnComboBox) before it will measure or draw
+// an item, and a class info claiming wxControl fails that even though the
+// C++ type does derive from it.
+wxIMPLEMENT_DYNAMIC_CLASS_XTI(wxComboBox, wxOwnerDrawnComboBox,
+                              "wx/combobox.h");
+#else
 wxIMPLEMENT_DYNAMIC_CLASS_XTI(wxComboBox, wxControl, "wx/combobox.h");
+#endif
 
 wxBEGIN_PROPERTIES_TABLE(wxComboBox)
 wxEVENT_PROPERTY( Select, wxEVT_COMBOBOX, wxCommandEvent )

--- a/src/common/framecmn.cpp
+++ b/src/common/framecmn.cpp
@@ -411,10 +411,14 @@ bool wxFrameBase::ShouldUpdateMenuFromIdle()
     // check if we're using the global menu bar as we don't get EVT_MENU_OPEN
     // for it and need to fall back to idle time updating even if normally
     // wxUSE_IDLEMENUUPDATES is set to 0 for wxGTK.
-#ifdef __WXGTK__
+#ifdef __WXGTK4__
+    // GtkPopoverMenuBar doesn't expose the popovers it creates, so GTK4 can't
+    // notify us when a menu is opened and we have to update it from idle.
+    return true;
+#elif defined(__WXGTK__)
     if ( wxApp::GTKIsUsingGlobalMenu() )
         return true;
-#endif // !__WXGTK__
+#endif // __WXGTK4__/__WXGTK__
 
     return wxUSE_IDLEMENUUPDATES != 0;
 }

--- a/src/common/popupcmn.cpp
+++ b/src/common/popupcmn.cpp
@@ -332,9 +332,69 @@ void wxPopupTransientWindow::Popup(wxWindow *winFocus)
     }
 }
 
+#ifdef __WXGTK4__
+
+extern "C" {
+
+// Called when the popover GTK4 builds a wxPopupWindow out of closes itself,
+// which with autohide turned on below is how a click outside of it arrives.
+static void wx_popup_closed(GtkPopover*, wxPopupTransientWindow* popup)
+{
+    popup->GTKOnPopoverClosed();
+}
+
+} // extern "C"
+
+#endif // __WXGTK4__
+
 bool wxPopupTransientWindow::Show( bool show )
 {
-#ifdef __WXGTK__
+#ifdef __WXGTK4__
+    // GTK4 has no grabs of any kind: gtk_grab_add(), gdk_seat_grab() and
+    // gdk_pointer_grab() are all gone. What replaces them for this particular
+    // job -- keeping a popup up until the user clicks somewhere else -- is a
+    // GtkPopover's own "autohide" mode, in which GTK takes and releases the
+    // grab itself and tells us about the dismissal through "closed".
+    //
+    // wxPopupWindow leaves autohide off, as a plain wxPopupWindow is not
+    // supposed to disappear on its own; it is only the transient flavour,
+    // here, that wants it.
+    if ( show )
+    {
+        if ( !m_gtkClosedHandler )
+        {
+            m_gtkClosedHandler = g_signal_connect(m_widget, "closed",
+                                                  G_CALLBACK(wx_popup_closed),
+                                                  this);
+        }
+
+        gtk_popover_set_autohide(GTK_POPOVER(m_widget), TRUE);
+    }
+    else
+    {
+        // Ask GTK to close the popover, and leave the autohide flag alone.
+        //
+        // GTK takes its grab when an autohiding popover is shown and gives it
+        // back when that popover is popped down, so the flag has to still be
+        // set at popdown. Clearing it while the popover is up means no popdown
+        // happens as far as GTK is concerned: the grab is never returned, and
+        // from then on GTK routes keyboard input to a popover that is not
+        // there any more. src/gtk/popupwin.cpp says the same about this flag --
+        // set it once, rather than switching it on and off around Show().
+        //
+        // "closed" means "the user dismissed this", so block the handler for
+        // the one emission caused here; otherwise every programmatic
+        // Dismiss() would report itself back through OnDismiss() as though
+        // the user had clicked outside.
+        if ( m_gtkClosedHandler )
+            g_signal_handler_block(m_widget, m_gtkClosedHandler);
+
+        gtk_popover_popdown(GTK_POPOVER(m_widget));
+
+        if ( m_gtkClosedHandler )
+            g_signal_handler_unblock(m_widget, m_gtkClosedHandler);
+    }
+#elif defined(__WXGTK__)
     if (!show)
     {
         GdkDisplay* display = gtk_widget_get_display(m_widget);
@@ -369,7 +429,7 @@ bool wxPopupTransientWindow::Show( bool show )
 
     bool ret = wxPopupWindow::Show( show );
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
     if (show)
     {
         gtk_grab_add( m_widget );

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -2413,8 +2413,16 @@ void wxWindowBase::SetSizer(wxSizer *sizer, bool deleteOld)
     {
         m_windowSizer->SetContainingWindow(nullptr);
 
+        // Stop pointing at the old sizer before destroying it, not after.
+        // Destroying a sizer tree detaches windows, which can reach the event
+        // loop, and anything that calls Layout() from there would otherwise
+        // find m_windowSizer still pointing into a tree that is halfway
+        // through being freed.
+        wxSizer* const oldSizer = m_windowSizer;
+        m_windowSizer = nullptr;
+
         if ( deleteOld )
-            delete m_windowSizer;
+            delete oldSizer;
     }
 
     m_windowSizer = sizer;

--- a/src/generic/caret.cpp
+++ b/src/generic/caret.cpp
@@ -127,6 +127,12 @@ void wxCaret::DoMove()
     if (m_overlay.IsNative())
     {
         m_overlay.Reset();
+
+        // Resetting a native overlay clears its contents, so redraw the caret
+        // immediately at its new position if it is currently visible.
+        if ( IsVisible() && !m_blinkedOut )
+            Refresh();
+
         return;
     }
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -19,11 +19,15 @@
 
 #ifndef WX_PRECOMP
     #ifdef __WXMSW__
-        #include "wx/app.h"          // GetRegisteredClassName()
         #include "wx/msw/private.h"
         #include "wx/msw/wrapwin.h"
         #include "wx/msw/wrapcctl.h" // include <commctrl.h> "properly"
     #endif
+    // Needed everywhere, not only under MSW for GetRegisteredClassName():
+    // wxTheApp is used in the destructor below. This only showed once this
+    // file was built for a port that has no precompiled headers, which until
+    // now it never was -- the generic control was used by wxMSW alone.
+    #include "wx/app.h"
     #include "wx/sizer.h"
     #include "wx/log.h"
     #include "wx/dcclient.h"

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -416,7 +416,9 @@ public:
 #if wxUSE_PRINTING_ARCHITECTURE
     wxCairoContext( wxGraphicsRenderer* renderer, const wxPrinterDC& dc );
 #endif
-#ifdef __WXGTK__
+// GdkWindow is gone under GTK4 and there is no drawable to make a Cairo
+// context from outside of a paint handler, see src/gtk/dc.cpp.
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
     wxCairoContext( wxGraphicsRenderer* renderer, GdkWindow *window );
 #endif
 #ifdef __WXMSW__
@@ -2319,7 +2321,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxMemoryDC& 
 #endif
 }
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
 wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, GdkWindow *window )
 : wxGraphicsContext(renderer)
 {
@@ -2335,7 +2337,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, GdkWindow *window 
     m_height = height;
 #endif
 }
-#endif // __WXGTK__
+#endif // __WXGTK__ && !__WXGTK4__
 
 #ifdef __WXMSW__
 
@@ -2451,7 +2453,15 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, wxWindow *window)
 
     wxASSERT_MSG( window->m_wxwindow, wxT("wxCairoContext needs a widget") );
 
+#ifdef __WXGTK4__
+    // Nothing to draw on: a GdkSurface has no Cairo context of its own and
+    // GTK only hands one out from its own snapshot vfunc. The context stays
+    // null, which Init() and every operation below cope with, so the size is
+    // still reported correctly but the drawing goes nowhere.
+    Init(nullptr, false);
+#else
     Init(gdk_cairo_create(window->GTKGetDrawingWindow()), true);
+#endif
 
     wxSize sz = window->GetSize();
     m_width = sz.x;
@@ -2538,8 +2548,25 @@ void wxCairoContext::Init(cairo_t *context, bool storeInitClip)
     // Attempt to find the system font scaling parameter (e.g. "Fonts->Scaling
     // Factor" in Gnome Tweaks, "Force font DPI" in KDE System Settings or
     // GDK_DPI_SCALE environment variable).
+#ifdef __WXGTK4__
+    // GdkScreen is gone, but gdk_screen_get_resolution() only ever reported
+    // the "gtk-xft-dpi" setting it is read from directly here, in 1024ths of
+    // a point. A negative value means "unset".
+    if ( GtkSettings* const settings = gtk_settings_get_default() )
+    {
+        int xftDpi = -1;
+        g_object_get(settings, "gtk-xft-dpi", &xftDpi, nullptr);
+
+        m_fontScalingFactor = xftDpi > 0 ? float(xftDpi / 1024.0 / 96.0) : 1.0f;
+    }
+    else
+    {
+        m_fontScalingFactor = 1.0f;
+    }
+#else
     GdkScreen* screen = gdk_screen_get_default();
     m_fontScalingFactor = screen ? float(gdk_screen_get_resolution(screen) / 96.0) : 1.0f;
+#endif
 #endif
 
     m_context = context;
@@ -3445,7 +3472,11 @@ wxGraphicsContext * wxCairoRenderer::CreateContextFromNativeContext(void * conte
 wxGraphicsContext * wxCairoRenderer::CreateContextFromNativeWindow( void * window )
 {
     ENSURE_LOADED_OR_RETURN(nullptr);
-#ifdef __WXGTK__
+#ifdef __WXGTK4__
+    // There are no native windows to draw on left under GTK4.
+    wxUnusedVar(window);
+    return nullptr;
+#elif defined(__WXGTK__)
     return new wxCairoContext(this, static_cast<GdkWindow*>(window));
 #elif defined(__WXMSW__)
     return new wxCairoContext(this, static_cast<HWND>(window));
@@ -3473,7 +3504,20 @@ wxGraphicsContext * wxCairoRenderer::CreateContextFromImage(wxImage& image)
 
 wxGraphicsContext * wxCairoRenderer::CreateMeasuringContext()
 {
-#ifdef __WXGTK__
+#ifdef __WXGTK4__
+    // GTK4 has no root window to measure against, and measuring never needed
+    // a real target in the first place: any surface will do.
+    cairo_surface_t* const surface =
+        cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
+    cairo_t* const cr = cairo_create(surface);
+    cairo_surface_destroy(surface);
+
+    // The ctor takes a reference of its own.
+    wxGraphicsContext* const gc = new wxCairoContext(this, cr);
+    cairo_destroy(cr);
+
+    return gc;
+#elif defined(__WXGTK__)
     return CreateContextFromNativeWindow(gdk_get_default_root_window());
 #elif defined(__WXMSW__)
     ENSURE_LOADED_OR_RETURN(nullptr);

--- a/src/generic/splash.cpp
+++ b/src/generic/splash.cpp
@@ -60,10 +60,14 @@ wxSplashScreen::wxSplashScreen(const wxBitmap& bitmap, long splashStyle, int mil
     // is going to disappear soon, indicate it by giving it this special style
     SetExtraStyle(GetExtraStyle() | wxWS_EX_TRANSIENT);
 
-#if defined(__WXGTK__)
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
     gtk_window_set_type_hint(GTK_WINDOW(m_widget),
                              GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
 #endif
+    // Note that there is nothing to do here under GTK4: window type hints were
+    // removed entirely, as they can't be honoured under Wayland where it's up
+    // to the compositor to decide how to present a window. This means the
+    // splash screen is no longer marked as such for the window manager.
 
     m_splashStyle = splashStyle;
     m_milliseconds = milliseconds;

--- a/src/generic/statusbr.cpp
+++ b/src/generic/statusbr.cpp
@@ -85,7 +85,7 @@ gboolean statusbar_query_tooltip(GtkWidget*   WXUNUSED(widget),
 wxBEGIN_EVENT_TABLE(wxStatusBarGeneric, wxWindow)
     EVT_PAINT(wxStatusBarGeneric::OnPaint)
     EVT_SIZE(wxStatusBarGeneric::OnSize)
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
     EVT_LEFT_DOWN(wxStatusBarGeneric::OnLeftDown)
     EVT_RIGHT_DOWN(wxStatusBarGeneric::OnRightDown)
 #endif
@@ -198,7 +198,16 @@ void wxStatusBarGeneric::DoUpdateFieldWidths()
 bool wxStatusBarGeneric::ShowsSizeGrip() const
 {
     // Currently drawing size grip is implemented only in wxGTK.
-#ifdef __WXGTK__
+    //
+    // And not under GTK4: resizing a window from a grip needs
+    // gdk_toplevel_begin_resize(), which wants the pointer position in
+    // surface coordinates and the GdkDevice it belongs to, i.e. exactly the
+    // coordinate translation and input device questions the Phase 2 and
+    // Phase 3 designs haven't settled yet. GTK itself dropped resize grips
+    // back in 3.14 on the grounds that windows are resized by dragging their
+    // edges, which is still how it works under GTK4, so not showing one is a
+    // reasonable state to be in meanwhile rather than a broken one.
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
     if ( !HasFlag(wxSTB_SIZEGRIP) )
         return false;
 
@@ -411,7 +420,7 @@ void wxStatusBarGeneric::OnPaint(wxPaintEvent& WXUNUSED(event) )
 {
     wxPaintDC dc(this);
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
     // Draw grip first
     if ( ShowsSizeGrip() )
     {
@@ -463,7 +472,7 @@ void wxStatusBarGeneric::OnSysColourChanged(wxSysColourChangedEvent& event)
     event.Skip();
 }
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__WXGTK4__)
 void wxStatusBarGeneric::OnLeftDown(wxMouseEvent& event)
 {
     int width, height;

--- a/src/propgrid/manager.cpp
+++ b/src/propgrid/manager.cpp
@@ -1224,6 +1224,7 @@ wxPropertyGridPage* wxPropertyGridManager::InsertPage( int index,
                  pageObj->GetToolId());
 
             m_pToolbar->Realize();
+            RecalculatePositions(m_width, m_height);
         }
     }
 #else

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -1131,6 +1131,35 @@ int  ScintillaWX::DoKeyDown(const wxKeyEvent& evt, bool* consumed)
             // look for any available layout that would produce an ASCII letter for
             // the given hardware keycode
             const unsigned keycode = evt.GetRawKeyFlags();
+#ifdef __WXGTK4__
+            // GdkKeymap is gone: gdk_display_map_keycode() returns all the
+            // (group, level) entries for the keycode at once, so filter them
+            // for the same shifted level and groups the loop below looks at.
+            GdkKeymapKey* keys;
+            guint* keyvals;
+            int nEntries;
+            if (gdk_display_map_keycode(gdk_display_get_default(), keycode,
+                                        &keys, &keyvals, &nEntries))
+            {
+                for (int group = 0; group < 4 && key == WXK_NONE; group++)
+                {
+                    for (int i = 0; i < nEntries; i++)
+                    {
+                        if (keys[i].group != group || keys[i].level != 1)
+                            continue;
+
+                        const unsigned keyval = keyvals[i];
+                        if (keyval >= 'A' && keyval <= 'Z')
+                        {
+                            key = keyval;
+                            break;
+                        }
+                    }
+                }
+                g_free(keys);
+                g_free(keyvals);
+            }
+#else
             GdkKeymap* keymap = gdk_keymap_get_for_display(gdk_display_get_default());
             GdkKeymapKey keymapKey = { keycode, 0, 1 };
             do {
@@ -1142,6 +1171,7 @@ int  ScintillaWX::DoKeyDown(const wxKeyEvent& evt, bool* consumed)
                 }
                 keymapKey.group++;
             } while (keymapKey.group < 4);
+#endif // __WXGTK4__/!__WXGTK4__
             if (key == WXK_NONE)
             {
                 // There may be no keyboard layouts with Latin keys available,


### PR DESCRIPTION
One step of the GTK4 port, split for review as upstream asked (#175). The series is cumulative: this applies on top of 0820518c97a13d0905a6e8af16b203d307586107 and the whole port is the last step of it.

Totally it will be 18 patches. Patch  17 will enable the port, patch 18 will provide it with CI coverage. 