### PR TITLE
Unix thread fixes

### DIFF
--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -1914,17 +1914,14 @@ void wxThreadModule::OnExit()
 
     {
         wxMutexLocker lock( *gs_mutexDeleteThread );
-        // are there any threads left which are being deleted right now?
-        size_t nThreadsBeingDeleted;
-        nThreadsBeingDeleted = gs_nThreadsBeingDeleted;
 
-        if ( nThreadsBeingDeleted > 0 )
+        // Check the predicate in a loop in to handle spurious wakeups.
+        while ( gs_nThreadsBeingDeleted > 0 )
         {
             wxLogTrace(TRACE_THREADS,
                        wxT("Waiting for %lu threads to disappear"),
-                       (unsigned long)nThreadsBeingDeleted);
+                       (unsigned long)gs_nThreadsBeingDeleted);
 
-            // have to wait until all of them disappear
             gs_condAllDeleted->Wait();
         }
     }

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -1912,6 +1912,7 @@ void wxThreadModule::OnExit()
 {
     wxASSERT_MSG( wxThread::IsMain(), wxT("only main thread can be here") );
 
+    // Wait until the threads which are already exiting really disappear.
     {
         wxMutexLocker lock( *gs_mutexDeleteThread );
 
@@ -1926,40 +1927,26 @@ void wxThreadModule::OnExit()
         }
     }
 
-    size_t count;
-
+    // If there any threads still left, warn about them but don't try to do
+    // anything: there is no thread-safe way of deleting them, we can't wait
+    // for a detached thread to finish and if it doesn't terminate before we
+    // delete gs_mutexAllThreads below, it will crash, so it's safer to just
+    // let it keep running and get killed when the process terminates.
     {
         wxMutexLocker lock(*gs_mutexAllThreads);
 
-        // terminate any threads left
-        count = gs_allThreads.GetCount();
+        const size_t count = gs_allThreads.GetCount();
         if ( count != 0u )
         {
             wxLogDebug(wxT("%lu threads were not terminated by the application."),
                        (unsigned long)count);
+
+            // We can't delete the mutexes below because they can still be used
+            // from the still running threads, so leak them too: it's better
+            // than crashing (and the leaks are not even reported as such by
+            // LSAN because we still keep pointers to the leaked objects).
+            return;
         }
-    } // unlock mutex before deleting the threads as they lock it in their dtor
-
-    for ( size_t n = 0u; n < count; n++ )
-    {
-        wxThread* thread;
-
-        {
-            wxMutexLocker lock(*gs_mutexAllThreads);
-
-            // The threads may remove themselves from the array in their dtor
-            // while we're not holding the mutex, so check that there are still
-            // any of them left and always take the first one, as deleting it
-            // removes the corresponding entry from the array.
-            if ( gs_allThreads.empty() )
-                break;
-
-            thread = gs_allThreads[0];
-        }
-
-        // Note that we must not hold the mutex while doing this, as the thread
-        // dtor locks it too.
-        thread->Delete();
     }
 
     delete gs_mutexAllThreads;

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -1942,9 +1942,24 @@ void wxThreadModule::OnExit()
 
     for ( size_t n = 0u; n < count; n++ )
     {
-        // Delete calls the destructor which removes the current entry. We
-        // should only delete the first one each time.
-        gs_allThreads[0]->Delete();
+        wxThread* thread;
+
+        {
+            wxMutexLocker lock(*gs_mutexAllThreads);
+
+            // The threads may remove themselves from the array in their dtor
+            // while we're not holding the mutex, so check that there are still
+            // any of them left and always take the first one, as deleting it
+            // removes the corresponding entry from the array.
+            if ( gs_allThreads.empty() )
+                break;
+
+            thread = gs_allThreads[0];
+        }
+
+        // Note that we must not hold the mutex while doing this, as the thread
+        // dtor locks it too.
+        thread->Delete();
     }
 
     delete gs_mutexAllThreads;

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -617,8 +617,8 @@ wxSemaError wxSemaphoreInternal::Wait()
             return wxSEMA_MISC_ERROR;
 
         wxLogTrace(TRACE_SEMA,
-                   wxT("Thread %p finished waiting for semaphore, count = %lu"),
-                   THR_ID_CAST(wxThread::GetCurrentId()), (unsigned long)m_count);
+                   "Thread %p finished waiting for semaphore, count = %zu",
+                   THR_ID_CAST(wxThread::GetCurrentId()), m_count);
     }
 
     m_count--;
@@ -684,8 +684,8 @@ wxSemaError wxSemaphoreInternal::Post()
     m_count++;
 
     wxLogTrace(TRACE_SEMA,
-               wxT("Thread %p about to signal semaphore, count = %lu"),
-               THR_ID_CAST(wxThread::GetCurrentId()), (unsigned long)m_count);
+               "Thread %p about to signal semaphore, count = %zu",
+               THR_ID_CAST(wxThread::GetCurrentId()), m_count);
 
     return m_cond.Signal() == wxCOND_NO_ERROR ? wxSEMA_NO_ERROR
                                               : wxSEMA_MISC_ERROR;
@@ -896,8 +896,8 @@ void *wxThreadInternal::PthreadStart(wxThread *thread)
                 pthread->m_exitcode = thread->Entry();
 
                 wxLogTrace(TRACE_THREADS,
-                           wxT("Thread %p Entry() returned %lu."),
-                           THR_ID(pthread), wxPtrToUInt(pthread->m_exitcode));
+                           "Thread %p Entry() returned %p.",
+                           THR_ID(pthread), pthread->m_exitcode);
 #ifdef CATCH_AND_RETHROW_FORCED_UNWIND
             }
             catch ( abi::__forced_unwind& )
