### PR TITLE
Don't draw list control items as disabled when only a parent is disabled

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3333,7 +3333,11 @@ void DrawGridLines(wxListCtrl* listctrl, int item, int gap = 0)
 // taking into account whether the control is enabled or not.
 wxColour GetEffectiveBackgroundColour(wxListCtrl* listctrl)
 {
-    if ( listctrl->IsEnabled() )
+    // Note that we must use IsThisEnabled() and not IsEnabled() here: the
+    // latter is also false when just a parent is disabled, which notably
+    // happens while a modal dialog is shown, and the items shouldn't appear
+    // disabled then, if only because the native control doesn't do it either.
+    if ( listctrl->IsThisEnabled() )
         return listctrl->GetBackgroundColour();
     else
         return wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);


### PR DESCRIPTION
GetEffectiveBackgroundColour() returns wxSYS_COLOUR_BTNFACE instead of the control background when the list is disabled, so that a disabled control looks disabled. It used IsEnabled(), which is also false when merely an ancestor is disabled, and showing a modal dialog disables the parent window of everything under it.

Every list control in the window behind a modal dialog therefore repainted its items in the "disabled" colour for as long as the dialog was shown. In dark mode this is very visible, as the items change from 0x202020 to 0x333333, but it affects the light mode as well for the items using custom attributes, where it is just much less noticeable.

Use IsThisEnabled(), which is documented as returning the intrinsic state of the window without taking its parents into account, so that only a control that was actually disabled is drawn as disabled. This also matches the native control, which doesn't change how it draws its items while a modal dialog is shown.