### PR TITLE
Make wx-provided std::make_unique<> fallback work for arrays

### DIFF
--- a/include/wx/private/make_unique.h
+++ b/include/wx/private/make_unique.h
@@ -13,15 +13,45 @@
 #include <memory>
 
 #if !defined(_MSC_VER) && __cplusplus < 201402L
-    #include <utility>    // for std::forward()
+    #include <cstddef>      // for std::size_t
+    #include <type_traits>  // for std::remove_extent
+    #include <utility>      // for std::forward()
+
+    namespace wxPrivate
+    {
+      // This helper is used to select the appropriate overload below, as in
+      // N3656 which had originally specified std::make_unique.
+      template <typename T>
+      struct MakeUniqueRet { typedef std::unique_ptr<T> SingleObject; };
+
+      template <typename T>
+      struct MakeUniqueRet<T[]> { typedef std::unique_ptr<T[]> UnknownBound; };
+
+      template <typename T, std::size_t N>
+      struct MakeUniqueRet<T[N]> { typedef void KnownBound; };
+    }
 
     namespace std
     {
       template <typename T, typename... Args>
-      std::unique_ptr<T> make_unique(Args&&... args)
+      typename wxPrivate::MakeUniqueRet<T>::SingleObject
+      make_unique(Args&&... args)
       {
           return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
       }
+
+      template <typename T>
+      typename wxPrivate::MakeUniqueRet<T>::UnknownBound
+      make_unique(std::size_t n)
+      {
+          typedef typename std::remove_extent<T>::type U;
+          return std::unique_ptr<T>(new U[n]());
+      }
+
+      // Creating arrays of known bound is not allowed.
+      template <typename T, typename... Args>
+      typename wxPrivate::MakeUniqueRet<T>::KnownBound
+      make_unique(Args&&...) = delete;
     }
 #endif
 


### PR DESCRIPTION
Make expressions like make_unique<unsigned char[]>(zipLen) compile in C++11 mode too.

This fixes building the tests in C++11 after the changes of c8003a0a06 (Use make_unique<>() instead of "new" in the tests, 2026-09-04).