### PR TITLE
Draw dark mode list control items once per row, not once per column

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3462,12 +3462,6 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
 
 WXLPARAM HandleItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD)
 {
-    if ( wxMSWDarkMode::IsActive() )
-    {
-        HandleItemPaint(listctrl, pLVCD);
-        return CDRF_SKIPDEFAULT;
-    }
-
     wxItemAttr* attr = listctrl->MSWGetItemColumnAttr(pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem);
 
     pLVCD->clrText = attr && attr->HasTextColour()
@@ -3547,6 +3541,26 @@ WXLPARAM wxListCtrl::OnCustomDraw(WXLPARAM lParam)
             break;
 
         case CDDS_ITEMPREPAINT:
+            // In dark mode we draw the items entirely on our own and we must
+            // do it here rather than when handling CDDS_SUBITEM below because
+            // HandleItemPaint() draws the whole row, including all of its
+            // columns, at once: calling it from the subitem handler would
+            // repeat the same drawing once per column, which is not only
+            // wasteful but also results in visible delays when scrolling
+            // lists with many columns.
+            if ( wxMSWDarkMode::IsActive() && InReportView() )
+            {
+                const int item = nmcd.dwItemSpec;
+
+                // As below, this message can be received with item == 0 even
+                // for an empty control, so check that the item really exists.
+                if ( item >= 0 && item < GetItemCount() )
+                {
+                    HandleItemPaint(this, pLVCD);
+                    return CDRF_SKIPDEFAULT;
+                }
+            }
+
             // set the text foreground and background colour for listview
             // and icon view, these don't get messages for subitems
             pLVCD->clrText = wxColourToRGB(GetForegroundColour());


### PR DESCRIPTION
In dark mode wxListCtrl draws its items itself instead of letting the native control do it. HandleItemPaint() draws an entire row, looping over all of its columns, but it was called from the CDDS_SUBITEM handler, which comctl32 sends once per column. Every row was therefore fully redrawn as many times as it has columns, each pass repeating a selection scan, a cursor hit test, a full row FillRect and a GetSubItemRect round trip per column.

For a report view with 9 columns this is 81 subitem draws per row instead of 9, which is visible as a delay between scrolling and the repaint.

Handle CDDS_ITEMPREPAINT instead, which arrives once per row, and return CDRF_SKIPDEFAULT there so no subitem messages are generated at all. This matches the intent already documented in HandleItemPaint(), which notes that it deliberately draws everything at once rather than using CDRF_NOTIFYSUBITEMDRAW.

Only report view is affected: other views never get subitem messages, so they took the unchanged code path before and still do.