### PR TITLE
Improve restoring TLW geometry in wxMSW

### DIFF
--- a/include/wx/msw/private/tlwgeom.h
+++ b/include/wx/msw/private/tlwgeom.h
@@ -10,13 +10,16 @@
 #ifndef _WX_MSW_PRIVATE_TLWGEOM_H_
 #define _WX_MSW_PRIVATE_TLWGEOM_H_
 
+#include "wx/display.h"
 #include "wx/log.h"
+#include "wx/utils.h"
 
 #include "wx/msw/private.h"
 
 // names for MSW-specific options
 #define wxPERSIST_TLW_MAX_X "xmax"
 #define wxPERSIST_TLW_MAX_Y "ymax"
+#define wxPERSIST_TLW_OFF_SCREEN "offscreen"
 
 class wxTLWGeometry : public wxTLWGeometryBase
 {
@@ -41,6 +44,14 @@ public:
 
         if ( !store.SaveValue(wxPERSIST_TLW_W, rc.right - rc.left) ||
              !store.SaveValue(wxPERSIST_TLW_H, rc.bottom - rc.top) )
+            return false;
+
+        // Also save whether the window was partly outside of the desktop, as
+        // this allows us to distinguish between the window having been put
+        // there on purpose and it having ended up there just because the
+        // display configuration has changed when restoring the geometry (see
+        // ApplyTo()).
+        if ( !store.SaveValue(wxPERSIST_TLW_OFF_SCREEN, m_offScreen) )
             return false;
 
         // Maximized/minimized state.
@@ -102,6 +113,8 @@ public:
             m_placement.ptMaxPosition.y = r.y;
         }
 
+        m_offScreen = store.RestoreValue(wxPERSIST_TLW_OFF_SCREEN, &tmp) && tmp;
+
         return true;
     }
 
@@ -145,11 +158,22 @@ public:
             }
         }
 
+        m_offScreen = !IsFullyOnScreen(GetNormalRect());
+
         return true;
     }
 
     virtual bool ApplyTo(wxTopLevelWindow* tlw) override
     {
+        // The saved geometry may not make sense any more, e.g. if the window
+        // had been shown on a monitor which is not connected any longer, and
+        // restoring it as is would leave the window invisible, so adjust it if
+        // this is the case unless the user had deliberately moved it off
+        // screen -- but even then do it if the window wouldn't be visible at
+        // all, as it couldn't be moved back by the user in this case.
+        if ( !m_offScreen || IsFullyOffScreen(GetNormalRect()) )
+            EnsureIsOnScreen();
+
         // There is a subtlety here: if the window is currently hidden,
         // restoring its geometry shouldn't show it, so we must use SW_HIDE as
         // show command, but showing it later should restore it to the correct
@@ -189,7 +213,74 @@ public:
     }
 
 private:
+    // Return the normal, i.e. neither maximized nor iconized, window rect.
+    wxRect GetNormalRect() const
+    {
+        return wxRectFromRECT(m_placement.rcNormalPosition);
+    }
+
+    // Return true if the given rectangle is entirely visible.
+    static bool IsFullyOnScreen(const wxRect& rect)
+    {
+        // Checking just the corners is enough for any reasonable display
+        // arrangement.
+        auto const isOnScreen = [](wxPoint const& pt) {
+            return wxDisplay::GetFromPoint(pt) != wxNOT_FOUND;
+        };
+
+        return isOnScreen(rect.GetTopLeft()) &&
+               isOnScreen(rect.GetTopRight()) &&
+               isOnScreen(rect.GetBottomLeft()) &&
+               isOnScreen(rect.GetBottomRight());
+    }
+
+    // Return true if no part of the given rectangle is visible.
+    static bool IsFullyOffScreen(const wxRect& rect)
+    {
+        return wxDisplay::GetFromRect(rect) == wxNOT_FOUND;
+    }
+
+    // Move the window back into the desktop if it wouldn't be entirely inside
+    // it at its saved position.
+    void EnsureIsOnScreen()
+    {
+        wxRect rect = GetNormalRect();
+
+        if ( IsFullyOnScreen(rect) )
+            return;
+
+        // Use the display showing the biggest part of the window or, if it is
+        // entirely outside of the desktop, the primary one -- note that the
+        // latter is not necessarily the display with index 0.
+        const int display = wxDisplay::GetFromRect(rect);
+        const wxRect rectDisplay =
+            display == wxNOT_FOUND
+                ? wxDisplay().GetClientArea()
+                : wxDisplay(static_cast<unsigned>(display)).GetClientArea();
+
+        // The geometry could have been saved when using a bigger monitor, so
+        // the window may need to be shrunk in order to fit into this display.
+        wxSize size = rect.GetSize();
+        size.DecTo(rectDisplay.GetSize());
+        rect.SetSize(size);
+
+        // Move the window just enough for it to become fully visible, but not
+        // more, in order to preserve its saved position as much as possible.
+        const int x = wxClip(rect.x, rectDisplay.x,
+                             rectDisplay.GetRight() - rect.width + 1);
+        const int y = wxClip(rect.y, rectDisplay.y,
+                             rectDisplay.GetBottom() - rect.height + 1);
+        rect.SetPosition(wxPoint(x, y));
+
+        wxCopyRectToRECT(rect, m_placement.rcNormalPosition);
+    }
+
+
     WINDOWPLACEMENT m_placement;
