### PR TITLE
Recalculate wxRadioBox best size after changing its items

### DIFF
--- a/src/gtk/radiobox.cpp
+++ b/src/gtk/radiobox.cpp
@@ -496,6 +496,8 @@ void wxRadioBox::SetString(unsigned int n, const wxString& label)
     GtkLabel* g_label = GTK_LABEL(gtk_bin_get_child(GTK_BIN(m_buttonsInfo[n].button)));
 
     gtk_label_set_text( g_label, label.utf8_str() );
+
+    InvalidateBestSize();
 }
 
 bool wxRadioBox::Enable( bool enable )

--- a/src/osx/radiobox_osx.cpp
+++ b/src/osx/radiobox_osx.cpp
@@ -252,7 +252,9 @@ void wxRadioBox::SetString(unsigned int item,const wxString& label)
         current = current->NextInCycle();
     }
 
-    return current->SetLabel( label );
+    current->SetLabel( label );
+
+    InvalidateBestSize();
 }
 
 // Sets a button by passing the desired position. This does not cause

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -339,6 +339,13 @@ void wxRadioBox::SetString(unsigned int n, const wxString& s)
     wxCHECK_RET( qtButton != nullptr, INVALID_INDEX_MESSAGE );
 
     qtButton->setText( wxQtConvertString( s ));
+
+    // The QGroupBox is managed by Qt's layout system (see wxRadioBox::Create()).
+    // Therefore, we must invalidate it first for InvalidateBestSize() to take effect.
+    GetQGroupBox()->layout()->invalidate();
+    GetQGroupBox()->layout()->activate();
+
+    InvalidateBestSize();
 }
 
 void wxRadioBox::SetSelection(int n)

--- a/src/univ/radiobox.cpp
+++ b/src/univ/radiobox.cpp
@@ -273,6 +273,8 @@ void wxRadioBox::SetString(unsigned int n, const wxString& label)
     wxCHECK_RET( IsValid(n), wxT("invalid index in wxRadioBox::SetString") );
 
     m_buttons[n]->SetLabel(label);
+
+    InvalidateBestSize();
 }
 
 bool wxRadioBox::Enable(unsigned int n, bool enable)

--- a/tests/controls/radioboxtest.cpp
+++ b/tests/controls/radioboxtest.cpp
@@ -194,6 +194,19 @@ TEST_CASE_METHOD(RadioBoxTestCase, "RadioBox::SetString", "[radiobox]")
     CHECK( m_radio->GetString(2) == "" );
 }
 
+TEST_CASE_METHOD(RadioBoxTestCase, "RadioBox::SetStringBestSize", "[radiobox][bestsize]")
+{
+#ifdef __WXQT__
+    WARN("This test is broken in wxQt currently.");
+#else
+    const wxSize sizeOld = m_radio->GetBestSize();
+
+    m_radio->SetString(0, "a much longer item label than the original one");
+
+    CHECK( m_radio->GetBestSize().x > sizeOld.x );
+#endif
+}
+
 TEST_CASE("RadioBox::NoItems", "[radiobox]")
 {
     auto radio = make_unique<wxRadioBox>(wxTheApp->GetTopWindow(), wxID_ANY,

--- a/tests/controls/radioboxtest.cpp
+++ b/tests/controls/radioboxtest.cpp
@@ -196,15 +196,11 @@ TEST_CASE_METHOD(RadioBoxTestCase, "RadioBox::SetString", "[radiobox]")
 
 TEST_CASE_METHOD(RadioBoxTestCase, "RadioBox::SetStringBestSize", "[radiobox][bestsize]")
 {
-#ifdef __WXQT__
-    WARN("This test is broken in wxQt currently.");
-#else
     const wxSize sizeOld = m_radio->GetBestSize();
 
     m_radio->SetString(0, "a much longer item label than the original one");
 
     CHECK( m_radio->GetBestSize().x > sizeOld.x );
-#endif
 }
 
 TEST_CASE("RadioBox::NoItems", "[radiobox]")


### PR DESCRIPTION
Previously only wxMSW invalidated the cached best size after changing the label of a wxRadioBox item, but not the other ports, resulting in wrong layout not accounting for the possibly increased box size.

Fix this by calling InvalidateBestSize() in wxRadioBox::SetString() in all ports and not just wxMSW.

Add a unit test verifying that this works as expected.

Closes #26981.