### PR TITLE
Make `wxRenameFile()` really atomic under MSW

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -267,6 +267,16 @@ Changes in behaviour which may result in build errors
 3.3.4: (released 2026-??-??)
 ----------------------------
 
+Please note that this is a list of changes compared to 3.2.11, the full list of
+changes since 3.3.3 also includes all changes between 3.2.11 and 3.2.12.
+
+wxMSW:
+
+- Incompatible change in wxRenameFile() behaviour: it doesn't copy the file
+  attributes any longer as it did since 3.3.0 (but only under Windows), use
+  wxFileName::CopyAttributesFrom() if you need to preserve them.
+
+
 NOTE: In addition to the note below, also incorporate (either by
       copy or by reference) all the changes in the 3.2 branch (i.e.
       everything in this file after 3.2.0 in that branch).

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -266,6 +266,9 @@ public:
         // values
     bool SetPermissions(int permissions);
 
+        // copy the supported attributes of the given file to this one
+    bool CopyAttributesFrom(const wxFileName& source) const;
+
     // Returns the native path for a file URL
     static wxFileName URLToFileName(const wxString& url);
 

--- a/include/wx/private/filename.h
+++ b/include/wx/private/filename.h
@@ -51,4 +51,13 @@ bool wxCreateTempFile(const wxString& prefix,
                       wxString *name);
 #endif
 
+// Set up the newly created temporary file strTemp which is going to replace
+// the existing file strName: this notably copies the attributes of the latter
+// to the former, so that they're preserved when the file is replaced.
+//
+// This is used to implement both wxTempFile and wxTempFFile.
+#if wxUSE_FILE || wxUSE_FFILE
+void wxInitTempFile(const wxString& strTemp, const wxString& strName);
+#endif // wxUSE_FILE || wxUSE_FFILE
+
 #endif // _WX_PRIVATE_FILENAME_H_

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -232,9 +232,11 @@ time_t wxFileModificationTime(const wxString& filename);
     overwritten if @a overwrite is @true (default) and the function fails if @a
     overwrite is @false.
 
-    Since wxWidgets 3.3.0, if @a overwrite is @true `ReplaceFile()` function is
-    used under MSW which allows to preserve the file attributes while replacing
-    its contents.
+    Since wxWidgets 3.3.4, `MoveFileEx()` is used under MSW, which makes
+    replacing the existing @a newpath atomic if both files are on the same
+    volume. Note that this function does @e not preserve the attributes of the
+    replaced file: use wxFileName::CopyAttributesFrom() before renaming if you
+    need to keep them.
 
     @header{wx/filefn.h}
 */

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -227,16 +227,23 @@ time_t wxFileModificationTime(const wxString& filename);
 /**
     Renames @a oldpath to @e newpath, returning @true if successful.
 
-    If @a newpath is a directory, @a oldpath is moved into it (@a overwrite is
-    ignored in this case). Otherwise, if @a newpath is an existing file, it is
-    overwritten if @a overwrite is @true (default) and the function fails if @a
-    overwrite is @false.
+    If @a newpath is an existing file, it is overwritten if @a overwrite is
+    @true (default) and the function fails if @a overwrite is @false.
 
     Since wxWidgets 3.3.4, `MoveFileEx()` is used under MSW, which makes
     replacing the existing @a newpath atomic if both files are on the same
     volume. Note that this function does @e not preserve the attributes of the
     replaced file: use wxFileName::CopyAttributesFrom() before renaming if you
     need to keep them.
+
+    @param oldpath
+        The path of the existing file to rename.
+    @param newpath
+        The new path for the file. Must be a file, not a directory.
+    @param overwrite
+        If @a newpath exists, it will be overwritten if @a overwrite is @true,
+        otherwise the function will fail. If it doesn't exist, this parameter
+        is ignored.
 
     @header{wx/filefn.h}
 */