@@ -1345,8 +1345,8 @@ bool wxThread::SetConcurrency(size_t level)
 
     if ( rc != 0 )
     {
-        wxLogSysError(rc, _("Failed to set thread concurrency level to %lu"),
-                      static_cast<unsigned long>(level));
+        wxLogSysError(rc, _("Failed to set thread concurrency level to %zu"),
+                      level);
         return false;
     }
 
@@ -1920,8 +1920,8 @@ void wxThreadModule::OnExit()
         while ( gs_nThreadsBeingDeleted > 0 )
         {
             wxLogTrace(TRACE_THREADS,
-                       wxT("Waiting for %lu threads to disappear"),
-                       (unsigned long)gs_nThreadsBeingDeleted);
+                       "Waiting for %zu threads to disappear",
+                       gs_nThreadsBeingDeleted);
 
             gs_condAllDeleted->Wait();
         }
@@ -1938,8 +1938,8 @@ void wxThreadModule::OnExit()
         const size_t count = gs_allThreads.GetCount();
         if ( count != 0u )
         {
-            wxLogDebug(wxT("%lu threads were not terminated by the application."),
-                       (unsigned long)count);
+            wxLogDebug("%zu threads were not terminated by the application.",
+                       count);
 
             // We can't delete the mutexes below because they can still be used
             // from the still running threads, so leak them too: it's better
@@ -1976,9 +1976,9 @@ static void ScheduleThreadForDeletion()
 
     gs_nThreadsBeingDeleted++;
 
-    wxLogTrace(TRACE_THREADS, wxT("%lu thread%s waiting to be deleted"),
-               (unsigned long)gs_nThreadsBeingDeleted,
-               gs_nThreadsBeingDeleted == 1 ? wxT("") : wxT("s"));
+    wxLogTrace(TRACE_THREADS, "%zu thread%s waiting to be deleted",
+               gs_nThreadsBeingDeleted,
+               gs_nThreadsBeingDeleted == 1 ? "" : "s");
 }
 
 static void DeleteThread(wxThread *This)
@@ -1995,8 +1995,8 @@ static void DeleteThread(wxThread *This)
     wxCHECK_RET( gs_nThreadsBeingDeleted > 0,
                  wxT("no threads scheduled for deletion, yet we delete one?") );
 
-    wxLogTrace(TRACE_THREADS, wxT("%lu threads remain scheduled for deletion."),
-               (unsigned long)gs_nThreadsBeingDeleted - 1);
+    wxLogTrace(TRACE_THREADS, "%zu threads remain scheduled for deletion.",
+               gs_nThreadsBeingDeleted - 1);
 
     if ( !--gs_nThreadsBeingDeleted )
     {

--- a/tests/thread/misc.cpp
+++ b/tests/thread/misc.cpp
@@ -126,6 +126,7 @@ class MyWaitingThread : public wxThread
 {
 public:
     MyWaitingThread( wxMutex *mutex, wxCondition *condition )
+        : wxThread(wxTHREAD_JOINABLE)
     {
         m_mutex = mutex;
         m_condition = condition;
@@ -345,22 +346,22 @@ TEST_CASE("MiscThread::ThreadConditions", "[thread]")
     //           condition.GetId(), gs_cond.GetId());
 
     // create and launch threads
-    MyWaitingThread *threads[10];
+    static const size_t NUM_THREADS = 10;
 
-    size_t n;
-    for ( n = 0; n < WXSIZEOF(threads); n++ )
+    std::vector<std::unique_ptr<MyWaitingThread>> threads;
+    for ( size_t n = 0; n < NUM_THREADS; n++ )
     {
-        threads[n] = new MyWaitingThread( &mutex, &condition );
+        threads.push_back(make_unique<MyWaitingThread>(&mutex, &condition));
     }
 
-    for ( n = 0; n < WXSIZEOF(threads); n++ )
+    for ( auto& t : threads )
     {
-        CHECK( threads[n]->Run() == wxTHREAD_NO_ERROR );
+        CHECK( t->Run() == wxTHREAD_NO_ERROR );
     }
 
     // wait until all threads run
     size_t nRunning = 0;
-    while ( nRunning < WXSIZEOF(threads) )
+    while ( nRunning < NUM_THREADS )
     {
         CHECK( gs_cond.Wait() == wxSEMA_NO_ERROR );
 
@@ -378,10 +379,15 @@ TEST_CASE("MiscThread::ThreadConditions", "[thread]")
     // wake all the (remaining) threads up, so that they can exit
     CHECK( condition.Broadcast() == wxCOND_NO_ERROR );
 
-    while ( nFinished < WXSIZEOF(threads) )
+    while ( nFinished < NUM_THREADS )
     {
         CHECK( gs_cond.Wait() == wxSEMA_NO_ERROR );
 
         nFinished++;
+    }
+
+    for ( auto& t : threads )
+    {
+        t->Wait();
     }
 }


### PR DESCRIPTION
I've seen a crash in the tests and quickly realized that it was a problem in the test. However while looking at this, I've also realized that our code in `wxThreadModule::OnExit()` was fundamentally MT-unsafe and AFAICS there is no way to make it safe, so I've just removed it (after fixing one problem that could be fixed).

Please let me know if I'm missing something here and if anybody sees any way to wait for all threads to exit in a MT-safe way. But I think it's fine to just let them die (or crash...), as it's a misuse of the API anyhow: all `wxThread`s are supposed to be terminated before the application exit.