### PR TITLE
Fix wxFrame's client size under wxQt

### DIFF
--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -60,6 +60,9 @@ public:
     QMainWindow *GetQMainWindow() const;
 
 protected:
+    // override wxWindow methods to take into account tool/menu/statusbars
+    virtual void DoSetClientSize(int width, int height) override;
+
     virtual wxPoint GetClientAreaOrigin() const override;
 
     virtual QWidget* QtGetParentWidget() const override;

--- a/include/wx/qt/toolbar.h
+++ b/include/wx/qt/toolbar.h
@@ -69,6 +69,8 @@ protected:
     virtual void DoToggleTool(wxToolBarToolBase *tool, bool toggle) override;
     virtual void DoSetToggle(wxToolBarToolBase *tool, bool toggle) override;
 
+    virtual void DoSetToolBitmapSize(const wxSize& size) override;
+
 private:
     long GetButtonStyle();
 

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -21,6 +21,8 @@
 
 #include <QtWidgets/QMainWindow>
 #include <QtWidgets/QMenuBar>
+#include <QtWidgets/QStatusBar>
+#include <QtWidgets/QToolBar>
 
 class wxQtMainWindow : public wxQtEventSignalHandler< QMainWindow, wxFrame >
 {
@@ -230,6 +232,62 @@ wxPoint wxFrame::GetClientAreaOrigin() const
     }
 
     return wxWindow::GetClientAreaOrigin();
+}
+
+// ----------------------------------------------------------------------------
+// wxFrame client size calculations
+// ----------------------------------------------------------------------------
+
+void wxFrame::DoSetClientSize(int width, int height)
+{
+    const bool hasPendingResize =
+        GetHandle()->testAttribute(Qt::WA_PendingResizeEvent);
+
+    auto menubar = GetMenuBar();
+    if ( menubar && menubar->IsShown() )
+    {
+        // QMenuBar doesn't report correct sizes while the parent window has
+        // pending resize. So we use heightForWidth() to get the correct height.
+        if ( hasPendingResize )
+            height += menubar->GetHandle()->heightForWidth(GetSize().x);
+        else
+            height += menubar->GetSize().y;
+    }
+
+#if wxUSE_STATUSBAR
+    auto statbar = GetStatusBar();
+    if ( statbar && statbar->IsShown() )
+    {
+        // QStatusBar doesn't report correct sizes while the parent window has
+        // pending resize. So we use sizeHint().height() to get the correct height.
+        if ( hasPendingResize )
+            height += statbar->GetHandle()->sizeHint().height();
+        else
+            height += statbar->GetSize().y;
+    }
+#endif // wxUSE_STATUSBAR
+
+#if wxUSE_TOOLBAR
+    auto toolbar = GetToolBar();
+    if ( toolbar && toolbar->IsShown() )
+    {
+        wxSize tbSize;
+
+        // QToolBar doesn't report correct sizes while the parent window has
+        // pending resize. So we use sizeHint() to get the correct size.
+        if ( hasPendingResize )
+            tbSize = wxQtConvertSize(toolbar->GetHandle()->sizeHint());
+        else
+            tbSize = toolbar->GetSize();
+
+        if ( toolbar->IsVertical() )
+            width  += tbSize.x;
+        else
+            height += tbSize.y;
+    }
+#endif // wxUSE_TOOLBAR
+
+    wxFrameBase::DoSetClientSize(width, height);
 }
 
 QMainWindow *wxFrame::GetQMainWindow() const

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -393,5 +393,12 @@ long wxToolBar::GetButtonStyle()
     return Qt::ToolButtonTextOnly;
 }
 
+void wxToolBar::DoSetToolBitmapSize(const wxSize& size)
+{
+    wxToolBarBase::DoSetToolBitmapSize(size);
+
+    GetQToolBar()->setIconSize( wxQtConvertSize(size) );
+}
+
 #endif // wxUSE_TOOLBAR
 


### PR DESCRIPTION
I noticed this when running the **internat** sample.

**Before** (notice the missing static text at the bottom of the window):
<img width="409" height="528" alt="internat_bad" src="https://github.com/user-attachments/assets/7c12204f-7a39-484a-afdb-cbbfd1d2888f" />

**After**:
<img width="409" height="572" alt="internat_good" src="https://github.com/user-attachments/assets/3892acbf-f256-4e2a-bb26-2dc4e6d0cdf0" />


Patch I used for testing:
```C++
diff --git a/samples/minimal/minimal.cpp b/samples/minimal/minimal.cpp
index 5f32257c6b..1d13fc8344 100644
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -26,6 +26,9 @@
     #include "wx/wx.h"
 #endif
 
+#include "bitmaps/open.xpm"
+#include "bitmaps/save.xpm"
+
 // ----------------------------------------------------------------------------
 // resources
 // ----------------------------------------------------------------------------
@@ -175,6 +178,35 @@ MyFrame::MyFrame(const wxString& title)
     CreateStatusBar(2);
     SetStatusText("Welcome to wxWidgets!");
 #endif // wxUSE_STATUSBAR
+
+#if wxUSE_TOOLBAR
+    wxToolBar* toolBar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                                       wxNO_BORDER|wxTB_FLAT|wxTB_NODIVIDER|wxTB_NOALIGN);
+
+    toolBar->SetToolBitmapSize(FromDIP(wxSize(32, 32)));
+    toolBar->AddTool(wxID_OPEN, wxString(), wxBitmap(open_xpm), _("Open"));
+    toolBar->AddTool(wxID_SAVEAS, wxString(), wxBitmap(save_xpm), _("Save"));
+    toolBar->AddSeparator();
+
+    toolBar->Realize();
+
+    SetToolBar(toolBar);
+#endif // wxUSE_TOOLBAR
+
+    wxPanel* const panel = new wxPanel(this);
+
+    wxSizer* const topSizer = new wxBoxSizer(wxVERTICAL);
+
+    topSizer->Add(new wxStaticText
+                      (
+                        panel,
+                        wxID_ANY,
+                        wxString("Just a random text to test wxFrame::SetClientSize()")
+                      ),
+                  wxSizerFlags().Center().Border());
+
+    panel->SetSizer(topSizer);
+    topSizer->SetSizeHints(this);
 }
 
 
@@ -188,16 +220,6 @@ void MyFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 {
-    wxMessageBox(wxString::Format
-                 (
-                    "Welcome to %s!\n"
-                    "\n"
-                    "This is the minimal wxWidgets sample\n"
-                    "running under %s.",
-                    wxVERSION_STRING,
-                    wxGetOsDescription()
-                 ),
-                 "About wxWidgets minimal sample",
-                 wxOK | wxICON_INFORMATION,
-                 this);
+    wxPoint pt = GetClientAreaOrigin();
+    wxLogDebug("client area origin: %d, %d", pt.x, pt.y);
 }

```

**Before**:
<img width="360" height="57" alt="Screenshot_bad" src="https://github.com/user-attachments/assets/71d8afcc-b4f2-41c6-b482-1bc0284af8c6" />

**After**:
<img width="360" height="148" alt="Screenshot_good" src="https://github.com/user-attachments/assets/101d833a-1b86-4736-a700-8ee5b26641e1" />