--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -1406,6 +1406,37 @@ public:
     bool SetPermissions(int permissions);
 
     /**
+        Copies the attributes of the given file to this one.
+
+        This function is useful when replacing an existing file by writing the
+        new contents to a temporary file and then renaming it over the old
+        one, as it allows the replacement to keep the attributes of the file
+        being replaced, which would be lost otherwise.
+
+        Under Unix this copies the file permissions (including setuid and
+        setgid bits). Under MSW it copies the hidden, system and
+        not-content-indexed attributes and the creation time (access and
+        modification times will presumably be modified by the program anyhow
+        and so are not copied). Under other platforms this function currently
+        does nothing but still returns @true.
+
+        Note that this function does @e not copy everything and, in
+        particular, under MSW it doesn't copy the read-only attribute, as this
+        would prevent the destination file from being modified or removed
+        later. It also currently doesn't copy the compressed and encrypted
+        attributes nor the access control lists.
+
+        @param source
+            The file to copy the attributes from. It must exist.
+
+        @return @true if all supported attributes were copied, @false if any of
+            them couldn't be (some of them may still have been copied).
+
+        @since 3.3.4
+    */
+    bool CopyAttributesFrom(const wxFileName& source) const;
+
+    /**
         Converts URL into a well-formed filename.
         The URL must use the @c file protocol.
         If the URL does not use @c file protocol

--- a/src/common/ffile.cpp
+++ b/src/common/ffile.cpp
@@ -29,6 +29,7 @@
 
 #include "wx/filename.h"
 #include "wx/ffile.h"
+#include "wx/private/filename.h"
 
 // ============================================================================
 // implementation of wxFFile
@@ -326,29 +327,7 @@ bool wxTempFFile::Open(const wxString& strName)
         return false;
     }
 
-    // The temp file should have the same attributes as the original one.
-    if ( wxFileExists(m_strName) )
-    {
-        if ( !wxFileName(m_strTemp).CopyAttributesFrom(m_strName) )
-        {
-            wxLogError(_("Error preserving all attributes of '%s'"), m_strName);
-        }
-    }
-#ifdef __UNIX__
-    else
-    {
-        // The file didn't exist, so just give it the default mode _using_
-        // user's umask (new files creation should respect umask)
-        mode_t mask = umask(0777);
-        mode_t mode = 0666 & ~mask;
-        umask(mask);
-
-        if ( chmod( (const char*) m_strTemp.fn_str(), mode) == -1 )
-        {
-            wxLogSysError(_("Failed to set temporary file permissions"));
-        }
-    }
-#endif // Unix
+    wxInitTempFile(m_strTemp, m_strName);
 
     return true;
 }

--- a/src/common/ffile.cpp
+++ b/src/common/ffile.cpp
@@ -326,27 +326,27 @@ bool wxTempFFile::Open(const wxString& strName)
         return false;
     }
 
-#ifdef __UNIX__
-    // the temp file should have the same permissions as the original one
-    mode_t mode;
-
-    wxStructStat st;
-    if ( wxStat(m_strName, &st) == 0 )
+    // The temp file should have the same attributes as the original one.
+    if ( wxFileExists(m_strName) )
     {
-        mode = st.st_mode;
+        if ( !wxFileName(m_strTemp).CopyAttributesFrom(m_strName) )
+        {
+            wxLogError(_("Error preserving all attributes of '%s'"), m_strName);
+        }
     }
+#ifdef __UNIX__
     else
     {
-        // file probably didn't exist, just give it the default mode _using_
+        // The file didn't exist, so just give it the default mode _using_
         // user's umask (new files creation should respect umask)
         mode_t mask = umask(0777);
-        mode = 0666 & ~mask;
+        mode_t mode = 0666 & ~mask;
         umask(mask);
-    }
 
-    if ( chmod( (const char*) m_strTemp.fn_str(), mode) == -1 )
-    {
-        wxLogSysError(_("Failed to set temporary file permissions"));
+        if ( chmod( (const char*) m_strTemp.fn_str(), mode) == -1 )
+        {
+            wxLogSysError(_("Failed to set temporary file permissions"));
+        }
     }
 #endif // Unix
 

--- a/src/common/ffile.cpp
+++ b/src/common/ffile.cpp
@@ -367,12 +367,7 @@ bool wxTempFFile::Commit()
 {
     m_file.Close();
 
-    if ( wxFile::Exists(m_strName) && wxRemove(m_strName) != 0 ) {
-        wxLogSysError(_("can't remove file '%s'"), m_strName);
-        return false;
-    }
-
-    if ( !wxRenameFile(m_strTemp, m_strName)  ) {
+    if ( !wxRenameFile(m_strTemp, m_strName) ) {
         wxLogSysError(_("can't commit changes to file '%s'"), m_strName);
         return false;
     }

--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -79,6 +79,7 @@
 #include  "wx/filename.h"
 #include  "wx/file.h"
 #include  "wx/filefn.h"
+#include  "wx/private/filename.h"
 
 // there is no distinction between text and binary files under Unix, so define
 // O_BINARY as 0 if the system headers don't do it already
@@ -546,29 +547,7 @@ bool wxTempFile::Open(const wxString& strName)
         return false;
     }
 
-    // The temp file should have the same attributes as the original one.
-    if ( wxFileExists(m_strName) )
-    {
-        if ( !wxFileName(m_strTemp).CopyAttributesFrom(m_strName) )
-        {
-            wxLogError(_("Error preserving all attributes of '%s'"), m_strName);
-        }
-    }
-#ifdef __UNIX__
-    else
-    {
-        // The file didn't exist, so just give it the default mode _using_
-        // user's umask (new files creation should respect umask)
-        mode_t mask = umask(0777);
-        mode_t mode = 0666 & ~mask;
-        umask(mask);
-
-        if ( chmod( (const char*) m_strTemp.fn_str(), mode) == -1 )
-        {
-            wxLogSysError(_("Failed to set temporary file permissions"));
-        }
-    }
-#endif // Unix
+    wxInitTempFile(m_strTemp, m_strName);
 
     return true;
 }

--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -546,27 +546,27 @@ bool wxTempFile::Open(const wxString& strName)
         return false;
     }
 
-#ifdef __UNIX__
-    // the temp file should have the same permissions as the original one
-    mode_t mode;
-
-    wxStructStat st;
-    if ( wxStat(m_strName, &st) == 0 )
+    // The temp file should have the same attributes as the original one.
+    if ( wxFileExists(m_strName) )
     {
-        mode = st.st_mode;
+        if ( !wxFileName(m_strTemp).CopyAttributesFrom(m_strName) )
+        {
+            wxLogError(_("Error preserving all attributes of '%s'"), m_strName);
+        }
     }
+#ifdef __UNIX__
     else
     {
-        // file probably didn't exist, just give it the default mode _using_
+        // The file didn't exist, so just give it the default mode _using_
         // user's umask (new files creation should respect umask)
         mode_t mask = umask(0777);
-        mode = 0666 & ~mask;
+        mode_t mode = 0666 & ~mask;
         umask(mask);
-    }
 
-    if ( chmod( (const char*) m_strTemp.fn_str(), mode) == -1 )
-    {
-        wxLogSysError(_("Failed to set temporary file permissions"));
+        if ( chmod( (const char*) m_strTemp.fn_str(), mode) == -1 )
+        {
+            wxLogSysError(_("Failed to set temporary file permissions"));
+        }
     }
 #endif // Unix
 

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -503,31 +503,6 @@ wxCopyFile (const wxString& file1, const wxString& file2, bool overwrite)
 bool
 wxRenameFile(const wxString& file1, const wxString& file2, bool overwrite)
 {
-#ifdef __WINDOWS__
-    // When overwriting, prefer using ReplaceFile() which allows to preserve
-    // the destination file attributes while replacing its contents.
-    if ( overwrite && wxFileExists(file2) )
-    {
-        if ( ::ReplaceFile
-               (
-                    file2.t_str(),  // File to replace.
-                    file1.t_str(),  // File to replace it with.
-                    nullptr,        // No backup file.
-                    REPLACEFILE_IGNORE_MERGE_ERRORS,
-                                    // Don't return error just because ACLs
-                                    // couldn't be preserved.
-                    wxRESERVED_PARAM,
-                    wxRESERVED_PARAM
-               ) )
-        {
-            return true;
-        }
-
-        // Continue with the normal rename logic if ReplaceFile() failed, it
-        // will probably fail as well but it shouldn't hurt to try.
-    }
-#endif // __WINDOWS__
-
     if ( !overwrite && wxFileExists(file2) )
     {
         wxLogError
@@ -538,6 +513,25 @@ wxRenameFile(const wxString& file1, const wxString& file2, bool overwrite)
 
         return false;
     }
+
+#ifdef __WINDOWS__
+    // Prefer MoveFileEx() to the CRT rename() used below because it can
+    // replace the already existing destination file and does it atomically,
+    // at least when both files are on the same volume (when they are not,
+    // MOVEFILE_COPY_ALLOWED makes it fall back on copying the file, which
+    // can't be atomic).
+    DWORD flags = MOVEFILE_COPY_ALLOWED;
+    if ( overwrite )
+        flags |= MOVEFILE_REPLACE_EXISTING;
+
+    if ( ::MoveFileEx(file1.t_str(), file2.t_str(), flags) )
+        return true;
+
+    // Still fall back on the generic code below if it failed: it may succeed
+    // in some cases in which MoveFileEx() doesn't, e.g. when the destination
+    // file is opened by another process, which prevents it from being
+    // replaced but not necessarily from being overwritten.
+#endif // __WINDOWS__
 
     // Normal system call
   if ( wxRename (file1, file2) == 0 )

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -2743,6 +2743,109 @@ bool wxFileName::SetPermissions(int permissions)
     return wxChmod(GetFullPath(), permissions) == 0;
 }
 
+#if defined(__WINDOWS__)
+
+namespace
+{
+
+bool CopyFileAttributes(const wxString& pathSrc, const wxString& pathDst)
+{
+    const DWORD attrsSrc = ::GetFileAttributes(pathSrc.t_str());
+    if ( attrsSrc == INVALID_FILE_ATTRIBUTES )
+    {
+        wxLogSysError(_("Failed to get attributes of '%s'"), pathSrc);
+        return false;
+    }
+
+    const DWORD attrsDst = ::GetFileAttributes(pathDst.t_str());
+    if ( attrsDst == INVALID_FILE_ATTRIBUTES )
+    {
+        wxLogSysError(_("Failed to get attributes of '%s'"), pathDst);
+        return false;
+    }
+
+    // Only these attributes can be usefully and successfully copied: notably
+    // FILE_ATTRIBUTE_READONLY is not copied because it would prevent the
+    // destination file from being written to or removed later, while the
+    // compressed and encrypted ones simply can't be set using this function.
+    constexpr DWORD ATTRS_TO_COPY = FILE_ATTRIBUTE_HIDDEN |
+                                    FILE_ATTRIBUTE_SYSTEM |
+                                    FILE_ATTRIBUTE_NOT_CONTENT_INDEXED;
+
+    // Note that this clears the attributes not set in the source file too.
+    const DWORD attrsNew = (attrsDst & ~ATTRS_TO_COPY) |
+                           (attrsSrc & ATTRS_TO_COPY);
+    if ( attrsNew != attrsDst &&
+            !::SetFileAttributes(pathDst.t_str(), attrsNew) )
+    {
+        wxLogSysError(_("Failed to set attributes of '%s'"), pathDst);
+        return false;
+    }
+
+    return true;
+}
+
+#if wxUSE_DATETIME
+bool CopyFileTimes(const wxFileName& src, const wxFileName& dst)
+{
+    // Preserve just the creation time, the others are going to be modified
+    // anyhow soon by the caller.
+    wxDateTime dtCreate;
+
+    return src.GetTimes(nullptr, nullptr, &dtCreate) &&
+                dst.SetTimes(nullptr, nullptr, &dtCreate);
+}
+#endif // wxUSE_DATETIME
+
+} // anonymous namespace
+
+#endif // __WINDOWS__
+
+bool wxFileName::CopyAttributesFrom(const wxFileName& source) const
+{
+    const wxString pathSrc = source.GetFullPath();
+    const wxString pathDst = GetFullPath();
+
+#if defined(__WINDOWS__)
+    bool ok = true;
+
+    if ( !CopyFileAttributes(pathSrc, pathDst) )
+        ok = false;
+
+#if wxUSE_DATETIME
+    if ( !CopyFileTimes(source, *this) )
+        ok = false;
+#endif // wxUSE_DATETIME
+
+    return ok;
+#elif defined(__UNIX_LIKE__)
+    // Under Unix we copy just the file mode: we can't set creation time.
+    wxStructStat st;
+    if ( wxStat(pathSrc, &st) != 0 )
+    {
+        wxLogSysError(_("Failed to get mode of '%s'"), pathSrc);
+        return false;
+    }
+
+    if ( wxChmod(pathDst, st.st_mode) != 0 )
+    {
+        wxLogSysError(_("Failed to set mode of '%s'"), pathDst);
+        return false;
+    }
+
+    return true;
+#else // other platform
+    wxUnusedVar(pathSrc);
+    wxUnusedVar(pathDst);
+
+    // Returning false from here would result in an error message being logged
+    // by the caller, which would be incomprehensible and there won't be
+    // anything that could possibly be done about it, so just pretend that we
+    // succeeded.
+    return true;
+#endif // platforms
+}
+
 // Returns the native path for a file URL
 wxFileName wxFileName::URLToFileName(const wxString& url)
 {

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -1208,6 +1208,36 @@ wxFileName::CreateTempFileName(const wxString& prefix, wxFFile *fileTemp)
 
 #endif // wxUSE_FFILE
 
+#if wxUSE_FILE || wxUSE_FFILE
+
+void wxInitTempFile(const wxString& strTemp, const wxString& strName)
+{
+    // The temp file should have the same attributes as the original one.
+    if ( wxFileExists(strName) )
+    {
+        if ( !wxFileName(strTemp).CopyAttributesFrom(strName) )
+        {
+            wxLogError(_("Error preserving all attributes of '%s'"), strName);
+        }
+    }
+#ifdef __UNIX__
+    else
+    {
+        // The file didn't exist, so just give it the default mode _using_
+        // user's umask (new files creation should respect umask)
+        mode_t mask = umask(0777);
+        mode_t mode = 0666 & ~mask;
+        umask(mask);
+
+        if ( chmod( (const char*) strTemp.fn_str(), mode) == -1 )
+        {
+            wxLogSysError(_("Failed to set temporary file permissions"));
+        }
+    }
+#endif // Unix
+}
+
+#endif // wxUSE_FILE || wxUSE_FFILE
 
 // ----------------------------------------------------------------------------
 // directory operations

--- a/tests/file/filefn.cpp
+++ b/tests/file/filefn.cpp
@@ -270,6 +270,29 @@ void FileFunctionsTestCase::DoRemoveFile(const wxString& filePath)
     CHECK( !file.Exists() );
 }
 
+namespace
+{
+
+void CreateFileWithContents(const wxString& path, const wxString& contents)
+{
+    wxFFile f(path, "w");
+    REQUIRE( f.IsOpened() );
+    REQUIRE( f.Write(contents) );
+}
+
+wxString GetFileContents(const wxString& path)
+{
+    wxFFile f(path, "r");
+    REQUIRE( f.IsOpened() );
+
+    wxString contents;
+    REQUIRE( f.ReadAll(&contents) );
+
+    return contents;
+}
+
+} // anonymous namespace
+
 TEST_CASE_METHOD(FileFunctionsTestCase,
                  "FileFunctions::RenameFile",
                  "[filefn]")
@@ -294,17 +317,18 @@ FileFunctionsTestCase::DoRenameFile(const wxString& oldFilePath,
 {
     INFO("File 1:" << oldFilePath << "  File 2: " << newFilePath);
 
+    // Use different contents for the two files to allow checking which of
+    // them the destination file has at the end.
+    const wxString contentsSrc("source");
+    const wxString contentsDst("destination");
+
     // Create temporary source file.
-    wxTextFile file;
-    REQUIRE( file.Create(oldFilePath) );
-    CHECK( file.Close() );
+    CreateFileWithContents(oldFilePath, contentsSrc);
 
     if ( withNew )
     {
         // Create destination file to test overwriting.
-        wxTextFile file2;
-        REQUIRE( file2.Create(newFilePath) );
-        CHECK( file2.Close() );
+        CreateFileWithContents(newFilePath, contentsDst);
 
         CHECK( wxFileExists(newFilePath) );
     }
@@ -329,6 +353,10 @@ FileFunctionsTestCase::DoRenameFile(const wxString& oldFilePath,
         CHECK( wxFileExists(oldFilePath) );
         CHECK( wxFileExists(newFilePath) );
 
+        // Neither file should have been modified.
+        CHECK( GetFileContents(oldFilePath) == contentsSrc );
+        CHECK( GetFileContents(newFilePath) == contentsDst );
+
         // Cleanup.
         wxRemoveFile(oldFilePath);
     }
@@ -338,6 +366,9 @@ FileFunctionsTestCase::DoRenameFile(const wxString& oldFilePath,
         // Verify that file has been renamed.
         CHECK( !wxFileExists(oldFilePath) );
         CHECK( wxFileExists(newFilePath) );
+
+        // And that it really has the contents of the source file.
+        CHECK( GetFileContents(newFilePath) == contentsSrc );
     }
 
     // Cleanup.

--- a/tests/file/filefn.cpp
+++ b/tests/file/filefn.cpp
@@ -320,8 +320,7 @@ FileFunctionsTestCase::DoRenameFile(const wxString& oldFilePath,
     }
 
     CHECK( wxFileExists(oldFilePath) );
-    CHECK( wxFileExists(oldFilePath) );
-    CHECK( wxFileExists(oldFilePath) );
+
     bool shouldFail = !overwrite && withNew;
     if ( shouldFail )
     {

--- a/tests/file/filetest.cpp
+++ b/tests/file/filetest.cpp
@@ -17,6 +17,7 @@
 
 #include "wx/ffile.h"
 #include "wx/file.h"
+#include "wx/filename.h"
 
 #include "testfile.h"
 
@@ -158,6 +159,60 @@ TEMPLATE_TEST_CASE("wxTempFile", "[file][temp]", wxTempFile)
     CHECK( tmpFile.Commit() );
 
     CheckFileContents(name, dataNew);
+}
+
+// Check that replacing an existing file preserves its attributes: this is
+// what wxFileName::CopyAttributesFrom() is used for in wxTempFile::Open().
+#if wxUSE_FFILE
+TEMPLATE_TEST_CASE("wxTempFile::Attributes", "[file][temp]",
+                   wxTempFile, wxTempFFile)
+#else
+TEMPLATE_TEST_CASE("wxTempFile::Attributes", "[file][temp]", wxTempFile)
+#endif
+{
+    constexpr const char* name = "wxtemp_attr_test";
+
+    // Ensure that it will be removed at the end of the test in any case.
+    TempFile tf(name);
+
+    {
+        wxFile f(name, wxFile::write);
+        REQUIRE( f.IsOpened() );
+        CHECK( f.Write("old") );
+    }
+
+    wxFileName fn(name);
+
+    // Give the file to be replaced some distinctive attributes.
+#if wxUSE_DATETIME
+    const wxDateTime dtOld(1, wxDateTime::Jan, 2000);
+    REQUIRE( fn.SetTimes(nullptr, nullptr, &dtOld) );
+#endif // wxUSE_DATETIME
+
+#ifndef __WINDOWS__
+    REQUIRE( fn.SetPermissions(wxS_IRUSR | wxS_IWUSR) );
+#endif // !__WINDOWS__
+
+    TestType tmpFile;
+    REQUIRE( tmpFile.Open(name) );
+    CHECK( tmpFile.Write("new") );
+    CHECK( tmpFile.Commit() );
+
+    CheckFileContents(name, "new");
+
+#ifdef __WINDOWS__
+#if wxUSE_DATETIME
+    // Under MSW the creation time of the replaced file must be preserved.
+    wxDateTime dtCreate;
+    REQUIRE( fn.GetTimes(nullptr, nullptr, &dtCreate) );
+    CHECK( dtCreate == dtOld );
+#endif // wxUSE_DATETIME
+#else // !__WINDOWS__
+    // Elsewhere its permissions must be.
+    wxStructStat st;
+    REQUIRE( wxStat(name, &st) == 0 );
+    CHECK( (st.st_mode & 0777) == 0600 );
+#endif // __WINDOWS__/!__WINDOWS__
 }
 
 #ifdef __LINUX__

--- a/tests/file/filetest.cpp
+++ b/tests/file/filetest.cpp
@@ -15,6 +15,7 @@
 
 #if wxUSE_FILE
 
+#include "wx/ffile.h"
 #include "wx/file.h"
 
 #include "testfile.h"
@@ -100,7 +101,13 @@ static void CheckFileContents(const wxString& name, const wxString& data)
     CHECK( s == data );
 }
 
-TEST_CASE("wxTempFile", "[file][temp]")
+// wxTempFile and wxTempFFile have exactly the same API, so run the same test
+// for both of them instead of duplicating it.
+#if wxUSE_FFILE
+TEMPLATE_TEST_CASE("wxTempFile", "[file][temp]", wxTempFile, wxTempFFile)
+#else
+TEMPLATE_TEST_CASE("wxTempFile", "[file][temp]", wxTempFile)
+#endif
 {
     constexpr const char* name = "wxtemp_test";
     const wxString dataOld("what is the meaning of life?");
@@ -128,7 +135,7 @@ TEST_CASE("wxTempFile", "[file][temp]")
 
     // First check that not committing the file doesn't do anything.
     {
-        wxTempFile discarded(name);
+        TestType discarded(name);
         CHECK( discarded.IsOpened() );
         CHECK( discarded.Write(dataNew) );
     }
@@ -145,7 +152,7 @@ TEST_CASE("wxTempFile", "[file][temp]")
     }
 
     // Next check that committing it does.
-    wxTempFile tmpFile;
+    TestType tmpFile;
     CHECK( tmpFile.Open(name) );
     CHECK( tmpFile.Write(dataNew) );
     CHECK( tmpFile.Commit() );

--- a/tests/file/filetest.cpp
+++ b/tests/file/filetest.cpp
@@ -187,6 +187,18 @@ TEMPLATE_TEST_CASE("wxTempFile::Attributes", "[file][temp]", wxTempFile)
 #if wxUSE_DATETIME
     const wxDateTime dtOld(1, wxDateTime::Jan, 2000);
     REQUIRE( fn.SetTimes(nullptr, nullptr, &dtOld) );
+
+#ifdef __WINDOWS__
+    // Setting the creation time is not always supported: notably, Wine
+    // silently ignores it, as there is no way to do it under Linux. So check
+    // that it was really set before checking that it is preserved below.
+    wxDateTime dtSet;
+    REQUIRE( fn.GetTimes(nullptr, nullptr, &dtSet) );
+
+    const bool canSetCreationTime = dtSet == dtOld;
+    if ( !canSetCreationTime )
+        WARN("Setting file creation time is not supported, not testing it.");
+#endif // __WINDOWS__
 #endif // wxUSE_DATETIME
 
 #ifndef __WINDOWS__
@@ -203,9 +215,12 @@ TEMPLATE_TEST_CASE("wxTempFile::Attributes", "[file][temp]", wxTempFile)
 #ifdef __WINDOWS__
 #if wxUSE_DATETIME
     // Under MSW the creation time of the replaced file must be preserved.
-    wxDateTime dtCreate;
-    REQUIRE( fn.GetTimes(nullptr, nullptr, &dtCreate) );
-    CHECK( dtCreate == dtOld );
+    if ( canSetCreationTime )
+    {
+        wxDateTime dtCreate;
+        REQUIRE( fn.GetTimes(nullptr, nullptr, &dtCreate) );
+        CHECK( dtCreate == dtOld );
+    }
 #endif // wxUSE_DATETIME
 #else // !__WINDOWS__
     // Elsewhere its permissions must be.


### PR DESCRIPTION
The main change here is to make renaming atomic (at least for the files on the same volume — it's not really possible otherwise), see #26713, but it does some cleanup/fixes in the related areas too.