### PR TITLE
MSW: Fix checkbox drawing for empty label

### DIFF
--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -599,7 +599,10 @@ bool wxMSWOwnerDrawnButtonBase::MSWDrawButton(WXDRAWITEMSTRUCT *item)
     {
         RECT oldLabelRect = rectLabel; // needed if right aligned
 
-        if ( !::DrawText(hdc, label.t_str(), label.length(), &rectLabel,
+        // If the label is empty, use a space character to avoid a focus
+        // rectangle size 0x0.
+        wxString s = label.empty() ? " " : label;
+        if ( !::DrawText(hdc, s.t_str(), s.length(), &rectLabel,
                          fmt | DT_CALCRECT) )
         {
             wxLogLastError(wxT("DrawText(DT_CALCRECT)"));

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -601,7 +601,7 @@ bool wxMSWOwnerDrawnButtonBase::MSWDrawButton(WXDRAWITEMSTRUCT *item)
 
         // If the label is empty, use a space character to avoid a focus
         // rectangle size 0x0.
-        wxString s = label.empty() ? " " : label;
+        auto s = label.empty() ? wxString(" ") : label;
         if ( !::DrawText(hdc, s.t_str(), s.length(), &rectLabel,
                          fmt | DT_CALCRECT) )
         {


### PR DESCRIPTION
For a checkbox with an empty label, do not draw the focus rectangle with size 0x0. See #26778.

Although the issue occurs with dark mode, this issue is not specific to dark mode. It affects the checkbox owner-draw mode, which also occurs when a custom color is set.

For an empty label, the native control draws the focus rectangle very wide:
<img width="386" height="105" alt="image" src="https://github.com/user-attachments/assets/d9f3b70d-c34f-4af2-a33e-4daf5f17152c" />

I was not able to determine that width, so I used a space character to represent the empty label:
<img width="386" height="105" alt="image" src="https://github.com/user-attachments/assets/d1836c09-42c5-4c37-9321-db2bb862d040" />