+
+    // True if the window was not entirely inside the visible area when its
+    // geometry was saved.
+    bool m_offScreen = false;
 };
 
 #endif // _WX_MSW_PRIVATE_TLWGEOM_H_

--- a/tests/persistence/testpersistence.h
+++ b/tests/persistence/testpersistence.h
@@ -27,7 +27,7 @@ public:
     }
 
     // Access the config object used for storing the settings.
-    const wxConfigBase& GetConfig() const
+    wxConfigBase& GetConfig() const
     {
         return *m_manager.GetConfig();
     }

--- a/tests/persistence/tlw.cpp
+++ b/tests/persistence/tlw.cpp
@@ -26,6 +26,12 @@
     #include "wx/gtk/private/backend.h"
 #endif // __WXGTK__
 
+#ifdef __WXMSW__
+    #include "asserthelper.h"
+
+    #include "wx/display.h"
+#endif
+
 // ----------------------------------------------------------------------------
 // constants
 // ----------------------------------------------------------------------------
@@ -209,3 +215,115 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
     }
 #endif // __WXMSW__
 }
+
+// This test is MSW-specific because the generic implementation used elsewhere
+// has its own, different, check for the window being off screen.
+#ifdef __WXMSW__
+
+TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW::OffScreen", "[persist][tlw]")
+{
+    const wxSize size(450, 350);
+
+    // Find a position at which only a small part of the frame is inside a
+    // display: this is what happens when the geometry saved while using a
+    // bigger desktop is restored on a smaller one, e.g. after disconnecting a
+    // monitor or when connecting to the machine remotely.
+    wxPoint pos;
+    const unsigned count = wxDisplay::GetCount();
+    for ( unsigned n = 0; n < count; n++ )
+    {
+        pos = wxDisplay(n).GetClientArea().GetBottomRight() - wxPoint(20, 20);
+
+        if ( wxDisplay::GetFromPoint(pos) != wxNOT_FOUND &&
+             wxDisplay::GetFromPoint(pos + size) == wxNOT_FOUND )
+        {
+            // Found a suitable position.
+            break;
+        }
+
+        pos = wxDefaultPosition;
+    }
+
+    if ( pos == wxDefaultPosition )
+    {
+        WARN("Unexpectedly didn't find a suitable position, skipping the test");
+        return;
+    }
+
+    // Simulate the geometry saved by a previous version of the program, which
+    // didn't record whether the window was off screen at all.
+    const auto saveGeometry = [this, size](const wxPoint& posSaved)
+    {
+        wxConfigBase& config = GetConfig();
+
+        config.Write(FRAME_OPTIONS_PREFIX "/x", posSaved.x);
+        config.Write(FRAME_OPTIONS_PREFIX "/y", posSaved.y);
+        config.Write(FRAME_OPTIONS_PREFIX "/w", size.x);
+        config.Write(FRAME_OPTIONS_PREFIX "/h", size.y);
+
+        // The previous versions didn't save this value at all.
+        config.DeleteEntry(FRAME_OPTIONS_PREFIX "/offscreen");
+    };
+
+    // Without this entry the window is assumed to have been fully visible
+    // when its geometry was saved and so has to be moved back on screen.
+    SECTION("Fix up")
+    {
+        saveGeometry(pos);
+
+        auto const frame = RestorePersistenceTestFrame();
+
+        // The frame shouldn't have been left almost completely off screen.
+        const wxRect rect = frame->GetScreenRect();
+        CHECK(wxDisplay::GetFromPoint(rect.GetTopLeft()) != wxNOT_FOUND);
+        CHECK(wxDisplay::GetFromPoint(rect.GetBottomRight()) != wxNOT_FOUND);
+
+        // The size should have been preserved.
+        CHECK(size == rect.GetSize());
+    }
+
+    // But if the window had already been off screen when its geometry was
+    // saved, it had been put there on purpose and must be left alone.
+    SECTION("Preserve")
+    {
+        saveGeometry(pos);
+        GetConfig().Write(FRAME_OPTIONS_PREFIX "/offscreen", 1);
+
+        auto const frame = RestorePersistenceTestFrame();
+
+        CHECK(wxRect(pos, size) == frame->GetScreenRect());
+    }
+
+    // Even a window which had been deliberately moved off screen must be
+    // moved back if it wouldn't be visible at all, as the user couldn't move
+    // it back in this case.
+    SECTION("Fix up hidden")
+    {
+        const wxRect rectPrimary = wxDisplay().GetClientArea();
+        const wxPoint posHidden =
+            rectPrimary.GetTopLeft() - wxPoint(10000, 10000);
+        REQUIRE(wxDisplay::GetFromRect(wxRect(posHidden, size)) == wxNOT_FOUND);
+
+        saveGeometry(posHidden);
+        GetConfig().Write(FRAME_OPTIONS_PREFIX "/offscreen", 1);
+
+        auto const frame = RestorePersistenceTestFrame();
+
+        // The frame should have been moved to the position inside the primary
+        // display closest to its saved one, i.e. its top left corner.
+        CHECK(wxRect(rectPrimary.GetTopLeft(), size) == frame->GetScreenRect());
+    }
+
+    // Check that saving the geometry of a window which is off screen does set
+    // the flag relied upon by the tests above.
+    SECTION("Save")
+    {
+        SavePersistenceTestFrame(pos, size);
+
+        int val = -1;
+        REQUIRE(GetConfig().Read(FRAME_OPTIONS_PREFIX "/offscreen", &val));
+        CHECK(val == 1);
+    }
+}
+
+#endif // __WXMSW__

