### PR TITLE
Fix cursor used while resizing wxAUI panes in wxGTK

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -5207,9 +5207,7 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
 
             if (HasLiveResize())
             {
-                m_frame->ReleaseMouse();
                 DoEndResizeAction(event);
-                m_frame->CaptureMouse();
             }
             else
             {

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6794,8 +6794,27 @@ void wxWindowGTK::DoCaptureMouse()
     {
         GdkDisplay* display = gdk_window_get_display(window);
         GdkSeat* seat = gdk_display_get_default_seat(display);
+
+        // Under Wayland, GDK resets the cursor to the default one when taking
+        // the grab unless the cursor to use during it is given explicitly, so
+        // pass it the cursor currently used by this window to avoid losing it,
+        // e.g. while dragging a sash. Note that we can't just use m_cursor
+        // here because the current cursor could have been set by a handler of
+        // wxSetCursorEvent, so retrieve it from the window itself, taking into
+        // account that it can be inherited from one of its parents.
+        GdkCursor* cursor = nullptr;
+        if (wxGTKImpl::IsWayland(window))
+        {
+            for (GdkWindow* w = window; w; w = gdk_window_get_effective_parent(w))
+            {
+                cursor = gdk_window_get_cursor(w);
+                if (cursor)
+                    break;
+            }
+        }
+
         gdk_seat_grab(seat, window, GDK_SEAT_CAPABILITY_ALL_POINTING, false,
-            nullptr, nullptr, nullptr, nullptr);
+            cursor, nullptr, nullptr, nullptr);
     }
     else
 #endif

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2437,7 +2437,12 @@ wxGTKImpl::WindowLeaveCallback(GtkWidget* WXUNUSED_UNLESS_DEBUG(widget),
     if ( AreGTKEventsBlocked() )
         return FALSE;
 
-    if (win->m_needCursorReset)
+    // If the mouse is captured, we don't send wxSetCursorEvent at all (see the
+    // motion and enter handlers), so we shouldn't reset the cursor set by an
+    // earlier one neither: the window can well get leave events while dragging
+    // something, e.g. when the mouse moves over one of its children, but the
+    // cursor set for the duration of the drag must remain in effect.
+    if (!g_captureWindow && win->m_needCursorReset)
         win->GTKUpdateCursor();
 
     // Event was emitted after an ungrab


### PR DESCRIPTION
While looking at #26901 I've realized that the cursor used while dragging a sash in wxAUI wasn't set correctly neither under X11 nor Wayland. It turns out that this was due to 2 separate bugs and I've also fixed another not quite a bug but certainly very weird behaviour of wxAUI.

Paul, please let me know if you see anything wrong with this. I've tested dragging sashes in the sample and the cursor now appears correctly both under Sway and under KWin, using either XWayland or Wayland, while previously it was broken in all of these cases.