### PR TITLE
Don't show server-side caption for `wxMiniFrame` under Wayland

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -2352,16 +2352,21 @@ void MyFrame::DlgCenteredParent(wxCommandEvent& WXUNUSED(event))
 void MyFrame::MiniFrame(wxCommandEvent& WXUNUSED(event))
 {
     wxFrame *frame = new wxMiniFrame(this, wxID_ANY, "Mini frame",
-                                     wxDefaultPosition, wxSize(300, 100),
+                                     wxDefaultPosition, wxDefaultSize,
                                      wxCAPTION | wxCLOSE_BOX);
-    new wxStaticText(frame,
-                     wxID_ANY,
-                     "Mini frames have slightly different appearance",
-                     wxPoint(5, 5));
-    new wxStaticText(frame,
-                     wxID_ANY,
-                     "from the normal frames but that's the only difference.",
-                     wxPoint(5, 25));
+    auto* const sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(
+        new wxStaticText(frame,
+                         wxID_ANY,
+                         "Mini frames have slightly different appearance"),
+        wxSizerFlags().Border());
+    sizer->Add(
+        new wxStaticText(frame,
+                         wxID_ANY,
+                         "from the normal frames but that's the only difference."),
+        wxSizerFlags().Border());
+    frame->SetSizer(sizer);
+    frame->SetSize(frame->GetBestSize());
 
     frame->CentreOnParent();
     frame->Show();

--- a/src/gtk/minifram.cpp
+++ b/src/gtk/minifram.cpp
@@ -328,7 +328,13 @@ bool wxMiniFrame::Create( wxWindow *parent, wxWindowID id, const wxString &title
       const wxPoint &pos, const wxSize &size,
       long style, const wxString &name )
 {
-    wxFrame::Create( parent, id, title, pos, size, style, name );
+    // Don't pass wxCAPTION to the base class because we never want to have the
+    // WM caption for this kind of frame, wxCAPTION only tells us to draw the
+    // caption ourselves.
+    wxFrame::Create( parent, id, title, pos, size, style & ~wxCAPTION, name );
+
+    // Still reflect the presence of wxCAPTION in m_windowStyle, if any.
+    m_windowStyle = style;
 
     if (style & wxRESIZE_BORDER)
         m_miniEdge = 4;


### PR DESCRIPTION
Without this change, the "Dialogs » Generic Dialogs » Mini-frame" menu command of the dialogs sample showed the frame with 2 captions under both KWin and Sway. Now only one is shown, just under Mutter (where this only accidentally worked before because Mutter doesn't provide the protocol that GTK uses).

@paulcor Please let me know if you see any problems or a better way to do this.