--- a/tests/persistence/tlw.cpp
+++ b/tests/persistence/tlw.cpp
@@ -36,8 +36,11 @@
 // local helpers
 // ----------------------------------------------------------------------------
 
+namespace
+{
+
 // Create the frame used for testing.
-static std::unique_ptr<wxFrame> CreatePersistenceTestFrame()
+std::unique_ptr<wxFrame> CreatePersistenceTestFrame()
 {
     auto frame =
         make_unique<wxFrame>(wxTheApp->GetTopWindow(), wxID_ANY, "wxTest");
@@ -45,6 +48,28 @@ static std::unique_ptr<wxFrame> CreatePersistenceTestFrame()
 
     return frame;
 }
+
+void SavePersistenceTestFrame(const wxPoint& pos, const wxSize& size)
+{
+    auto frame = CreatePersistenceTestFrame();
+    frame->SetPosition(pos);
+    frame->SetSize(size);
+
+    CHECK(wxPersistenceManager::Get().Register(frame.get()));
+
+    // Destroy the frame immediately to cause its geometry to be saved.
+}
+
+std::unique_ptr<wxFrame> RestorePersistenceTestFrame()
+{
+    auto frame = CreatePersistenceTestFrame();
+
+    CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame.get()));
+
+    return frame;
+}
+
+} // anonymous namespace
 
 // ----------------------------------------------------------------------------
 // tests themselves
@@ -65,16 +90,7 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
 
     // Save the frame geometry.
     {
-        auto frame = CreatePersistenceTestFrame();
-
-        // Set the geometry before saving.
-        frame->SetPosition(pos);
-        frame->SetSize(size);
-
-        CHECK(wxPersistenceManager::Get().Register(frame.get()));
-
-        // Destroy the frame immediately, i.e. don't use Destroy() here.
-        frame.reset();
+        SavePersistenceTestFrame(pos, size);
 
         // Test that the relevant keys have been stored correctly.
         int val = -1;
@@ -101,11 +117,9 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
     // Now try recreating the frame using the restored values.
     bool checkIconized = true;
     {
-        auto const frame = CreatePersistenceTestFrame();
+        auto const frame = RestorePersistenceTestFrame();
 
-        // Test that the object was registered and restored.
-        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame.get()));
-
+        // Test that the object was restored.
         if ( checkPosition )
         {
             CHECK(pos.x == frame->GetPosition().x);
@@ -142,9 +156,7 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
 
     // Check geometry after restoring the minimized frame.
     {
-        auto const frame = CreatePersistenceTestFrame();
-
-        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame.get()));
+        auto const frame = RestorePersistenceTestFrame();
 
         // As above, we need to show the frame for it to be actually iconized.
         frame->Show();
