### PR TITLE
MSW: Fix dark mode task dialog DrawThemeTextEx flags

### DIFF
--- a/src/msw/taskdlg.cpp
+++ b/src/msw/taskdlg.cpp
@@ -658,11 +658,13 @@ void TDPaintText(HDC hdc, const TDPageState& s)
         {
             part = TDLG_MAININSTRUCTIONPANE;
             brBg = s.brPrimary;
+            dtF |= DT_WORD_ELLIPSIS;
         }
         else if ( el.automationId == L"ContentText" )
         {
             part = TDLG_CONTENTPANE;
             brBg = s.brPrimary;
+            dtF |= DT_WORD_ELLIPSIS;
         }
         else if ( el.automationId == L"ExpandedFooterText" )
         {
@@ -701,8 +703,6 @@ void TDPaintText(HDC hdc, const TDPageState& s)
 
             part = TDLG_VERIFICATIONTEXT;
             brBg = s.brSecondary;
-
-            dtF = DT_LEFT | DT_VCENTER | DT_NOPREFIX;
         }
 
         if ( !part )


### PR DESCRIPTION
Fix some flags to `DrawThemeTextEx()` for proper alignment and truncation, matching the light mode appearance.

To reproduce the problems, run the app below in dark mode. The text "line2" incorrectly appears twice, both dark and light. The checkbox text is incorrectly truncated.
```
#include <wx/wx.h>
#include <wx/richmsgdlg.h>

class MyFrame : public wxFrame {
public:
    MyFrame();
    void OnShowDialog(wxCommandEvent& event);
};

MyFrame::MyFrame()
    : wxFrame(nullptr, wxID_ANY, "Sample", wxPoint(300, 200), wxSize(350, 200))
{
    wxPanel* panel = new wxPanel(this, wxID_ANY);
    wxButton* btn = new wxButton(panel, wxID_ANY, "Show wxRichMessageDialog", wxPoint(50, 50));
    btn->Bind(wxEVT_BUTTON, &MyFrame::OnShowDialog, this);
}

void MyFrame::OnShowDialog(wxCommandEvent& WXUNUSED(event))
{
    const char* text = "line1#################################################################################################\nline2";
    wxRichMessageDialog dialog(this, text);
    dialog.SetExtendedMessage(text);
    dialog.ShowCheckBox("Don't show this message again (VerificationCheckBox)");
    dialog.ShowModal();
}

class MyApp: public wxApp {
public:
    virtual bool OnInit() override
    {
        (new MyFrame)->Show(true);
        return true;
    }
};
wxIMPLEMENT_APP(MyApp);
```