@@ -183,9 +195,7 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
     // maximized frame size, and its normal size is lost and can't be restored.
 #ifdef __WXMSW__
     {
-        auto const frame = CreatePersistenceTestFrame();
-
-        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame.get()));
+        auto const frame = RestorePersistenceTestFrame();
 
         CHECK(frame->IsMaximized());
         CHECK(!frame->IsIconized());

--- a/tests/persistence/tlw.cpp
+++ b/tests/persistence/tlw.cpp
@@ -37,9 +37,10 @@
 // ----------------------------------------------------------------------------
 
 // Create the frame used for testing.
-static wxFrame* CreatePersistenceTestFrame()
+static std::unique_ptr<wxFrame> CreatePersistenceTestFrame()
 {
-    wxFrame* const frame = new wxFrame(wxTheApp->GetTopWindow(), wxID_ANY, "wxTest");
+    auto frame =
+        make_unique<wxFrame>(wxTheApp->GetTopWindow(), wxID_ANY, "wxTest");
     frame->SetName("frame");
 
     return frame;
@@ -64,16 +65,16 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
 
     // Save the frame geometry.
     {
-        wxFrame* const frame = CreatePersistenceTestFrame();
+        auto frame = CreatePersistenceTestFrame();
 
         // Set the geometry before saving.
         frame->SetPosition(pos);
         frame->SetSize(size);
 
-        CHECK(wxPersistenceManager::Get().Register(frame));
+        CHECK(wxPersistenceManager::Get().Register(frame.get()));
 
         // Destroy the frame immediately, i.e. don't use Destroy() here.
-        delete frame;
+        frame.reset();
 
         // Test that the relevant keys have been stored correctly.
         int val = -1;
@@ -100,10 +101,10 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
     // Now try recreating the frame using the restored values.
     bool checkIconized = true;
     {
-        wxFrame* const frame = CreatePersistenceTestFrame();
+        auto const frame = CreatePersistenceTestFrame();
 
         // Test that the object was registered and restored.
-        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame));
+        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame.get()));
 
         if ( checkPosition )
         {
@@ -129,7 +130,7 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
         }
         else
         {
-            if ( !WaitFor("frame to be iconized", [frame]() {
+            if ( !WaitFor("frame to be iconized", [&]() {
                         return frame->IsIconized();
                     }) )
             {
@@ -137,15 +138,13 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
             }
         }
 #endif // __WXGTK__
-
-        delete frame;
     }
 
     // Check geometry after restoring the minimized frame.
     {
-        wxFrame* const frame = CreatePersistenceTestFrame();
+        auto const frame = CreatePersistenceTestFrame();
 
-        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame));
+        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame.get()));
 
         // As above, we need to show the frame for it to be actually iconized.
         frame->Show();
@@ -154,7 +153,7 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
         if ( checkIconized )
         {
 #ifdef __WXGTK__
-            WaitFor("frame to be iconized", [frame]() {
+            WaitFor("frame to be iconized", [&]() {
                 return frame->IsIconized();
             });
 #endif // __WXGTK__
@@ -176,8 +175,6 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
         // for it to be really maximized, it must be shown.
         frame->Maximize();
         frame->Show();
-
-        delete frame;
     }
 
     // Check geometry after restoring the maximized frame.
@@ -186,9 +183,9 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
     // maximized frame size, and its normal size is lost and can't be restored.
 #ifdef __WXMSW__
     {
-        wxFrame* const frame = CreatePersistenceTestFrame();
+        auto const frame = CreatePersistenceTestFrame();
 
-        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame));
+        CHECK(wxPersistenceManager::Get().RegisterAndRestore(frame.get()));
 
         CHECK(frame->IsMaximized());
         CHECK(!frame->IsIconized());
@@ -199,8 +196,6 @@ TEST_CASE_METHOD(PersistenceTests, "wxPersistTLW", "[persist][tlw]")
         CHECK(pos.y == frame->GetPosition().y);
         CHECK(size.x == frame->GetSize().GetWidth());
         CHECK(size.y == frame->GetSize().GetHeight());
-
-        delete frame;
     }
 #endif // __WXMSW__
 }


### PR DESCRIPTION
Don't restore windows that are almost (but not completely) off the screen.